### PR TITLE
fix: branch isolation and worktree enforcement (Plan 1 - v3 Architecture)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Git worktrees (created by scripts/create-worktree.sh)
+worktrees/

--- a/plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/impl-branch-gate.sh
+# PreToolUse (Bash): Block git operations on main during implementation
+#
+# Inverse of branch-gate.sh - impl must NOT be on main for git commit/push.
+# Research/plan skills require main; impl requires a feature branch.
+#
+# Exit codes:
+#   0 - Allowed (on feature branch or non-git command)
+#   2 - Blocked (on main during impl git operation)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Only enforce for impl command
+if [[ "${RALPH_COMMAND:-}" != "impl" ]]; then
+  allow
+fi
+
+command=$(get_field '.tool_input.command')
+if [[ -z "$command" ]]; then
+  allow
+fi
+
+# Only check git commit/push/add operations
+if [[ "$command" != *"git commit"* ]] && [[ "$command" != *"git push"* ]] && [[ "$command" != *"git add"* ]]; then
+  allow
+fi
+
+# Allow git checkout/switch commands (agent may be switching TO a worktree)
+if [[ "$command" =~ ^[[:space:]]*git[[:space:]]+(checkout|switch) ]]; then
+  allow
+fi
+
+# Check current branch
+current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+
+if [[ "$current_branch" == "main" ]] || [[ "$current_branch" == "master" ]]; then
+  block "Implementation git operations blocked on main branch
+
+Current branch: $current_branch
+Command: $command
+
+Implementation must commit to a feature branch, not main.
+
+To fix:
+1. Create worktree: ./scripts/create-worktree.sh GH-NNN
+2. cd worktrees/GH-NNN/
+3. Then run your git commands
+
+Never commit implementation changes to main."
+fi
+
+allow

--- a/plugin/ralph-hero/hooks/scripts/impl-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-postcondition.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 # ralph-hero/hooks/scripts/impl-postcondition.sh
-# Stop: Verify progress made or PR created
+# Stop: Verify implementation made progress in a worktree
 #
 # Exit codes:
-#   0 - Postconditions met
+#   0 - Postconditions met (work done in worktree)
+#   2 - No worktree work detected (blocks session end)
 
 set -euo pipefail
 source "$(dirname "$0")/hook-utils.sh"
 
 read_input > /dev/null
+
+# Only enforce for impl command
+if [[ "${RALPH_COMMAND:-}" != "impl" ]]; then
+  allow
+fi
 
 ticket_id="${RALPH_TICKET_ID:-}"
 if [[ -z "$ticket_id" ]]; then
@@ -16,20 +22,40 @@ if [[ -z "$ticket_id" ]]; then
   ticket_id=$(echo "$current_dir" | grep -oE 'GH-[0-9]+' | head -1)
 fi
 
+# If we can't determine the ticket, allow (may be early exit)
 if [[ -z "$ticket_id" ]]; then
   allow
 fi
 
-worktree_dir="${RALPH_WORKTREE_DIR:-../worktrees}"
-if [[ -d "$worktree_dir/$ticket_id" ]]; then
-  echo "Worktree exists: $worktree_dir/$ticket_id"
+# Resolve the main repo root (works correctly inside worktrees)
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" ]]; then
+  PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
+else
+  PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
 fi
 
+worktree_path="$PROJECT_ROOT/worktrees/$ticket_id"
+
+if [[ ! -d "$worktree_path" ]]; then
+  block "Implementation postcondition failed: No worktree found
+
+Expected worktree at: $worktree_path
+Ticket: $ticket_id
+
+Implementation must create and work in a worktree.
+Run: ./scripts/create-worktree.sh $ticket_id"
+fi
+
+# Check that the feature branch has commits ahead of main
 branch_name="feature/$ticket_id"
-if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
-  commit_count=$(git rev-list --count "main..$branch_name" 2>/dev/null || echo "0")
-  echo "Branch $branch_name has $commit_count commit(s) ahead of main"
+if git -C "$worktree_path" rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+  commit_count=$(git -C "$worktree_path" rev-list --count "main..$branch_name" 2>/dev/null || echo "0")
+  if [[ "$commit_count" == "0" ]]; then
+    warn "Worktree exists but branch $branch_name has no commits ahead of main. Phase may not have completed."
+  else
+    echo "Implementation postcondition passed: $commit_count commit(s) on $branch_name"
+  fi
 fi
 
-echo "Implementation postcondition check passed"
 allow

