### PR TITLE
feat: add marketplace.json for self-hosted plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "ralph-hero",
+  "description": "Autonomous workflow plugins for GitHub Projects V2",
+  "owner": {
+    "name": "Chad Dubiel",
+    "url": "https://github.com/cdubiel08"
+  },
+  "plugins": [
+    {
+      "name": "ralph-hero",
+      "description": "The naive hero picks tickets, does their best work, and moves on. Autonomous triage, research, planning, and implementation with GitHub Projects V2.",
+      "source": "."
+    }
+  ]
+}


### PR DESCRIPTION
Allows installation via:
  /plugin marketplace add cdubiel08/ralph-hero
  /plugin install ralph-hero@ralph-hero