### PR TITLE
fix: disambiguate task list IDs (T-N) from GitHub issues (GH-N)

### DIFF
--- a/plugin/ralph-hero/skills/ralph-hero/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-hero/SKILL.md
@@ -107,8 +107,8 @@ Research all leaf issues in "Research Needed" state in parallel.
 Spawn ALL research tasks in a SINGLE message for true parallelism:
 ```
 Task(subagent_type="general-purpose", run_in_background=true,
-     prompt="Use Skill(skill='ralph-hero:ralph-research', args='NNN') to research issue #NNN: [title].",
-     description="Research #NNN")
+     prompt="Use Skill(skill='ralph-hero:ralph-research', args='NNN') to research issue GH-NNN: [title].",
+     description="Research GH-NNN")
 ```
 
 Wait for all research to complete, then re-call `detect_pipeline_position`. If phase == PLAN, proceed to planning.
@@ -124,15 +124,15 @@ Issues are in the SAME GROUP if they share the same parent or are connected via 
 For single-issue groups:
 ```
 Task(subagent_type="general-purpose",
-     prompt="Use Skill(skill='ralph-hero:ralph-plan', args='NNN') to create a plan for #NNN.",
-     description="Plan #NNN")
+     prompt="Use Skill(skill='ralph-hero:ralph-plan', args='NNN') to create a plan for GH-NNN.",
+     description="Plan GH-NNN")
 ```
 
 For multi-issue groups:
 ```
 Task(subagent_type="general-purpose",
-     prompt="Use Skill(skill='ralph-hero:ralph-plan', args='[PRIMARY]') to create a GROUP plan. Group: #AAA, #BBB, #CCC.",
-     description="Plan group #[PRIMARY]")
+     prompt="Use Skill(skill='ralph-hero:ralph-plan', args='[PRIMARY]') to create a GROUP plan. Group: GH-AAA, GH-BBB, GH-CCC.",
+     description="Plan group GH-[PRIMARY]")
 ```
 
 After planning, check `RALPH_REVIEW_MODE`:
@@ -147,7 +147,7 @@ Spawn parallel review tasks for all plan groups:
 ```
 Task(subagent_type="general-purpose", run_in_background=true,
      prompt="Use Skill(skill='ralph-hero:ralph-review', args='NNN') to review the plan. Return: APPROVED or NEEDS_ITERATION.",
-     description="Review #NNN")
+     description="Review GH-NNN")
 ```
 
 **Routing**:
@@ -171,8 +171,8 @@ Execute implementation sequentially respecting dependency order from `detect_gro
 For each issue in order (wait for each to complete before starting next):
 ```
 Task(subagent_type="general-purpose",
-     prompt="Use Skill(skill='ralph-hero:ralph-impl', args='NNN') to implement #NNN. Follow the plan exactly.",
-     description="Implement #NNN")
+     prompt="Use Skill(skill='ralph-hero:ralph-impl', args='NNN') to implement GH-NNN. Follow the plan exactly.",
+     description="Implement GH-NNN")
 ```
 
 If any implementation fails, STOP immediately. Do NOT continue to next issue.

--- a/plugin/ralph-hero/skills/ralph-plan/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-plan/SKILL.md
@@ -155,7 +155,7 @@ primary_issue: 123
 
 | Phase | Issue | Title | Estimate |
 |-------|-------|-------|----------|
-| 1 | #123 | [Title] | XS |
+| 1 | GH-123 | [Title] | XS |
 
 **Why grouped**: [Explanation]
 
@@ -174,7 +174,7 @@ primary_issue: 123
 
 ---
 
-## Phase 1: [#123 Title]
+## Phase 1: [GH-123 Title]
 > **Issue**: [URL] | **Research**: [URL] | **Depends on**: (if applicable)
 
 ### Changes Required
@@ -202,7 +202,7 @@ primary_issue: 123
 
 ```bash
 git add thoughts/shared/plans/YYYY-MM-DD-*.md
-git commit -m "docs(plan): GH-NNN implementation plan"  # or "#123, #124, #125 group plan"
+git commit -m "docs(plan): GH-NNN implementation plan"  # or "GH-123, GH-124, GH-125 group plan"
 git push origin main
 ```
 

--- a/plugin/ralph-hero/skills/ralph-review/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-review/SKILL.md
@@ -320,7 +320,7 @@ result = TaskOutput(task_id=[critique-task-id], block=true, timeout=300000)
 
 **If APPROVED**:
 ```
-Review complete for #NNN: [Title]
+Review complete for GH-NNN: [Title]
 
 Mode: [INTERACTIVE/AUTO]
 Result: APPROVED
