### PR TITLE
feat(scripts): add remote ref checking to create-worktree.sh

### DIFF
--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -28,6 +28,7 @@ mkdir -p "$WORKTREE_BASE"
 
 echo "Fetching latest from origin..."
 git fetch origin main 2>/dev/null || git fetch origin master 2>/dev/null || echo "Warning: Could not fetch from origin"
+git fetch origin "$BRANCH_NAME" 2>/dev/null || true
 
 BASE_BRANCH="origin/main"
 if ! git rev-parse --verify "$BASE_BRANCH" &>/dev/null; then
@@ -47,8 +48,11 @@ if [ -d "$WORKTREE_PATH" ]; then
 fi
 
 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-  echo "Branch $BRANCH_NAME exists, checking out..."
+  echo "Branch $BRANCH_NAME exists locally, checking out..."
   git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+  echo "Branch $BRANCH_NAME exists on remote, creating local tracking branch..."
+  git worktree add --track -b "$BRANCH_NAME" "$WORKTREE_PATH" "origin/$BRANCH_NAME"
 else
   echo "Creating new branch $BRANCH_NAME from $BASE_BRANCH..."
   git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$BASE_BRANCH"
@@ -61,3 +65,6 @@ echo "  Branch: $BRANCH_NAME"
 echo ""
 echo "To work in this worktree:"
 echo "  cd $WORKTREE_PATH"
+echo ""
+echo "To remove this worktree:"
+echo "  ./scripts/remove-worktree.sh $TICKET_ID"


### PR DESCRIPTION
## Summary

- Adds 3-way branch detection to `create-worktree.sh`: local branch, remote-only branch, or new from `origin/main`
- Fetches the specific branch name from remote before checking refs, so remote-only branches are discovered
- Adds removal instructions to the worktree creation output

## Changes

- **`scripts/create-worktree.sh`**: 
  - Fetch the target branch from remote (`git fetch origin "$BRANCH_NAME"`) before ref checks
  - Add `elif` for `refs/remotes/origin/$BRANCH_NAME` to create a local tracking branch via `git worktree add --track -b`
  - Print `remove-worktree.sh` usage in the post-creation output

## Test plan

- [x] Local branch exists: uses existing branch (unchanged behavior)
- [x] Remote-only branch: creates local tracking branch from remote ref
- [x] New branch: creates from `origin/main` (unchanged behavior)
- [x] Removal instructions printed after worktree creation

Closes #203