### PR TITLE
fix(mcp-server): use z.coerce.number() for all numeric tool params

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,13 @@ Set these in `.claude/settings.local.json` (recommended, gitignored):
 |----------|----------|-------------|-------------|
 | `RALPH_HERO_GITHUB_TOKEN` | **Yes** | `settings.local.json` | GitHub PAT with `repo` + `project` scopes |
 | `RALPH_GH_OWNER` | Yes | `settings.local.json` or `.mcp.json` default | GitHub owner (user or org) |
-| `RALPH_GH_REPO` | Yes | `settings.local.json` or `.mcp.json` default | Repository name |
+| `RALPH_GH_REPO` | No† | `settings.local.json` or `.mcp.json` default | Repository name (inferred from project if omitted) |
 | `RALPH_GH_PROJECT_NUMBER` | Yes | `settings.local.json` or `.mcp.json` default | GitHub Projects V2 number |
 | `RALPH_GH_REPO_TOKEN` | No | `settings.local.json` | Separate repo token (falls back to `RALPH_HERO_GITHUB_TOKEN`) |
 | `RALPH_GH_PROJECT_TOKEN` | No | `settings.local.json` | Separate project token (falls back to repo token) |
 | `RALPH_GH_PROJECT_OWNER` | No | `settings.local.json` | Project owner if different from repo owner |
+
+†`RALPH_GH_REPO` is inferred from the repositories linked to the project via `link_repository`. Only set it explicitly as a tiebreaker when multiple repos are linked. Bootstrap: `setup_project` → `link_repository` → repo is inferred. See #23.
 
 ### Key Implementation Details
 

--- a/plugin/ralph-hero/README.md
+++ b/plugin/ralph-hero/README.md
@@ -125,13 +125,15 @@ For fully autonomous operation:
 | `RALPH_GH_REPO_TOKEN` | No | Separate token for repo operations (issues, PRs, comments) |
 | `RALPH_GH_PROJECT_TOKEN` | No | Separate token for project operations (fields, workflow state) |
 | `RALPH_GH_OWNER` | Yes | Repository owner (user or org) |
-| `RALPH_GH_REPO` | Yes | Repository name |
+| `RALPH_GH_REPO` | No† | Repository name |
 | `RALPH_GH_PROJECT_OWNER` | No | Project owner if different from repo owner |
 | `RALPH_GH_PROJECT_NUMBER` | Yes | GitHub Project V2 number |
 | `MAX_ITERATIONS` | No | Max loop iterations (default: 10) |
 | `TIMEOUT` | No | Per-task timeout (default: 15m) |
 
 *Either `RALPH_HERO_GITHUB_TOKEN` or `RALPH_GH_REPO_TOKEN` must be set.
+
+†`RALPH_GH_REPO` is inferred from the repositories linked to the project (via `link_repository`). It only needs to be set explicitly as a tiebreaker when multiple repos are linked. Bootstrap: run `setup_project` → `link_repository` → repo is inferred automatically.
 
 ### Token Scopes
 

