### PR TITLE
feat(impl): replace git add -A with specific file staging to prevent cross-agent contamination

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/impl-staging-gate.sh
+# PreToolUse (Bash): Block blanket git staging during implementation
+#
+# Prevents `git add -A`, `git add .`, `git add --all` which can
+# stage files from other agents or prior failed runs.
+# Agents must use `git add <specific-files>` instead.
+#
+# Note: `git add -u` is deliberately NOT blocked. Unlike -A/--all,
+# -u only re-stages already-tracked files (no untracked additions)
+# and is sometimes legitimately needed for multi-file updates within
+# a phase's file ownership scope.
+#
+# Exit codes:
+#   0 - Allowed (specific file staging or non-git-add command)
+#   2 - Blocked (blanket staging command detected)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Only enforce for impl command
+if [[ "${RALPH_COMMAND:-}" != "impl" ]]; then
+  allow
+fi
+
+command=$(get_field '.tool_input.command')
+if [[ -z "$command" ]]; then
+  allow
+fi
+
+# Only check git add operations
+if [[ "$command" != *"git add"* ]]; then
+  allow
+fi
+
+# Extract arguments after "git add" and check each for blanket patterns.
+# Checking individual arguments avoids false positives on filenames
+# like "file-A.txt" that contain flag-like substrings.
+add_args=$(echo "$command" | sed -n 's/.*git[[:space:]]*add[[:space:]]*//p')
+for arg in $add_args; do
+  case "$arg" in
+    -A|--all|.)
+      block "Blanket git staging blocked during implementation
+
+Command: $command
+
+Use specific file staging instead:
+  git add <file1> <file2> ...
+
+Why: 'git add -A' / 'git add .' can stage files from other agents,
+prior failed runs, or editor temp files. Stage only the files you
+intentionally modified for this phase.
+
+Tip: Run 'git status --porcelain' first to review all changes,
+then stage only files listed in the plan's File Ownership Summary."
+      ;;
+  esac
+done
+
+allow

--- a/plugin/ralph-hero/skills/ralph-impl/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-impl/SKILL.md
@@ -17,6 +17,8 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/impl-staging-gate.sh"
+        - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/impl-branch-gate.sh"
   PostToolUse:
     - matcher: "Bash"

--- a/thoughts/shared/plans/2026-02-18-GH-0087-git-add-specific-staging.md
+++ b/thoughts/shared/plans/2026-02-18-GH-0087-git-add-specific-staging.md
@@ -29,13 +29,13 @@ The fix is a defense-in-depth approach: update SKILL.md instructions to use spec
 - Address Mode uses PR file list as its staging constraint
 
 ### Verification
-- [ ] SKILL.md Step 7 no longer contains `git add -A`
-- [ ] SKILL.md Address Mode A5 no longer contains `git add -A`
-- [ ] `impl-staging-gate.sh` exists and blocks blanket staging commands
-- [ ] `impl-staging-gate.sh` is registered in SKILL.md frontmatter PreToolUse hooks
-- [ ] `impl-staging-gate.sh` allows `git add <specific-files>` to pass through
-- [ ] Step 7 instructions reference plan's File Ownership Summary for expected files
-- [ ] Address Mode instructions use PR file list as staging constraint
+- [x] SKILL.md Step 7 no longer contains `git add -A`
+- [x] SKILL.md Address Mode A5 no longer contains `git add -A`
+- [x] `impl-staging-gate.sh` exists and blocks blanket staging commands
+- [x] `impl-staging-gate.sh` is registered in SKILL.md frontmatter PreToolUse hooks
+- [x] `impl-staging-gate.sh` allows `git add <specific-files>` to pass through
+- [x] Step 7 instructions reference plan's File Ownership Summary for expected files
+- [x] Address Mode instructions use PR file list as staging constraint
 
 ## What We're NOT Doing
 
@@ -252,10 +252,10 @@ allow
 ### Success Criteria
 
 #### Automated Verification
-- [ ] `test -x plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh` passes (file exists and is executable)
-- [ ] `bash -n plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh` passes (valid shell syntax)
-- [ ] `grep -c 'impl-staging-gate.sh' plugin/ralph-hero/skills/ralph-impl/SKILL.md` returns `1` (registered in frontmatter)
-- [ ] Hook appears BEFORE `impl-branch-gate.sh` in the Bash matcher hooks array
+- [x] `test -x plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh` passes (file exists and is executable)
+- [x] `bash -n plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh` passes (valid shell syntax)
+- [x] `grep -c 'impl-staging-gate.sh' plugin/ralph-hero/skills/ralph-impl/SKILL.md` returns `1` (registered in frontmatter)
+- [x] Hook appears BEFORE `impl-branch-gate.sh` in the Bash matcher hooks array
 
 #### Manual Verification
 - [ ] Hook blocks `git add -A` with a helpful error message


### PR DESCRIPTION
## Summary

Replaces blanket `git add -A` in the ralph-impl skill with specific file staging, preventing one agent's commit from scooping up another agent's uncommitted files.

**Root cause**: During a multi-agent team session, commit `434e970` on `main` contained 1,308 lines across 12 files from 3 different agents because `git add -A` staged everything in the shared working directory.

**Changes**:

### Phase 1: SKILL.md specific file staging
- **Step 7** (commit flow): Replaced `git add -A` with `git status --porcelain` filtering against the plan's File Ownership Summary, followed by `git add <specific-files>`
- **Address Mode A5** (PR feedback flow): Same replacement
- Added warnings against blanket staging commands

### Phase 2: impl-staging-gate.sh enforcement hook
- New `PreToolUse→Bash` hook that blocks `git add -A`, `git add .`, and `git add --all` during implementation
- Uses `case`-based argument matching (no regex false positives on filenames like `file-A.txt`)
- Explicit comment documenting why `git add -u` is deliberately not blocked (only re-stages tracked files)
- Registered in SKILL.md frontmatter hooks, ordered before `impl-branch-gate.sh`

Closes #87

## Context

Third layer of defense against multi-agent collisions, complementing:
- #53 (template integrity enforcement) — prevents agents from bypassing skills
- #85 (`context: fork`) — isolates skill execution context

Together these three fixes address all identified root causes of the Feb 18 multi-agent collision on `main`.

## Test plan

- [x] `git add -A` no longer appears as executable instruction in SKILL.md
- [x] `impl-staging-gate.sh` passes `bash -n` syntax check
- [x] Hook is executable (`-x` permission)
- [x] Hook registered in SKILL.md frontmatter
- [x] Specific file staging instructions reference plan's File Ownership Summary
- [ ] Run `/ralph-impl` and verify hook blocks `git add -A` attempts
- [ ] Run `/ralph-impl` and verify specific file staging works end-to-end

---
Generated with Claude Code (Ralph GitHub Team Mode)