### PR TITLE
fix: filter unexpanded ${VAR} env literals in MCP server

### DIFF
--- a/plugin/ralph-hero/mcp-server/package-lock.json
+++ b/plugin/ralph-hero/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ralph-hero-mcp-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ralph-hero-mcp-server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/plugin/ralph-hero/mcp-server/package.json
+++ b/plugin/ralph-hero/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-hero-mcp-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server for GitHub Projects V2 - Ralph workflow automation",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -21,16 +21,23 @@ import { registerRelationshipTools } from "./tools/relationship-tools.js";
 /**
  * Initialize the GitHub client from environment variables.
  */
+function resolveEnv(name: string): string | undefined {
+  const val = process.env[name];
+  // Claude Code passes unexpanded ${VAR} literals for unset env vars in .mcp.json
+  if (!val || val.startsWith("${")) return undefined;
+  return val;
+}
+
 function initGitHubClient(): GitHubClient {
   // Repo token: for repository operations (issues, PRs, comments)
   const repoToken =
-    process.env.RALPH_GH_REPO_TOKEN ||
-    process.env.RALPH_HERO_GITHUB_TOKEN;
+    resolveEnv("RALPH_GH_REPO_TOKEN") ||
+    resolveEnv("RALPH_HERO_GITHUB_TOKEN");
 
   // Project token: for Projects V2 operations (fields, workflow state)
   // Falls back to repo token if not set
   const projectToken =
-    process.env.RALPH_GH_PROJECT_TOKEN || repoToken;
+    resolveEnv("RALPH_GH_PROJECT_TOKEN") || repoToken;
 
   if (!repoToken) {
     console.error(
@@ -51,11 +58,11 @@ function initGitHubClient(): GitHubClient {
     process.exit(1);
   }
 
-  const owner = process.env.RALPH_GH_OWNER;
-  const repo = process.env.RALPH_GH_REPO;
-  const projectOwner = process.env.RALPH_GH_PROJECT_OWNER || owner;
-  const projectNumber = process.env.RALPH_GH_PROJECT_NUMBER
-    ? parseInt(process.env.RALPH_GH_PROJECT_NUMBER, 10)
+  const owner = resolveEnv("RALPH_GH_OWNER");
+  const repo = resolveEnv("RALPH_GH_REPO");
+  const projectOwner = resolveEnv("RALPH_GH_PROJECT_OWNER") || owner;
+  const projectNumber = resolveEnv("RALPH_GH_PROJECT_NUMBER")
+    ? parseInt(resolveEnv("RALPH_GH_PROJECT_NUMBER")!, 10)
     : undefined;
 
   if (!owner || !repo) {
@@ -74,7 +81,7 @@ function initGitHubClient(): GitHubClient {
   }
 
   const repoTokenSource =
-    process.env.RALPH_GH_REPO_TOKEN ? "RALPH_GH_REPO_TOKEN" : "RALPH_HERO_GITHUB_TOKEN";
+    resolveEnv("RALPH_GH_REPO_TOKEN") ? "RALPH_GH_REPO_TOKEN" : "RALPH_HERO_GITHUB_TOKEN";
   console.error(`[ralph-hero] Repo token: ${repoTokenSource}`);
 
   if (projectToken !== repoToken) {


### PR DESCRIPTION
## Summary

- Add `resolveEnv()` helper that filters out unexpanded `${VAR}` literal strings passed by Claude Code's `.mcp.json` env handling
- Fixes "Bad credentials" auth failures for single-token setups

## Root Cause

Claude Code's plugin framework passes **all** declared env vars from `.mcp.json` to the MCP server process. For vars not set in the user's shell (e.g., `RALPH_GH_REPO_TOKEN`), it passes the literal string `"${RALPH_GH_REPO_TOKEN}"` instead of an empty value.

The token resolution chain (`RALPH_GH_REPO_TOKEN || RALPH_HERO_GITHUB_TOKEN`) then picks up the literal `"${RALPH_GH_REPO_TOKEN}"` as a real token and sends it to GitHub — resulting in "Bad credentials".

## Fix

```typescript
function resolveEnv(name: string): string | undefined {
  const val = process.env[name];
  if (!val || val.startsWith("${")) return undefined;
  return val;
}
```

All `process.env.*` reads in `initGitHubClient()` now go through `resolveEnv()`, so unexpanded variable references are treated as unset.

## Test plan

- [x] 21/21 tests passing
- [x] Published as npm v1.1.1
- [x] Verified: health check returns `auth: ok` with single-token setup where `RALPH_GH_REPO_TOKEN` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)