### PR TITLE
feat(list-issues): add has/no presence and exclude* negation filters

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
@@ -50,3 +50,59 @@ describe("list_issues structural", () => {
     expect(issueToolsSrc).toContain("stateReason: content?.stateReason");
   });
 });
+
+describe("list_issues has/no presence filters structural", () => {
+  it("Zod schema includes has param with enum", () => {
+    expect(issueToolsSrc).toContain('"workflowState", "estimate", "priority", "labels", "assignees"');
+  });
+
+  it("Zod schema includes both has and no params", () => {
+    expect(issueToolsSrc).toMatch(/has:\s*z\s*\.array/);
+    expect(issueToolsSrc).toMatch(/no:\s*z\s*\.array/);
+  });
+
+  it("has filter applies every() check", () => {
+    expect(issueToolsSrc).toContain("args.has!.every");
+  });
+
+  it("no filter applies every() with negation", () => {
+    expect(issueToolsSrc).toContain("!hasField(item, field");
+  });
+
+  it("hasField helper handles all five field types", () => {
+    expect(issueToolsSrc).toContain('case "workflowState"');
+    expect(issueToolsSrc).toContain('case "estimate"');
+    expect(issueToolsSrc).toContain('case "priority"');
+    expect(issueToolsSrc).toContain('case "labels"');
+    expect(issueToolsSrc).toContain('case "assignees"');
+  });
+});
+
+describe("list_issues exclude negation filters structural", () => {
+  it("Zod schema includes excludeWorkflowStates param", () => {
+    expect(issueToolsSrc).toContain("excludeWorkflowStates");
+  });
+
+  it("Zod schema includes excludeEstimates param", () => {
+    expect(issueToolsSrc).toContain("excludeEstimates");
+  });
+
+  it("Zod schema includes excludePriorities param", () => {
+    expect(issueToolsSrc).toContain("excludePriorities");
+  });
+
+  it("Zod schema includes excludeLabels param", () => {
+    expect(issueToolsSrc).toContain("excludeLabels");
+  });
+
+  it("negation filters use Array.includes for matching", () => {
+    expect(issueToolsSrc).toContain("excludeWorkflowStates!.includes");
+    expect(issueToolsSrc).toContain("excludeEstimates!.includes");
+    expect(issueToolsSrc).toContain("excludePriorities!.includes");
+    expect(issueToolsSrc).toContain("excludeLabels!.includes");
+  });
+
+  it("items without field values are not excluded via ?? coercion", () => {
+    expect(issueToolsSrc).toContain('?? ""');
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -86,6 +86,48 @@ export function registerIssueTools(
         .describe(
           "Filter by close reason: completed, not_planned, reopened",
         ),
+      has: z
+        .array(z.enum(["workflowState", "estimate", "priority", "labels", "assignees"]))
+        .optional()
+        .describe(
+          "Include only items where these fields are non-empty. " +
+          "Valid fields: workflowState, estimate, priority, labels, assignees",
+        ),
+      no: z
+        .array(z.enum(["workflowState", "estimate", "priority", "labels", "assignees"]))
+        .optional()
+        .describe(
+          "Include only items where these fields are empty/absent. " +
+          "Valid fields: workflowState, estimate, priority, labels, assignees",
+        ),
+      excludeWorkflowStates: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exclude items matching any of these Workflow State names " +
+          '(e.g., ["Done", "Canceled"])',
+        ),
+      excludeEstimates: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exclude items matching any of these Estimate values " +
+          '(e.g., ["M", "L", "XL"])',
+        ),
+      excludePriorities: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exclude items matching any of these Priority values " +
+          '(e.g., ["P3"])',
+        ),
+      excludeLabels: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exclude items that have ANY of these labels " +
+          '(e.g., ["wontfix", "duplicate"])',
+        ),
       updatedSince: z
         .string()
         .optional()
@@ -222,6 +264,60 @@ export function registerIssueTools(
               (content?.labels as { nodes: Array<{ name: string }> })?.nodes ||
               [];
             return labels.some((l) => l.name === args.label);
+          });
+        }
+
+        // Filter by field presence (has)
+        if (args.has && args.has.length > 0) {
+          items = items.filter((item) =>
+            args.has!.every((field) => hasField(item, field as PresenceField)),
+          );
+        }
+
+        // Filter by field absence (no)
+        if (args.no && args.no.length > 0) {
+          items = items.filter((item) =>
+            args.no!.every((field) => !hasField(item, field as PresenceField)),
+          );
+        }
+
+        // Filter by excluded workflow states
+        if (args.excludeWorkflowStates && args.excludeWorkflowStates.length > 0) {
+          items = items.filter(
+            (item) =>
+              !args.excludeWorkflowStates!.includes(
+                getFieldValue(item, "Workflow State") ?? "",
+              ),
+          );
+        }
+
+        // Filter by excluded estimates
+        if (args.excludeEstimates && args.excludeEstimates.length > 0) {
+          items = items.filter(
+            (item) =>
+              !args.excludeEstimates!.includes(
+                getFieldValue(item, "Estimate") ?? "",
+              ),
+          );
+        }
+
+        // Filter by excluded priorities
+        if (args.excludePriorities && args.excludePriorities.length > 0) {
+          items = items.filter(
+            (item) =>
+              !args.excludePriorities!.includes(
+                getFieldValue(item, "Priority") ?? "",
+              ),
+          );
+        }
+
+        // Filter by excluded labels
+        if (args.excludeLabels && args.excludeLabels.length > 0) {
+          items = items.filter((item) => {
+            const content = item.content as Record<string, unknown> | null;
+            const labels =
+              (content?.labels as { nodes: Array<{ name: string }> })?.nodes || [];
+            return !labels.some((l) => args.excludeLabels!.includes(l.name));
           });
         }
 
