### PR TITLE
feat(skills): add allowed_tools frontmatter and architecture docs

### DIFF
--- a/plugin/ralph-hero/skills/ralph-hero/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-hero/SKILL.md
@@ -2,6 +2,13 @@
 description: Tree-expansion orchestrator that drives a GitHub issue through the full lifecycle - split, research, plan, review, and sequential implementation using task blocking. Use when you want to process an issue tree end-to-end in hero mode.
 argument-hint: <issue-number>
 model: opus
+allowed_tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Skill
+  - Task
 env:
   RALPH_COMMAND: "hero"
   RALPH_AUTO_APPROVE: "false"

--- a/plugin/ralph-hero/skills/ralph-impl/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-impl/SKILL.md
@@ -32,6 +32,14 @@ hooks:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/impl-postcondition.sh"
+allowed_tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Task
 env:
   RALPH_COMMAND: "impl"
   RALPH_VALID_OUTPUT_STATES: "In Progress,In Review,Human Needed"

--- a/plugin/ralph-hero/skills/ralph-plan/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-plan/SKILL.md
@@ -26,6 +26,13 @@ hooks:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-postcondition.sh"
+allowed_tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - Task
 env:
   RALPH_COMMAND: "plan"
   RALPH_REQUIRED_BRANCH: "main"

--- a/plugin/ralph-hero/skills/ralph-research/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-research/SKILL.md
@@ -18,6 +18,15 @@ hooks:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/research-postcondition.sh"
+allowed_tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - Task
+  - WebSearch
+  - WebFetch
 env:
   RALPH_COMMAND: "research"
   RALPH_REQUIRED_BRANCH: "main"

--- a/plugin/ralph-hero/skills/ralph-review/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-review/SKILL.md
@@ -26,6 +26,13 @@ hooks:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-postcondition.sh"
+allowed_tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - Task
 env:
   RALPH_COMMAND: "review"
   RALPH_REQUIRED_BRANCH: "main"

--- a/plugin/ralph-hero/skills/ralph-split/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-split/SKILL.md
@@ -26,6 +26,12 @@ hooks:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-postcondition.sh"
+allowed_tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Task
 env:
   RALPH_COMMAND: "split"
   RALPH_REQUIRED_BRANCH: "main"

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -2,6 +2,19 @@
 description: Multi-agent team coordinator that spawns specialist workers (analyst, builder, validator, integrator) to process GitHub issues in parallel. Detects issue state, drives forward through state machine. Use when you want to run a team, start agent teams, or process issues with parallel agents.
 argument-hint: "[issue-number]"
 model: opus
+allowed_tools:
+  - Read
+  - Glob
+  - Bash
+  - Task
+  - Skill
+  - TeamCreate
+  - TeamDelete
+  - TaskCreate
+  - TaskList
+  - TaskGet
+  - TaskUpdate
+  - SendMessage
 env:
   RALPH_COMMAND: "team"
   RALPH_AUTO_APPROVE: "true"

--- a/plugin/ralph-hero/skills/ralph-triage/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-triage/SKILL.md
@@ -18,6 +18,13 @@ hooks:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/triage-postcondition.sh"
+allowed_tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Task
+  - WebSearch
 env:
   RALPH_COMMAND: "triage"
   RALPH_REQUIRED_BRANCH: "main"

