### PR TITLE
refactor(agents): move PR creation from team-lead to integrator worker

### DIFF
--- a/plugin/ralph-hero/agents/ralph-builder.md
+++ b/plugin/ralph-hero/agents/ralph-builder.md
@@ -19,7 +19,7 @@ You are a **BUILDER** in the Ralph Team.
 5. `TaskUpdate(taskId, status="completed", description="...")` with appropriate result format:
    - **Plan**: `"PLAN COMPLETE: [ticket/group]\nPlan: [path]\nPhases: [N]\nFile ownership: [groups]\nReady for review."`
    - **Implement**: `"IMPLEMENTATION COMPLETE\nTicket: #NNN\nPhases: [N] of [M]\nFiles: [list]\nTests: [PASSING/FAILING]\nCommit: [hash]\nWorktree: [path]"`
-6. Repeat from step 1. If no tasks, SendMessage `team-lead` that implementation is complete (lead handles PR creation).
+6. Repeat from step 1. If no tasks, SendMessage `team-lead` that implementation is complete (integrator handles PR creation).
 
 ## Handling Revision Requests
 
@@ -27,7 +27,7 @@ If lead sends revision feedback (from reviewer rejection): read the feedback fro
 
 ## Implementation Notes
 
-- DO NOT push to remote for implementation — lead handles PR creation.
+- DO NOT push to remote for implementation — integrator handles PR creation.
 - If task description includes EXCLUSIVE FILE OWNERSHIP list: verify the skill only modified files in your list. Report conflicts to lead via SendMessage.
 
 ## Shutdown

--- a/plugin/ralph-hero/agents/ralph-integrator.md
+++ b/plugin/ralph-hero/agents/ralph-integrator.md
@@ -1,6 +1,6 @@
 ---
 name: ralph-integrator
-description: Integration specialist - handles PR merge, worktree cleanup, and git operations for completed implementations
+description: Integration specialist - handles PR creation, merge, worktree cleanup, and git operations for completed implementations
 tools: Read, Glob, Bash, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__update_issue, ralph_hero__update_workflow_state, ralph_hero__create_comment, ralph_hero__advance_children, ralph_hero__list_sub_issues
 model: sonnet
 color: orange
@@ -10,21 +10,46 @@ You are an **INTEGRATOR** in the Ralph Team.
 
 ## Task Loop
 
-1. `TaskList()` — find tasks with "Merge" or "Integrate" in subject, `pending`, empty `blockedBy`, no `owner`
+1. `TaskList()` — find tasks with "Create PR", "Merge", or "Integrate" in subject, `pending`, empty `blockedBy`, no `owner`
 2. Claim lowest-ID match: `TaskUpdate(taskId, status="in_progress", owner="integrator")`
-3. `TaskGet(taskId)` — extract issue number from description
-4. Fetch issue: `get_issue(number)` — verify In Review state, find PR link in comments
-5. Check PR readiness: `gh pr view [N] --json state,reviews,mergeable,statusCheckRollup`
+3. `TaskGet(taskId)` — extract issue number (and group info if present) from description
+4. Dispatch by task subject:
+   - **"Create PR"**: Go to PR Creation Procedure below
+   - **"Merge" or "Integrate"**: Go to Merge Procedure below
+
+## PR Creation Procedure
+
+When task subject contains "Create PR":
+
+1. Fetch issue: `get_issue(number)` — extract title, group context
+2. Determine worktree and branch:
+   - **Single issue**: Worktree at `worktrees/GH-NNN`, branch `feature/GH-NNN`
+   - **Group**: Worktree at `worktrees/GH-[PRIMARY]`, branch `feature/GH-[PRIMARY]`
+3. Push branch: `git push -u origin [branch]` from the worktree directory
+4. Create PR via `gh pr create`:
+   - **Single issue**: Title: `feat: [title]`. Body: summary + `Closes #NNN` (bare `#NNN` is GitHub PR syntax) + change summary from task description.
+   - **Group**: Body: summary + `Closes #NNN` for each issue (bare `#NNN` is GitHub PR syntax) + changes by phase.
+5. Move ALL issues (and children) to "In Review" via `advance_children`. NEVER to "Done" -- that requires PR merge.
+6. `TaskUpdate(taskId, status="completed", description="PR CREATED\nTicket: #NNN\nPR: [URL]\nBranch: [branch]\nState: In Review")`
+7. **CRITICAL**: Full result MUST be in task description -- lead cannot see your command output.
+8. Return to task loop (step 1).
+
+## Merge Procedure
+
+When task subject contains "Merge" or "Integrate":
+
+1. Fetch issue: `get_issue(number)` — verify In Review state, find PR link in comments
+2. Check PR readiness: `gh pr view [N] --json state,reviews,mergeable,statusCheckRollup`
    - If not ready: report status, keep task in_progress, go idle (will be re-checked)
