### PR TITLE
fix(cli): resolve latest plugin version at runtime

### DIFF
--- a/plugin/ralph-hero/docs/cli.md
+++ b/plugin/ralph-hero/docs/cli.md
@@ -59,10 +59,7 @@ just uninstall-cli
 
 ### How It Works
 
-The installer:
-1. Symlinks the justfile to `~/.config/ralph-hero/justfile`
-2. Copies a wrapper script to `~/.local/bin/ralph`
-3. The wrapper delegates to `just --justfile` so all recipes work normally
+The installer copies a wrapper script to `~/.local/bin/ralph`. At runtime, the wrapper automatically resolves the latest installed plugin version from `~/.claude/plugins/cache/ralph-hero/ralph-hero/`. Plugin updates are picked up immediately — no need to re-run `install-cli`.
 
 Override the justfile location with `RALPH_JUSTFILE`:
 
@@ -204,6 +201,6 @@ Recipes inherit environment variables from `.env` (via `set dotenv-load` in the 
 | `RALPH_HERO_GITHUB_TOKEN` | GitHub PAT with `repo` + `project` scopes |
 | `RALPH_GH_OWNER` | GitHub owner (user or org) |
 | `RALPH_GH_PROJECT_NUMBER` | GitHub Projects V2 number |
-| `RALPH_JUSTFILE` | Override justfile path for global `ralph` command (default: `~/.config/ralph-hero/justfile`) |
+| `RALPH_JUSTFILE` | Override justfile path for global `ralph` command (default: auto-resolved from plugin cache) |
 
 See the main [CLAUDE.md](../../../CLAUDE.md) for full configuration details.

--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -162,14 +162,13 @@ install-cli:
     #!/usr/bin/env bash
     set -eu
     PLUGIN_DIR="{{justfile_directory()}}"
-    CONFIG_DIR="$HOME/.config/ralph-hero"
     BIN_DIR="$HOME/.local/bin"
-    mkdir -p "$CONFIG_DIR" "$BIN_DIR"
-    ln -sf "$PLUGIN_DIR/justfile" "$CONFIG_DIR/justfile"
+    mkdir -p "$BIN_DIR"
     cp "$PLUGIN_DIR/scripts/ralph-cli.sh" "$BIN_DIR/ralph"
     chmod +x "$BIN_DIR/ralph"
     echo "Installed: $BIN_DIR/ralph"
-    echo "  Justfile: $CONFIG_DIR/justfile -> $PLUGIN_DIR/justfile"
+    echo "  Resolves latest plugin version at runtime from:"
+    echo "  ~/.claude/plugins/cache/ralph-hero/ralph-hero/"
     if ! echo "$PATH" | tr ':' '\n' | grep -qx "$BIN_DIR"; then
         echo ""
         echo "WARNING: $BIN_DIR is not in your PATH."
@@ -183,31 +182,26 @@ install-cli:
     echo "  ralph team 42"
     echo "For tab completions: just install-completions bash  (or zsh)"
 
-# Remove global 'ralph' command and config
+# Remove global 'ralph' command
 uninstall-cli:
     #!/usr/bin/env bash
     set -eu
-    CONFIG_DIR="$HOME/.config/ralph-hero"
     BIN_DIR="$HOME/.local/bin"
-    removed=0
     if [ -f "$BIN_DIR/ralph" ]; then
         rm "$BIN_DIR/ralph"
         echo "Removed: $BIN_DIR/ralph"
-        removed=1
-    fi
-    if [ -L "$CONFIG_DIR/justfile" ]; then
-        rm "$CONFIG_DIR/justfile"
-        echo "Removed: $CONFIG_DIR/justfile"
-        removed=1
-    fi
-    if [ -d "$CONFIG_DIR" ] && [ -z "$(ls -A "$CONFIG_DIR")" ]; then
-        rmdir "$CONFIG_DIR"
-        echo "Removed: $CONFIG_DIR/"
-    fi
-    if [ "$removed" -eq 0 ]; then
-        echo "Nothing to uninstall -- ralph CLI was not installed."
-    else
+        # Clean up legacy symlink if present
+        CONFIG_DIR="$HOME/.config/ralph-hero"
+        if [ -L "$CONFIG_DIR/justfile" ]; then
+            rm "$CONFIG_DIR/justfile"
+            echo "Removed legacy symlink: $CONFIG_DIR/justfile"
+        fi
+        if [ -d "$CONFIG_DIR" ] && [ -z "$(ls -A "$CONFIG_DIR")" ]; then
+            rmdir "$CONFIG_DIR"
+        fi
         echo "Ralph CLI uninstalled."
+    else
+        echo "Nothing to uninstall -- ralph CLI was not installed."
     fi
 
 # Install shell completions for the global 'ralph' command

--- a/plugin/ralph-hero/scripts/ralph-cli.sh
+++ b/plugin/ralph-hero/scripts/ralph-cli.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 # ralph -- global CLI for Ralph Hero workflows
-# Delegates to just --justfile, resolving the justfile via symlink or env var.
+# Resolves the latest installed plugin version at runtime.
 set -euo pipefail
 
-RALPH_JUSTFILE="${RALPH_JUSTFILE:-$HOME/.config/ralph-hero/justfile}"
+RALPH_JUSTFILE="${RALPH_JUSTFILE:-}"
 
-if [ ! -f "$RALPH_JUSTFILE" ]; then
-    echo "Error: Ralph justfile not found at $RALPH_JUSTFILE"
-    echo "Run 'just install-cli' from the ralph-hero plugin directory to set up."
+if [ -z "$RALPH_JUSTFILE" ]; then
+    CACHE_DIR="$HOME/.claude/plugins/cache/ralph-hero/ralph-hero"
+    if [ -d "$CACHE_DIR" ]; then
+        LATEST=$(ls -v "$CACHE_DIR" | tail -1)
+        RALPH_JUSTFILE="$CACHE_DIR/$LATEST/justfile"
+    fi
+fi
+
+if [ -z "$RALPH_JUSTFILE" ] || [ ! -f "$RALPH_JUSTFILE" ]; then
+    echo "Error: Ralph justfile not found."
+    echo "Install: claude plugin install https://github.com/cdubiel08/ralph-hero"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Replaces static symlink in `install-cli` with dynamic version resolution at runtime
- `ralph-cli.sh` now auto-discovers the latest installed plugin from `~/.claude/plugins/cache/`
- No need to re-run `install-cli` after plugin updates

## Changes
- **`scripts/ralph-cli.sh`**: Scan cache directory for latest version instead of hardcoded `~/.config/ralph-hero/justfile` default
- **`justfile` `install-cli`**: Remove symlink creation, just copy the wrapper script
- **`justfile` `uninstall-cli`**: Simplified cleanup (legacy symlink removal kept for backwards compat)
- **`docs/cli.md`**: Updated "How It Works" and env var description

Closes #288

## Test plan
- [ ] `just install-cli` copies wrapper to `~/.local/bin/ralph` without creating symlink
- [ ] `ralph triage 42` resolves to latest plugin cache version
- [ ] `RALPH_JUSTFILE=/custom/path ralph status` still overrides
- [ ] `just uninstall-cli` removes `~/.local/bin/ralph`

🤖 Generated with [Claude Code](https://claude.com/claude-code)