### PR TITLE
fix: publish MCP server to npm for reliable plugin distribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,25 +26,17 @@ ralph-hero/
 │       │   │   ├── relationship-tools.ts
 │       │   │   └── view-tools.ts
 │       │   └── __tests__/          # Vitest tests
-│       ├── dist/                   # Compiled JS (COMMITTED — see below)
+│       ├── dist/                   # Compiled JS (gitignored, published to npm)
 │       ├── package.json
 │       └── tsconfig.json
 └── thoughts/                    # Research docs, plans, decisions
 ```
 
-## Critical: dist/ Must Be Committed
+## MCP Server Distribution
 
-Claude Code does **not** run `npm install` or build steps during plugin installation. It copies the plugin directory as-is. If `dist/` is missing, the MCP server silently fails to start and no tools are available.
+The MCP server is published to npm as `ralph-hero-mcp-server` and consumed via `npx` in `.mcp.json`. This follows the standard MCP ecosystem pattern used by official servers (`@modelcontextprotocol/server-*`) and plugins (Firebase, Context7).
 
-**After ANY change to MCP server source (`src/`), you MUST:**
-
-```bash
-cd plugin/ralph-hero/mcp-server
-npx tsc
-git add dist/
-```
-
-The `.gitignore` excludes `dist/__tests__/` and sourcemaps to keep the repo clean — only runtime `.js` and `.d.ts` files are tracked.
+The `dist/` directory is **not** committed to git. It is built and published via `npm publish` (the `prepublishOnly` script runs `tsc` automatically).
 
 ## Development
 
@@ -53,8 +45,15 @@ The `.gitignore` excludes `dist/__tests__/` and sourcemaps to keep the repo clea
 ```bash
 cd plugin/ralph-hero/mcp-server
 npm install          # Install dependencies
-npx tsc              # Build TypeScript -> dist/
-npx vitest run       # Run tests (21 tests)
+npm run build        # Build TypeScript -> dist/
+npm test             # Run tests (vitest)
+```
+
+### Publishing
+
+```bash
+cd plugin/ralph-hero/mcp-server
+npm publish          # Builds automatically via prepublishOnly, then publishes
 ```
 
 ### Environment Variables

--- a/plugin/ralph-hero/.gitignore
+++ b/plugin/ralph-hero/.gitignore
@@ -1,5 +1,3 @@
 node_modules/
 *.local.md
-mcp-server/dist/__tests__/
-mcp-server/dist/**/*.map
-mcp-server/dist/**/*.d.ts.map
+mcp-server/dist/

--- a/plugin/ralph-hero/.mcp.json
+++ b/plugin/ralph-hero/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "ralph-github": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/dist/index.js"],
+      "command": "npx",
+      "args": ["-y", "ralph-hero-mcp-server@latest"],
       "env": {
         "RALPH_GH_REPO_TOKEN": "${RALPH_GH_REPO_TOKEN}",
         "RALPH_GH_PROJECT_TOKEN": "${RALPH_GH_PROJECT_TOKEN}",

--- a/plugin/ralph-hero/mcp-server/.npmignore
+++ b/plugin/ralph-hero/mcp-server/.npmignore
@@ -1,0 +1,5 @@
+src/
+**/*.map
+**/*.d.ts
+**/*.d.ts.map
+__tests__/

--- a/plugin/ralph-hero/mcp-server/package.json
+++ b/plugin/ralph-hero/mcp-server/package.json
@@ -4,11 +4,17 @@
   "description": "MCP server for GitHub Projects V2 - Ralph workflow automation",
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "ralph-hero-mcp-server": "dist/index.js"
+  },
+  "files": [
+    "dist/**/*.js"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
     "start": "node dist/index.js",
-    "postinstall": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
@@ -21,6 +27,19 @@
     "typescript": "^5.7.0",
     "vitest": "^4.0.18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdubiel08/ralph-hero.git",
+    "directory": "plugin/ralph-hero/mcp-server"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "github-projects",
+    "claude-code",
+    "ralph-hero"
+  ],
+  "license": "MIT",
   "engines": {
     "node": ">=18.0.0"
   }

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Ralph GitHub MCP Server - Entry Point
  *


### PR DESCRIPTION
## Summary

- Migrate MCP server from git-committed `dist/` to npm package distribution via `npx`
- Follow the standard MCP ecosystem pattern used by `@modelcontextprotocol/server-*`, Firebase, and Context7 plugins
- Eliminate the fragile `dist/` tracking that caused #10

## Changes

- **`.mcp.json`**: `node dist/index.js` → `npx -y ralph-hero-mcp-server@latest`
- **`package.json`**: Added `bin`, `files`, `prepublishOnly`, `repository`, `license`, `keywords`
- **`src/index.ts`**: Added `#!/usr/bin/env node` shebang for npx execution
- **`.npmignore`**: New file — excludes src, sourcemaps, declarations from npm package
- **`.gitignore`**: Now ignores all of `mcp-server/dist/`
- **`CLAUDE.md`**: Documented npm distribution workflow

## Why

Claude Code's plugin framework copies files as-is during install — it does **not** run `npm install` or build steps. The previous approach of committing `dist/` to git was fragile: the v2.1.0 release shipped without it, silently breaking all MCP tools for users (#10).

The npm+npx pattern is the standard in the MCP ecosystem:
| Plugin | Pattern |
|--------|---------|
| Firebase | `npx -y firebase-tools@latest mcp` |
| Context7 | `npx -y @upstash/context7-mcp` |
| Official MCP servers | `npx -y @modelcontextprotocol/server-*` |

## Package verification

- Build: `tsc` compiles cleanly, shebang preserved in output
- Tests: 21/21 passing
- Package: 12 files, 22.3 kB (only `.js` runtime files)

## Test plan

- [x] Run `npm pack --dry-run` — verify only `.js` files and `package.json` included
- [x] Run `npm publish` — publish initial version to npm registry
- [x] Verify `npx -y ralph-hero-mcp-server@latest` starts the server
- [ ] Install plugin fresh, verify MCP tools load without manual build step
- [ ] Bump `plugin.json` to v2.2.0 and tag release

Fixes #10
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)