### PR TITLE
feat(mcp-server): port presence and negation filters to list_project_items (#143)

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/project-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/project-tools.test.ts
@@ -59,3 +59,69 @@ describe("list_project_items structural", () => {
     );
   });
 });
+
+describe("list_project_items has/no presence filters structural", () => {
+  it("Zod schema includes has param with enum", () => {
+    expect(projectToolsSrc).toContain('"workflowState", "estimate", "priority", "labels", "assignees"');
+  });
+
+  it("Zod schema includes both has and no params", () => {
+    expect(projectToolsSrc).toMatch(/has:\s*z\s*\.array/);
+    expect(projectToolsSrc).toMatch(/no:\s*z\s*\.array/);
+  });
+
+  it("has filter applies every() check", () => {
+    expect(projectToolsSrc).toContain("args.has!.every");
+  });
+
+  it("no filter applies every() with negation", () => {
+    expect(projectToolsSrc).toContain("!hasField(item, field");
+  });
+
+  it("hasField helper handles all five field types", () => {
+    expect(projectToolsSrc).toContain('case "workflowState"');
+    expect(projectToolsSrc).toContain('case "estimate"');
+    expect(projectToolsSrc).toContain('case "priority"');
+    expect(projectToolsSrc).toContain('case "labels"');
+    expect(projectToolsSrc).toContain('case "assignees"');
+  });
+});
+
+describe("list_project_items exclude negation filters structural", () => {
+  it("Zod schema includes excludeWorkflowStates param", () => {
+    expect(projectToolsSrc).toContain("excludeWorkflowStates");
+  });
+
+  it("Zod schema includes excludeEstimates param", () => {
+    expect(projectToolsSrc).toContain("excludeEstimates");
+  });
+
+  it("Zod schema includes excludePriorities param", () => {
+    expect(projectToolsSrc).toContain("excludePriorities");
+  });
+
+  it("negation filters use Array.includes for matching", () => {
+    expect(projectToolsSrc).toContain("excludeWorkflowStates!.includes");
+    expect(projectToolsSrc).toContain("excludeEstimates!.includes");
+    expect(projectToolsSrc).toContain("excludePriorities!.includes");
+  });
+
+  it("items without field values are not excluded via ?? coercion", () => {
+    expect(projectToolsSrc).toContain('?? ""');
+  });
+
+  it("does not include excludeLabels (project items lack labels in GraphQL)", () => {
+    // project-tools does NOT have excludeLabels - only issue-tools does
+    // because list_project_items items may not have labels in the content fragment
+    // This is intentional per Phase 3 spec
+    expect(projectToolsSrc).not.toContain("excludeLabels");
+  });
+
+  it("hasFilters guard includes new filter params", () => {
+    expect(projectToolsSrc).toContain("args.has");
+    expect(projectToolsSrc).toContain("args.no");
+    expect(projectToolsSrc).toContain("args.excludeWorkflowStates");
+    expect(projectToolsSrc).toContain("args.excludeEstimates");
+    expect(projectToolsSrc).toContain("args.excludePriorities");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
@@ -413,6 +413,41 @@ export function registerProjectTools(
         .string()
         .optional()
         .describe("Filter by Priority name (P0, P1, P2, P3)"),
+      has: z
+        .array(z.enum(["workflowState", "estimate", "priority", "labels", "assignees"]))
+        .optional()
+        .describe(
+          "Include only items where these fields are non-empty. " +
+          "Valid fields: workflowState, estimate, priority, labels, assignees",
+        ),
+      no: z
+        .array(z.enum(["workflowState", "estimate", "priority", "labels", "assignees"]))
+        .optional()
+        .describe(
+          "Include only items where these fields are empty/absent. " +
+          "Valid fields: workflowState, estimate, priority, labels, assignees",
+        ),
+      excludeWorkflowStates: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exclude items matching any of these Workflow State names " +
+          '(e.g., ["Done", "Canceled"])',
+        ),
+      excludeEstimates: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exclude items matching any of these Estimate values " +
+          '(e.g., ["M", "L", "XL"])',
+        ),
+      excludePriorities: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exclude items matching any of these Priority values " +
+          '(e.g., ["P3"])',
+        ),
       itemType: z
         .enum(["ISSUE", "PULL_REQUEST", "DRAFT_ISSUE"])
         .optional()
@@ -468,7 +503,12 @@ export function registerProjectTools(
         }
 
         // When filters are active, fetch more items to ensure adequate results after filtering
-        const hasFilters = args.updatedSince || args.updatedBefore || args.itemType;
+        const hasFilters = args.updatedSince || args.updatedBefore || args.itemType ||
+          (args.has && args.has.length > 0) ||
+          (args.no && args.no.length > 0) ||
+          (args.excludeWorkflowStates && args.excludeWorkflowStates.length > 0) ||
+          (args.excludeEstimates && args.excludeEstimates.length > 0) ||
+          (args.excludePriorities && args.excludePriorities.length > 0);
         const maxItems = hasFilters ? 500 : (args.limit || 50);
 
         // Fetch all project items with field values
@@ -561,6 +601,50 @@ export function registerProjectTools(
           );
         }
 
+        // Filter by field presence (has)
+        if (args.has && args.has.length > 0) {
+          items = items.filter((item) =>
+            args.has!.every((field) => hasField(item, field as PresenceField)),
+          );
+        }
+
+        // Filter by field absence (no)
+        if (args.no && args.no.length > 0) {
+          items = items.filter((item) =>
+            args.no!.every((field) => !hasField(item, field as PresenceField)),
+          );
+        }
+
+        // Filter by excluded workflow states
+        if (args.excludeWorkflowStates && args.excludeWorkflowStates.length > 0) {
+          items = items.filter(
+            (item) =>
+              !args.excludeWorkflowStates!.includes(
+                getFieldValue(item, "Workflow State") ?? "",
+              ),
+          );
+        }
+
+        // Filter by excluded estimates
+        if (args.excludeEstimates && args.excludeEstimates.length > 0) {
+          items = items.filter(
+            (item) =>
+              !args.excludeEstimates!.includes(
+                getFieldValue(item, "Estimate") ?? "",
+              ),
+          );
+        }
+
+        // Filter by excluded priorities
+        if (args.excludePriorities && args.excludePriorities.length > 0) {
+          items = items.filter(
+            (item) =>
+              !args.excludePriorities!.includes(
+                getFieldValue(item, "Priority") ?? "",
+              ),
+          );
+        }
+
         // Filter by updatedSince
         if (args.updatedSince) {
           const since = parseDateMath(args.updatedSince).getTime();
@@ -650,6 +734,29 @@ function getFieldValue(
       fv.__typename === "ProjectV2ItemFieldSingleSelectValue",
   );
   return fieldValue?.name;
+}
+
+type PresenceField = "workflowState" | "estimate" | "priority" | "labels" | "assignees";
+
+function hasField(item: RawProjectItem, field: PresenceField): boolean {
+  switch (field) {
+    case "workflowState":
+      return getFieldValue(item, "Workflow State") !== undefined;
+    case "estimate":
+      return getFieldValue(item, "Estimate") !== undefined;
+    case "priority":
+      return getFieldValue(item, "Priority") !== undefined;
+    case "labels": {
+      const content = item.content as Record<string, unknown> | null;
+      const labels = (content?.labels as { nodes: Array<{ name: string }> })?.nodes || [];
+      return labels.length > 0;
+    }
+    case "assignees": {
+      const content = item.content as Record<string, unknown> | null;
+      const assignees = (content?.assignees as { nodes: Array<{ login: string }> })?.nodes || [];
+      return assignees.length > 0;
+    }
+  }
 }
 
 async function fetchProject(


### PR DESCRIPTION
## Summary
- Ports `has`/`no` presence filters and `excludeWorkflowStates`/`excludeEstimates`/`excludePriorities` negation filters from `list_issues` to `list_project_items` (Phase 3 of group-GH-141)
- Adds `hasField` helper for 5 field types (workflowState, estimate, priority, labels, assignees)
- Updates `hasFilters` pagination guard to fetch more items when new filters are active
- Adds 12 structural tests for the new filters
- No `excludeLabels` for project items since PRs/DraftIssues lack labels in the GraphQL content fragment

Closes #143

## Test plan
- [x] TypeScript builds cleanly
- [x] All 419 tests pass (12 new structural tests for presence/negation filters)
- [ ] Manual: `list_project_items` with `has: ["estimate"]` returns only items with estimates
- [ ] Manual: `list_project_items` with `excludeWorkflowStates: ["Done"]` excludes done items

🤖 Generated with [Claude Code](https://claude.com/claude-code)