### PR TITLE
feat(state-machine): add ralph_merge command for post-merge Done transition

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/ralph-state-machine.json
+++ b/plugin/ralph-hero/hooks/scripts/ralph-state-machine.json
@@ -67,7 +67,7 @@
       "description": "Ticket completed",
       "allowed_transitions": [],
       "required_by_commands": [],
-      "produces_for_commands": ["ralph_triage", "ralph_impl"],
+      "produces_for_commands": ["ralph_triage", "ralph_impl", "ralph_merge"],
       "is_terminal": true
     },
     "Canceled": {
@@ -191,6 +191,19 @@
         "Ticket reached In Review or escalated to Human Needed"
       ]
     },
+    "ralph_merge": {
+      "description": "Transition issues to Done after PR merge",
+      "valid_input_states": ["In Review"],
+      "valid_output_states": ["Done", "Human Needed"],
+      "preconditions": [
+        "PR must be merged",
+        "Ticket must be in In Review state"
+      ],
+      "postconditions": [
+        "Ticket moved to Done",
+        "GitHub issue closed via PR auto-link"
+      ]
+    },
     "ralph_review": {
       "description": "Review implementation plans before execution",
       "valid_input_states": ["Plan in Review"],
@@ -274,7 +287,8 @@
       "ralph_plan": "Plan in Review",
       "ralph_impl": "In Review",
       "ralph_review": "In Progress",
-      "ralph_split": "Backlog"
+      "ralph_split": "Backlog",
+      "ralph_merge": "Done"
     },
     "__ESCALATE__": {
       "*": "Human Needed"

--- a/plugin/ralph-hero/mcp-server/src/__tests__/state-resolution.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/state-resolution.test.ts
@@ -42,6 +42,9 @@ describe("resolveState - semantic intents", () => {
     expect(() => resolveState("__LOCK__", "ralph_hero")).toThrow(
       /not valid for ralph_hero/i,
     );
+    expect(() => resolveState("__LOCK__", "ralph_merge")).toThrow(
+      /not valid for ralph_merge/i,
+    );
   });
 
   it("resolves __COMPLETE__ for commands with single completion target", () => {
@@ -59,6 +62,9 @@ describe("resolveState - semantic intents", () => {
     );
     expect(resolveState("__COMPLETE__", "ralph_split").resolvedState).toBe(
       "Backlog",
+    );
+    expect(resolveState("__COMPLETE__", "ralph_merge").resolvedState).toBe(
+      "Done",
     );
   });
 
@@ -120,6 +126,10 @@ describe("resolveState - direct state names", () => {
     expect(resolveState("In Review", "ralph_impl").resolvedState).toBe(
       "In Review",
     );
+    expect(resolveState("Done", "ralph_merge").resolvedState).toBe("Done");
+    expect(
+      resolveState("Human Needed", "ralph_merge").resolvedState,
+    ).toBe("Human Needed");
   });
 
   it("rejects states not in command's allowed outputs with recovery", () => {
@@ -134,6 +144,9 @@ describe("resolveState - direct state names", () => {
     );
     expect(() => resolveState("In Progress", "ralph_triage")).toThrow(
       /not a valid output for ralph_triage/i,
+    );
+    expect(() => resolveState("In Progress", "ralph_merge")).toThrow(
+      /not a valid output for ralph_merge/i,
     );
   });
 
@@ -166,6 +179,7 @@ describe("resolveState - command validation", () => {
     expect(resolveState("__LOCK__", "plan").resolvedState).toBe(
       "Plan in Progress",
     );
+    expect(resolveState("__COMPLETE__", "merge").resolvedState).toBe("Done");
   });
 });
 

--- a/plugin/ralph-hero/mcp-server/src/lib/state-resolution.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/state-resolution.ts
@@ -22,6 +22,7 @@ const SEMANTIC_INTENTS: Record<string, Record<string, string | null>> = {
     ralph_plan: "Plan in Review",
     ralph_impl: "In Review",
     ralph_review: "In Progress",
+    ralph_merge: "Done",
   },
   __ESCALATE__: { "*": "Human Needed" },
   __CLOSE__: { "*": "Done" },
@@ -44,6 +45,7 @@ const COMMAND_ALLOWED_STATES: Record<string, string[]> = {
   ralph_impl: ["In Progress", "In Review", "Human Needed"],
   ralph_review: ["In Progress", "Ready for Plan", "Human Needed"],
   ralph_hero: ["In Review", "Human Needed"],
+  ralph_merge: ["Done", "Human Needed"],
 };
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary

- Adds `ralph_merge` command to the state machine so issues can transition to "Done" after PR merge
- `__COMPLETE__` resolves to "Done", allowed outputs are `["Done", "Human Needed"]`
- Enables manual fallback when GH Actions automation doesn't fire

## Changes

- **`ralph-state-machine.json`**: Add `ralph_merge` command definition with valid input state "In Review" and outputs "Done"/"Human Needed"; add to `__COMPLETE__` intent mapping; register in "Done" state's `produces_for_commands`
- **`state-resolution.ts`**: Add `ralph_merge` to `SEMANTIC_INTENTS.__COMPLETE__` and `COMMAND_ALLOWED_STATES`
- **`state-resolution.test.ts`**: Add test coverage for `ralph_merge` across intent resolution, direct state validation, command prefix normalization, and rejection of invalid states

## Test plan

- [x] All 449 existing tests pass
- [x] New `ralph_merge` tests verify `__COMPLETE__` resolves to "Done"
- [x] Tests verify "Done" and "Human Needed" are valid outputs
- [x] Tests verify invalid states (e.g., "In Progress") are rejected
- [x] Command prefix normalization works (`merge` -> `ralph_merge`)

Closes #79