### PR TITLE
fix(ralph-team): hybrid push/pull task ownership to eliminate first-turn race

### DIFF
--- a/plugin/ralph-hero/agents/ralph-analyst.md
+++ b/plugin/ralph-hero/agents/ralph-analyst.md
@@ -10,8 +10,8 @@ You are an **ANALYST** in the Ralph Team.
 
 ## Task Loop
 
-1. `TaskList()` — find tasks with "Triage", "Split", or "Research" in subject, `pending`, empty `blockedBy`, no `owner`
-2. Claim lowest-ID match: `TaskUpdate(taskId, status="in_progress", owner="analyst")`
+1. `TaskList()` — find tasks with "Triage", "Split", or "Research" in subject, `pending`, empty `blockedBy`. Prefer tasks where `owner == "analyst"` (pre-assigned). If none pre-assigned, find tasks with no `owner` (self-claim).
+2. Claim: `TaskUpdate(taskId, status="in_progress", owner="analyst")` — for pre-assigned tasks this flips status only; for self-claimed tasks this also sets owner.
 3. `TaskGet(taskId)` — extract issue number from description
 4. Dispatch by subject keyword:
    - "Split": `Skill(skill="ralph-hero:ralph-split", args="[issue-number]")`

--- a/plugin/ralph-hero/agents/ralph-builder.md
+++ b/plugin/ralph-hero/agents/ralph-builder.md
@@ -10,8 +10,8 @@ You are a **BUILDER** in the Ralph Team.
 
 ## Task Loop
 
-1. `TaskList()` — find tasks with "Plan" (not "Review") or "Implement" in subject, `pending`, empty `blockedBy`, no `owner`
-2. Claim lowest-ID match: `TaskUpdate(taskId, status="in_progress", owner="builder")`
+1. `TaskList()` — find tasks with "Plan" (not "Review") or "Implement" in subject, `pending`, empty `blockedBy`. Prefer tasks where `owner == "builder"` (pre-assigned). If none pre-assigned, find tasks with no `owner` (self-claim).
+2. Claim: `TaskUpdate(taskId, status="in_progress", owner="builder")` — for pre-assigned tasks this flips status only; for self-claimed tasks this also sets owner.
 3. `TaskGet(taskId)` — extract issue number from description
 4. Dispatch by subject keyword:
    - "Plan": `Skill(skill="ralph-hero:ralph-plan", args="[issue-number]")`

--- a/plugin/ralph-hero/agents/ralph-integrator.md
+++ b/plugin/ralph-hero/agents/ralph-integrator.md
@@ -10,8 +10,8 @@ You are an **INTEGRATOR** in the Ralph Team.
 
 ## Task Loop
 
-1. `TaskList()` — find tasks with "Create PR", "Merge", or "Integrate" in subject, `pending`, empty `blockedBy`, no `owner`
-2. Claim lowest-ID match: `TaskUpdate(taskId, status="in_progress", owner="integrator")`
+1. `TaskList()` — find tasks with "Create PR", "Merge", or "Integrate" in subject, `pending`, empty `blockedBy`. Prefer tasks where `owner == "integrator"` (pre-assigned). If none pre-assigned, find tasks with no `owner` (self-claim).
+2. Claim: `TaskUpdate(taskId, status="in_progress", owner="integrator")` — for pre-assigned tasks this flips status only; for self-claimed tasks this also sets owner.
 3. `TaskGet(taskId)` — extract issue number (and group info if present) from description
 4. Dispatch by task subject:
    - **"Create PR"**: Go to PR Creation Procedure below

--- a/plugin/ralph-hero/agents/ralph-validator.md
+++ b/plugin/ralph-hero/agents/ralph-validator.md
@@ -10,8 +10,8 @@ You are a **VALIDATOR** in the Ralph Team.
 
 ## Task Loop
 
-1. `TaskList()` — find tasks with "Review" or "Validate" in subject, `pending`, empty `blockedBy`, no `owner`
-2. Claim lowest-ID match: `TaskUpdate(taskId, status="in_progress", owner="validator")`
+1. `TaskList()` — find tasks with "Review" or "Validate" in subject, `pending`, empty `blockedBy`. Prefer tasks where `owner == "validator"` (pre-assigned). If none pre-assigned, find tasks with no `owner` (self-claim).
+2. Claim: `TaskUpdate(taskId, status="in_progress", owner="validator")` — for pre-assigned tasks this flips status only; for self-claimed tasks this also sets owner.
 3. `TaskGet(taskId)` — extract issue number from description
 4. `Skill(skill="ralph-hero:ralph-review", args="[issue-number]")`
 5. `TaskUpdate(taskId, status="completed", description="VALIDATION VERDICT\nTicket: #NNN\nPlan: [path]\nVERDICT: [APPROVED/NEEDS_ITERATION]\n[blocking issues with file:line evidence]\n[warnings]\n[what's good]")`

--- a/plugin/ralph-hero/skills/shared/conventions.md
+++ b/plugin/ralph-hero/skills/shared/conventions.md
@@ -130,7 +130,7 @@ Workers hand off to the next pipeline stage via peer-to-peer SendMessage, bypass
 
 ### Rules
 
