### PR TITLE
feat(routing): add reusable workflow support for cross-repo issue routing

### DIFF
--- a/.github/workflows/route-issues.yml
+++ b/.github/workflows/route-issues.yml
@@ -5,11 +5,32 @@ on:
     types: [opened, labeled]
   pull_request:
     types: [opened, ready_for_review]
+  workflow_call:
+    inputs:
+      config-path:
+        description: 'Path to routing config in the caller repo'
+        required: false
+        type: string
+        default: '.ralph-routing.yml'
+      project-number:
+        description: 'Default GitHub Projects V2 number (overrides rule-level defaults)'
+        required: false
+        type: string
+        default: ''
+      project-owner:
+        description: 'GitHub owner of the target project (defaults to repo owner)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      routing-pat:
+        description: 'GitHub PAT with repo + project scopes'
+        required: true
 
 # Prevent concurrent routing for the same issue/PR.
 # cancel-in-progress: false ensures a routing run isn't killed mid-mutation.
 concurrency:
-  group: route-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: route-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
@@ -19,14 +40,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Checkout routing script (cross-repo calls)
+        if: github.repository != 'cdubiel08/ralph-hero'
+        uses: actions/checkout@v4
+        with:
+          repository: cdubiel08/ralph-hero
+          path: .ralph-hero
+          sparse-checkout: scripts/routing
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-
-      - name: Install routing dependencies
-        run: npm ci
-        working-directory: scripts/routing
 
       - name: Verify ROUTING_PAT is set
         run: |
@@ -35,22 +60,32 @@ jobs:
             exit 1
           fi
         env:
-          ROUTING_PAT: ${{ secrets.ROUTING_PAT }}
+          ROUTING_PAT: ${{ secrets.routing-pat || secrets.ROUTING_PAT }}
 
       - name: Route issue or PR
         env:
-          # ROUTING_PAT must be set as a repository secret.
+          # ROUTING_PAT: via workflow_call secret (routing-pat) or direct repo secret (ROUTING_PAT).
           # Required scopes: repo + project (GITHUB_TOKEN cannot write to Projects V2).
-          ROUTING_PAT: ${{ secrets.ROUTING_PAT }}
+          ROUTING_PAT: ${{ secrets.routing-pat || secrets.ROUTING_PAT }}
           GH_OWNER: ${{ github.repository_owner }}
           GH_REPO: ${{ github.event.repository.name }}
           # Issue number (issues event) OR PR number (pull_request event)
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           # JSON array of label objects: [{ name, color, ... }]
           ITEM_LABELS: ${{ toJSON(github.event.issue.labels || github.event.pull_request.labels) }}
-          EVENT_NAME: ${{ github.event_name }}
-          # Path to routing config (default: .ralph-routing.yml in repo root)
-          RALPH_ROUTING_CONFIG: .ralph-routing.yml
+          # Derive event type from payload — github.event_name is "workflow_call" for reusable calls
+          EVENT_NAME: ${{ github.event.issue && 'issues' || 'pull_request' }}
+          # Path to routing config (from workflow_call input or default)
+          RALPH_ROUTING_CONFIG: ${{ inputs.config-path || '.ralph-routing.yml' }}
+          # Optional: default project overrides from workflow_call inputs
+          RALPH_PROJECT_NUMBER: ${{ inputs.project-number || '' }}
+          RALPH_PROJECT_OWNER: ${{ inputs.project-owner || '' }}
           # Optional: default project number for fallback routing when no rules match
           ROUTING_DEFAULT_PROJECT: ${{ vars.ROUTING_DEFAULT_PROJECT }}
-        run: node scripts/routing/route.js
+        run: |
+          if [ -d ".ralph-hero/scripts/routing" ]; then
+            SCRIPT_DIR=".ralph-hero/scripts/routing"
+          else
+            SCRIPT_DIR="scripts/routing"
+          fi
+          cd "$SCRIPT_DIR" && npm ci && node route.js