--- a/plugin/ralph-hero/hooks/scripts/impl-verify-commit.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-verify-commit.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # ralph-hero/hooks/scripts/impl-verify-commit.sh
-# PostToolUse (Bash): Verify phase commit succeeded
+# PostToolUse (Bash): Verify phase commit/push succeeded
 #
 # Exit codes:
 #   0 - Git operation successful or not a git command
+#   2 - Push rejected or pre-commit hook failed (blocks)
 
 set -euo pipefail
 source "$(dirname "$0")/hook-utils.sh"
@@ -19,18 +20,28 @@ if [[ "$command" != *"git commit"* ]] && [[ "$command" != *"git push"* ]]; then
   allow
 fi
 
-tool_output=$(get_field '.tool_output // ""')
+tool_output=$(get_field '.tool_output')
 
 if [[ "$tool_output" == *"nothing to commit"* ]]; then
   warn "Git commit had nothing to commit. Phase changes may not have been staged with 'git add'."
 fi
 
 if [[ "$tool_output" == *"rejected"* ]] || [[ "$tool_output" == *"failed to push"* ]]; then
-  warn "Git push was rejected. Try: git pull --rebase origin [branch] && git push"
+  block "Git push was rejected
+
+$tool_output
+
+To fix: git pull --rebase origin [branch] && git push
+
+Do not proceed to the next phase until push succeeds."
 fi
 
 if [[ "$tool_output" == *"pre-commit hook"* ]] && [[ "$tool_output" == *"failed"* ]]; then
-  warn "Pre-commit hook failed. Fix issues before continuing to next phase."
+  block "Pre-commit hook failed
+
+$tool_output
+
+Fix the issues reported by the pre-commit hook before continuing."
 fi
 
 allow

--- a/plugin/ralph-hero/hooks/scripts/impl-worktree-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-worktree-gate.sh
@@ -1,35 +1,61 @@
 #!/bin/bash
 # ralph-hero/hooks/scripts/impl-worktree-gate.sh
-# PreToolUse (Write|Edit): Warn if not in worktree
+# PreToolUse (Write|Edit): Block writes outside worktree during implementation
 #
 # Environment:
-#   RALPH_WORKTREE_DIR - Expected worktree directory (default: ../worktrees)
+#   RALPH_COMMAND - Current command (only enforced for "impl")
 #
 # Exit codes:
-#   0 - Always allows (warnings only)
+#   0 - Allowed (in worktree or non-impl command)
+#   2 - Blocked (impl writes outside worktree)
 
 set -euo pipefail
 source "$(dirname "$0")/hook-utils.sh"
 
 read_input > /dev/null
+
+# Only enforce for impl command
+if [[ "${RALPH_COMMAND:-}" != "impl" ]]; then
+  allow
+fi
+
 file_path=$(get_field '.tool_input.file_path')
 
-# Skip checks for non-code files
+# Allow writes to thoughts/ and docs/ (research artifacts go on main)
 if [[ "$file_path" == *"/thoughts/"* ]] || [[ "$file_path" == *"/docs/"* ]]; then
   allow
 fi
 
-worktree_dir="${RALPH_WORKTREE_DIR:-../worktrees}"
-current_dir="$(pwd)"
-
-if [[ "$current_dir" != *"worktrees"* ]] && [[ "$current_dir" != *"$worktree_dir"* ]]; then
-  warn "Implementation should run in worktree
-
-Current: $current_dir
-Expected: Inside $worktree_dir/GH-NNN/
-
-Worktrees provide isolation for implementation.
-Consider running: ./scripts/create-worktree.sh GH-NNN"
+# Resolve the main repo root (works correctly inside worktrees)
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" ]]; then
+  PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
+else
+  PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
 fi
 
-allow
+# Check if file_path is inside a worktree
+if [[ -n "$PROJECT_ROOT" ]]; then
+  WORKTREE_BASE="$PROJECT_ROOT/worktrees"
+  if [[ "$file_path" == "$WORKTREE_BASE/"* ]]; then
+    allow
+  fi
+fi
+
+# Check if CWD is in a worktree (agent may use relative paths)
+current_dir="$(pwd)"
+if [[ "$current_dir" == *"/worktrees/"* ]]; then
+  allow
+fi
+
+block "Implementation writes must be in a worktree
+
+File: $file_path
+Current directory: $current_dir
+
+To fix:
+1. Create worktree: ./scripts/create-worktree.sh GH-NNN
+2. Change to worktree: cd worktrees/GH-NNN/
+3. Then make your changes
+
+Implementation requires branch isolation to prevent changes on main."

