### PR TITLE
chore: bump plugin to 2.1.0 and mcp-server to 1.1.0

### DIFF
--- a/plugin/ralph-hero/.claude-plugin/plugin.json
+++ b/plugin/ralph-hero/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-hero",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The naive hero picks tickets, does their best work, and moves on. Autonomous triage, research, planning, and implementation with GitHub Projects V2.",
   "author": {
     "name": "Chad Dubiel",

--- a/plugin/ralph-hero/mcp-server/package-lock.json
+++ b/plugin/ralph-hero/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ralph-hero-mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ralph-hero-mcp-server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/plugin/ralph-hero/mcp-server/package.json
+++ b/plugin/ralph-hero/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-hero-mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for GitHub Projects V2 - Ralph workflow automation",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Reflects new features on this branch:
- Split-owner/dual-token support for org repos with personal projects
- Fully qualified plugin skill invocations (ralph-hero:skill-name)
- Pull-based team architecture with self-claiming workers