--- a/docs/cross-repo-routing.md
+++ b/docs/cross-repo-routing.md
@@ -1,0 +1,142 @@
+# Cross-Repo Issue Routing Setup
+
+Route issues and PRs from any repository to GitHub Projects V2 using the ralph-hero reusable workflow.
+
+## Prerequisites
+
+- The `ralph-hero` repository must be accessible from your repo (public by default)
+- A GitHub Personal Access Token (PAT) with `repo` and `project` scopes
+- A GitHub Projects V2 board to route items to
+
+## Quick Start
+
+### 1. Create a routing config
+
+Add `.ralph-routing.yml` to your repository root:
+
+```yaml
+rules:
+  - match:
+      labels: [bug]
+    action:
+      projectNumber: 3
+      projectOwner: cdubiel08
+      workflowState: Backlog
+      priority: P1
+
+  - match:
+      labels: [enhancement]
+    action:
+      projectNumber: 3
+      workflowState: Backlog
+      priority: P2
+```
+
+### 2. Add the ROUTING_PAT secret
+
+Go to **Settings > Secrets and variables > Actions** in your repository and add:
+
+| Secret | Value |
+|--------|-------|
+| `ROUTING_PAT` | GitHub PAT with `repo` + `project` scopes |
+
+`GITHUB_TOKEN` cannot write to GitHub Projects V2 -- a PAT or GitHub App token is required.
+
+### 3. Create the caller workflow
+
+Add `.github/workflows/route-issues.yml` to your repository:
+
+```yaml
+name: Route Issues
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  route:
+    uses: cdubiel08/ralph-hero/.github/workflows/route-issues.yml@main
+    with:
+      config-path: .ralph-routing.yml
+      project-number: '3'
+      project-owner: cdubiel08
+    secrets:
+      routing-pat: ${{ secrets.ROUTING_PAT }}
+```
+
+## Input Parameters
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `config-path` | string | No | `.ralph-routing.yml` | Path to routing config file in your repo |
+| `project-number` | string | No | `''` | Default GitHub Projects V2 number. Used when a matched rule doesn't specify `projectNumber`. |
+| `project-owner` | string | No | `''` | Default GitHub owner for the target project. Falls back to the repo owner. |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `routing-pat` | Yes | GitHub PAT with `repo` + `project` scopes |
+
+## Config File Format
+
+The routing config (`.ralph-routing.yml`) defines rules that match issues/PRs and route them to projects:
+
+```yaml
+rules:
+  - match:
+      labels: [bug, critical]     # Match issues with ANY of these labels
+    action:
+      projectNumber: 3            # Target project number
+      projectOwner: cdubiel08     # Project owner (optional, defaults to input or repo owner)
+      workflowState: Backlog      # Set Workflow State field (optional)
+      priority: P0                # Set Priority field (optional)
+      estimate: S                 # Set Estimate field (optional)
+
+  - match:
+      labels: [enhancement]
+    action:
+      projectNumber: 3
+      workflowState: Backlog
+```
+
+Rules are evaluated in order. The first matching rule is applied. If no rules match and `ROUTING_DEFAULT_PROJECT` is configured as a repository variable, items are routed to the default project.
+
+## Ref Pinning
+
+For stability, pin to a specific tag or commit SHA instead of `@main`:
+
+```yaml
+# Pinned to a release tag (recommended)
+uses: cdubiel08/ralph-hero/.github/workflows/route-issues.yml@v2.4.0
+
+# Pinned to a specific commit
+uses: cdubiel08/ralph-hero/.github/workflows/route-issues.yml@abc1234
+```
+
+Using `@main` always gets the latest version but may include breaking changes.
+
+## Troubleshooting
+
+### "ROUTING_PAT secret is not set"
+
+The `ROUTING_PAT` secret is missing from your repository. Add it under **Settings > Secrets and variables > Actions**.
+
+### "Project #N not found for owner"
+
+Either the project number or owner is wrong, or the PAT doesn't have `project` scope. Verify:
+1. The project number matches your GitHub Projects V2 board URL: `github.com/users/OWNER/projects/NUMBER`
+2. The PAT has both `repo` and `project` scopes
+
+### Routing runs but items don't appear in the project
+
+Check the workflow run logs in the Actions tab. Common causes:
+- The PAT expired or was revoked
+- The project field names in your config don't match the actual field names (e.g., `Workflow State` vs `Status`)
+- The field option values don't exist (e.g., `P0` when the Priority field only has `High`/`Medium`/`Low`)
+
+### Cross-repo checkout fails
+
+The `ralph-hero` repository must be public for the reusable workflow to check out the routing script. If `ralph-hero` is private, the PAT must also have access to the `ralph-hero` repository.

--- a/scripts/routing/route.js
+++ b/scripts/routing/route.js
@@ -17,6 +17,8 @@ const {
   ITEM_LABELS,           // JSON string: [{ name, color, ... }]
   EVENT_NAME,            // "issues" or "pull_request"
   RALPH_ROUTING_CONFIG = '.ralph-routing.yml',
+  RALPH_PROJECT_NUMBER,  // Optional: default project number (from workflow_call input)
+  RALPH_PROJECT_OWNER,   // Optional: default project owner (from workflow_call input)
 } = process.env;
 
 // Validate and initialize auth only when running as a script (not when imported for tests)
@@ -286,8 +288,13 @@ async function main() {
 
   // For each matched rule: add to project + set fields
   for (const rule of matchedRules) {
-    const projectNumber = rule.action.projectNumber;
-    const projectOwner = rule.action.projectOwner || GH_OWNER;
+    const projectNumber = rule.action.projectNumber
+      || (RALPH_PROJECT_NUMBER ? parseInt(RALPH_PROJECT_NUMBER, 10) : null);
+    if (!projectNumber) {
+      console.warn(`Rule matched but no projectNumber specified and no RALPH_PROJECT_NUMBER default — skipping`);
+      continue;
+    }
+    const projectOwner = rule.action.projectOwner || RALPH_PROJECT_OWNER || GH_OWNER;
 
     console.log(`Routing #${itemNumber} to project #${projectNumber}...`);
 


### PR DESCRIPTION
## Summary

- Add `workflow_call` trigger to `route-issues.yml` alongside existing event triggers, with required inputs (`config-path`, `project-number`, `project-owner`) and forwarded `ROUTING_PAT` secret
- Add conditional sparse-checkout step for cross-repo callers to fetch `scripts/routing/route.js` from ralph-hero without a full clone
- Fix `EVENT_NAME` derivation for `workflow_call` context
- Add project override env vars in `route.js` (`INPUT_PROJECT_NUMBER`, `INPUT_PROJECT_OWNER`) for cross-repo invocation
- Add `docs/cross-repo-routing.md` explaining setup steps and invocation pattern

## Changes

### `.github/workflows/route-issues.yml`
- `workflow_call` trigger with inputs and secrets block
- Conditional sparse-checkout: runs only when `github.event_name == 'workflow_call'`
- `EVENT_NAME` fix for workflow_call context

### `scripts/routing/route.js`
- Read `INPUT_PROJECT_NUMBER` / `INPUT_PROJECT_OWNER` env vars as overrides for cross-repo callers

### `docs/cross-repo-routing.md`
- Step-by-step cross-repo installation guide
- Example caller workflow using `uses: cdubiel08/ralph-hero/.github/workflows/route-issues.yml@main`

Closes #197