--- a/plugin/ralph-hero/hooks/scripts/pre-worktree-validator.sh
+++ b/plugin/ralph-hero/hooks/scripts/pre-worktree-validator.sh
@@ -6,37 +6,36 @@
 #   0 - Allowed (with context about existing worktree if any)
 #   2 - Blocked (worktree exists and is in use by another process)
 
-set -e
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
 
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-WORKTREE_BASE="$PROJECT_ROOT/../worktrees"
+read_input > /dev/null
 
-INPUT=$(cat)
-
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
+TOOL_NAME=$(get_field '.tool_name')
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
-  exit 0
+  allow
 fi
 
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+COMMAND=$(get_field '.tool_input.command')
 
 if [[ ! "$COMMAND" =~ create-worktree\.sh ]]; then
-  exit 0
+  allow
 fi
 
 TICKET_ID=$(echo "$COMMAND" | grep -oE 'GH-[0-9]+' | head -1)
 
 if [[ -z "$TICKET_ID" ]]; then
-  exit 0
+  allow
 fi
 
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+WORKTREE_BASE="$PROJECT_ROOT/worktrees"
 WORKTREE_PATH="$WORKTREE_BASE/$TICKET_ID"
 
 if [[ -d "$WORKTREE_PATH" ]]; then
   if lsof +D "$WORKTREE_PATH" &>/dev/null; then
-    cat >&2 <<EOF
-WORKTREE COLLISION DETECTED
+    block "WORKTREE COLLISION DETECTED
 
 Worktree for $TICKET_ID already exists and is IN USE:
   $WORKTREE_PATH
@@ -48,32 +47,12 @@ Actions:
 2. Check if another /ralph-impl or /ralph-hero is running on this ticket
 3. If the process is stuck, manually clean up: git worktree remove $WORKTREE_PATH
 
-Do NOT create a new worktree while another process is using it.
-EOF
-    exit 2
+Do NOT create a new worktree while another process is using it."
   fi
 
   CURRENT_BRANCH=$(cd "$WORKTREE_PATH" && git branch --show-current 2>/dev/null || echo "unknown")
 
-  cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "additionalContext": "Worktree for $TICKET_ID already exists at $WORKTREE_PATH.\nCurrent branch: $CURRENT_BRANCH\n\nRECOMMENDED: Reuse the existing worktree instead of creating a new one.\nChange your command to: cd $WORKTREE_PATH"
-  }
-}
-EOF
-  exit 0
+  allow_with_context "Worktree for $TICKET_ID already exists at $WORKTREE_PATH. Current branch: $CURRENT_BRANCH. RECOMMENDED: Reuse the existing worktree instead of creating a new one. Change your command to: cd $WORKTREE_PATH"
 fi
 
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "additionalContext": "No existing worktree for $TICKET_ID. Creating new worktree at $WORKTREE_PATH."
-  }
-}
-EOF
-exit 0
+allow_with_context "No existing worktree for $TICKET_ID. Creating new worktree at $WORKTREE_PATH."

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Create a git worktree for isolated feature development
+#
+# Usage: ./scripts/create-worktree.sh TICKET-ID [branch-name]
+#
+# Examples:
+#   ./scripts/create-worktree.sh GH-42
+#   ./scripts/create-worktree.sh GH-42 my-custom-branch
+
+set -e
+
+TICKET_ID="${1:?Usage: $0 TICKET_ID [BRANCH_NAME]}"
+BRANCH_NAME="${2:-feature/$TICKET_ID}"
+
+# Always resolve from git root to handle being called from any directory
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -z "$PROJECT_ROOT" ]]; then
+  echo "Error: Not in a git repository"
+  exit 1
+fi
+
+WORKTREE_BASE="$PROJECT_ROOT/worktrees"
+WORKTREE_PATH="$WORKTREE_BASE/$TICKET_ID"
+
+cd "$PROJECT_ROOT"
+
+mkdir -p "$WORKTREE_BASE"
+
+echo "Fetching latest from origin..."
+git fetch origin main 2>/dev/null || git fetch origin master 2>/dev/null || echo "Warning: Could not fetch from origin"
+
+BASE_BRANCH="origin/main"
+if ! git rev-parse --verify "$BASE_BRANCH" &>/dev/null; then
+  BASE_BRANCH="origin/master"
+  if ! git rev-parse --verify "$BASE_BRANCH" &>/dev/null; then
+    echo "Error: Could not find origin/main or origin/master"
+    exit 1
+  fi
+fi
+
+if [ -d "$WORKTREE_PATH" ]; then
+  echo "Worktree already exists at: $WORKTREE_PATH"
+  CURRENT_BRANCH=$(cd "$WORKTREE_PATH" && git branch --show-current 2>/dev/null || echo "unknown")
+  echo "Current branch: $CURRENT_BRANCH"
+  echo "Use: cd $WORKTREE_PATH"
+  exit 0
+fi
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  echo "Branch $BRANCH_NAME exists, checking out..."
+  git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+else
+  echo "Creating new branch $BRANCH_NAME from $BASE_BRANCH..."
+  git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$BASE_BRANCH"
+fi
+
+echo ""
+echo "Worktree created successfully!"
+echo "  Path: $WORKTREE_PATH"
+echo "  Branch: $BRANCH_NAME"
+echo ""
+echo "To work in this worktree:"
+echo "  cd $WORKTREE_PATH"

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Remove a git worktree
+#
+# Usage: ./scripts/remove-worktree.sh TICKET-ID
+
+set -e
+
+TICKET_ID="${1:?Usage: $0 TICKET_ID}"
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -z "$PROJECT_ROOT" ]]; then
+  echo "Error: Not in a git repository"
+  exit 1
+fi
+
+WORKTREE_PATH="$PROJECT_ROOT/worktrees/$TICKET_ID"
+
+if [ ! -d "$WORKTREE_PATH" ]; then
+  echo "No worktree found at: $WORKTREE_PATH"
+  exit 0
+fi
+
+cd "$PROJECT_ROOT"
+
+echo "Removing worktree: $WORKTREE_PATH"
+git worktree remove "$WORKTREE_PATH" --force
+echo "Worktree removed: $TICKET_ID"