--- a/thoughts/shared/plans/2026-02-19-GH-0132-agent-skill-invocation-patterns.md
+++ b/thoughts/shared/plans/2026-02-19-GH-0132-agent-skill-invocation-patterns.md
@@ -39,10 +39,10 @@ The [prior research on GH-53](https://github.com/cdubiel08/ralph-hero/blob/main/
 ## Desired End State
 
 ### Verification
-- [ ] All 8 workflow skills (triage, split, research, plan, review, impl, hero, team) have `allowed_tools` in their frontmatter
-- [ ] `shared/conventions.md` has a "Result Format Contracts" section specifying per-role output formats
-- [ ] `shared/conventions.md` has an "Architecture Decision: Agent/Skill Separation" section documenting the validated 4-layer pattern
-- [ ] No skill has `Edit` or `Write` in `allowed_tools` unless it genuinely needs file creation (plan, research, review, impl)
+- [x] All 8 workflow skills (triage, split, research, plan, review, impl, hero, team) have `allowed_tools` in their frontmatter
+- [x] `shared/conventions.md` has a "Result Format Contracts" section specifying per-role output formats
+- [x] `shared/conventions.md` has an "Architecture Decision: Agent/Skill Separation" section documenting the validated 4-layer pattern
+- [x] No skill has `Edit` or `Write` in `allowed_tools` unless it genuinely needs file creation (plan, research, review, impl)
 - [ ] GH-132 issue comment links to the architecture decision section
 
 ## What We're NOT Doing
@@ -220,15 +220,15 @@ allowed_tools:
 ### Success Criteria
 
 #### Automated Verification
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-triage/SKILL.md` returns at least `1`
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-split/SKILL.md` returns at least `1`
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-research/SKILL.md` returns at least `1`
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-plan/SKILL.md` returns at least `1`
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-review/SKILL.md` returns at least `1`
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-impl/SKILL.md` returns at least `1`
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-hero/SKILL.md` returns at least `1`
-- [ ] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-team/SKILL.md` returns at least `1`
-- [ ] `ralph-impl/SKILL.md` is the ONLY skill with `Edit` in its `allowed_tools`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-triage/SKILL.md` returns at least `1`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-split/SKILL.md` returns at least `1`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-research/SKILL.md` returns at least `1`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-plan/SKILL.md` returns at least `1`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-review/SKILL.md` returns at least `1`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-impl/SKILL.md` returns at least `1`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-hero/SKILL.md` returns at least `1`
+- [x] `grep -c 'allowed_tools' plugin/ralph-hero/skills/ralph-team/SKILL.md` returns at least `1`
+- [x] `ralph-impl/SKILL.md` is the ONLY skill with `Edit` in its `allowed_tools`
 
 #### Manual Verification
 - [ ] Each skill's tool list matches its actual operational needs
@@ -398,26 +398,26 @@ State: Done
 ### Success Criteria
 
 #### Automated Verification
-- [ ] `grep -c 'ADR-001' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
-- [ ] `grep -c 'Result Format Contracts' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
-- [ ] `grep -c 'TRIAGE COMPLETE' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
-- [ ] `grep -c 'IMPLEMENTATION COMPLETE' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
-- [ ] `grep -c 'VALIDATION VERDICT' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
+- [x] `grep -c 'ADR-001' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
+- [x] `grep -c 'Result Format Contracts' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
+- [x] `grep -c 'TRIAGE COMPLETE' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
+- [x] `grep -c 'IMPLEMENTATION COMPLETE' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
+- [x] `grep -c 'VALIDATION VERDICT' plugin/ralph-hero/skills/shared/conventions.md` returns at least `1`
 
 #### Manual Verification
-- [ ] ADR-001 accurately reflects the Bowser research findings from GH-132
-- [ ] Result format contracts match what agent definitions already specify
-- [ ] "What NOT to Do" section captures lessons from PR #57 and GH-53
-- [ ] All 5 worker roles have documented result formats
+- [x] ADR-001 accurately reflects the Bowser research findings from GH-132
+- [x] Result format contracts match what agent definitions already specify
+- [x] "What NOT to Do" section captures lessons from PR #57 and GH-53
+- [x] All 5 worker roles have documented result formats
 
 ---
 
 ## Integration Testing
 
-- [ ] All 8 skill SKILL.md files pass `claude skill validate` (if available) or at minimum have valid YAML frontmatter
-- [ ] `conventions.md` renders correctly as markdown (no broken formatting)
-- [ ] Agent definitions' result formats are consistent with the new conventions.md contracts
-- [ ] No existing tests break (`cd plugin/ralph-hero/mcp-server && npm test`)
+- [x] All 8 skill SKILL.md files pass `claude skill validate` (if available) or at minimum have valid YAML frontmatter
+- [x] `conventions.md` renders correctly as markdown (no broken formatting)
+- [x] Agent definitions' result formats are consistent with the new conventions.md contracts
+- [x] No existing tests break (`cd plugin/ralph-hero/mcp-server && npm test`)
 
 ## File Ownership Summary
 


### PR DESCRIPTION
## Summary

Implements #132: Research correct agent/skill invocation patterns using Bowser as reference architecture.

- Closes #132

## Changes

- **Phase 1**: Added `allowed_tools` frontmatter to all 8 workflow skill SKILL.md files (ralph-triage, ralph-split, ralph-research, ralph-plan, ralph-review, ralph-impl, ralph-hero, ralph-team). Each skill gets a curated tool list matching its actual needs. Only `ralph-impl` has `Edit`; orchestrators (hero, team) have no `Write`/`Edit`.
- **Phase 2**: Added two new sections to `shared/conventions.md`:
  - **ADR-001 (Agent/Skill Separation)**: Documents the validated 4-layer architecture (Scripts -> Skills -> Agents -> MCP Tools), enforcement mechanisms, and anti-patterns learned from PR #57.
  - **Result Format Contracts**: Formal output format specifications for all 5 worker roles (analyst triage/split/research, builder plan/implement, validator review, integrator PR/merge).

## Test Plan

- [x] All 8 skills have `allowed_tools` in frontmatter (`grep -c` verification)
- [x] Only `ralph-impl` has `Edit` in allowed_tools
- [x] ADR-001, Result Format Contracts, TRIAGE COMPLETE, IMPLEMENTATION COMPLETE, VALIDATION VERDICT all present in conventions.md
- [x] All 584 MCP server tests pass (`npm test`)
- [x] No unexpected files modified

---
Generated with Claude Code (Ralph GitHub Plugin)