### PR TITLE
feat(mcp-server): add advance_parent tool for upward epic state propagation

### DIFF
--- a/plugin/ralph-hero/agents/ralph-integrator.md
+++ b/plugin/ralph-hero/agents/ralph-integrator.md
@@ -1,7 +1,7 @@
 ---
 name: ralph-integrator
 description: Integration specialist - handles PR creation, merge, worktree cleanup, and git operations for completed implementations
-tools: Read, Glob, Bash, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__update_issue, ralph_hero__update_workflow_state, ralph_hero__create_comment, ralph_hero__advance_children, ralph_hero__list_sub_issues
+tools: Read, Glob, Bash, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__update_issue, ralph_hero__update_workflow_state, ralph_hero__create_comment, ralph_hero__advance_children, ralph_hero__advance_parent, ralph_hero__list_sub_issues
 model: sonnet
 color: orange
 ---
@@ -45,8 +45,9 @@ When task subject contains "Merge" or "Integrate":
    a. Merge: `gh pr merge [N] --merge --delete-branch`
    b. Clean worktree: `scripts/remove-worktree.sh GH-NNN` (from git root)
    c. Update state: `update_workflow_state(number, state="Done")` for each issue
-   d. Advance parent: `advance_children(parentNumber=EPIC)` if epic member
-   e. Post comment: merge completion summary
+   d. Advance parent (downward): `advance_children(parentNumber=EPIC)` if epic member
+   e. Advance parent (upward): `advance_parent(number=ISSUE)` -- checks if all siblings are at a gate state and advances the parent if so
+   f. Post comment: merge completion summary
 4. `TaskUpdate(taskId, status="completed", description="MERGE COMPLETE\nTicket: #NNN\nPR: [URL] merged\nBranch: deleted\nWorktree: removed\nState: Done")`
 5. **CRITICAL**: Full result MUST be in task description — lead cannot see your command output.
 6. Return to task loop (step 1). If no tasks, go idle.

--- a/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect } from "vitest";
 import {
   STATE_ORDER,
   VALID_STATES,
+  PARENT_GATE_STATES,
   WORKFLOW_STATE_TO_STATUS,
   stateIndex,
   compareStates,
   isEarlierState,
   isValidState,
+  isParentGateState,
 } from "../lib/workflow-states.js";
 
 describe("stateIndex", () => {
@@ -94,6 +96,36 @@ describe("VALID_STATES completeness", () => {
     }
     expect(VALID_STATES).toContain("Canceled");
     expect(VALID_STATES).toContain("Human Needed");
+  });
+});
+
+describe("PARENT_GATE_STATES", () => {
+  it("contains exactly the expected gate states", () => {
+    expect(PARENT_GATE_STATES).toEqual(["Ready for Plan", "In Review", "Done"]);
+  });
+
+  it("does not include intermediate states", () => {
+    expect(PARENT_GATE_STATES).not.toContain("Research in Progress");
+    expect(PARENT_GATE_STATES).not.toContain("Plan in Progress");
+    expect(PARENT_GATE_STATES).not.toContain("In Progress");
+    expect(PARENT_GATE_STATES).not.toContain("Backlog");
+  });
+});
+
+describe("isParentGateState", () => {
+  it("returns true for gate states", () => {
+    expect(isParentGateState("Ready for Plan")).toBe(true);
+    expect(isParentGateState("In Review")).toBe(true);
+    expect(isParentGateState("Done")).toBe(true);
+  });
+
+  it("returns false for non-gate states", () => {
+    expect(isParentGateState("Backlog")).toBe(false);
+    expect(isParentGateState("Research in Progress")).toBe(false);
+    expect(isParentGateState("Plan in Progress")).toBe(false);
+    expect(isParentGateState("In Progress")).toBe(false);
+    expect(isParentGateState("Human Needed")).toBe(false);
+    expect(isParentGateState("Canceled")).toBe(false);
   });
 });
 

--- a/plugin/ralph-hero/mcp-server/src/lib/workflow-states.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/workflow-states.ts
@@ -44,6 +44,23 @@ export const HUMAN_STATES: readonly string[] = [
 ] as const;
 
 /**
+ * Gate states that trigger parent advancement when ALL children reach them.
+ * Intermediate "in progress" states should NOT advance the parent.
+ */
+export const PARENT_GATE_STATES: readonly string[] = [
+  "Ready for Plan",
+  "In Review",
+  "Done",
+] as const;
+
+/**
+ * Check if a state is a parent advancement gate.
+ */
+export function isParentGateState(state: string): boolean {
+  return PARENT_GATE_STATES.includes(state);
+}
+
+/**
  * Valid workflow states for the project (all known states).
  */
 export const VALID_STATES: readonly string[] = [

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -88,6 +88,7 @@ Use `phase` to determine tasks (Section 4.2) and first teammate (Section 4.3). T
 - Group membership is immutable once detected
 - Tree issues: each phase runs at group speed; independent branches proceed independently
 - **Child state advancement**: Lead MUST advance children via `ralph_hero__advance_children` when parent advances
+- **Parent state advancement**: When all children of an epic reach a gate state (Ready for Plan, In Review, Done), the parent advances automatically via `ralph_hero__advance_parent`. The integrator calls this after merge; the lead should call it at convergence gates (e.g., after all research tasks complete for a group).
 
 After detecting pipeline position, check for fast-track eligibility (Section 3.1), then proceed to Section 4.
 


### PR DESCRIPTION
## Summary

- Adds new `ralph_hero__advance_parent` MCP tool that checks all siblings' workflow states and advances the parent epic when ALL children reach a gate state (Ready for Plan, In Review, Done)
- Adds `PARENT_GATE_STATES` constant and `isParentGateState` helper to `workflow-states.ts`
- Wires `advance_parent` into the integrator merge flow (step 3e) and documents usage in SKILL.md group tracking

Closes #61

## Changes

| File | Change |
|------|--------|
| `workflow-states.ts` | Added `PARENT_GATE_STATES` constant and `isParentGateState()` helper |
| `relationship-tools.ts` | Added `ralph_hero__advance_parent` tool (~170 lines): resolves parent from child, fetches siblings, finds minimum state, advances parent if all at gate |
| `workflow-states.test.ts` | Added 4 new test cases for gate state constant and helper (175 total tests pass) |
| `ralph-integrator.md` | Added `advance_parent` to tools list; added step 3e (upward advancement) to merge flow |
| `SKILL.md` | Documented parent state advancement in Group Tracking section |

## Key design decisions

- "Human Needed" and "Canceled" children **block** parent advancement (not in `STATE_ORDER`)
- Minimum child state determines target, not the child passed as argument
- Does NOT call `advance_children` afterward (independent operations)
- Follows same config resolution pattern as `advance_children` for consistency

## Test plan

- [x] `npm run build` succeeds with no TypeScript errors
- [x] `npm test` -- all 175 tests pass (4 new gate state tests)
- [x] Grep: `advance_parent` registered in relationship-tools.ts
- [x] Grep: `PARENT_GATE_STATES` exported from workflow-states.ts
- [x] Grep: `advance_parent` in integrator tools list and merge flow
- [x] Grep: `advance_parent` documented in SKILL.md group tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)