### PR TITLE
fix: unify plugin and npm package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,28 +73,15 @@ jobs:
             fi
           fi
 
-      - name: Bump npm package version
+      - name: Bump version
         id: version
         env:
           BUMP_TYPE: ${{ steps.bump.outputs.type }}
         run: |
           NEW_VERSION=$(npm version "$BUMP_TYPE" --no-git-tag-version | tr -d 'v')
           echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Bump plugin version
-        working-directory: plugin/ralph-hero/.claude-plugin
-        env:
-          BUMP_TYPE: ${{ steps.bump.outputs.type }}
-        run: |
-          CURRENT=$(jq -r '.version' plugin.json)
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          case "$BUMP_TYPE" in
-            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH + 1)) ;;
-          esac
-          jq --arg v "$MAJOR.$MINOR.$PATCH" '.version = $v' plugin.json > tmp.json && mv tmp.json plugin.json
-          echo "Bumped plugin version to $MAJOR.$MINOR.$PATCH"
+          PLUGIN_JSON="../.claude-plugin/plugin.json"
+          jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN_JSON" > tmp.json && mv tmp.json "$PLUGIN_JSON"
 
       - name: Commit version bump and tag
         working-directory: .

--- a/plugin/ralph-hero/mcp-server/package-lock.json
+++ b/plugin/ralph-hero/mcp-server/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "ralph-hero-mcp-server",
-  "version": "1.3.3",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ralph-hero-mcp-server",
-      "version": "1.3.3",
-      "hasInstallScript": true,
+      "version": "2.4.3",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@octokit/graphql": "^9.0.3",
         "@octokit/plugin-paginate-graphql": "^6.0.0",
         "zod": "^3.25.0"
+      },
+      "bin": {
+        "ralph-hero-mcp-server": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/plugin/ralph-hero/mcp-server/package.json
+++ b/plugin/ralph-hero/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-hero-mcp-server",
-  "version": "1.3.3",
+  "version": "2.4.3",
   "description": "MCP server for GitHub Projects V2 - Ralph workflow automation",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Synced `package.json` version (`1.3.3`) up to match `plugin.json` (`2.4.3`) so both files use the same version
- Simplified the release workflow from two separate bump steps into one that writes the same version to both files
- Git tags will now track the plugin version, which is what Claude Code's auto-update mechanism checks

## Context
The plugin.json and package.json versions had drifted apart because the release workflow bumped them independently. Git tags were tracking the npm version (`v1.3.3`) while the plugin reported `2.4.3`, causing confusion and potentially breaking plugin auto-updates.

## Test plan
- [x] Verify `package.json`, `package-lock.json`, and `plugin.json` all show `2.4.3`
- [x] Verify release workflow has a single unified bump step
- [ ] After merge, confirm next auto-release tags with the unified version

🤖 Generated with [Claude Code](https://claude.com/claude-code)