### PR TITLE
feat(cli): add doctor recipe for setup diagnostics

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -74,6 +74,89 @@ setup budget="1.00" timeout="10m":
 report issue="" budget="1.00" timeout="10m":
     @just _run_skill "report" "{{issue}}" "{{budget}}" "{{timeout}}"
 
+# Diagnose setup issues - checks env, deps, plugin manifest, and API connectivity
+doctor:
+    #!/usr/bin/env bash
+    set -eu
+    errors=0; warnings=0
+    echo "=== Ralph Doctor ==="
+    echo ""
+    echo "--- Environment Variables ---"
+    for var in RALPH_HERO_GITHUB_TOKEN RALPH_GH_OWNER RALPH_GH_PROJECT_NUMBER; do
+        if [ -z "${!var:-}" ]; then
+            echo "FAIL: $var is not set"
+            errors=$((errors + 1))
+        else
+            if [ "$var" = "RALPH_HERO_GITHUB_TOKEN" ]; then
+                echo "  OK: $var (set, redacted)"
+            else
+                echo "  OK: $var = ${!var}"
+            fi
+        fi
+    done
+    echo ""
+    echo "--- Dependencies ---"
+    for cmd in just npx node; do
+        if command -v "$cmd" &>/dev/null; then
+            echo "  OK: $cmd ($(command -v "$cmd"))"
+        else
+            echo "FAIL: $cmd not found"
+            errors=$((errors + 1))
+        fi
+    done
+    if command -v mcp &>/dev/null; then
+        echo "  OK: mcp (mcptools)"
+    else
+        echo "WARN: mcp (mcptools) not installed -- quick-* recipes unavailable"
+        echo "      Install: brew tap f/mcptools && brew install mcp"
+        warnings=$((warnings + 1))
+    fi
+    if command -v claude &>/dev/null; then
+        echo "  OK: claude CLI"
+    else
+        echo "WARN: claude CLI not found -- LLM-powered recipes unavailable"
+        warnings=$((warnings + 1))
+    fi
+    echo ""
+    echo "--- Plugin Files ---"
+    if [ -f .claude-plugin/plugin.json ]; then
+        if node -e "JSON.parse(require('fs').readFileSync('.claude-plugin/plugin.json','utf8'))" 2>/dev/null; then
+            echo "  OK: .claude-plugin/plugin.json (valid JSON)"
+        else
+            echo "FAIL: .claude-plugin/plugin.json (invalid JSON)"
+            errors=$((errors + 1))
+        fi
+    else
+        echo "FAIL: .claude-plugin/plugin.json not found"
+        errors=$((errors + 1))
+    fi
+    if [ -f .mcp.json ]; then
+        if node -e "JSON.parse(require('fs').readFileSync('.mcp.json','utf8'))" 2>/dev/null; then
+            echo "  OK: .mcp.json (valid JSON)"
+        else
+            echo "FAIL: .mcp.json (invalid JSON)"
+            errors=$((errors + 1))
+        fi
+    else
+        echo "FAIL: .mcp.json not found"
+        errors=$((errors + 1))
+    fi
+    echo ""
+    if command -v mcp &>/dev/null && [ -n "${RALPH_HERO_GITHUB_TOKEN:-}" ]; then
+        echo "--- API Health Check ---"
+        just _mcp_call "ralph_hero__health_check" '{}' || {
+            echo "FAIL: API health check failed"
+            errors=$((errors + 1))
+        }
+        echo ""
+    else
+        echo "--- API Health Check ---"
+        echo "SKIP: mcptools or RALPH_HERO_GITHUB_TOKEN not available"
+        echo ""
+    fi
+    echo "=== Summary: $errors error(s), $warnings warning(s) ==="
+    if [ "$errors" -gt 0 ]; then exit 1; fi
+
 # --- Quick Actions (no LLM, requires mcptools) ---
 
 # Pipeline status dashboard - instant, no API cost

--- a/thoughts/shared/plans/2026-02-21-GH-0073-ralph-doctor-cli-command.md
+++ b/thoughts/shared/plans/2026-02-21-GH-0073-ralph-doctor-cli-command.md
@@ -23,14 +23,14 @@ The justfile (`plugin/ralph-hero/justfile`, 139 lines) has LLM-powered recipes v
 ## Desired End State
 
 ### Verification
