### PR TITLE
fix: only pin .mcp.json and justfile when MCP source changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
           jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN_JSON" > tmp.json && mv tmp.json "$PLUGIN_JSON"
 
       - name: Pin version in justfile and .mcp.json
+        if: steps.classify.outputs.mcp_changed == 'true'
         working-directory: .
         env:
           NEW_VERSION: ${{ steps.version.outputs.new }}
@@ -130,14 +131,17 @@ jobs:
         working-directory: .
         env:
           NEW_VERSION: ${{ steps.version.outputs.new }}
+          MCP_CHANGED: ${{ steps.classify.outputs.mcp_changed }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add plugin/ralph-hero/mcp-server/package.json
           git add plugin/ralph-hero/mcp-server/package-lock.json
           git add plugin/ralph-hero/.claude-plugin/plugin.json
-          git add plugin/ralph-hero/justfile
-          git add plugin/ralph-hero/.mcp.json
+          if [ "$MCP_CHANGED" = "true" ]; then
+            git add plugin/ralph-hero/justfile
+            git add plugin/ralph-hero/.mcp.json
+          fi
           git commit -m "chore(release): v${NEW_VERSION} [skip ci]"
           git tag "v${NEW_VERSION}"
           git pull --rebase origin main

--- a/plugin/ralph-hero/.mcp.json
+++ b/plugin/ralph-hero/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "ralph-github": {
       "command": "npx",
-      "args": ["-y", "ralph-hero-mcp-server@2.4.53"],
+      "args": ["-y", "ralph-hero-mcp-server@2.4.48"],
       "env": {
         "RALPH_GH_OWNER": "${RALPH_GH_OWNER:-cdubiel08}",
         "RALPH_GH_REPO": "${RALPH_GH_REPO:-ralph-hero}",

--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -360,7 +360,7 @@ _mcp_call tool params:
         exit 1
     fi
     raw=$(mcp call "{{tool}}" --params '{{params}}' \
-        npx -y ralph-hero-mcp-server@2.4.53)
+        npx -y ralph-hero-mcp-server@2.4.48)
     if command -v jq &>/dev/null; then
         if echo "$raw" | jq -e '.isError // false' > /dev/null 2>&1; then
             echo "$raw" | jq -r '.content[0].text' >&2


### PR DESCRIPTION
## Summary
- Adds `if: mcp_changed == 'true'` guard to the "Pin version in justfile and .mcp.json" release step
- Makes `git add` for justfile and .mcp.json conditional on MCP source changes in the commit step
- Reverts .mcp.json and justfile pins from `@2.4.53` (unpublished) to `@2.4.48` (actual npm latest)

## Problem
Plugin-only releases (skills, agents, hooks, scripts) bumped the npm version pin in `.mcp.json` and `justfile`, but only published to npm when MCP source changed. This created references to unpublished npm versions, breaking the MCP server.

## Test plan
- [ ] Verify `npx -y ralph-hero-mcp-server@2.4.48` starts successfully
- [ ] Review workflow logic confirms plugin-only changes won't bump the npm pin
- [ ] `npm view ralph-hero-mcp-server version` returns `2.4.48`

🤖 Generated with [Claude Code](https://claude.com/claude-code)