### PR TITLE
feat(team): implement bough model for current-phase-only task creation

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/team-task-completed.sh
+++ b/plugin/ralph-hero/hooks/scripts/team-task-completed.sh
@@ -2,8 +2,8 @@
 # ralph-hero/hooks/scripts/team-task-completed.sh
 # TaskCompleted: Guide team lead after a teammate completes a task
 #
-# Peer-to-peer handoffs handle routine pipeline progression.
-# Lead only needs to act on exceptions (review rejections) or
+# Bough advancement: lead checks convergence and creates next-phase tasks.
+# Lead also acts on exceptions (review rejections) and
 # pipeline drain (intake of new GitHub issues).
 #
 # Exit codes:
@@ -28,7 +28,9 @@ EOF
 else
   cat >&2 <<EOF
 Task completed by $TEAMMATE: "$TASK_SUBJECT"
-Peer handoff handles routine pipeline progression.
+ACTION: Check pipeline convergence via detect_pipeline_position.
+If phase converged: create next-bough tasks (Section 4.2) and assign to idle workers.
+If not converged: wait for remaining tasks to complete. No lead action needed.
 CHECK: Are there idle workers with no unblocked tasks? If so, pull new GitHub issues.
 EOF
 fi

--- a/thoughts/shared/plans/2026-02-21-GH-0257-bough-model-skill-md.md
+++ b/thoughts/shared/plans/2026-02-21-GH-0257-bough-model-skill-md.md
@@ -26,13 +26,13 @@ Section 4.4 (lines 156-167) delegates routine progression to peer-to-peer handof
 
 ## Desired End State
 ### Verification
-- [ ] Section 4.2 creates tasks ONLY for the current pipeline phase (bough)
-- [ ] Section 4.4 includes convergence-driven bough advancement as a dispatch responsibility
-- [ ] Section 5 allows mid-pipeline assignment for bough advancement
-- [ ] `team-task-completed.sh` guides the lead to check pipeline convergence
-- [ ] Section 3.1 (XS fast-track) remains coherent with the bough model
-- [ ] Build succeeds: `cd plugin/ralph-hero/mcp-server && npm run build`
-- [ ] Tests pass: `cd plugin/ralph-hero/mcp-server && npm test`
+- [x] Section 4.2 creates tasks ONLY for the current pipeline phase (bough)
+- [x] Section 4.4 includes convergence-driven bough advancement as a dispatch responsibility
+- [x] Section 5 allows mid-pipeline assignment for bough advancement
+- [x] `team-task-completed.sh` guides the lead to check pipeline convergence
+- [x] Section 3.1 (XS fast-track) remains coherent with the bough model
+- [x] Build succeeds: `cd plugin/ralph-hero/mcp-server && npm run build`
+- [x] Tests pass: `cd plugin/ralph-hero/mcp-server && npm test`
 
 ## What We're NOT Doing
 - Modifying `conventions.md` (that is GH-258 scope)
@@ -116,12 +116,12 @@ EOF
 ```
 
 ### Success Criteria
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm run build && npm test` passes
-- [ ] Manual: Section 4.2 describes current-phase-only task creation (no sequential blocking of future phases)
-- [ ] Manual: Section 4.4 lists bough advancement as primary dispatch responsibility
-- [ ] Manual: Section 5 no longer prohibits mid-pipeline assignment
-- [ ] Manual: `team-task-completed.sh` guides lead to check `detect_pipeline_position` convergence
-- [ ] Manual: Section 3.1 (XS fast-track) still coherently creates Implement + PR + Merge as a single bough exception
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm run build && npm test` passes
+- [x] Manual: Section 4.2 describes current-phase-only task creation (no sequential blocking of future phases)
+- [x] Manual: Section 4.4 lists bough advancement as primary dispatch responsibility
+- [x] Manual: Section 5 no longer prohibits mid-pipeline assignment
+- [x] Manual: `team-task-completed.sh` guides lead to check `detect_pipeline_position` convergence
+- [x] Manual: Section 3.1 (XS fast-track) still coherently creates Implement + PR + Merge as a single bough exception
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes #257

Replaces the upfront sequential task chain with a bough model where the team lead creates tasks only for the current pipeline phase, then advances to the next phase when convergence is detected.

## Changes

- **`skills/ralph-team/SKILL.md`**:
  - Section 4.2: Renamed to "Create Tasks for Current Phase Only (Bough Model)" — tasks created per-phase, not as a full sequential chain
  - Section 4.4: Bough advancement added as primary dispatch responsibility — lead checks `detect_pipeline_position` convergence after task completion
  - Section 5: Updated to allow mid-pipeline assignment for bough advancement
  - XS fast-track exception preserved (Implement + PR + Merge as single bough)

- **`hooks/scripts/team-task-completed.sh`**:
  - Updated guidance to direct lead to check pipeline convergence via `detect_pipeline_position`
  - Replaced peer-to-peer handoff guidance with bough advancement instructions

## Test Plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Section 4.2 describes current-phase-only task creation
- [x] Section 4.4 lists bough advancement as primary dispatch responsibility
- [x] XS fast-track coherent with bough model

---
Generated with Claude Code (Ralph GitHub Plugin)