### PR TITLE
fix(orchestrator-skills): add tree-aware assessment before SPLIT phase

### DIFF
--- a/plugin/ralph-hero/skills/ralph-hero/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-hero/SKILL.md
@@ -101,7 +101,14 @@ Execute the phase indicated by `phase`. Do NOT interpret workflow states yoursel
 
 Split all M/L/XL issues until only XS/S leaves remain.
 
-For each M/L/XL issue, spawn a background split task:
+**Pre-check**: The `detect_pipeline_position` response's `issues` array includes `subIssueCount` for each issue. Only split issues where `subIssueCount === 0`. Issues that already have children have been split previously -- their children will be picked up by later phases (RESEARCH, PLAN, etc.) based on their own workflow state.
+
+If you need to inspect the existing tree before deciding, call:
+```
+ralph_hero__list_sub_issues(owner=$RALPH_GH_OWNER, repo=$RALPH_GH_REPO, number=NNN, depth=2)
+```
+
+For each M/L/XL issue **with `subIssueCount === 0`**, spawn a background split task:
 ```
 Task(subagent_type="general-purpose", run_in_background=true,
      prompt="Use Skill(skill='ralph-hero:ralph-split', args='NNN') to split issue #NNN.",

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -89,6 +89,8 @@ Call `ralph_hero__detect_pipeline_position(owner=$RALPH_GH_OWNER, repo=$RALPH_GH
 - `convergence`: Whether group is ready for next gate
 - `recommendation`: Suggested next action
 
+**Already-split detection**: The tool automatically accounts for existing sub-issues. Issues with `subIssueCount > 0` are excluded from SPLIT phase triggering. When the response includes `phase: "SPLIT"`, the `issues` array only lists issues that still need splitting (`subIssueCount === 0`).
+
 Use `phase` to determine tasks (Section 4.2) and first teammate (Section 4.3). Trust the tool's convergence assessment -- do not re-check manually.
 
 **TERMINAL**: PR exists or all issues done. The team NEVER moves issues to Done -- that requires PR merge.
@@ -127,6 +129,8 @@ Based on pipeline position (Section 3), create tasks with sequential blocking: R
 
 **Subject patterns** (workers match on these to self-claim):
 - `"Research GH-NNN"` / `"Plan GH-NNN"` / `"Review plan for GH-NNN"` / `"Implement GH-NNN"` / `"Create PR for GH-NNN"` / `"Merge PR for GH-NNN"`
+
+**SPLIT tasks**: Only create split tasks for issues without existing children (`subIssueCount === 0` in the `detect_pipeline_position` response). Issues that already have sub-issues are automatically excluded from the SPLIT phase by the detection tool, so they should not appear in the `issues` array. This is defense-in-depth -- verify before creating tasks.
 
 **Review task creation** depends on `RALPH_REVIEW_MODE`:
 - `interactive`: Create "Review plan for GH-NNN" task. Implement is blocked by Review.

--- a/thoughts/shared/plans/2026-02-21-GH-0248-orchestrator-skills-tree-aware-split.md
+++ b/thoughts/shared/plans/2026-02-21-GH-0248-orchestrator-skills-tree-aware-split.md
@@ -141,10 +141,10 @@ Wait for all splits, then re-call `detect_pipeline_position` to check if more sp
 ```
 
 ### Success Criteria
-- [ ] Manual: Read `plugin/ralph-hero/skills/ralph-hero/SKILL.md` and confirm the SPLIT phase section includes the pre-check instruction referencing `subIssueCount` and `list_sub_issues(depth=2)`
-- [ ] Manual: Read `plugin/ralph-hero/skills/ralph-team/SKILL.md` Section 3 and confirm it mentions automatic already-split detection
-- [ ] Manual: Read `plugin/ralph-hero/skills/ralph-team/SKILL.md` Section 4.2 and confirm it notes SPLIT task filtering by `subIssueCount`
-- [ ] Manual: Confirm `plugin/ralph-hero/skills/ralph-split/SKILL.md` is unchanged (Step 2.25 already handles existing children)
+- [x] Manual: Read `plugin/ralph-hero/skills/ralph-hero/SKILL.md` and confirm the SPLIT phase section includes the pre-check instruction referencing `subIssueCount` and `list_sub_issues(depth=2)`
+- [x] Manual: Read `plugin/ralph-hero/skills/ralph-team/SKILL.md` Section 3 and confirm it mentions automatic already-split detection
+- [x] Manual: Read `plugin/ralph-hero/skills/ralph-team/SKILL.md` Section 4.2 and confirm it notes SPLIT task filtering by `subIssueCount`
+- [x] Manual: Confirm `plugin/ralph-hero/skills/ralph-split/SKILL.md` is unchanged (Step 2.25 already handles existing children)
 
 ---
 


### PR DESCRIPTION
## Summary
Implements #248: Add tree-aware pre-check to SPLIT phase in orchestrator skill files.

- Closes #248

## Changes
- **ralph-hero SKILL.md**: Added pre-check block to SPLIT phase that inspects `subIssueCount` from `detect_pipeline_position` response. Only spawns split tasks for issues with `subIssueCount === 0`. References `list_sub_issues(depth=2)` for deeper tree inspection.
- **ralph-team SKILL.md Section 3**: Added note explaining that `detect_pipeline_position` automatically excludes already-split issues from SPLIT phase triggering.
- **ralph-team SKILL.md Section 4.2**: Added SPLIT task filtering note -- only create split tasks for issues without existing children (defense-in-depth).
- **ralph-split SKILL.md**: Unchanged (Step 2.25 already handles existing children correctly).

## Test Plan
- Prompt-only changes (no TypeScript code) -- no automated tests needed
- Verified all three SKILL.md files are consistent in referencing `subIssueCount`
- Verified pre-check does not conflict with existing SPLIT loop logic
- Confirmed ralph-split SKILL.md unchanged

## Epic
- Parent: #202

---
Generated with Claude Code (Ralph GitHub Plugin)