-- [ ] `doctor` recipe exists in justfile with two-phase check structure
-- [ ] Phase 1 checks env vars (RALPH_HERO_GITHUB_TOKEN, RALPH_GH_OWNER, RALPH_GH_PROJECT_NUMBER)
-- [ ] Phase 1 checks dependencies (just, npx, node required; mcp optional)
-- [ ] Phase 1 checks plugin manifest (`.claude-plugin/plugin.json` exists, valid JSON)
-- [ ] Phase 1 checks MCP config (`.mcp.json` exists, valid JSON)
-- [ ] Phase 2 runs `health_check` via `_mcp_call` when mcptools and token are available
-- [ ] Summary line shows error/warning counts
-- [ ] Exit code 1 if any errors found, 0 otherwise
+- [x] `doctor` recipe exists in justfile with two-phase check structure
+- [x] Phase 1 checks env vars (RALPH_HERO_GITHUB_TOKEN, RALPH_GH_OWNER, RALPH_GH_PROJECT_NUMBER)
+- [x] Phase 1 checks dependencies (just, npx, node required; mcp optional)
+- [x] Phase 1 checks plugin manifest (`.claude-plugin/plugin.json` exists, valid JSON)
+- [x] Phase 1 checks MCP config (`.mcp.json` exists, valid JSON)
+- [x] Phase 2 runs `health_check` via `_mcp_call` when mcptools and token are available
+- [x] Summary line shows error/warning counts
+- [x] Exit code 1 if any errors found, 0 otherwise
 
 ## What We're NOT Doing
 - Subcommand targeting (`doctor env`, `doctor api`) -- single command runs all checks
@@ -158,9 +158,9 @@ doctor:
 | `plugin/ralph-hero/justfile` | Add `doctor` recipe (~55 lines) in Utility Recipes section |
 
 ### Success Criteria
-- [ ] Automated: `grep -c "^doctor" plugin/ralph-hero/justfile` returns 1
-- [ ] Automated: `grep "RALPH_HERO_GITHUB_TOKEN\|RALPH_GH_OWNER\|RALPH_GH_PROJECT_NUMBER" plugin/ralph-hero/justfile | grep -c "var"` returns at least 1 (env var checks)
-- [ ] Automated: `grep "health_check" plugin/ralph-hero/justfile | wc -l` returns at least 1 (API check reference)
+- [x] Automated: `grep -c "^doctor" plugin/ralph-hero/justfile` returns 1
+- [x] Automated: `grep "RALPH_HERO_GITHUB_TOKEN\|RALPH_GH_OWNER\|RALPH_GH_PROJECT_NUMBER" plugin/ralph-hero/justfile | grep -c "var"` returns at least 1 (env var checks)
+- [x] Automated: `grep "health_check" plugin/ralph-hero/justfile | wc -l` returns at least 1 (API check reference)
 - [ ] Manual: `just doctor` runs and shows OK/FAIL/WARN status for each check category
 - [ ] Manual: `just doctor` exits 0 when all required checks pass
 - [ ] Manual: `just doctor` exits 1 when a required env var is missing


### PR DESCRIPTION
## Summary

Implements #73: adds a `doctor` justfile recipe that diagnoses setup issues by running local checks and optionally invoking the `health_check` MCP tool via mcptools for API validation.

- Closes #73

## Changes

- Added `doctor` recipe (~80 lines) in the Utility Recipes section of `plugin/ralph-hero/justfile`
- **Phase 1 (local checks, always run):**
  - Environment variables: `RALPH_HERO_GITHUB_TOKEN`, `RALPH_GH_OWNER`, `RALPH_GH_PROJECT_NUMBER`
  - Dependencies: `just`, `npx`, `node` (required, FAIL); `mcp`, `claude` (optional, WARN)
  - Plugin files: `.claude-plugin/plugin.json` and `.mcp.json` (existence + valid JSON)
- **Phase 2 (API checks, when mcptools + token available):**
  - Runs `health_check` via existing `_mcp_call` helper
  - Gracefully skips with SKIP message when prerequisites missing
- Output uses `OK`/`FAIL`/`WARN`/`SKIP` prefixes, summary line with error/warning counts
- Exit code 1 if any errors found, 0 otherwise
- Token value redacted in output to prevent accidental exposure

## Test Plan

- [ ] `grep -c "^doctor" plugin/ralph-hero/justfile` returns 1
- [ ] `just doctor` runs and shows OK/FAIL/WARN status for each check category
- [ ] `just doctor` exits 0 when all required checks pass
- [ ] `just doctor` exits 1 when a required env var is missing
- [ ] `just doctor` shows WARN (not FAIL) for missing mcptools
- [ ] `just doctor` skips API checks gracefully when mcptools is not installed
- [ ] `just --list` shows the `doctor` recipe with its description

## Epic

- Parent: #59

---
Generated with Claude Code (Ralph GitHub Plugin)