@@ -333,7 +333,7 @@ Ready for implementation. Run /ralph-impl NNN
 
 **If NEEDS_ITERATION**:
 ```
-Review complete for #NNN: [Title]
+Review complete for GH-NNN: [Title]
 
 Mode: [INTERACTIVE/AUTO]
 Result: NEEDS ITERATION

--- a/plugin/ralph-hero/skills/ralph-split/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-split/SKILL.md
@@ -120,9 +120,9 @@ After verifying issue needs splitting:
 
 ```
 analyze_task = TaskCreate(
-  subject: "#NNN: Analyze scope",
-  description: "Research scope and identify split boundaries for #NNN",
-  activeForm: "Analyzing scope for #NNN...",
+  subject: "GH-NNN: Analyze scope",
+  description: "Research scope and identify split boundaries for GH-NNN",
+  activeForm: "Analyzing scope for GH-NNN...",
   metadata: {
     "issue_number": "NNN",
     "command": "split",
@@ -132,8 +132,8 @@ analyze_task = TaskCreate(
 )
 
 create_task = TaskCreate(
-  subject: "#NNN: Create sub-issues",
-  description: "Create XS/S sub-issues from #NNN",
+  subject: "GH-NNN: Create sub-issues",
+  description: "Create XS/S sub-issues from GH-NNN",
   activeForm: "Creating sub-issues...",
   addBlockedBy: [analyze_task],
   metadata: {
@@ -409,8 +409,8 @@ Next: Run /ralph-research or /ralph-plan on sub-issues as appropriate.
 
 | Situation | Action |
 |-----------|--------|
-| Can't identify natural split boundaries | @mention: "Unable to decompose #NNN. Scope is atomic or unclear." |
-| Split would create too many issues (>5) | @mention: "#NNN decomposes into [N] issues. Confirm this is acceptable." |
+| Can't identify natural split boundaries | @mention: "Unable to decompose GH-NNN. Scope is atomic or unclear." |
+| Split would create too many issues (>5) | @mention: "GH-NNN decomposes into [N] issues. Confirm this is acceptable." |
 | Circular dependencies in proposed split | @mention: "Proposed split has circular dependency. Need guidance." |
 | Issue is actually XS/Small after research | Update estimate instead of splitting |
 

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -83,7 +83,7 @@ Use `phase` to determine tasks (Section 4.2) and first teammate (Section 4.3). T
 
 ### Group Tracking
 
-- **GROUP_TICKETS**: Encoded in task descriptions (e.g., "Plan group #42 (#42, #43, #44)")
+- **GROUP_TICKETS**: Encoded in task descriptions (e.g., "Plan group GH-42 (GH-42, GH-43, GH-44)")
 - **GROUP_PRIMARY**: Used for worktree naming, planner/implementer spawning
 - **IS_GROUP**: Determines per-group vs per-issue tasks
 - Group membership is immutable once detected
@@ -106,14 +106,14 @@ For XS issues (estimate=1) with specific, actionable descriptions: skip research
 
 **CRITICAL**: Create team BEFORE any tasks. Tasks created before TeamCreate become orphaned.
 
-Team name must be unique: `TEAM_NAME = "ralph-team-GH-NNN"` (use issue number or group primary). Use for ALL subsequent `team_name` parameters.
+Team name must be unique: `TEAM_NAME = "ralph-team-GH-NNN"` (e.g., `ralph-team-GH-42`; use issue number or group primary). Use for ALL subsequent `team_name` parameters.
 
 ### 4.2 Create Tasks for Remaining Phases
 
 Based on pipeline position (Section 3), create tasks with sequential blocking: Research -> Plan -> Review -> Implement -> PR.
 
 **Subject patterns** (workers match on these to self-claim):
-- `"Research #NNN"` / `"Plan #NNN"` / `"Review plan for #NNN"` / `"Implement #NNN"` / `"Create PR for #NNN"`
+- `"Research GH-NNN"` / `"Plan GH-NNN"` / `"Review plan for GH-NNN"` / `"Implement GH-NNN"` / `"Create PR for GH-NNN"`
 
 **Groups** (IS_GROUP=true): Research tasks are per-issue; Plan/Review/Implement/PR are per-group using GROUP_PRIMARY. Include all issue numbers in descriptions. Plan is blocked by ALL research tasks.
 
@@ -145,8 +145,8 @@ The Stop hook prevents premature shutdown -- you cannot stop while GitHub has pr
 ### 4.5 Lead Creates PR (Only Direct Work)
 
 After implementation completes, lead pushes and creates PR via `gh pr create`:
-- **Single issue**: `git push -u origin feature/GH-NNN` from `worktrees/GH-NNN`. Title: `feat: [title]`. Body: summary, `Closes #NNN`, change summary from implementer's task description.
-- **Group**: Push from `worktrees/GH-[PRIMARY]`. Body: summary, `Closes #NNN` for each issue, changes by phase.
+- **Single issue**: `git push -u origin feature/GH-NNN` from `worktrees/GH-NNN`. Title: `feat: [title]`. Body: summary, `Closes #NNN` (bare `#NNN` here is GitHub PR syntax, not our convention), change summary from implementer's task description.
+- **Group**: Push from `worktrees/GH-[PRIMARY]`. Body: summary, `Closes #NNN` for each issue (bare `#NNN` is GitHub PR syntax), changes by phase.
 
 **After PR creation**: Move ALL issues (and children) to "In Review" via `advance_children`. NEVER to "Done" -- that requires PR merge (external event). Then return to dispatch loop.
 
@@ -196,7 +196,7 @@ No prescribed roster -- spawn what's needed. Each teammate receives a minimal pr
    ```
    Task(subagent_type="[agent-type]", team_name=TEAM_NAME, name="[role]",
         prompt=[resolved template content],
-        description="[Role] #NNN")
+        description="[Role] GH-NNN")
    ```
 
 See `shared/conventions.md` "Spawn Template Protocol" for full placeholder reference, authoring rules, and naming conventions.

--- a/plugin/ralph-hero/skills/ralph-triage/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-triage/SKILL.md
@@ -287,7 +287,7 @@ After triage action is complete, scan for related issues in Backlog or Research 
    - blockingNumber: [earlier-phase-issue-number]
    ```
 
-   Example: A test config issue (#10) that must complete before test implementation issues (#11, #12) can start:
+   Example: A test config issue (GH-10) that must complete before test implementation issues (GH-11, GH-12) can start:
    ```
    # Config issue blocks the implementation issues
    ralph_hero__add_dependency(blockedNumber=11, blockingNumber=10)

--- a/plugin/ralph-hero/skills/shared/conventions.md
+++ b/plugin/ralph-hero/skills/shared/conventions.md
@@ -2,6 +2,19 @@
 
 Common protocols referenced by all Ralph skills. Skills should link here rather than duplicating this content.
 
+## Identifier Disambiguation
+
+Task list IDs and GitHub issue numbers use different prefixes to avoid confusion:
+
+| Entity | Prefix | Example | Scope |
+|--------|--------|---------|-------|
+| Task list item | `T-` | T-7 | Session-local, ephemeral |
+| GitHub issue | `GH-` | GH-49 | Repository-scoped, permanent |
+
+- **Task subjects and spawn templates** use `GH-NNN` when referencing GitHub issues (e.g., `"Research GH-42"`)
+- **Task list IDs** (from TaskCreate/TaskList) are referenced as `T-N` in lead messages and instructions
+- **Exception**: GitHub PR body `Closes #NNN` syntax uses bare `#NNN` because GitHub requires it
+
 ## Escalation Protocol
 
 When encountering complexity, uncertainty, or states that don't align with protocol, **escalate via GitHub issue comment** by @mentioning the appropriate person.
@@ -149,7 +162,7 @@ Available templates: `researcher`, `planner`, `reviewer`, `implementer`, `triage
 
 If `IS_GROUP=true` for the issue:
 ```
-{GROUP_CONTEXT} = "Group: #{PRIMARY} (#{A}, #{B}, #{C}). Plan covers all group issues."
+{GROUP_CONTEXT} = "Group: GH-{PRIMARY} (GH-{A}, GH-{B}, GH-{C}). Plan covers all group issues."
 ```
 
 If `IS_GROUP=false`:
@@ -175,7 +188,7 @@ If a placeholder resolves to an empty string, remove the ENTIRE LINE containing 
 
 Example -- planner template before substitution:
 ```
-Plan #42: Add caching.
+Plan GH-42: Add caching.
 {GROUP_CONTEXT}
 
 Invoke: Skill(skill="ralph-hero:ralph-plan", args="42")
@@ -183,7 +196,7 @@ Invoke: Skill(skill="ralph-hero:ralph-plan", args="42")
 
 After substitution when IS_GROUP=false (GROUP_CONTEXT is empty):
 ```
-Plan #42: Add caching.
+Plan GH-42: Add caching.
 
 Invoke: Skill(skill="ralph-hero:ralph-plan", args="42")
 ```
@@ -227,7 +240,7 @@ Skills should be invoked via forked subprocesses to isolate context:
 ```
 Task(subagent_type="general-purpose",
      prompt="Skill(skill='ralph-hero:ralph-research', args='42')",
-     description="Research #42")
+     description="Research GH-42")
 ```
 
 This ensures:
@@ -368,4 +381,4 @@ This ensures subsequent phases find the artifact via the primary channel.
 ### Known Limitations
 
 - **10-comment limit**: `get_issue` returns only the last 10 comments. For issues with many status updates, early comments (e.g., the research document comment) may scroll off. This is why the glob fallback is essential — it provides a reliable secondary discovery path when comments are no longer visible.
-- **Group glob for non-primary issues**: Group plans use the primary issue number in filenames (e.g., `group-GH-0042-*.md`). Non-primary group members (e.g., #43, #44) won't match `*GH-43*`. The comment-based path handles groups correctly since the plan skill posts to ALL group issues. The glob fallback should try `*group*GH-{primary}*` after `*GH-{number}*` fails.
+- **Group glob for non-primary issues**: Group plans use the primary issue number in filenames (e.g., `group-GH-0042-*.md`). Non-primary group members (e.g., GH-43, GH-44) won't match `*GH-43*`. The comment-based path handles groups correctly since the plan skill posts to ALL group issues. The glob fallback should try `*group*GH-{primary}*` after `*GH-{number}*` fails.

--- a/plugin/ralph-hero/templates/spawn/implementer.md
+++ b/plugin/ralph-hero/templates/spawn/implementer.md
@@ -1,4 +1,4 @@
-Implement #{ISSUE_NUMBER}: {TITLE}.
+Implement GH-{ISSUE_NUMBER}: {TITLE}.
 {WORKTREE_CONTEXT}
 
 Invoke: Skill(skill="ralph-hero:ralph-impl", args="{ISSUE_NUMBER}")

--- a/plugin/ralph-hero/templates/spawn/planner.md
+++ b/plugin/ralph-hero/templates/spawn/planner.md
@@ -1,4 +1,4 @@
-Plan #{ISSUE_NUMBER}: {TITLE}.
+Plan GH-{ISSUE_NUMBER}: {TITLE}.
 {GROUP_CONTEXT}
 
 Invoke: Skill(skill="ralph-hero:ralph-plan", args="{ISSUE_NUMBER}")

--- a/plugin/ralph-hero/templates/spawn/researcher.md
+++ b/plugin/ralph-hero/templates/spawn/researcher.md
@@ -1,4 +1,4 @@
-Research #{ISSUE_NUMBER}: {TITLE}.
+Research GH-{ISSUE_NUMBER}: {TITLE}.
 
 Invoke: Skill(skill="ralph-hero:ralph-research", args="{ISSUE_NUMBER}")
 

--- a/plugin/ralph-hero/templates/spawn/reviewer.md
+++ b/plugin/ralph-hero/templates/spawn/reviewer.md
@@ -1,4 +1,4 @@
-Review plan for #{ISSUE_NUMBER}: {TITLE}.
+Review plan for GH-{ISSUE_NUMBER}: {TITLE}.
 {GROUP_CONTEXT}
 
 Invoke: Skill(skill="ralph-hero:ralph-review", args="{ISSUE_NUMBER}")

--- a/plugin/ralph-hero/templates/spawn/splitter.md
+++ b/plugin/ralph-hero/templates/spawn/splitter.md
@@ -1,4 +1,4 @@
-Split #{ISSUE_NUMBER}: {TITLE}.
+Split GH-{ISSUE_NUMBER}: {TITLE}.
 Too large for direct implementation (estimate: {ESTIMATE}).
 
 Invoke: Skill(skill="ralph-hero:ralph-split", args="{ISSUE_NUMBER}")

--- a/plugin/ralph-hero/templates/spawn/triager.md
+++ b/plugin/ralph-hero/templates/spawn/triager.md
@@ -1,4 +1,4 @@
-Triage #{ISSUE_NUMBER}: {TITLE}.
+Triage GH-{ISSUE_NUMBER}: {TITLE}.
 Estimate: {ESTIMATE}.
 
 Invoke: Skill(skill="ralph-hero:ralph-triage", args="{ISSUE_NUMBER}")


### PR DESCRIPTION
## Summary

Implements GH-54: Task list IDs and GitHub issue numbers use same `#N` notation causing teammate confusion.

Adopts disambiguated naming convention throughout the plugin:
- **T-N** for internal task list IDs (e.g., T-7)
- **GH-N** for GitHub issue references (e.g., GH-49)

Closes #54

## Changes

- Updated all 6 spawn templates to use `GH-{ISSUE_NUMBER}` instead of `#{ISSUE_NUMBER}`
- Updated 6 skill SKILL.md files to use `GH-NNN` prefix for issue references
- Added "Identifier Disambiguation" section to `shared/conventions.md` documenting the convention

## Test plan

- [ ] Verify spawn templates use GH-N format consistently
- [ ] Verify no bare #N GitHub issue references remain in skill files
- [ ] Confirm conventions.md documents both T-N and GH-N formats

---
Generated with Claude Code (Ralph GitHub Team Mode)