### PR TITLE
feat(routing): GitHub Actions routing workflow and evaluation script

### DIFF
--- a/.github/workflows/route-issues.yml
+++ b/.github/workflows/route-issues.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install routing dependencies
+        run: npm ci
+        working-directory: scripts/routing
+
       - name: Verify ROUTING_PAT is set
         run: |
           if [ -z "$ROUTING_PAT" ]; then

--- a/scripts/routing/package-lock.json
+++ b/scripts/routing/package-lock.json
@@ -1,0 +1,123 @@
+{
+  "name": "ralph-routing",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ralph-routing",
+      "version": "1.0.0",
+      "dependencies": {
+        "@octokit/graphql": "^9.0.3",
+        "yaml": "^2.7.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
+      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/scripts/routing/package.json
+++ b/scripts/routing/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ralph-routing",
+  "version": "1.0.0",
+  "private": true,
+  "description": "GitHub Actions routing script for issue/PR project assignment",
+  "dependencies": {
+    "@octokit/graphql": "^9.0.3",
+    "yaml": "^2.7.0"
+  }
+}

--- a/scripts/routing/route.js
+++ b/scripts/routing/route.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+'use strict';
+
+const { graphql } = require('@octokit/graphql');
+const yaml = require('yaml');
+const fs = require('fs');
+
+// ---------------------------------------------------------------------------
+// 1. Read environment variables (set by route-issues.yml workflow from #169)
+// ---------------------------------------------------------------------------
+
+const {
+  ROUTING_PAT,
+  GH_OWNER,
+  GH_REPO,
+  ITEM_NUMBER,
+  ITEM_LABELS,           // JSON string: [{ name, color, ... }]
+  EVENT_NAME,            // "issues" or "pull_request"
+  RALPH_ROUTING_CONFIG = '.ralph-routing.yml',
+} = process.env;
+
+if (!ROUTING_PAT) {
+  console.error('::error::ROUTING_PAT is not set. Cannot write to Projects V2.');
+  process.exit(1);
+}
+
+const graphqlWithAuth = graphql.defaults({
+  headers: { authorization: `token ${ROUTING_PAT}` },
+});
+
+// ---------------------------------------------------------------------------
+// 2. Config loader (stub — TODO: replace with import from #168 config loader)
+// ---------------------------------------------------------------------------
+
+function loadConfig(configPath) {
+  if (!fs.existsSync(configPath)) return { rules: [] };
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  return yaml.parse(raw) ?? { rules: [] };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Rule evaluator (stub — TODO: replace with import from #167 matching engine)
+// ---------------------------------------------------------------------------
+
+function evaluateRules(rules, issueContext) {
+  return rules.filter(rule => {
+    if (!rule.match) return false;
+    if (rule.match.labels) {
+      return rule.match.labels.some(l => issueContext.labels.includes(l));
+    }
+    return false;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 4. GraphQL helpers
+// ---------------------------------------------------------------------------
+
+async function fetchContentNodeId(gql, owner, repo, number, eventName) {
+  const field = eventName === 'pull_request' ? 'pullRequest' : 'issue';
+  const result = await gql(
+    `query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        item: ${field}(number: $number) { id }
+      }
+    }`,
+    { owner, repo, number },
+  );
+  if (!result.repository || !result.repository.item || !result.repository.item.id) {
+    throw new Error(`#${number} not found in ${owner}/${repo}`);
+  }
+  return result.repository.item.id;
+}
+
+async function fetchProjectMeta(gql, owner, projectNumber) {
+  // Try both user and organization owner types (same pattern as MCP server)
+  for (const ownerType of ['user', 'organization']) {
+    try {
+      const result = await gql(
+        `query($owner: String!, $number: Int!) {
+          ${ownerType}(login: $owner) {
+            projectV2(number: $number) {
+              id
+              fields(first: 20) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
+                    id name
+                    options { id name }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+        { owner, number: projectNumber },
+      );
+      const project = result[ownerType] && result[ownerType].projectV2;
+      if (project) {
+        const fields = {};
+        for (const f of project.fields.nodes) {
+          if (f.name) fields[f.name] = { id: f.id, options: f.options || [] };
+        }
+        return { projectId: project.id, fields };
+      }
+    } catch {
+      // Try next owner type
+    }
+  }
+  throw new Error(`Project #${projectNumber} not found for owner "${owner}"`);
+}
+
+async function addToProject(gql, projectId, contentId) {
+  const result = await gql(
+    `mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }`,
+    { projectId, contentId },
+  );
+  return result.addProjectV2ItemById.item.id;
+}
+
+async function setField(gql, projectId, itemId, fields, fieldName, optionName) {
+  const field = fields[fieldName];
+  if (!field) {
+    console.warn(`Field "${fieldName}" not found in project — skipping`);
+    return;
+  }
+  const option = field.options.find(o => o.name === optionName);
+  if (!option) {
+    console.warn(`Option "${optionName}" not valid for field "${fieldName}" — skipping`);
+    return;
+  }
+
+  await gql(
+    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+        value: { singleSelectOptionId: $optionId }
+      }) { projectV2Item { id } }
+    }`,
+    { projectId, itemId, fieldId: field.id, optionId: option.id },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Load routing config
+  const config = loadConfig(RALPH_ROUTING_CONFIG);
+  if (!config.rules || !config.rules.length) {
+    console.log('No routing rules configured. Skipping.');
+    return;
+  }
+
+  // Build issue context from env
+  const labels = JSON.parse(ITEM_LABELS || '[]').map(l => l.name);
+  const itemNumber = parseInt(ITEM_NUMBER, 10);
+  const issueContext = {
+    number: itemNumber,
+    labels,
+    repo: GH_REPO,
+    owner: GH_OWNER,
+    eventName: EVENT_NAME,
+  };
+
+  // Evaluate rules
+  const matchedRules = evaluateRules(config.rules, issueContext);
+  if (!matchedRules.length) {
+    console.log(`No routing rules matched for #${itemNumber}.`);
+    return;
+  }
+
+  // Fetch issue/PR node ID
+  const contentId = await fetchContentNodeId(
+    graphqlWithAuth, GH_OWNER, GH_REPO, itemNumber, EVENT_NAME,
+  );
+
+  // For each matched rule: add to project + set fields
+  for (const rule of matchedRules) {
+    const projectNumber = rule.action.projectNumber;
+    const projectOwner = rule.action.projectOwner || GH_OWNER;
+
+    console.log(`Routing #${itemNumber} to project #${projectNumber}...`);
+
+    // Resolve project ID and field IDs
+    const { projectId, fields } = await fetchProjectMeta(
+      graphqlWithAuth, projectOwner, projectNumber,
+    );
+
+    // Add item to project (idempotent — re-adding returns existing item)
+    const projectItemId = await addToProject(graphqlWithAuth, projectId, contentId);
+
+    // Set field values from rule action
+    if (rule.action.workflowState) {
+      await setField(graphqlWithAuth, projectId, projectItemId, fields, 'Workflow State', rule.action.workflowState);
+    }
+    if (rule.action.priority) {
+      await setField(graphqlWithAuth, projectId, projectItemId, fields, 'Priority', rule.action.priority);
+    }
+    if (rule.action.estimate) {
+      await setField(graphqlWithAuth, projectId, projectItemId, fields, 'Estimate', rule.action.estimate);
+    }
+
+    console.log(`Routed #${itemNumber} to project #${projectNumber}`);
+  }
+}
+
+main().catch(err => {
+  console.error('::error::Routing failed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Atomic implementation of 2 related issues for the GitHub Actions routing workflow:

- Closes #169
- Closes #171

## Changes

### Phase 1: GH-169 — Workflow scaffold
- Created `.github/workflows/route-issues.yml` with triggers for `issues: [opened, labeled]` and `pull_request: [opened, ready_for_review]`
- Per-item concurrency group prevents racing mutations on the same issue/PR
- `ROUTING_PAT` verification step before routing (GITHUB_TOKEN cannot write to Projects V2)
- All env vars passed safely via `env:` block (no injection risk)

### Phase 2: GH-171 — Routing evaluation script
- Created `scripts/routing/route.js` standalone CJS script with:
  - Stub `loadConfig()` (TODO: replace with #168 config loader)
  - Stub `evaluateRules()` with label matching (TODO: replace with #167 matching engine)
  - `fetchContentNodeId()` — resolves issue/PR number to node ID
  - `fetchProjectMeta()` — tries both user/organization owner types
  - `addToProject()` — idempotent `addProjectV2ItemById` mutation
  - `setField()` — sets single-select field values with graceful warnings
  - `main()` — orchestrates config load → rule evaluation → project routing
- Created `scripts/routing/package.json` with `@octokit/graphql` and `yaml` dependencies
- Updated workflow to add `npm ci` step for script dependencies

## Test Plan
- [x] Workflow YAML is syntactically valid
- [x] `node -c scripts/routing/route.js` passes syntax check
- [x] `npm install` in `scripts/routing/` succeeds
- [x] Script env var names match workflow env var names exactly
- [x] Concurrency group uses correct expression for issue/PR number
- [x] `ROUTING_PAT` verification step exits 1 when secret missing
- [ ] End-to-end: Issue opened triggers workflow → script routes to project (requires ROUTING_PAT secret)

---
Generated with Claude Code (Ralph GitHub Plugin)