-6. If ready:
+3. If ready:
    a. Merge: `gh pr merge [N] --merge --delete-branch`
    b. Clean worktree: `scripts/remove-worktree.sh GH-NNN` (from git root)
    c. Update state: `update_workflow_state(number, state="Done")` for each issue
    d. Advance parent: `advance_children(parentNumber=EPIC)` if epic member
    e. Post comment: merge completion summary
-7. `TaskUpdate(taskId, status="completed", description="MERGE COMPLETE\nTicket: #NNN\nPR: [URL] merged\nBranch: deleted\nWorktree: removed\nState: Done")`
-8. **CRITICAL**: Full result MUST be in task description — lead cannot see your command output.
-9. Repeat from step 1. If no tasks, go idle.
+4. `TaskUpdate(taskId, status="completed", description="MERGE COMPLETE\nTicket: #NNN\nPR: [URL] merged\nBranch: deleted\nWorktree: removed\nState: Done")`
+5. **CRITICAL**: Full result MUST be in task description — lead cannot see your command output.
+6. Return to task loop (step 1). If no tasks, go idle.
 
 ## Serialization
 

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -32,7 +32,6 @@ You are the **Ralph GitHub Team Coordinator** -- a team lead who keeps a team of
 **Your ONLY direct work**:
 - Task list management (create/assign/monitor)
 - GitHub issue queries (read-only to detect pipeline position)
-- PR creation (after implementation completes)
 - Team lifecycle (TeamCreate, teammate spawning, shutdown, TeamDelete)
 - **Finding new work for idle teammates** (this is your most important job)
 
@@ -125,8 +124,6 @@ Based on pipeline position (Section 3), create tasks with sequential blocking: R
 
 **Single issues** (IS_GROUP=false): One task per phase, sequential blocking.
 
-**PR task** is always lead's direct work (not delegated to a teammate).
-
 ### 4.3 Spawn Workers for Available Tasks
 
 Check TaskList for pending, unblocked tasks. Spawn one worker per role with available work (see Section 6 for spawn template). Workers self-claim -- no assignment messages needed.
@@ -144,19 +141,9 @@ Your dispatch responsibilities:
 1. **Exception handling**: When a review task completes with NEEDS_ITERATION, create a revision task with "Plan" in subject. The builder will self-claim. Terminal state is "In Review", never "Done".
 2. **Worker gaps**: If a role has unblocked tasks but no active worker (never spawned, or crashed), spawn one (Section 6). Workers self-claim.
 3. **Intake**: When idle notifications arrive and TaskList shows no pending tasks, pull new issues from GitHub via `pick_actionable_issue` for each idle role (Analyst->"Backlog", Analyst->"Research Needed", Builder->"Ready for Plan", Validator->"Plan in Review" (interactive mode only), Builder->"In Progress", Integrator->"In Review"). Create task chains for found issues.
-4. **PR creation**: When all implementation tasks for an issue/group complete, push and create PR (Section 4.5). This is your only direct work.
-
 The Stop hook prevents premature shutdown -- you cannot stop while GitHub has processable issues. Trust it.
 
-### 4.5 Lead Creates PR (Only Direct Work)
-
-After implementation completes, lead pushes and creates PR via `gh pr create`:
-- **Single issue**: `git push -u origin feature/GH-NNN` from `worktrees/GH-NNN`. Title: `feat: [title]`. Body: summary, `Closes #NNN` (bare `#NNN` here is GitHub PR syntax, not our convention), change summary from builder's task description.
-- **Group**: Push from `worktrees/GH-[PRIMARY]`. Body: summary, `Closes #NNN` for each issue (bare `#NNN` is GitHub PR syntax), changes by phase.
-
-**After PR creation**: Move ALL issues (and children) to "In Review" via `advance_children`. NEVER to "Done" -- that requires PR merge (external event). Create "Merge PR for #NNN" task for Integrator to pick up. Then return to dispatch loop.
-
-### 4.6 Shutdown and Cleanup
+### 4.5 Shutdown and Cleanup
 
 Only when dispatch loop confirms no more work. Send `shutdown_request` to each teammate, then `TeamDelete()`. Report: issues processed, PRs created.
 
