### PR TITLE
feat: HOP architecture — template-based agent spawning (Plan 2 - v3 Architecture)

### DIFF
--- a/plugin/ralph-hero/templates/spawn/implementer.md
+++ b/plugin/ralph-hero/templates/spawn/implementer.md
@@ -1,0 +1,8 @@
+Implement #{ISSUE_NUMBER}: {TITLE}.
+{WORKTREE_CONTEXT}
+
+Invoke: Skill(skill="ralph-hero:ralph-impl", args="{ISSUE_NUMBER}")
+
+Report results per your agent definition.
+DO NOT push to remote. The lead handles pushing and PR creation.
+Then check TaskList for more implementation tasks. If none, notify team-lead.

--- a/plugin/ralph-hero/templates/spawn/planner.md
+++ b/plugin/ralph-hero/templates/spawn/planner.md
@@ -1,0 +1,7 @@
+Plan #{ISSUE_NUMBER}: {TITLE}.
+{GROUP_CONTEXT}
+
+Invoke: Skill(skill="ralph-hero:ralph-plan", args="{ISSUE_NUMBER}")
+
+Report results per your agent definition.
+Then check TaskList for more plan tasks. If none, hand off per shared/conventions.md.

--- a/plugin/ralph-hero/templates/spawn/researcher.md
+++ b/plugin/ralph-hero/templates/spawn/researcher.md
@@ -1,0 +1,6 @@
+Research #{ISSUE_NUMBER}: {TITLE}.
+
+Invoke: Skill(skill="ralph-hero:ralph-research", args="{ISSUE_NUMBER}")
+
+Report results per your agent definition.
+Then check TaskList for more research tasks. If none, hand off per shared/conventions.md.

--- a/plugin/ralph-hero/templates/spawn/reviewer.md
+++ b/plugin/ralph-hero/templates/spawn/reviewer.md
@@ -1,0 +1,7 @@
+Review plan for #{ISSUE_NUMBER}: {TITLE}.
+{GROUP_CONTEXT}
+
+Invoke: Skill(skill="ralph-hero:ralph-review", args="{ISSUE_NUMBER}")
+
+Report results per your agent definition.
+Then check TaskList for more review tasks. If none, hand off per shared/conventions.md.

--- a/plugin/ralph-hero/templates/spawn/splitter.md
+++ b/plugin/ralph-hero/templates/spawn/splitter.md
@@ -1,0 +1,7 @@
+Split #{ISSUE_NUMBER}: {TITLE}.
+Too large for direct implementation (estimate: {ESTIMATE}).
+
+Invoke: Skill(skill="ralph-hero:ralph-split", args="{ISSUE_NUMBER}")
+
+Report results per your agent definition.
+Then check TaskList for more split tasks.

--- a/plugin/ralph-hero/templates/spawn/triager.md
+++ b/plugin/ralph-hero/templates/spawn/triager.md
@@ -1,0 +1,7 @@
+Triage #{ISSUE_NUMBER}: {TITLE}.
+Estimate: {ESTIMATE}.
+
+Invoke: Skill(skill="ralph-hero:ralph-triage", args="{ISSUE_NUMBER}")
+
+Report results per your agent definition.
+Then check TaskList for more triage tasks.


### PR DESCRIPTION
## Summary

Replaces ralph-team's inline spawn prompts with a Higher-Order Prompt (HOP) system. Spawn prompts are now parameterized template files with `{PLACEHOLDER}` substitution, inspired by Bowser's composable prompt architecture.

### What Changed
- **6 spawn templates** created in `plugin/ralph-hero/templates/spawn/` (researcher, planner, reviewer, implementer, triager, splitter)
- **ralph-team SKILL.md Section 6** refactored from inline prompt construction to template-based resolution
- **conventions.md** extended with Spawn Template Protocol, placeholder reference, and authoring rules

### What Didn't Change (by design)
- **ralph-hero SKILL.md** — hero mode keeps inline 1-liner prompts (review finding B3)
- **No result templates** — agent `.md` files remain the single source of truth for result formats (review finding B1)
- **No skill changes** — skills are unchanged (that's Plan 3)

### Key Design Decisions
- Templates are under 15 lines each — minimal context, skills fetch their own via `get_issue`
- Path resolution uses `Bash("echo $CLAUDE_PLUGIN_ROOT")` as safe fallback for template reads
- Adding a new agent role = creating a new template file (zero orchestrator changes)

### Review Findings Incorporated
- **B1**: Dropped Phase 5 (result templates) — avoids triple source of truth
- **B3**: Skipped Phase 4 (hero mode) — keeps working inline prompts
- **B4**: Added Template Authoring Rules to conventions.md
- **W1-W4**: Path resolution, idle-nudge guidance, empty-line semantics, splitter mapping

## Test plan
- [ ] Verify all 6 templates contain required placeholders
- [ ] Verify ralph-team Section 6 references templates, no inline prompts
- [ ] Verify conventions.md has complete protocol documentation
- [ ] Manual: Run `/ralph-team [test-issue]` and verify template-based spawning works

## References
- Plan: `thoughts/shared/plans/2026-02-17-plan-2-hop-architecture.md`
- Review: `thoughts/shared/plans/2026-02-17-plan-2-review-critique.md`
- Epic: `thoughts/shared/plans/2026-02-17-ralph-hero-v3-architecture-epic.md`
- Predecessor: PR #39 (Plan 1 - Branch Isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)