-- **Never use TaskUpdate with `owner` parameter** to assign tasks to other teammates. Workers self-claim only.
+- **Lead pre-assigns at spawn only**: The lead sets `owner` via `TaskUpdate` immediately before spawning a worker. After spawn, workers self-claim subsequent tasks. Do NOT assign tasks mid-pipeline via TaskUpdate or SendMessage.
 - **SendMessage is fire-and-forget** -- no acknowledgment mechanism. The handoff wakes the peer; they self-claim from TaskList.
 - **Lead gets visibility** via idle notification DM summaries -- no need to CC the lead on handoffs.
 - **Multiple handoffs are fine** -- if 3 analysts complete and all message the builder, the builder wakes 3 times and claims one task each time.

--- a/thoughts/shared/plans/2026-02-20-GH-0200-task-ownership-push-pull-hybrid.md
+++ b/thoughts/shared/plans/2026-02-20-GH-0200-task-ownership-push-pull-hybrid.md
@@ -183,18 +183,18 @@ Pre-assignment is atomic -- the task is owned before the worker's first turn beg
 
 ### Success Criteria
 
-- [ ] Automated: `grep -c "Never assign tasks" plugin/ralph-hero/skills/ralph-team/SKILL.md` returns 0
-- [ ] Automated: `grep -c "Never use TaskUpdate with .owner. parameter" plugin/ralph-hero/skills/shared/conventions.md` returns 0
-- [ ] Automated: `grep -c "Pre-assign at spawn" plugin/ralph-hero/skills/ralph-team/SKILL.md` returns 1
-- [ ] Automated: `grep -c "Lead pre-assigns at spawn" plugin/ralph-hero/skills/shared/conventions.md` returns 1
-- [ ] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-analyst.md` returns at least 1
-- [ ] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-builder.md` returns at least 1
-- [ ] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-validator.md` returns at least 1
-- [ ] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-integrator.md` returns at least 1
-- [ ] Manual: Lead's Section 4.3 includes `TaskUpdate(taskId, owner="[role]")` step before spawning
-- [ ] Manual: Agent definitions support BOTH pre-assigned (`owner == "[role]"`) and self-claimed (`no owner`) discovery
-- [ ] Manual: Peer-to-peer handoff protocol in conventions.md is unchanged (fire-and-forget SendMessage, workers self-claim from TaskList)
-- [ ] Manual: No spawn template files were modified (templates remain unchanged)
+- [x] Automated: `grep -c "Never assign tasks" plugin/ralph-hero/skills/ralph-team/SKILL.md` returns 0
+- [x] Automated: `grep -c "Never use TaskUpdate with .owner. parameter" plugin/ralph-hero/skills/shared/conventions.md` returns 0
+- [x] Automated: `grep -c "Pre-assign at spawn" plugin/ralph-hero/skills/ralph-team/SKILL.md` returns 1
+- [x] Automated: `grep -c "Lead pre-assigns at spawn" plugin/ralph-hero/skills/shared/conventions.md` returns 1
+- [x] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-analyst.md` returns at least 1
+- [x] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-builder.md` returns at least 1
+- [x] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-validator.md` returns at least 1
+- [x] Automated: `grep -c "pre-assigned" plugin/ralph-hero/agents/ralph-integrator.md` returns at least 1
+- [x] Manual: Lead's Section 4.3 includes `TaskUpdate(taskId, owner="[role]")` step before spawning
+- [x] Manual: Agent definitions support BOTH pre-assigned (`owner == "[role]"`) and self-claimed (`no owner`) discovery
+- [x] Manual: Peer-to-peer handoff protocol in conventions.md is unchanged (fire-and-forget SendMessage, workers self-claim from TaskList)
+- [x] Manual: No spawn template files were modified (templates remain unchanged)
 
 ---
 


### PR DESCRIPTION
## Summary

Implements #200: tasks not self-assigned on first iteration causing race conditions.

- Closes #200

## Changes

- **SKILL.md Section 4.3**: Lead now pre-assigns `owner` via `TaskUpdate(taskId, owner="[role]")` before spawning each worker
- **SKILL.md Section 5**: Replaced "Never assign tasks" prohibition with "Pre-assign at spawn, pull-based thereafter"
- **SKILL.md Section 9**: Updated "Pull-based claiming" limitation to "Hybrid claiming"
- **conventions.md**: Updated handoff rule from "Never use TaskUpdate with owner" to "Lead pre-assigns at spawn only"
- **All 4 agent definitions** (analyst, builder, validator, integrator): Updated task loop to prefer `owner == "[role]"` (pre-assigned) tasks, with fallback to `no owner` (self-claim) for subsequent pipeline tasks

## Test Plan

- [ ] Run `/ralph-team [issue-number]` with a fresh issue -- verify first-turn tasks are owned before worker execution begins
- [ ] Verify peer-to-peer handoff still works after the initial pre-assigned task completes
- [ ] Verify group research with 3 analysts: each gets a unique pre-assignment
- [ ] Verify no regression in the ralph-hero (non-team) skill which uses ephemeral subagents
- [ ] No spawn template files were modified (templates remain unchanged)

## Epic

- Parent: #209

---
Generated with Claude Code (Ralph GitHub Plugin)