### PR TITLE
feat(routing): implement routing config loader and live validation

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/empty-rules.yml
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/empty-rules.yml
@@ -1,0 +1,2 @@
+version: 1
+rules: []

--- a/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/invalid-schema.yml
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/invalid-schema.yml
@@ -1,0 +1,4 @@
+version: 2
+rules:
+  - match: {}
+    action: {}

--- a/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/invalid-yaml.yml
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/invalid-yaml.yml
@@ -1,0 +1,4 @@
+version: 1
+rules:
+  - name: "broken
+    indentation problem

--- a/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/no-version.yml
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/no-version.yml
@@ -1,0 +1,5 @@
+rules:
+  - match:
+      repo: "owner/repo"
+    action:
+      projectNumber: 3

--- a/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/valid-config.yml
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/fixtures/valid-config.yml
@@ -1,0 +1,16 @@
+version: 1
+stopOnFirstMatch: true
+rules:
+  - name: "Route bugs to project 3"
+    match:
+      labels:
+        any: ["bug"]
+    action:
+      projectNumber: 3
+      workflowState: "Backlog"
+  - name: "Route enhancements"
+    match:
+      labels:
+        any: ["enhancement"]
+    action:
+      projectNumber: 3

--- a/plugin/ralph-hero/mcp-server/src/__tests__/routing-config.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/routing-config.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import {
+  loadRoutingConfig,
+  validateRulesLive,
+} from "../lib/routing-config.js";
+import { FieldOptionCache } from "../lib/cache.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const fixtures = join(__dirname, "fixtures");
+
+// ---------------------------------------------------------------------------
+// loadRoutingConfig
+// ---------------------------------------------------------------------------
+
+describe("loadRoutingConfig", () => {
+  it("returns loaded status for valid config", async () => {
+    const result = await loadRoutingConfig(join(fixtures, "valid-config.yml"));
+    expect(result.status).toBe("loaded");
+    if (result.status !== "loaded") throw new Error("expected loaded");
+    expect(result.config.version).toBe(1);
+    expect(result.config.stopOnFirstMatch).toBe(true);
+    expect(result.config.rules).toHaveLength(2);
+    expect(result.config.rules[0].action.workflowState).toBe("Backlog");
+    expect(result.filePath).toContain("valid-config.yml");
+  });
+
+  it("returns loaded status for empty rules", async () => {
+    const result = await loadRoutingConfig(join(fixtures, "empty-rules.yml"));
+    expect(result.status).toBe("loaded");
+    if (result.status !== "loaded") throw new Error("expected loaded");
+    expect(result.config.rules).toHaveLength(0);
+  });
+
+  it("returns missing status for non-existent file", async () => {
+    const result = await loadRoutingConfig(
+      join(fixtures, "nonexistent.yml"),
+    );
+    expect(result.status).toBe("missing");
+    if (result.status !== "missing") throw new Error("expected missing");
+    expect(result.config.version).toBe(1);
+    expect(result.config.rules).toHaveLength(0);
+    expect(result.config.stopOnFirstMatch).toBe(true);
+  });
+
+  it("returns error for invalid YAML", async () => {
+    const result = await loadRoutingConfig(
+      join(fixtures, "invalid-yaml.yml"),
+    );
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("expected error");
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].phase).toBe("yaml_parse");
+  });
+
+  it("returns error for invalid schema (wrong version)", async () => {
+    const result = await loadRoutingConfig(
+      join(fixtures, "invalid-schema.yml"),
+    );
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("expected error");
+    expect(
+      result.errors.some((e) => e.phase === "schema_validation"),
+    ).toBe(true);
+  });
+
+  it("returns error for missing version", async () => {
+    const result = await loadRoutingConfig(
+      join(fixtures, "no-version.yml"),
+    );
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("expected error");
+    expect(
+      result.errors.some((e) => e.phase === "schema_validation"),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRulesLive
+// ---------------------------------------------------------------------------
+
+describe("validateRulesLive", () => {
+  function createFieldCache(
+    workflowStates: string[],
+  ): FieldOptionCache {
+    const cache = new FieldOptionCache();
+    cache.populate("project-1", [
+      {
+        id: "field-1",
+        name: "Workflow State",
+        options: workflowStates.map((name, i) => ({
+          id: `opt-${i}`,
+          name,
+        })),
+      },
+    ]);
+    return cache;
+  }
+
+  it("returns no errors when all workflow states exist", () => {
+    const cache = createFieldCache(["Backlog", "Todo", "In Progress", "Done"]);
+    const errors = validateRulesLive(
+      {
+        version: 1,
+        stopOnFirstMatch: true,
+        rules: [
+          {
+            match: { labels: { any: ["bug"] }, negate: false },
+            action: { projectNumber: 3, workflowState: "Backlog" },
+            enabled: true,
+          },
+        ],
+      },
+      cache,
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("returns errors for non-existent workflow state", () => {
+    const cache = createFieldCache(["Backlog", "Todo"]);
+    const errors = validateRulesLive(
+      {
+        version: 1,
+        stopOnFirstMatch: true,
+        rules: [
+          {
+            match: { labels: { any: ["bug"] }, negate: false },
+            action: { projectNumber: 3, workflowState: "NonexistentState" },
+            enabled: true,
+          },
+        ],
+      },
+      cache,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].phase).toBe("live_validation");
+    expect(errors[0].path).toContain("workflowState");
+    expect(errors[0].message).toContain("NonexistentState");
+    expect(errors[0].message).toContain("Backlog");
+  });
+
+  it("returns no errors for rules without workflowState", () => {
+    const cache = createFieldCache(["Backlog"]);
+    const errors = validateRulesLive(
+      {
+        version: 1,
+        stopOnFirstMatch: true,
+        rules: [
+          {
+            match: { labels: { any: ["bug"] }, negate: false },
+            action: { projectNumber: 3 },
+            enabled: true,
+          },
+        ],
+      },
+      cache,
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("skips disabled rules", () => {
+    const cache = createFieldCache(["Backlog"]);
+    const errors = validateRulesLive(
+      {
+        version: 1,
+        stopOnFirstMatch: true,
+        rules: [
+          {
+            match: { labels: { any: ["bug"] }, negate: false },
+            action: { projectNumber: 3, workflowState: "InvalidState" },
+            enabled: false,
+          },
+        ],
+      },
+      cache,
+    );
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/lib/routing-config.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/routing-config.ts
@@ -1,0 +1,127 @@
+/**
+ * Routing config loader and live validation.
+ *
+ * Two-phase validation:
+ * 1. Structural: YAML parse + Zod schema validation (loadRoutingConfig)
+ * 2. Referential: field option checks against FieldOptionCache (validateRulesLive)
+ *
+ * Consumers:
+ * - #178 configure_routing tool: loads config for CRUD operations
+ * - #179 validate_rules operation: calls validateRulesLive
+ */
+
+import { readFile } from "fs/promises";
+import { parse as yamlParse } from "yaml";
+import { RoutingConfigSchema, type RoutingConfig } from "./routing-types.js";
+import type { FieldOptionCache } from "./cache.js";
+
+const DEFAULT_CONFIG: RoutingConfig = {
+  version: 1,
+  stopOnFirstMatch: true,
+  rules: [],
+};
+
+export interface ConfigError {
+  phase: "yaml_parse" | "schema_validation" | "live_validation";
+  path: string[];
+  message: string;
+}
+
+export type LoadResult =
+  | { status: "loaded"; config: RoutingConfig; filePath: string }
+  | { status: "missing"; config: RoutingConfig }
+  | { status: "error"; errors: ConfigError[] };
+
+/**
+ * Load and validate a routing config file.
+ *
+ * Returns a discriminated union:
+ * - "loaded": valid config parsed from file
+ * - "missing": file not found, returns default empty config
+ * - "error": YAML parse or schema validation errors
+ */
+export async function loadRoutingConfig(
+  configPath: string,
+): Promise<LoadResult> {
+  // Read file — gracefully handle missing files
+  let contents: string;
+  try {
+    contents = await readFile(configPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { status: "missing", config: DEFAULT_CONFIG };
+    }
+    throw err;
+  }
+
+  // Parse YAML
+  let parsed: unknown;
+  try {
+    parsed = yamlParse(contents);
+  } catch (err) {
+    return {
+      status: "error",
+      errors: [
+        {
+          phase: "yaml_parse",
+          path: [],
+          message: err instanceof Error ? err.message : String(err),
+        },
+      ],
+    };
+  }
+
+  // Validate against Zod schema
+  const result = RoutingConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    const errors: ConfigError[] = result.error.issues.map((issue) => ({
+      phase: "schema_validation" as const,
+      path: issue.path.map(String),
+      message: issue.message,
+    }));
+    return { status: "error", errors };
+  }
+
+  return { status: "loaded", config: result.data, filePath: configPath };
+}
+
+/**
+ * Validate routing rules against live project field data.
+ *
+ * Checks that referenced workflow states exist in the FieldOptionCache.
+ * The caller must ensure the cache is populated (via ensureFieldCache)
+ * before calling this function.
+ *
+ * Skips disabled rules (enabled === false).
+ */
+export function validateRulesLive(
+  config: RoutingConfig,
+  fieldCache: FieldOptionCache,
+): ConfigError[] {
+  const errors: ConfigError[] = [];
+
+  for (let i = 0; i < config.rules.length; i++) {
+    const rule = config.rules[i];
+
+    // Skip disabled rules
+    if (rule.enabled === false) continue;
+
+    // Validate workflowState references
+    if (rule.action.workflowState) {
+      const optionId = fieldCache.resolveOptionId(
+        "Workflow State",
+        rule.action.workflowState,
+      );
+      if (optionId === undefined) {
+        const valid = fieldCache.getOptionNames("Workflow State");
+        errors.push({
+          phase: "live_validation",
+          path: ["rules", String(i), "action", "workflowState"],
+          message: `Workflow state "${rule.action.workflowState}" not found in project. Valid: ${valid.join(", ")}`,
+        });
+      }
+    }
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Summary

- Add `lib/routing-config.ts` — `loadRoutingConfig(configPath)` reads YAML file, parses with `eemeli/yaml`, validates with Zod schema; returns discriminated union `LoadResult` with `status: 'loaded' | 'missing' | 'error'`; gracefully returns empty config `{ version: 1, rules: [] }` for missing files
- Add `validateRulesLive(config, fieldCache, client)` — referential validation that checks project field options against FieldOptionCache (two-phase: structural then referential)
- Test suite uses real YAML fixture files in `__tests__/fixtures/`

## Changes

### `lib/routing-config.ts`
- `loadRoutingConfig()`: file read + YAML parse + Zod structural validation
- `validateRulesLive()`: FieldOptionCache-backed referential checks
- Imports GH-166 types (`RoutingConfig`, `RoutingRule`)

### `__tests__/routing-config.test.ts` + fixtures
- Fixture files: `valid-config.yml`, `empty-rules.yml`, `invalid-yaml.yml`, `invalid-schema.yml`, `no-version.yml`
- Unit tests for loader and live validation with mocked FieldOptionCache

Closes #168