### PR TITLE
Fix .mcp.json env pattern - stop masking inherited tokens

### DIFF
--- a/plugin/ralph-hero/.mcp.json
+++ b/plugin/ralph-hero/.mcp.json
@@ -4,13 +4,9 @@
       "command": "npx",
       "args": ["-y", "ralph-hero-mcp-server@latest"],
       "env": {
-        "RALPH_GH_REPO_TOKEN": "${RALPH_GH_REPO_TOKEN}",
-        "RALPH_GH_PROJECT_TOKEN": "${RALPH_GH_PROJECT_TOKEN}",
-        "RALPH_HERO_GITHUB_TOKEN": "${RALPH_HERO_GITHUB_TOKEN}",
-        "RALPH_GH_OWNER": "${RALPH_GH_OWNER}",
-        "RALPH_GH_REPO": "${RALPH_GH_REPO}",
-        "RALPH_GH_PROJECT_OWNER": "${RALPH_GH_PROJECT_OWNER}",
-        "RALPH_GH_PROJECT_NUMBER": "${RALPH_GH_PROJECT_NUMBER}"
+        "RALPH_GH_OWNER": "${RALPH_GH_OWNER:-cdubiel08}",
+        "RALPH_GH_REPO": "${RALPH_GH_REPO:-ralph-hero}",
+        "RALPH_GH_PROJECT_NUMBER": "${RALPH_GH_PROJECT_NUMBER:-3}"
       }
     }
   }

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -41,17 +41,20 @@ function initGitHubClient(): GitHubClient {
     console.error(
       "[ralph-hero] Error: No GitHub token found.\n" +
         "\n" +
-        "Set one of these environment variables:\n" +
-        "  RALPH_GH_REPO_TOKEN      - Token with 'repo' scope (for issues/PRs)\n" +
-        "  RALPH_GH_PROJECT_TOKEN   - Token with 'project' scope (for project fields)\n" +
-        "  RALPH_HERO_GITHUB_TOKEN  - Single token with both scopes\n" +
+        "Quick fix — add to .claude/settings.local.json:\n" +
         "\n" +
-        "For org repos where project is owned by a different user:\n" +
-        "  RALPH_GH_REPO_TOKEN    = PAT with org repo access\n" +
-        "  RALPH_GH_PROJECT_TOKEN = PAT with personal project access\n" +
+        '  {\n' +
+        '    "env": {\n' +
+        '      "RALPH_HERO_GITHUB_TOKEN": "ghp_your_token_here"\n' +
+        "    }\n" +
+        "  }\n" +
         "\n" +
-        "Generate tokens at: https://github.com/settings/tokens\n" +
-        "Required scopes: 'repo' and/or 'project'",
+        "Then restart Claude Code.\n" +
+        "\n" +
+        "Generate a token at: https://github.com/settings/tokens\n" +
+        "Required scopes: repo, project\n" +
+        "\n" +
+        "For advanced setups (dual tokens, org projects), run /ralph-setup.",
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

- Remove token vars from `.mcp.json` `env` block — they were overwriting inherited env vars with unexpanded `${VAR}` literals, preventing the MCP server from starting
- Add `${VAR:-default}` fallbacks for non-sensitive config (owner, repo, project number)
- Simplify server startup error message to point users to `settings.local.json`
- Rewrite setup skill Quick Start with clear 3-step configuration guide

This follows the pattern used by all official Claude Code plugins (GitHub, Firebase, Slack, Linear) — none pass auth tokens through the `.mcp.json` `env` block.

Fixes #28
Related: #27

## Test plan

- [ ] Start Claude Code in ralph-hero project with token in `settings.local.json` — MCP server connects
- [ ] Start Claude Code without any token set — server fails with clear error pointing to `settings.local.json`
- [ ] Run `/ralph-setup` — Quick Start section displays correctly
- [ ] Verify `.mcp.json` defaults work for non-sensitive vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)