### PR TITLE
docs: add multi-project configuration to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,20 @@ Set these in `.claude/settings.local.json` (recommended, gitignored):
 }
 ```
 
+For multi-project setups (cross-project dashboard, multiple boards):
+
+```json
+{
+  "env": {
+    "RALPH_HERO_GITHUB_TOKEN": "ghp_xxx",
+    "RALPH_GH_OWNER": "cdubiel08",
+    "RALPH_GH_REPO": "ralph-hero",
+    "RALPH_GH_PROJECT_NUMBER": "3",
+    "RALPH_GH_PROJECT_NUMBERS": "3,5,7"
+  }
+}
+```
+
 **Do NOT put tokens in `.mcp.json`** — the `env` block can overwrite inherited values with unexpanded `${VAR}` literals, preventing the MCP server from starting. Only non-sensitive defaults with fallbacks belong in `.mcp.json` (e.g., `${RALPH_GH_OWNER:-cdubiel08}`).
 
 | Variable | Required | Where to set | Description |
@@ -87,11 +101,21 @@ Set these in `.claude/settings.local.json` (recommended, gitignored):
 | `RALPH_GH_OWNER` | Yes | `settings.local.json` or `.mcp.json` default | GitHub owner (user or org) |
 | `RALPH_GH_REPO` | No† | `settings.local.json` or `.mcp.json` default | Repository name (inferred from project if omitted) |
 | `RALPH_GH_PROJECT_NUMBER` | Yes | `settings.local.json` or `.mcp.json` default | GitHub Projects V2 number |
+| `RALPH_GH_PROJECT_NUMBERS` | No | `settings.local.json` | Comma-separated project numbers for cross-project dashboard (e.g., `"3,5,7"`) |
 | `RALPH_GH_REPO_TOKEN` | No | `settings.local.json` | Separate repo token (falls back to `RALPH_HERO_GITHUB_TOKEN`) |
 | `RALPH_GH_PROJECT_TOKEN` | No | `settings.local.json` | Separate project token (falls back to repo token) |
 | `RALPH_GH_PROJECT_OWNER` | No | `settings.local.json` | Project owner if different from repo owner |
 
 †`RALPH_GH_REPO` is inferred from the repositories linked to the project via `link_repository`. Only set it explicitly as a tiebreaker when multiple repos are linked. Bootstrap: `setup_project` → `link_repository` → repo is inferred. See #23.
+
+### Multi-Project Configuration
+
+Ralph supports managing multiple GitHub Projects V2 boards from a single instance:
+
+- **`RALPH_GH_PROJECT_NUMBER`** remains the default/primary project for all tools
+- **`RALPH_GH_PROJECT_NUMBERS`** (comma-separated) enables cross-project aggregation -- the `pipeline_dashboard` tool auto-aggregates across all listed projects
+- **Per-call override**: All project-aware tools accept an optional `projectNumber` parameter to target a specific project, regardless of defaults
+- Single-project mode (no `RALPH_GH_PROJECT_NUMBERS`) continues to work unchanged
 
 ### Key Implementation Details
 

--- a/thoughts/shared/plans/2026-02-21-GH-0152-multi-project-docs.md
+++ b/thoughts/shared/plans/2026-02-21-GH-0152-multi-project-docs.md
@@ -27,10 +27,10 @@ Single issue implementation: GH-152 -- Add multi-project configuration documenta
 ## Desired End State
 
 ### Verification
-- [ ] `RALPH_GH_PROJECT_NUMBERS` row added to env var table
-- [ ] Multi-project example block added after existing single-project example
-- [ ] "Multi-Project Configuration" subsection added after env var table
-- [ ] No code changes -- docs only
+- [x] `RALPH_GH_PROJECT_NUMBERS` row added to env var table
+- [x] Multi-project example block added after existing single-project example
+- [x] "Multi-Project Configuration" subsection added after env var table
+- [x] No code changes -- docs only
 
 ## What We're NOT Doing
 
@@ -105,13 +105,13 @@ Ralph supports managing multiple GitHub Projects V2 boards from a single instanc
 ### Success Criteria
 
 #### Automated Verification
-- [ ] No build/test impact (docs-only change)
+- [x] No build/test impact (docs-only change)
 
 #### Manual Verification
-- [ ] `RALPH_GH_PROJECT_NUMBERS` appears in env var table with correct description
-- [ ] Multi-project example block shows all 5 env vars including `RALPH_GH_PROJECT_NUMBERS`
-- [ ] Subsection explains single vs multi-project modes and per-call override
-- [ ] Existing documentation is unchanged (no regressions)
+- [x] `RALPH_GH_PROJECT_NUMBERS` appears in env var table with correct description
+- [x] Multi-project example block shows all 5 env vars including `RALPH_GH_PROJECT_NUMBERS`
+- [x] Subsection explains single vs multi-project modes and per-call override
+- [x] Existing documentation is unchanged (no regressions)
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes #152

Adds multi-project configuration documentation to CLAUDE.md for cross-project dashboard support.

## Changes

- **`CLAUDE.md`**:
  - Added multi-project example block showing `RALPH_GH_PROJECT_NUMBERS` env var
  - Added `RALPH_GH_PROJECT_NUMBERS` row to environment variable table
  - Added "Multi-Project Configuration" subsection explaining single vs multi-project modes and per-call override

- **Plan doc**: Marked all verification checkboxes complete

## Test Plan

- [x] Docs-only change — no build/test impact
- [x] `RALPH_GH_PROJECT_NUMBERS` documented in env var table
- [x] Multi-project example and subsection present

---
Generated with Claude Code (Ralph GitHub Plugin)