### PR TITLE
feat(mcp-server): enrich list_project_items with repository info (GH-225)

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/project-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/project-tools.test.ts
@@ -87,6 +87,36 @@ describe("list_project_items has/no presence filters structural", () => {
   });
 });
 
+describe("list_project_items repository info structural", () => {
+  it("GraphQL Issue fragment includes repository fields", () => {
+    expect(projectToolsSrc).toContain("repository { nameWithOwner name owner { login } }");
+  });
+
+  it("repository fragment appears in both Issue and PullRequest", () => {
+    const repoMatches = projectToolsSrc.match(/repository \{ nameWithOwner name owner \{ login \} \}/g);
+    expect(repoMatches).toHaveLength(2);
+  });
+
+  it("response mapping includes owner field", () => {
+    expect(projectToolsSrc).toContain("owner: (content?.repository");
+  });
+
+  it("response mapping includes repo field", () => {
+    expect(projectToolsSrc).toContain("repo: (content?.repository");
+  });
+
+  it("response mapping includes nameWithOwner field", () => {
+    expect(projectToolsSrc).toContain("nameWithOwner: (content?.repository");
+  });
+
+  it("DraftIssue items return null for repo fields (no repository fragment)", () => {
+    // DraftIssue content block does NOT include repository - verify graceful null fallback
+    const draftIssueBlock = projectToolsSrc.match(/\.\.\. on DraftIssue \{[^}]+\}/)?.[0];
+    expect(draftIssueBlock).toBeDefined();
+    expect(draftIssueBlock).not.toContain("repository");
+  });
+});
+
 describe("list_project_items exclude negation filters structural", () => {
   it("Zod schema includes excludeWorkflowStates param", () => {
     expect(projectToolsSrc).toContain("excludeWorkflowStates");

--- a/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
@@ -532,12 +532,14 @@ export function registerProjectTools(
                         updatedAt
                         labels(first: 10) { nodes { name } }
                         assignees(first: 5) { nodes { login } }
+                        repository { nameWithOwner name owner { login } }
                       }
                       ... on PullRequest {
                         number
                         title
                         state
                         url
+                        repository { nameWithOwner name owner { login } }
                       }
                       ... on DraftIssue {
                         title
@@ -679,6 +681,9 @@ export function registerProjectTools(
             state: content?.state,
             url: content?.url,
             updatedAt: content?.updatedAt ?? null,
+            owner: (content?.repository as { owner?: { login?: string } })?.owner?.login ?? null,
+            repo: (content?.repository as { name?: string })?.name ?? null,
+            nameWithOwner: (content?.repository as { nameWithOwner?: string })?.nameWithOwner ?? null,
             workflowState: getFieldValue(item, "Workflow State"),
             estimate: getFieldValue(item, "Estimate"),
             priority: getFieldValue(item, "Priority"),


### PR DESCRIPTION
## Summary
- Adds `repository { nameWithOwner name owner { login } }` to the `list_project_items` GraphQL query for both Issue and PullRequest content types
- Maps response fields `owner`, `repo`, `nameWithOwner` so agents can identify which repository each project item belongs to
- DraftIssue items gracefully return `null` for repo fields (no repository fragment)

Closes #225

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 425 tests pass (`npm test`)
- [x] 6 new structural tests verify GraphQL fragments and response mapping
- [ ] CI validates across Node 18, 20, 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)