--- a/scripts/test-branch-isolation.sh
+++ b/scripts/test-branch-isolation.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Integration test: verify branch isolation for impl workflow
+#
+# Usage: ./scripts/test-branch-isolation.sh
+#
+# Tests:
+# 1. create-worktree.sh creates proper worktree
+# 2. impl-worktree-gate blocks writes outside worktree
+# 3. impl-branch-gate blocks git operations on main
+#
+# NOTE: Tests 2-3 validate blocking behavior by running hooks from the
+# main repo root (not from inside a worktree). If this script is invoked
+# from a worktree, it resolves the main repo via --git-common-dir.
+
+set -e
+
+# Resolve the MAIN repo root even when run from inside a worktree
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+if [[ -n "$GIT_COMMON_DIR" && "$GIT_COMMON_DIR" != ".git" && "$GIT_COMMON_DIR" != "$(pwd)/.git" ]]; then
+  MAIN_ROOT=$(dirname "$GIT_COMMON_DIR")
+else
+  MAIN_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+fi
+
+# PROJECT_ROOT is the worktree or repo we're running from (where scripts/ lives)
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+cd "$PROJECT_ROOT"
+
+TICKET="GH-TEST-$$"  # Unique per run
+PASS=0
+FAIL=0
+HOOK_DIR="$PROJECT_ROOT/plugin/ralph-hero/hooks/scripts"
+
+check() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected=$expected, got=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Run a hook from a specific directory with RALPH_COMMAND=impl
+# Usage: run_hook_from <dir> <hook-script> <json-input>
+# Returns: exit code of the hook
+run_hook_from() {
+  local dir="$1"
+  local hook="$2"
+  local input="$3"
+  local rc=0
+  (export RALPH_COMMAND="impl" && cd "$dir" && echo "$input" | bash "$hook") 2>/dev/null || rc=$?
+  echo "$rc"
+}
+
+echo "=== Branch Isolation Integration Tests ==="
+echo "Main repo: $MAIN_ROOT"
+echo "Script root: $PROJECT_ROOT"
+echo ""
+
+# Test 1: create-worktree.sh
+echo "Test 1: Worktree creation"
+./scripts/create-worktree.sh "$TICKET"
+check "Worktree directory exists" "true" "$([ -d worktrees/$TICKET ] && echo true || echo false)"
+check "Branch created" "true" "$(git show-ref --verify --quiet refs/heads/feature/$TICKET && echo true || echo false)"
+
+# Test 2: impl-worktree-gate blocks outside worktree
+# Run blocking test from main repo root so CWD doesn't contain /worktrees/
+echo ""
+echo "Test 2: Worktree gate enforcement"
+
+result=$(run_hook_from "$MAIN_ROOT" "$HOOK_DIR/impl-worktree-gate.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"'"$MAIN_ROOT"'/plugin/ralph-hero/test-file.txt"}}')
+check "Write outside worktree blocked" "2" "$result"
+
+result=$(run_hook_from "$PROJECT_ROOT" "$HOOK_DIR/impl-worktree-gate.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"'"$PROJECT_ROOT"'/worktrees/'"$TICKET"'/test-file.txt"}}')
+check "Write inside worktree allowed" "0" "$result"
+
+# Test 3: impl-branch-gate blocks on main
+# Run blocking test from main repo root (which is on the 'main' branch)
+echo ""
+echo "Test 3: Branch gate enforcement"
+
+result=$(run_hook_from "$MAIN_ROOT" "$HOOK_DIR/impl-branch-gate.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}')
+check "Git commit on main blocked" "2" "$result"
+
+result=$(run_hook_from "$PROJECT_ROOT/worktrees/$TICKET" "$HOOK_DIR/impl-branch-gate.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m test"}}')
+check "Git commit on feature branch allowed" "0" "$result"
+
+# Cleanup
+echo ""
+echo "Cleaning up test worktree..."
+./scripts/remove-worktree.sh "$TICKET"
+git branch -D "feature/$TICKET" 2>/dev/null || true
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Fixes 5 reinforcing bugs that caused implementation agents to write changes directly to main instead of isolated worktree branches. This is Plan 1 of the Ralph Hero v3 Architecture epic.

### Bugs Fixed
- **Bug 1**: `impl-worktree-gate.sh` only warned (exit 0) but never blocked writes outside worktrees
- **Bug 2**: `create-worktree.sh` was missing from the repo - impl SKILL.md referenced a non-existent script
- **Bug 3**: `impl-postcondition.sh` didn't verify implementation work was done in a worktree
- **Bug 4**: `impl-verify-commit.sh` only warned on push rejections
- **Bug 5**: No branch enforcement prevented `git commit` on main during implementation

### Changes

**New files:**
- `scripts/create-worktree.sh` - Creates git worktrees for isolated feature development
- `scripts/remove-worktree.sh` - Removes git worktrees cleanly
- `scripts/test-branch-isolation.sh` - Integration test (6 tests, all passing)
- `plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh` - Blocks git operations on main during impl
- `.gitignore` - Excludes `worktrees/` directory

**Modified files:**
- `plugin/ralph-hero/hooks/scripts/impl-worktree-gate.sh` - Upgraded from warn→block, fixed PROJECT_ROOT resolution for worktree CWD
- `plugin/ralph-hero/hooks/scripts/impl-verify-commit.sh` - Upgraded from warn→block on push rejection
- `plugin/ralph-hero/hooks/scripts/impl-postcondition.sh` - Upgraded from warn→block, fixed PROJECT_ROOT resolution using `--git-common-dir`
- `plugin/ralph-hero/hooks/scripts/pre-worktree-validator.sh` - Fixed worktree path from `../worktrees` to `worktrees/`, migrated to hook-utils.sh
- `plugin/ralph-hero/skills/ralph-impl/SKILL.md` - Fixed all `../worktrees` references to use `$GIT_ROOT/worktrees`, registered impl-branch-gate hook

### Review Fixes Incorporated
Plan was reviewed before implementation. Three critical bugs were found in the proposed code and fixed:
- **C1**: `git rev-parse --show-toplevel` returns worktree path inside worktrees → use `--git-common-dir` 
- **C2**: Integration test `set -e` + expected non-zero exits → capture with `|| result=$?` pattern
- **C3**: `pre-worktree-validator.sh` checked wrong directory for worktrees → fixed path

## Test plan
- [x] Integration test passes: `./scripts/test-branch-isolation.sh` (6/6)
- [x] `bash -n` syntax check passes on all 8 scripts
- [ ] shellcheck on all scripts
- [ ] Manual test: `ralph_team` on a test issue creates proper branch isolation

## References
- Plan: `thoughts/shared/plans/2026-02-17-plan-1-critical-bug-fixes.md`
- Review: `thoughts/shared/plans/2026-02-17-plan-1-review-critique.md`
- Epic: `thoughts/shared/plans/2026-02-17-ralph-hero-v3-architecture-epic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)