### PR TITLE
fix: resolve create_issue failure and workflow state transition bugs

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/github-client.ts
+++ b/plugin/ralph-hero/mcp-server/src/github-client.ts
@@ -198,18 +198,20 @@ export function createGitHubClient(clientConfig: GitHubClientConfig): GitHubClie
       mutation: string,
       variables?: Record<string, unknown>,
     ): Promise<T> {
-      // Invalidate related cache entries on mutations
-      // (conservative: clear all cache on any mutation)
-      cache.clear();
-      return executeGraphQL<T>(mutation, variables);
+      // Invalidate cached query results but preserve stable node ID lookups
+      // (issue-node-id and project-item-id entries remain valid across mutations)
+      cache.invalidatePrefix("query:");
+      const result = await executeGraphQL<T>(mutation, variables);
+      return result;
     },
 
     async projectMutate<T>(
       mutation: string,
       variables?: Record<string, unknown>,
     ): Promise<T> {
-      cache.clear();
-      return executeGraphQL<T>(mutation, variables, projectGraphqlWithAuth);
+      cache.invalidatePrefix("query:");
+      const result = await executeGraphQL<T>(mutation, variables, projectGraphqlWithAuth);
+      return result;
     },
 
     getRateLimitStatus() {

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -774,14 +774,14 @@ export function registerIssueTools(
               };
             };
           }>(
-            `query($owner: String!, $repo: String!, $query: String) {
+            `query($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
-                labels(first: 100, query: $query) {
+                labels(first: 100) {
                   nodes { id name }
                 }
               }
             }`,
-            { owner, repo, query: "" },
+            { owner, repo },
             { cache: true, cacheTtlMs: 5 * 60 * 1000 },
           );
 


### PR DESCRIPTION
## Summary
- **Fixes #5**: Remove forbidden `query` variable name from label-fetching GraphQL query. `@octokit/graphql` v9 reserves `query`, `method`, and `url` as option keys — using `$query` as a GraphQL variable caused the library to reject the request before `createIssue` could run.
- **Fixes #6**: Replace `cache.clear()` with `cache.invalidatePrefix("query:")` in `mutate()` and `projectMutate()`. The aggressive full-cache wipe destroyed stable node ID lookups (`issue-node-id:*`, `project-item-id:*`) between sequential state transitions, forcing re-resolution under API latency/eventual consistency.

## Test plan
- [x] All 21 existing tests pass
- [ ] Manually test `create_issue` with labels to verify no GraphQL variable error
- [ ] Manually test sequential workflow state transitions: Research Needed → Research in Progress → Ready for Plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)