### PR TITLE
feat(cli): shell tab completion and CLI docs

### DIFF
--- a/plugin/ralph-hero/docs/cli.md
+++ b/plugin/ralph-hero/docs/cli.md
@@ -1,0 +1,157 @@
+# Ralph CLI Reference
+
+Ralph workflows are exposed as [`just`](https://github.com/casey/just) recipes in `plugin/ralph-hero/justfile`.
+
+## Prerequisites
+
+1. **just** -- install via one of:
+   ```bash
+   cargo install just          # Rust toolchain
+   brew install just           # macOS/Linuxbrew
+   sudo apt install just       # Debian/Ubuntu (24.04+)
+   ```
+
+2. **claude** -- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
+
+3. **timeout** -- included in GNU coreutils (pre-installed on most Linux)
+
+## Quick Start
+
+```bash
+cd plugin/ralph-hero
+
+# List all available recipes
+just
+
+# Triage a specific issue
+just triage 42
+
+# Run the full autonomous loop
+just loop
+
+# Launch multi-agent team on an issue
+just team 42
+```
+
+## Recipes
+
+### Individual Phase Recipes
+
+Each phase recipe accepts an optional issue number, budget, and timeout:
+
+```bash
+just <recipe> [issue] [budget=default] [timeout=default]
+```
+
+| Recipe | Default Budget | Default Timeout | Description |
+|--------|---------------|-----------------|-------------|
+| `triage` | $1.00 | 15m | Assess validity, close duplicates, route to research |
+| `split` | $1.00 | 15m | Split large issue into XS/S sub-issues |
+| `research` | $2.00 | 15m | Investigate codebase, create findings document |
+| `plan` | $3.00 | 15m | Create implementation plan from research |
+| `review` | $2.00 | 15m | Review and critique an implementation plan |
+| `impl` | $5.00 | 15m | Implement issue following approved plan |
+| `hygiene` | $0.50 | 10m | Project hygiene check (no issue number) |
+| `status` | $0.50 | 10m | Pipeline status dashboard (no issue number) |
+
+Examples:
+
+```bash
+# Triage issue #42
+just triage 42
+
+# Research with higher budget
+just research 42 budget=4.00
+
+# Implement with longer timeout
+just impl 42 timeout=30m
+```
+
+### Orchestrator Recipes
+
+| Recipe | Default Timeout | Description |
+|--------|-----------------|-------------|
+| `team` | 30m | Multi-agent team coordinator |
+| `hero` | 30m | Tree-expansion orchestrator |
+| `loop` | 60m | Sequential autonomous loop |
+
+The `loop` recipe accepts additional parameters:
+
+```bash
+just loop mode=all review=skip split=auto hygiene=auto timeout=60m
+```
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `mode` | `all`, `triage`, `split`, `research`, `plan`, `review`, `impl`, `hygiene`, `analyst`, `builder`, `validator`, `integrator` | `all` | Run specific phase only |
+| `review` | `skip`, `auto`, `interactive` | `skip` | Review mode |
+| `split` | `auto`, `skip` | `auto` | Split mode |
+| `hygiene` | `auto`, `skip` | `auto` | Hygiene mode |
+
+### Utility Recipes
+
+| Recipe | Default Budget | Default Timeout | Description |
+|--------|---------------|-----------------|-------------|
+| `setup` | $1.00 | 10m | One-time GitHub Project V2 setup |
+| `report` | $1.00 | 10m | Generate project status report |
+| `completions` | -- | -- | Generate shell tab completions |
+
+## Tab Completion
+
+Generate and install tab completions for your shell:
+
+### Bash
+
+```bash
+# Add to ~/.bashrc:
+eval "$(just --completions bash)"
+```
+
+### Zsh
+
+```bash
+# Add to ~/.zshrc:
+eval "$(just --completions zsh)"
+```
+
+### Fish
+
+```bash
+# Add to ~/.config/fish/config.fish:
+just --completions fish | source
+```
+
+Or generate completions on demand:
+
+```bash
+just completions bash    # Output bash completions
+just completions zsh     # Output zsh completions
+just completions fish    # Output fish completions
+```
+
+## Overriding from Project Root
+
+If invoking from the repository root instead of `plugin/ralph-hero/`:
+
+```bash
+just --justfile plugin/ralph-hero/justfile triage 42
+```
+
+Or set an alias:
+
+```bash
+alias ralph='just --justfile plugin/ralph-hero/justfile'
+ralph triage 42
+```
+
+## Environment Variables
+
+Recipes inherit environment variables from `.env` (via `set dotenv-load` in the justfile) and from the shell. Required variables:
+
+| Variable | Description |
+|----------|-------------|
+| `RALPH_HERO_GITHUB_TOKEN` | GitHub PAT with `repo` + `project` scopes |
+| `RALPH_GH_OWNER` | GitHub owner (user or org) |
+| `RALPH_GH_PROJECT_NUMBER` | GitHub Projects V2 number |
+
+See the main [CLAUDE.md](../../../CLAUDE.md) for full configuration details.

--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -74,6 +74,12 @@ setup budget="1.00" timeout="10m":
 report issue="" budget="1.00" timeout="10m":
     @just _run_skill "report" "{{issue}}" "{{budget}}" "{{timeout}}"
 
+# --- Completion & Documentation ---
+
+# Generate shell tab completions (bash, zsh, fish, powershell, elvish)
+completions shell="bash":
+    @just --completions {{shell}}
+
 # --- Internal Helpers ---
 
 _run_skill skill issue budget timeout:


### PR DESCRIPTION
## Summary

- Closes #253

Adds shell tab completion recipe and comprehensive CLI documentation for the Ralph justfile.

## Changes

- **`plugin/ralph-hero/justfile`**: Added `completions` recipe wrapping `just --completions <shell>` (bash, zsh, fish, powershell, elvish)
- **`plugin/ralph-hero/docs/cli.md`** (NEW): Full CLI reference covering:
  - Prerequisites and installation
  - Quick start examples
  - All recipe parameters with defaults
  - Tab completion setup for bash, zsh, fish
  - Invoking from project root with `--justfile` or alias
  - Environment variable reference

## Test Plan

- [x] `npm run build` passes (no TypeScript changes)
- [x] `npm test` passes (627 tests, no regressions)
- [ ] `just completions bash` outputs valid bash completion script (requires `just`)
- [ ] Tab completion works after `eval "$(just --completions bash)"`

---
Generated with Claude Code (Ralph GitHub Plugin)