@@ -185,6 +172,7 @@ No prescribed roster -- spawn what's needed. Each teammate receives a minimal pr
    | "Plan" (not "Review") | builder | `planner.md` | ralph-builder |
    | "Review" | validator | `reviewer.md` | ralph-validator |
    | "Implement" | builder | `implementer.md` | ralph-builder |
+   | "Create PR" | integrator | `integrator.md` | ralph-integrator |
    | "Merge" or "Integrate" | integrator | `integrator.md` | ralph-integrator |
 
 2. **Resolve template path**: `Bash("echo $CLAUDE_PLUGIN_ROOT")` to get the plugin root, then read:

--- a/plugin/ralph-hero/skills/shared/conventions.md
+++ b/plugin/ralph-hero/skills/shared/conventions.md
@@ -98,7 +98,7 @@ Workers hand off to the next pipeline stage via peer-to-peer SendMessage, bypass
 |---|---|---|
 | `ralph-analyst` | Builder | `ralph-builder` |
 | `ralph-builder` (plan done) | Validator | `ralph-validator` (if `RALPH_REVIEW_MODE=interactive`) |
-| `ralph-builder` (impl done) | Lead (PR creation) | `team-lead` |
+| `ralph-builder` (impl done) | Integrator (PR creation) | `ralph-integrator` |
 | `ralph-validator` (approved) | Builder | `ralph-builder` |
 | `ralph-validator` (rejected) | Builder (re-plan) | `ralph-builder` |
 

--- a/plugin/ralph-hero/templates/spawn/implementer.md
+++ b/plugin/ralph-hero/templates/spawn/implementer.md
@@ -4,5 +4,5 @@ Implement GH-{ISSUE_NUMBER}: {TITLE}.
 Invoke: Skill(skill="ralph-hero:ralph-impl", args="{ISSUE_NUMBER}")
 
 Report results per your agent definition.
-DO NOT push to remote. The lead handles pushing and PR creation.
+DO NOT push to remote. The integrator handles pushing and PR creation.
 Then check TaskList for more implementation tasks. If none, notify team-lead.

--- a/plugin/ralph-hero/templates/spawn/integrator.md
+++ b/plugin/ralph-hero/templates/spawn/integrator.md
@@ -1,4 +1,5 @@
-Merge PR for #{ISSUE_NUMBER}: {TITLE}.
+Integration task for GH-{ISSUE_NUMBER}: {TITLE}.
 
-Check PR status and merge if ready per your agent definition.
+Check your task subject to determine the operation (Create PR or Merge PR).
+Follow the corresponding procedure in your agent definition.
 Report results. Then check TaskList for more integration tasks.


### PR DESCRIPTION
## Summary

- Moves PR creation responsibility from team-lead (SKILL.md) to integrator worker (ralph-integrator.md), making the lead a pure coordinator with zero direct work
- Updates all downstream references in builder, spawn templates, and conventions to route PR creation handoffs to the integrator
- Adds structured PR Creation Procedure and Merge Procedure sections to the integrator agent definition

Closes #69

## Changes (6 markdown files, 0 code changes)

| File | Change |
|------|--------|
| `SKILL.md` | Removed PR creation from lead identity, dispatch loop, and Section 4.5; added "Create PR" to spawn table |
| `ralph-integrator.md` | Added PR Creation Procedure, restructured as dispatch (Create PR vs Merge), updated description |
| `ralph-builder.md` | Changed handoff target from lead to integrator |
| `implementer.md` template | Changed push/PR reference from lead to integrator |
| `integrator.md` template | Generalized to handle both Create PR and Merge PR tasks |
| `conventions.md` | Updated Pipeline Handoff Protocol: builder (impl done) -> integrator |

## Test plan

- [x] Grep verification: "PR creation" removed from SKILL.md (0 matches)
- [x] Grep verification: "Lead Creates PR" removed from SKILL.md (0 matches)
- [x] Grep verification: "Create PR" present in SKILL.md spawn table
- [x] Grep verification: "Create PR" and "gh pr create" present in ralph-integrator.md
- [x] Grep verification: "lead handles PR" removed from ralph-builder.md (0 matches)
- [x] Grep verification: "integrator handles PR" present in ralph-builder.md
- [x] Grep verification: "lead handles" removed from implementer.md template (0 matches)
- [x] Grep verification: "Create PR" present in integrator.md template
- [x] Grep verification: "Lead (PR creation)" removed from conventions.md (0 matches)
- [x] Grep verification: "Integrator (PR creation)" present in conventions.md
- [x] Section numbering clean: 4.1-4.5 with no gaps or dangling references

🤖 Generated with [Claude Code](https://claude.com/claude-code)