### PR TITLE
fix: enforce template integrity for teammate spawning

### DIFF
--- a/plugin/ralph-hero/agents/ralph-builder.md
+++ b/plugin/ralph-hero/agents/ralph-builder.md
@@ -1,7 +1,7 @@
 ---
 name: ralph-builder
 description: Builder worker - composes plan, implement, and self-review skills for the full build lifecycle
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, Task, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__update_issue, ralph_hero__update_workflow_state, ralph_hero__create_comment, ralph_hero__detect_group, ralph_hero__list_sub_issues, ralph_hero__list_dependencies
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill, Task, TaskList, TaskGet, TaskUpdate, SendMessage
 model: sonnet
 color: cyan
 ---

--- a/plugin/ralph-hero/agents/ralph-validator.md
+++ b/plugin/ralph-hero/agents/ralph-validator.md
@@ -1,7 +1,7 @@
 ---
 name: ralph-validator
 description: Quality gate - invokes ralph-review skill for plan critique and future quality validation
-tools: Read, Write, Glob, Grep, Skill, Task, Bash, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__update_issue, ralph_hero__update_workflow_state, ralph_hero__create_comment
+tools: Read, Write, Glob, Grep, Skill, Task, Bash, TaskList, TaskGet, TaskUpdate, SendMessage
 model: opus
 color: blue
 ---

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -197,6 +197,21 @@ No prescribed roster -- spawn what's needed. Each teammate receives a minimal pr
 
 See `shared/conventions.md` "Spawn Template Protocol" for full placeholder reference, authoring rules, and naming conventions.
 
+### Template Integrity
+
+**CRITICAL**: The resolved template content is the COMPLETE spawn prompt. Do NOT add any additional context.
+
+**Rules**:
+- The prompt passed to `Task()` must be the template output and NOTHING else
+- Resolved prompts must be under 10 lines. If longer, you have violated template integrity
+- The agent discovers all context it needs via skill invocation -- that is the entire point of HOP
+
+**Anti-patterns** (NEVER do these):
+- Prepending root cause analysis, research hints, or investigation guidance
+- Including file paths, code snippets, or architectural context not in the template
+- Replacing template content with custom multi-paragraph instructions
+- Adding "Key files:", "Context:", or "Background:" sections
+
 ### Per-Role Instance Limits
 
 - **Analyst**: Up to 3 parallel (`analyst`, `analyst-2`, `analyst-3`)
@@ -240,7 +255,7 @@ GitHub Projects is source of truth. Hooks enforce valid transitions at the tool 
 - **Task status may lag**: Check work product directly (Glob, git log). If done, mark it yourself. If not, nudge then replace.
 - **Task list scoping**: All tasks MUST be created AFTER TeamCreate (Section 4.1).
 - **State trusts GitHub**: If workflow state is wrong, behavior will be wrong.
-- **Teammate GitHub access**: All 4 workers have scoped `ralph_hero__*` MCP tool access in their frontmatter. Analyst has the widest set (14 tools); validator has the narrowest (5 tools).
+- **Teammate GitHub access**: Only analyst and integrator have `ralph_hero__*` MCP tools. Builder and validator access GitHub exclusively through skill invocations.
 - **No external momentum**: Dispatch loop + hooks are the only momentum mechanism.
 - **No session resumption**: Committed work survives; teammates are lost. Recovery: new `/ralph-team` with same issue -- state detection resumes.
 - **Pull-based claiming**: Tasks MUST use consistent subjects ("Research", "Plan", "Review", "Implement", "Triage", "Split", "Merge"). Workers match on these.

--- a/plugin/ralph-hero/skills/shared/conventions.md
+++ b/plugin/ralph-hero/skills/shared/conventions.md
@@ -233,6 +233,20 @@ Templates are named by role: `{role}.md` matching the agent type:
 - Teammates message the lead using `recipient="team-lead"` exactly
 - Result reporting follows the agent's `.md` definition, not the spawn template
 
+### Template Integrity
+
+Resolved template content is the COMPLETE prompt for spawned teammates. Orchestrators MUST NOT add context beyond placeholder substitution.
+
+**Line-count guardrail**: A correctly resolved prompt is 5-8 lines. If the prompt exceeds 10 lines, the orchestrator has violated template integrity by adding prohibited context.
+
+**Prohibited additions**:
+- Research hints, root cause analysis, or investigation guidance
+- File paths or code snippets not present in the template
+- Custom instructions replacing or augmenting template content
+- "Key files:", "Context:", "Background:" sections
+
+**Why this matters**: Agents invoke skills in isolated context windows. When the orchestrator front-loads context, agents skip skill invocation and work directly, bypassing hook enforcement and postcondition validation.
+
 ## Skill Invocation Convention
 
 ### Default: Fork via Task()


### PR DESCRIPTION
## Summary

Implements #53: Teammate agents perform work in primary context instead of invoking skills.

Three layers of defense to enforce HOP template integrity:

- **SKILL.md Section 6**: Added "Template Integrity" subsection with rules and anti-patterns forbidding orchestrators from augmenting spawn templates
- **conventions.md**: Added "Template Integrity" subsection to Spawn Template Protocol with line-count guardrail (10-line max) and rationale
- **Agent tool reduction**: Removed `ralph_hero__*` MCP tools from `ralph-builder` and `ralph-validator` agents so they must use skill invocations for GitHub access

Analyst and integrator retain MCP tools intentionally (triage needs direct GitHub access; integrator does PR/merge ops directly).

Closes #53

## Changes
- `plugin/ralph-hero/skills/ralph-team/SKILL.md` - Template Integrity subsection + updated Known Limitations
- `plugin/ralph-hero/skills/shared/conventions.md` - Template Integrity subsection in Spawn Template Protocol
- `plugin/ralph-hero/agents/ralph-builder.md` - Removed 8 `ralph_hero__*` tools
- `plugin/ralph-hero/agents/ralph-validator.md` - Removed 5 `ralph_hero__*` tools

## Test Plan
- [ ] `grep "Template Integrity" plugin/ralph-hero/skills/ralph-team/SKILL.md` matches
- [ ] `grep "Anti-patterns" plugin/ralph-hero/skills/ralph-team/SKILL.md` matches
- [ ] `grep "Template Integrity" plugin/ralph-hero/skills/shared/conventions.md` matches
- [ ] `grep "Line-count guardrail" plugin/ralph-hero/skills/shared/conventions.md` matches
- [ ] `grep "ralph_hero__" plugin/ralph-hero/agents/ralph-builder.md` returns no matches
- [ ] `grep "ralph_hero__" plugin/ralph-hero/agents/ralph-validator.md` returns no matches
- [ ] `grep "ralph_hero__" plugin/ralph-hero/agents/ralph-analyst.md` still returns matches (unchanged)
- [ ] `grep "ralph_hero__" plugin/ralph-hero/agents/ralph-integrator.md` still returns matches (unchanged)

---
Generated with Claude Code (Ralph GitHub Plugin)