--- a/plugin/ralph-hero/mcp-server/src/tools/batch-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/batch-tools.ts
@@ -231,7 +231,7 @@ export function registerBatchTools(
         .optional()
         .describe("Repository name. Defaults to env var"),
       issues: z
-        .array(z.number())
+        .array(z.coerce.number())
         .min(1)
         .max(MAX_ISSUES)
         .describe("Issue numbers to update (1-50)"),

--- a/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
@@ -259,7 +259,7 @@ export function registerDashboardTools(
         .default(48)
         .describe("Hours before flagging stuck issues (default: 48)"),
       wipLimits: z
-        .record(z.number())
+        .record(z.coerce.number())
         .optional()
         .describe(
           'Per-state WIP limits, e.g. { "In Progress": 3 }',

--- a/plugin/ralph-hero/mcp-server/src/tools/hygiene-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/hygiene-tools.ts
@@ -64,7 +64,7 @@ export function registerHygieneTools(
           "Days before unassigned Backlog items are flagged as orphaned (default: 14)",
         ),
       wipLimits: z
-        .record(z.number())
+        .record(z.coerce.number())
         .optional()
         .describe('Per-state WIP limits, e.g. { "In Progress": 3 }'),
       format: z

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -154,7 +154,7 @@ export function registerIssueTools(
         .default("CREATED_AT")
         .describe("Order by field"),
       limit: z
-        .number()
+        .coerce.number()
         .optional()
         .default(50)
         .describe("Max items to return (default 50)"),
@@ -433,7 +433,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       includeGroup: z
         .boolean()
         .optional()
@@ -943,7 +943,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       title: z.string().optional().describe("New issue title"),
       body: z.string().optional().describe("New issue body (Markdown)"),
       labels: z
@@ -1053,7 +1053,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       state: z
         .string()
         .describe(
@@ -1148,7 +1148,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       estimate: z.string().describe("Estimate value (XS, S, M, L, XL)"),
     },
     async (args) => {
@@ -1202,7 +1202,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       priority: z.string().describe("Priority value (P0, P1, P2, P3)"),
     },
     async (args) => {
@@ -1256,7 +1256,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       body: z.string().describe("Comment body (Markdown)"),
     },
     async (args) => {
@@ -1318,7 +1318,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number (seed for group detection)"),
+      number: z.coerce.number().describe("Issue number (seed for group detection)"),
     },
     async (args) => {
       try {
@@ -1390,7 +1390,7 @@ export function registerIssueTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number (any issue in the group)"),
+      number: z.coerce.number().describe("Issue number (any issue in the group)"),
       targetState: z
         .string()
         .describe("The state all issues must be in (e.g., 'Ready for Plan')"),

--- a/plugin/ralph-hero/mcp-server/src/tools/project-management-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/project-management-tools.ts
@@ -47,7 +47,7 @@ export function registerProjectManagementTools(
     {
       owner: z.string().optional().describe("GitHub owner. Defaults to env var"),
       repo: z.string().optional().describe("Repository name. Defaults to env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       unarchive: z.boolean().optional().default(false)
         .describe("If true, unarchive instead of archive (default: false)"),
     },
@@ -120,7 +120,7 @@ export function registerProjectManagementTools(
     {
       owner: z.string().optional().describe("GitHub owner. Defaults to env var"),
       repo: z.string().optional().describe("Repository name. Defaults to env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
     },
     async (args) => {
       try {
@@ -181,7 +181,7 @@ export function registerProjectManagementTools(
     {
       owner: z.string().optional().describe("GitHub owner. Defaults to env var"),
       repo: z.string().optional().describe("Repository name. Defaults to env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
     },
     async (args) => {
       try {
@@ -344,7 +344,7 @@ export function registerProjectManagementTools(
     {
       owner: z.string().optional().describe("GitHub owner. Defaults to env var"),
       repo: z.string().optional().describe("Repository name. Defaults to env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
       field: z.string().describe("Field name to clear (e.g., 'Estimate', 'Priority', 'Workflow State')"),
     },
     async (args) => {
@@ -540,8 +540,8 @@ export function registerProjectManagementTools(
     {
       owner: z.string().optional().describe("GitHub owner. Defaults to env var"),
       repo: z.string().optional().describe("Repository name. Defaults to env var"),
-      number: z.number().describe("Issue number to reposition"),
-      afterNumber: z.number().optional()
+      number: z.coerce.number().describe("Issue number to reposition"),
+      afterNumber: z.coerce.number().optional()
         .describe("Issue number to place after; omit to move to top"),
     },
     async (args) => {

--- a/plugin/ralph-hero/mcp-server/src/tools/relationship-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/relationship-tools.ts
@@ -56,9 +56,9 @@ export function registerRelationshipTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      parentNumber: z.number().describe("Parent issue number"),
+      parentNumber: z.coerce.number().describe("Parent issue number"),
       childNumber: z
-        .number()
+        .coerce.number()
         .describe("Child issue number (will become sub-issue of parent)"),
       replaceParent: z
         .boolean()
@@ -136,7 +136,7 @@ export function registerRelationshipTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Parent issue number"),
+      number: z.coerce.number().describe("Parent issue number"),
     },
     async (args) => {
       try {
@@ -318,8 +318,8 @@ export function registerRelationshipTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      blockedNumber: z.number().describe("Issue number that was blocked"),
-      blockingNumber: z.number().describe("Issue number that was the blocker"),
+      blockedNumber: z.coerce.number().describe("Issue number that was blocked"),
+      blockingNumber: z.coerce.number().describe("Issue number that was the blocker"),
     },
     async (args) => {
       try {
@@ -390,7 +390,7 @@ export function registerRelationshipTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Issue number"),
+      number: z.coerce.number().describe("Issue number"),
     },
     async (args) => {
       try {
@@ -528,7 +528,7 @@ export function registerRelationshipTools(
         .string()
         .optional()
         .describe("Repository name. Defaults to GITHUB_REPO env var"),
-      number: z.number().describe("Parent issue number"),
+      number: z.coerce.number().describe("Parent issue number"),
       targetState: z
         .string()
         .describe(

--- a/plugin/ralph-hero/mcp-server/src/tools/routing-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/routing-tools.ts
@@ -65,13 +65,13 @@ export function registerRoutingTools(
           }),
           action: z.object({
             workflowState: z.string().optional(),
-            projectNumber: z.number().optional(),
+            projectNumber: z.coerce.number().optional(),
           }),
         })
         .optional()
         .describe("Rule definition (required for add_rule, update_rule)"),
       ruleIndex: z
-        .number()
+        .coerce.number()
         .optional()
         .describe(
           "Zero-based rule index (required for update_rule, remove_rule)",

--- a/plugin/ralph-hero/mcp-server/src/tools/sync-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/sync-tools.ts
@@ -213,7 +213,7 @@ export function registerSyncTools(
     {
       owner: z.string().optional().describe("GitHub owner. Defaults to env var"),
       repo: z.string().optional().describe("Repository name. Defaults to env var"),
-      number: z.number().describe("Issue number to sync"),
+      number: z.coerce.number().describe("Issue number to sync"),
       workflowState: z
         .string()
         .describe('Target Workflow State to propagate (e.g., "In Progress")'),

--- a/thoughts/shared/plans/2026-02-20-GH-177-parent-auto-advance.md
+++ b/thoughts/shared/plans/2026-02-20-GH-177-parent-auto-advance.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-02-20
-status: in_review
+status: complete
 github_issues: [177]
 github_urls:
   - https://github.com/cdubiel08/ralph-hero/issues/177
@@ -29,17 +29,17 @@ Single-issue implementation. When all child (sub-issue) issues of a parent issue
 ## Desired End State
 
 ### Verification
-- [ ] `.github/workflows/advance-parent.yml` exists and triggers on `issues: [closed]`
-- [ ] Closed with `state_reason != "completed"` exits early (no advancement)
-- [ ] Issue with no parent exits early (no advancement)
-- [ ] Parent with mixed children (some open, some closed) does not advance
-- [ ] Parent with all children closed as "completed" advances to Done
-- [ ] Parent with a child closed as "not_planned" does not advance (not all COMPLETED)
-- [ ] Parent already at Done is skipped (idempotent)
-- [ ] Parent issue is closed with `--reason completed` after advancement (cascading)
-- [ ] `workflow_dispatch` trigger allows manual testing with issue number input
-- [ ] Concurrency group prevents parallel advancement for same parent
-- [ ] All inputs passed via safe `env:` blocks (no `${{ }}` in `run:` commands)
+- [x] `.github/workflows/advance-parent.yml` exists and triggers on `issues: [closed]`
+- [x] Closed with `state_reason != "completed"` exits early (no advancement)
+- [x] Issue with no parent exits early (no advancement)
+- [x] Parent with mixed children (some open, some closed) does not advance
+- [x] Parent with all children closed as "completed" advances to Done
+- [x] Parent with a child closed as "not_planned" does not advance (not all COMPLETED)
+- [x] Parent already at Done is skipped (idempotent)
+- [x] Parent issue is closed with `--reason completed` after advancement (cascading)
+- [x] `workflow_dispatch` trigger allows manual testing with issue number input
+- [x] Concurrency group prevents parallel advancement for same parent
+- [x] All inputs passed via safe `env:` blocks (no `${{ }}` in `run:` commands)
 
 ## What We're NOT Doing
 - No handling of non-Done gate states (Ready for Plan, In Review) -- that's the MCP tool's domain
@@ -397,8 +397,8 @@ jobs:
 **Concurrency note**: No explicit concurrency group is needed on this workflow. Each `issues: [closed]` event targets a different child issue. The parent update step is idempotent (skips if already Done). The parent close step checks `state == CLOSED` before closing. Multiple children closing simultaneously would each check convergence independently, and the first to update wins -- subsequent runs see "already Done" and no-op.
 
 ### Success Criteria
-- [ ] Automated: workflow YAML is valid (parseable by GitHub Actions)
-- [ ] Automated: shell syntax valid (`bash -n`)
+- [x] Automated: workflow YAML is valid (parseable by GitHub Actions)
+- [x] Automated: shell syntax valid (`bash -n`)
 - [ ] Manual: `workflow_dispatch` with a child issue number triggers parent check
 - [ ] Manual: parent with all children completed advances to Done
 - [ ] Manual: parent with incomplete children does not advance


### PR DESCRIPTION
## Summary

- Replaces `z.number()` with `z.coerce.number()` across all 8 tool files so string-typed numerics (e.g. `"23"`) are accepted without validation errors
- Covers scalar issue numbers, project numbers, rule indices, array elements (`batch_update` issues list), and record values (`wipLimits`)
- Zero behavior change for callers already passing integers; purely additive tolerance

## Files changed

| File | Fields fixed |
|------|-------------|
| `issue-tools.ts` | `number` ×8, `limit` |
| `sync-tools.ts` | `number` |
| `routing-tools.ts` | `projectNumber`, `ruleIndex` |
| `project-management-tools.ts` | `number` ×4, `afterNumber` |
| `relationship-tools.ts` | `parentNumber`, `childNumber`, `number` ×3, `blockedNumber`, `blockingNumber` |
| `batch-tools.ts` | `issues` array elements |
| `dashboard-tools.ts` | `wipLimits` record values |
| `hygiene-tools.ts` | `wipLimits` record values |

Also includes carried-over doc updates from the GH-23 multi-repo session (CLAUDE.md, README.md, research/plan docs).

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] CI passes on Node 18/20/22
- [ ] Manually verify a tool call with a string issue number (e.g. `get_issue(number: "42")`) no longer returns a Zod validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)