### PR TITLE
fix(team): clean up conflicting handoff rules and peer-wake messaging

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/team-teammate-idle.sh
+++ b/plugin/ralph-hero/hooks/scripts/team-teammate-idle.sh
@@ -3,9 +3,9 @@
 # TeammateIdle: Guide team lead when a teammate goes idle
 #
 # Workers go idle when no tasks match their role. This is normal
-# if upstream stages haven't completed yet. Peers will wake this
-# teammate when work unblocks. Only act if the pipeline has drained
-# and new GitHub issues need pulling.
+# if upstream stages haven't completed yet. The Stop hook will
+# block shutdown if matching tasks exist in TaskList. Only act if
+# the pipeline has drained and new GitHub issues need pulling.
 #
 # Exit codes:
 #   0 - Always (guidance only, never blocks)
@@ -20,7 +20,7 @@ TEAMMATE=$(echo "$INPUT" | jq -r '.teammate_name // "unknown"')
 cat >&2 <<EOF
 $TEAMMATE is idle.
 This is NORMAL if upstream pipeline stages haven't completed yet.
-Peers will wake this teammate when work unblocks.
+Stop hook will block shutdown if matching tasks appear in TaskList.
 ACTION: Only intervene if TaskList shows NO pending/in-progress tasks at all.
 If pipeline is drained: use pick_actionable_issue to find new GitHub work.
 EOF


### PR DESCRIPTION
## Summary

- Closes #258

Removes conflicting peer-to-peer handoff rules from conventions.md, aligning with the bough model introduced in GH-257. Replaces peer-wake messaging with lead-driven bough advancement and Stop hook work discovery.

## Changes

- **`skills/shared/conventions.md`**:
  - Pipeline Handoff Protocol: replaced peer-to-peer SendMessage instructions with lead-driven bough advancement
  - Simplified handoff procedure: workers check TaskList, then notify lead if idle
  - Updated assignment rules: lead assigns at spawn and bough advancement
  - Updated team agents note: references typed subagents

- **`hooks/scripts/team-teammate-idle.sh`**:
  - Replaced "peers will wake this teammate" with Stop hook guidance
  - Consistent with bough model where lead creates next-phase tasks

## Test Plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] No peer-to-peer SendMessage handoff instructions remain in conventions.md
- [x] Handoff procedure simplified to 3 steps (was 4 with sub-steps)

---
Generated with Claude Code (Ralph GitHub Plugin)