@@ -1661,6 +1757,29 @@ function getFieldValue(
       fv.__typename === "ProjectV2ItemFieldSingleSelectValue",
   );
   return fieldValue?.name;
+}
+
+type PresenceField = "workflowState" | "estimate" | "priority" | "labels" | "assignees";
+
+function hasField(item: RawProjectItem, field: PresenceField): boolean {
+  switch (field) {
+    case "workflowState":
+      return getFieldValue(item, "Workflow State") !== undefined;
+    case "estimate":
+      return getFieldValue(item, "Estimate") !== undefined;
+    case "priority":
+      return getFieldValue(item, "Priority") !== undefined;
+    case "labels": {
+      const content = item.content as Record<string, unknown> | null;
+      const labels = (content?.labels as { nodes: Array<{ name: string }> })?.nodes || [];
+      return labels.length > 0;
+    }
+    case "assignees": {
+      const content = item.content as Record<string, unknown> | null;
+      const assignees = (content?.assignees as { nodes: Array<{ login: string }> })?.nodes || [];
+      return assignees.length > 0;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Atomic implementation of 2 related issues from the GH-106 filter enhancement epic:

- Closes #141 — Add `has`/`no` presence filters to `list_issues`
- Closes #142 — Add `exclude*` negation filters to `list_issues`

## Changes

### GH-141: Presence filters
- Added `has` and `no` array params to `list_issues` Zod schema with `z.enum` validation for 5 field types (`workflowState`, `estimate`, `priority`, `labels`, `assignees`)
- Added `hasField` helper function with switch-based presence checks: `getFieldValue !== undefined` for single-select fields, `.length > 0` for content arrays
- Added two filter blocks in the filter chain using `every()` for AND logic

### GH-142: Negation filters
- Added `excludeWorkflowStates`, `excludeEstimates`, `excludePriorities`, `excludeLabels` array params to Zod schema
- Added four negation filter blocks using `Array.includes()` with `?? ""` coercion to protect items with undefined field values from exclusion
- Label exclusion uses ANY-match semantics (`excludeLabels: ["a", "b"]` excludes items with label "a" OR "b")

### Tests
- 11 new structural tests covering schema params, filter logic, helper coverage, and coercion behavior

## Test Plan
- [x] `npm run build` — no type errors
- [x] `npm test` — 387/387 tests passing (11 new)
- [ ] Manual: verify `has: ["estimate"]` returns only items with estimates set
- [ ] Manual: verify `excludeWorkflowStates: ["Done"]` excludes Done items but keeps items with no workflow state

---
Generated with Claude Code (Ralph GitHub Plugin)