### PR TITLE
fix(skill): expose CLAUDE_PLUGIN_ROOT as shell env var in ralph-team

### DIFF
--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -19,6 +19,7 @@ env:
   RALPH_COMMAND: "team"
   RALPH_AUTO_APPROVE: "true"
   CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
+  CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}"
 hooks:
   TaskCompleted:
     - hooks:


### PR DESCRIPTION
## Summary

- `CLAUDE_PLUGIN_ROOT` is expanded by the plugin framework in YAML frontmatter (hooks work), but is **not** automatically injected as a shell environment variable
- The ralph-team skill runs `Bash("echo $CLAUDE_PLUGIN_ROOT")` to resolve the spawn template path, which returns empty — breaking teammate spawning
- Adding `CLAUDE_PLUGIN_ROOT: "${CLAUDE_PLUGIN_ROOT}"` to the skill's `env:` block causes the framework to expand and explicitly set it as a shell env var

## Test plan

- [ ] Run `/ralph-team <issue-number>` and verify `echo $CLAUDE_PLUGIN_ROOT` resolves to the plugin root path
- [ ] Verify spawn template is read successfully and teammates are spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)