### PR TITLE
feat: batch_update tool for bulk field operations

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/batch-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/batch-tools.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for batch-tools: aliased GraphQL query/mutation builders
+ * and batch_update input validation logic.
+ *
+ * The query/mutation builders are pure functions and can be tested
+ * without mocking. Integration behavior (actual GraphQL execution)
+ * is tested manually.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildBatchResolveQuery,
+  buildBatchMutationQuery,
+  buildBatchFieldValueQuery,
+} from "../tools/batch-tools.js";
+
+// ---------------------------------------------------------------------------
+// buildBatchResolveQuery
+// ---------------------------------------------------------------------------
+
+describe("buildBatchResolveQuery", () => {
+  it("generates correct aliases for N issues", () => {
+    const { queryString, variables } = buildBatchResolveQuery(
+      "testOwner",
+      "testRepo",
+      [10, 20, 30],
+    );
+
+    // Should have aliases i0, i1, i2
+    expect(queryString).toContain("i0:");
+    expect(queryString).toContain("i1:");
+    expect(queryString).toContain("i2:");
+    expect(queryString).not.toContain("i3:");
+
+    // Should reference the variable names
+    expect(queryString).toContain("$n0: Int!");
+    expect(queryString).toContain("$n1: Int!");
+    expect(queryString).toContain("$n2: Int!");
+
+    // Variables should be populated
+    expect(variables.owner).toBe("testOwner");
+    expect(variables.repo).toBe("testRepo");
+    expect(variables.n0).toBe(10);
+    expect(variables.n1).toBe(20);
+    expect(variables.n2).toBe(30);
+  });
+
+  it("includes projectItems in the issue query", () => {
+    const { queryString } = buildBatchResolveQuery("o", "r", [1]);
+    expect(queryString).toContain("projectItems");
+    expect(queryString).toContain("project { id }");
+  });
+
+  it("generates a valid query for a single issue", () => {
+    const { queryString, variables } = buildBatchResolveQuery("o", "r", [42]);
+    expect(queryString).toContain("i0:");
+    expect(queryString).toContain("$n0: Int!");
+    expect(variables.n0).toBe(42);
+    // Should not have i1
+    expect(queryString).not.toContain("i1:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBatchMutationQuery
+// ---------------------------------------------------------------------------
+
+describe("buildBatchMutationQuery", () => {
+  it("generates correct aliases for N updates", () => {
+    const { mutationString, variables } = buildBatchMutationQuery(
+      "proj-123",
+      [
+        { alias: "u10_0", itemId: "item-a", fieldId: "field-ws", optionId: "opt-rn" },
+        { alias: "u10_1", itemId: "item-a", fieldId: "field-est", optionId: "opt-xs" },
+        { alias: "u20_0", itemId: "item-b", fieldId: "field-ws", optionId: "opt-rn" },
+      ],
+    );
+
+    // Should have all three aliases
+    expect(mutationString).toContain("u10_0:");
+    expect(mutationString).toContain("u10_1:");
+    expect(mutationString).toContain("u20_0:");
+
+    // Project ID variable
+    expect(variables.projectId).toBe("proj-123");
+
+    // Per-alias variables
+    expect(variables.item_u10_0).toBe("item-a");
+    expect(variables.field_u10_0).toBe("field-ws");
+    expect(variables.opt_u10_0).toBe("opt-rn");
+
+    expect(variables.item_u10_1).toBe("item-a");
+    expect(variables.field_u10_1).toBe("field-est");
+    expect(variables.opt_u10_1).toBe("opt-xs");
+
+    expect(variables.item_u20_0).toBe("item-b");
+    expect(variables.field_u20_0).toBe("field-ws");
+    expect(variables.opt_u20_0).toBe("opt-rn");
+  });
+
+  it("starts with a mutation keyword", () => {
+    const { mutationString } = buildBatchMutationQuery("proj", [
+      { alias: "u0", itemId: "i", fieldId: "f", optionId: "o" },
+    ]);
+    expect(mutationString.trimStart()).toMatch(/^mutation\(/);
+  });
+
+  it("uses correct GraphQL mutation name", () => {
+    const { mutationString } = buildBatchMutationQuery("proj", [
+      { alias: "u0", itemId: "i", fieldId: "f", optionId: "o" },
+    ]);
+    expect(mutationString).toContain("updateProjectV2ItemFieldValue");
+  });
+
+  it("references singleSelectOptionId in the value", () => {
+    const { mutationString } = buildBatchMutationQuery("proj", [
+      { alias: "u0", itemId: "i", fieldId: "f", optionId: "o" },
+    ]);
+    expect(mutationString).toContain("singleSelectOptionId");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBatchFieldValueQuery
+// ---------------------------------------------------------------------------
+
+describe("buildBatchFieldValueQuery", () => {
+  it("generates correct aliases for field value queries", () => {
+    const { queryString, variables } = buildBatchFieldValueQuery([
+      { alias: "fv10", itemId: "item-a" },
+      { alias: "fv20", itemId: "item-b" },
+    ]);
+
+    // Should have both aliases
+    expect(queryString).toContain("fv10:");
+    expect(queryString).toContain("fv20:");
+
+    // Variables
+    expect(variables.id_fv10).toBe("item-a");
+    expect(variables.id_fv20).toBe("item-b");
+  });
+
+  it("queries for single select field values", () => {
+    const { queryString } = buildBatchFieldValueQuery([
+      { alias: "fv1", itemId: "item-x" },
+    ]);
+    expect(queryString).toContain("ProjectV2ItemFieldSingleSelectValue");
+    expect(queryString).toContain("fieldValues");
+  });
+
+  it("includes field name in the query", () => {
+    const { queryString } = buildBatchFieldValueQuery([
+      { alias: "fv1", itemId: "item-x" },
+    ]);
+    expect(queryString).toContain("ProjectV2FieldCommon");
+    expect(queryString).toContain("name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Variable naming safety
+// ---------------------------------------------------------------------------
+
+describe("variable naming safety", () => {
+  it("does not use reserved @octokit/graphql variable names", () => {
+    // @octokit/graphql v9 reserves 'query', 'method', and 'url'
+    const reserved = ["query", "method", "url"];
+
+    const { variables: resolveVars } = buildBatchResolveQuery("o", "r", [1, 2, 3]);
+    for (const key of Object.keys(resolveVars)) {
+      expect(reserved).not.toContain(key);
+    }
+
+    const { variables: mutVars } = buildBatchMutationQuery("p", [
+      { alias: "u0", itemId: "i", fieldId: "f", optionId: "o" },
+    ]);
+    for (const key of Object.keys(mutVars)) {
+      expect(reserved).not.toContain(key);
+    }
+
+    const { variables: fvVars } = buildBatchFieldValueQuery([
+      { alias: "fv0", itemId: "i" },
+    ]);
+    for (const key of Object.keys(fvVars)) {
+      expect(reserved).not.toContain(key);
+    }
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -18,6 +18,7 @@ import { registerViewTools } from "./tools/view-tools.js";
 import { registerIssueTools } from "./tools/issue-tools.js";
 import { registerRelationshipTools } from "./tools/relationship-tools.js";
 import { registerDashboardTools } from "./tools/dashboard-tools.js";
+import { registerBatchTools } from "./tools/batch-tools.js";
 
 /**
  * Initialize the GitHub client from environment variables.
@@ -296,6 +297,9 @@ async function main(): Promise<void> {
 
   // Dashboard and pipeline visualization tools
   registerDashboardTools(server, client, fieldCache);
+
+  // Phase 5: Batch operations
+  registerBatchTools(server, client, fieldCache);
 
   // Connect via stdio transport
   const transport = new StdioServerTransport();

--- a/plugin/ralph-hero/mcp-server/src/tools/batch-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/batch-tools.ts
@@ -1,0 +1,486 @@
+/**
+ * MCP tools for batch operations on GitHub Projects V2 issues.
+ *
+ * Provides bulk-update capabilities using aliased GraphQL queries and
+ * mutations for efficient batch processing (one API call per step
+ * instead of one per issue).
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { GitHubClient } from "../github-client.js";
+import { FieldOptionCache } from "../lib/cache.js";
+import { isEarlierState } from "../lib/workflow-states.js";
+import { toolSuccess, toolError } from "../types.js";
+import {
+  ensureFieldCache,
+  resolveConfig,
+  resolveFullConfig,
+} from "../lib/helpers.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ResolvedIssue {
+  number: number;
+  nodeId: string;
+  projectItemId: string;
+}
+
+interface BatchResult {
+  succeeded: Array<{ number: number; updates: Record<string, string> }>;
+  skipped: Array<{ number: number; reason: string }>;
+  errors: Array<{ number: number; error: string }>;
+  summary: { total: number; succeeded: number; skipped: number; errors: number };
+}
+
+// ---------------------------------------------------------------------------
+// Aliased GraphQL builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an aliased query to resolve issue node IDs and project item IDs
+ * in a single GraphQL call.
+ */
+export function buildBatchResolveQuery(
+  owner: string,
+  repo: string,
+  issueNumbers: number[],
+): { queryString: string; variables: Record<string, unknown> } {
+  const variables: Record<string, unknown> = {
+    owner,
+    repo,
+  };
+
+  const varDecls = ["$owner: String!", "$repo: String!"];
+  const aliases: string[] = [];
+
+  for (let i = 0; i < issueNumbers.length; i++) {
+    const varName = `n${i}`;
+    varDecls.push(`$${varName}: Int!`);
+    variables[varName] = issueNumbers[i];
+    aliases.push(
+      `i${i}: repository(owner: $owner, name: $repo) {
+        issue(number: $${varName}) {
+          id
+          projectItems(first: 5) {
+            nodes {
+              id
+              project { id }
+            }
+          }
+        }
+      }`,
+    );
+  }
+
+  const queryString = `query(${varDecls.join(", ")}) {\n  ${aliases.join("\n  ")}\n}`;
+  return { queryString, variables };
+}
+
+/**
+ * Build an aliased mutation to update multiple project item fields
+ * in a single GraphQL call.
+ */
+export function buildBatchMutationQuery(
+  projectId: string,
+  updates: Array<{
+    alias: string;
+    itemId: string;
+    fieldId: string;
+    optionId: string;
+  }>,
+): { mutationString: string; variables: Record<string, unknown> } {
+  const variables: Record<string, unknown> = {
+    projectId,
+  };
+
+  const varDecls = ["$projectId: ID!"];
+  const aliases: string[] = [];
+
+  for (const update of updates) {
+    const itemVar = `item_${update.alias}`;
+    const fieldVar = `field_${update.alias}`;
+    const optVar = `opt_${update.alias}`;
+
+    varDecls.push(`$${itemVar}: ID!`, `$${fieldVar}: ID!`, `$${optVar}: String!`);
+    variables[itemVar] = update.itemId;
+    variables[fieldVar] = update.fieldId;
+    variables[optVar] = update.optionId;
+
+    aliases.push(
+      `${update.alias}: updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId,
+        itemId: $${itemVar},
+        fieldId: $${fieldVar},
+        value: { singleSelectOptionId: $${optVar} }
+      }) {
+        projectV2Item { id }
+      }`,
+    );
+  }
+
+  const mutationString = `mutation(${varDecls.join(", ")}) {\n  ${aliases.join("\n  ")}\n}`;
+  return { mutationString, variables };
+}
+
+/**
+ * Build an aliased query to fetch current field values for multiple
+ * project items.
+ */
+export function buildBatchFieldValueQuery(
+  projectItemIds: Array<{ alias: string; itemId: string }>,
+): { queryString: string; variables: Record<string, unknown> } {
+  const variables: Record<string, unknown> = {};
+  const varDecls: string[] = [];
+  const aliases: string[] = [];
+
+  for (const { alias, itemId } of projectItemIds) {
+    const varName = `id_${alias}`;
+    varDecls.push(`$${varName}: ID!`);
+    variables[varName] = itemId;
+    aliases.push(
+      `${alias}: node(id: $${varName}) {
+        ... on ProjectV2Item {
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                __typename
+                name
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }`,
+    );
+  }
+
+  const queryString = `query(${varDecls.join(", ")}) {\n  ${aliases.join("\n  ")}\n}`;
+  return { queryString, variables };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VALID_FIELDS = ["workflow_state", "estimate", "priority"] as const;
+type BatchField = (typeof VALID_FIELDS)[number];
+
+const FIELD_NAME_MAP: Record<BatchField, string> = {
+  workflow_state: "Workflow State",
+  estimate: "Estimate",
+  priority: "Priority",
+};
+
+const MAX_ISSUES = 50;
+const MAX_OPERATIONS = 3;
+const MUTATION_CHUNK_SIZE = 50; // Max aliases per mutation
+
+// ---------------------------------------------------------------------------
+// Register batch tools
+// ---------------------------------------------------------------------------
+
+export function registerBatchTools(
+  server: McpServer,
+  client: GitHubClient,
+  fieldCache: FieldOptionCache,
+): void {
+  server.tool(
+    "ralph_hero__batch_update",
+    "Bulk-update project fields (workflow state, estimate, priority) across multiple issues in a single call. Uses aliased GraphQL for efficiency (~2 API calls instead of 3N). Returns: succeeded, skipped, errors arrays with per-issue status. Recovery: partial failures don't abort the batch; check errors array for issues that need manual retry.",
+    {
+      owner: z
+        .string()
+        .optional()
+        .describe("GitHub owner. Defaults to env var"),
+      repo: z
+        .string()
+        .optional()
+        .describe("Repository name. Defaults to env var"),
+      issues: z
+        .array(z.number())
+        .min(1)
+        .max(MAX_ISSUES)
+        .describe("Issue numbers to update (1-50)"),
+      operations: z
+        .array(
+          z.object({
+            field: z
+              .enum(["workflow_state", "estimate", "priority"])
+              .describe("Field to update"),
+            value: z.string().describe("Target value (e.g., 'Research Needed', 'XS', 'P1')"),
+          }),
+        )
+        .min(1)
+        .max(MAX_OPERATIONS)
+        .describe("Field updates to apply to all issues (1-3)"),
+      skipIfAtOrPast: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "For workflow_state operations, skip issues already at or past the target state (default: false)",
+        ),
+    },
+    async (args) => {
+      try {
+        // Validate operations
+        for (const op of args.operations) {
+          if (!VALID_FIELDS.includes(op.field as BatchField)) {
+            return toolError(
+              `Invalid field "${op.field}". Valid fields: ${VALID_FIELDS.join(", ")}`,
+            );
+          }
+        }
+
+        const { owner, repo, projectNumber, projectOwner } = resolveFullConfig(
+          client,
+          args,
+        );
+
+        // Ensure field cache is populated
+        await ensureFieldCache(client, fieldCache, projectOwner, projectNumber);
+
+        const projectId = fieldCache.getProjectId();
+        if (!projectId) {
+          return toolError("Could not resolve project ID");
+        }
+
+        // Validate option names up front (before any API calls)
+        for (const op of args.operations) {
+          const projectFieldName = FIELD_NAME_MAP[op.field as BatchField];
+          const optionId = fieldCache.resolveOptionId(projectFieldName, op.value);
+          if (!optionId) {
+            const validOptions = fieldCache.getOptionNames(projectFieldName);
+            return toolError(
+              `Invalid value "${op.value}" for field "${op.field}". ` +
+                `Valid options: ${validOptions.join(", ")}`,
+            );
+          }
+        }
+
+        const result: BatchResult = {
+          succeeded: [],
+          skipped: [],
+          errors: [],
+          summary: { total: args.issues.length, succeeded: 0, skipped: 0, errors: 0 },
+        };
+
+        // Step 1: Batch resolve node IDs and project item IDs
+        const { queryString: resolveQuery, variables: resolveVars } =
+          buildBatchResolveQuery(owner, repo, args.issues);
+
+        let resolveResult: Record<string, {
+          issue: {
+            id: string;
+            projectItems: {
+              nodes: Array<{ id: string; project: { id: string } }>;
+            };
+          } | null;
+        }>;
+
+        try {
+          resolveResult = await client.query(resolveQuery, resolveVars);
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error);
+          return toolError(`Failed to resolve issues: ${message}`);
+        }
+
+        // Parse resolved issues
+        const resolved: Map<number, ResolvedIssue> = new Map();
+        for (let i = 0; i < args.issues.length; i++) {
+          const issueNumber = args.issues[i];
+          const alias = `i${i}`;
+          const data = resolveResult[alias];
+
+          if (!data?.issue) {
+            result.errors.push({
+              number: issueNumber,
+              error: `Issue #${issueNumber} not found in ${owner}/${repo}`,
+            });
+            continue;
+          }
+
+          const projectItem = data.issue.projectItems.nodes.find(
+            (item) => item.project.id === projectId,
+          );
+
+          if (!projectItem) {
+            result.errors.push({
+              number: issueNumber,
+              error: `Issue #${issueNumber} is not in the project`,
+            });
+            continue;
+          }
+
+          // Cache the resolved IDs
+          client.getCache().set(
+            `issue-node-id:${owner}/${repo}#${issueNumber}`,
+            data.issue.id,
+            30 * 60 * 1000,
+          );
+          client.getCache().set(
+            `project-item-id:${owner}/${repo}#${issueNumber}`,
+            projectItem.id,
+            30 * 60 * 1000,
+          );
+
+          resolved.set(issueNumber, {
+            number: issueNumber,
+            nodeId: data.issue.id,
+            projectItemId: projectItem.id,
+          });
+        }
+
+        // Step 2: Pre-filter with skipIfAtOrPast
+        const hasWorkflowStateOp = args.operations.some(
+          (op) => op.field === "workflow_state",
+        );
+
+        if (args.skipIfAtOrPast && hasWorkflowStateOp && resolved.size > 0) {
+          const wsOp = args.operations.find((op) => op.field === "workflow_state")!;
+
+          // Build batch query for current field values
+          const itemsToCheck = Array.from(resolved.entries()).map(
+            ([num, issue]) => ({
+              alias: `fv${num}`,
+              itemId: issue.projectItemId,
+            }),
+          );
+
+          const { queryString: fvQuery, variables: fvVars } =
+            buildBatchFieldValueQuery(itemsToCheck);
+
+          try {
+            const fvResult = await client.query<
+              Record<string, {
+                fieldValues?: {
+                  nodes: Array<{
+                    __typename?: string;
+                    name?: string;
+                    field?: { name: string };
+                  }>;
+                };
+              } | null>
+            >(fvQuery, fvVars);
+
+            for (const [num, issue] of resolved) {
+              const alias = `fv${num}`;
+              const fvData = fvResult[alias];
+              const wsValue = fvData?.fieldValues?.nodes?.find(
+                (fv) =>
+                  fv.field?.name === "Workflow State" &&
+                  fv.__typename === "ProjectV2ItemFieldSingleSelectValue",
+              )?.name;
+
+              if (wsValue && !isEarlierState(wsValue, wsOp.value)) {
+                result.skipped.push({
+                  number: num,
+                  reason:
+                    wsValue === wsOp.value
+                      ? "Already at target state"
+                      : "Already past target state",
+                });
+                resolved.delete(num);
+              }
+            }
+          } catch {
+            // If field value fetch fails, proceed without filtering
+          }
+        }
+
+        // Step 3: Build and execute aliased mutations
+        if (resolved.size > 0) {
+          const updates: Array<{
+            alias: string;
+            itemId: string;
+            fieldId: string;
+            optionId: string;
+            issueNumber: number;
+            field: string;
+            value: string;
+          }> = [];
+
+          for (const [num, issue] of resolved) {
+            for (let opIdx = 0; opIdx < args.operations.length; opIdx++) {
+              const op = args.operations[opIdx];
+              const projectFieldName = FIELD_NAME_MAP[op.field as BatchField];
+              const fieldId = fieldCache.getFieldId(projectFieldName)!;
+              const optionId = fieldCache.resolveOptionId(projectFieldName, op.value)!;
+
+              updates.push({
+                alias: `u${num}_${opIdx}`,
+                itemId: issue.projectItemId,
+                fieldId,
+                optionId,
+                issueNumber: num,
+                field: op.field,
+                value: op.value,
+              });
+            }
+          }
+
+          // Chunk mutations if needed
+          const chunks: typeof updates[] = [];
+          for (let i = 0; i < updates.length; i += MUTATION_CHUNK_SIZE) {
+            chunks.push(updates.slice(i, i + MUTATION_CHUNK_SIZE));
+          }
+
+          const failedIssues = new Set<number>();
+
+          for (const chunk of chunks) {
+            const { mutationString, variables: mutVars } = buildBatchMutationQuery(
+              projectId,
+              chunk,
+            );
+
+            try {
+              await client.projectMutate(mutationString, mutVars);
+              // All aliases in this chunk succeeded
+            } catch (error: unknown) {
+              // Batch mutation failed — treat entire chunk as failed
+              // and fall back to recording errors per-issue
+              const message = error instanceof Error ? error.message : String(error);
+              for (const update of chunk) {
+                failedIssues.add(update.issueNumber);
+              }
+              // Only add one error per issue (not per operation)
+              const issuesInChunk = new Set(chunk.map((u) => u.issueNumber));
+              for (const num of issuesInChunk) {
+                if (!result.errors.some((e) => e.number === num)) {
+                  result.errors.push({
+                    number: num,
+                    error: `Mutation failed: ${message}`,
+                  });
+                }
+              }
+            }
+          }
+
+          // Record succeeded issues
+          for (const [num] of resolved) {
+            if (!failedIssues.has(num)) {
+              const issueUpdates: Record<string, string> = {};
+              for (const op of args.operations) {
+                issueUpdates[op.field] = op.value;
+              }
+              result.succeeded.push({ number: num, updates: issueUpdates });
+            }
+          }
+        }
+
+        // Compute summary
+        result.summary.succeeded = result.succeeded.length;
+        result.summary.skipped = result.skipped.length;
+        result.summary.errors = result.errors.length;
+
+        return toolSuccess(result);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return toolError(`Failed to batch update: ${message}`);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `ralph_hero__batch_update` MCP tool for bulk field updates (workflow state, priority, estimate) across 1-50 issues in ~2 API calls
- Uses aliased GraphQL queries/mutations for efficient batching
- Supports `skipIfAtOrPast` for idempotent state transitions

Replaces closed PR #76 (rebased onto main after #74 and #75 merged).

Split from #35.

## Test plan
- [x] 11 unit tests for aliased query builders and data transforms
- [x] All 155 tests pass locally (95 core + 49 dashboard + 11 batch)
- [ ] CI passes on Node 18/20/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)