### PR TITLE
feat(skills): add stream-scoped group support to plan and impl skills

### DIFF
--- a/plugin/ralph-hero/skills/ralph-impl/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-impl/SKILL.md
@@ -105,6 +105,7 @@ After fetching the issue, check its current state:
       - `thoughts/shared/plans/*GH-$(printf '%04d' ${number})*`
       Use the most recent match if multiple found.
    6. **Group fallback**: If standard glob fails, try `thoughts/shared/plans/*group*GH-{primary}*` where `{primary}` is the primary issue number from the issue's group context.
+   6b. **Stream fallback**: If group fallback also fails, try `thoughts/shared/plans/*stream*GH-{number}*` to find stream plans containing this issue.
    7. **If fallback found, self-heal**: Post the missing comment to the issue:
       ```
       ralph_hero__create_comment(owner, repo, number, body="## Implementation Plan\n\nhttps://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/[path]\n\n(Self-healed: artifact was found on disk but not linked via comment)")
@@ -161,9 +162,12 @@ Choose the worktree identifier based on context:
 
 | Condition | WORKTREE_ID |
 |-----------|-------------|
+| Stream member (epic) | `GH-[EPIC_NUMBER]-stream-[SORTED-ISSUES]` (e.g., "GH-40-stream-42-44") |
 | Epic member | `GH-[EPIC_NUMBER]` (e.g., "GH-42") |
 | Group plan (not epic) | `GH-[primary_issue]` from plan frontmatter |
 | Single issue | `GH-[issue-number]` |
+
+Stream detection: if plan frontmatter contains `stream_id`, use the stream worktree naming. This takes precedence over the generic epic member row.
 
 **5.3. Check for Existing Worktree and Sync**
 
@@ -269,7 +273,13 @@ gh pr create --title "[Title]" --body "$(cat <<'EOF'
 ## Test Plan
 [From plan document - automated verification + integration testing]
 
-[If epic, add:]
+[If stream, add:]
+## Stream Context
+- Epic: #[EPIC_NUMBER]
+- Stream: [STREAM_ID] ([N] of [TOTAL_STREAMS] streams)
+- Stream issues: [list of #NNN]
+
+[If epic (non-stream), add:]
 ## Epic
 - Parent: #[EPIC_NUMBER]
 

--- a/plugin/ralph-hero/skills/ralph-plan/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-plan/SKILL.md
@@ -146,7 +146,7 @@ See shared/conventions.md for error handling.
 
 ### Step 4: Create Implementation Plan
 
-**Filename**: `thoughts/shared/plans/YYYY-MM-DD-group-GH-NNN-description.md` (use primary issue number; for single issues: `YYYY-MM-DD-GH-NNN-description.md`)
+**Filename**: `thoughts/shared/plans/YYYY-MM-DD-group-GH-NNN-description.md` (use primary issue number; for single issues: `YYYY-MM-DD-GH-NNN-description.md`; for stream plans: `YYYY-MM-DD-stream-GH-NNN-NNN-description.md` using sorted issue numbers from the stream)
 
 **Template** (works for both single issues and groups; for N=1 omit "Why grouped" and simplify):
 
@@ -158,6 +158,10 @@ github_issues: [123, 124, 125]
 github_urls:
   - https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/issues/123
 primary_issue: 123
+# Stream fields (include only when planning a work stream):
+stream_id: "stream-123-125"
+stream_issues: [123, 125]
+epic_issue: 40
 ---
 
 # [Description] - Atomic Implementation Plan

--- a/thoughts/shared/plans/2026-02-22-GH-0324-stream-scoped-plan-impl-skills.md
+++ b/thoughts/shared/plans/2026-02-22-GH-0324-stream-scoped-plan-impl-skills.md
@@ -264,7 +264,7 @@ PR title for streams: append `[stream-X-Y of GH-EPIC]` (e.g., `feat(auth): Token
 | `plugin/ralph-hero/skills/ralph-impl/SKILL.md` | Add stream worktree row, add stream glob fallback, add stream PR template |
 
 ### Success Criteria
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm run build` succeeds (no TS changes, verifies nothing broken)
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm run build` succeeds (no TS changes, verifies nothing broken)
 - [ ] Manual: conventions.md contains "Work Streams" section with stream ID format, naming conventions, context resolution, and lifecycle
 - [ ] Manual: conventions.md standard input metadata includes `stream_id`, `stream_primary`, `stream_members`, `epic_issue`
 - [ ] Manual: Plan skill SKILL.md filename convention includes stream variant


### PR DESCRIPTION
## Summary
Implements #324: Adjust plan and impl skills for stream-scoped groups

- Closes #324

## Changes
- **conventions.md**: Added "Work Streams" section with stream ID format, naming conventions, lifecycle. Added `{STREAM_CONTEXT}` resolution. Extended standard input metadata with `stream_id`, `stream_primary`, `stream_members`, `epic_issue`. Added stream plan row to Deterministic File Naming table. Added stream glob fallback to Fallback Discovery.
- **ralph-plan/SKILL.md**: Added stream filename convention (`YYYY-MM-DD-stream-GH-NNN-NNN-description.md`). Added conditional stream frontmatter fields (`stream_id`, `stream_issues`, `epic_issue`).
- **ralph-impl/SKILL.md**: Added stream worktree row (`GH-[EPIC]-stream-[SORTED-ISSUES]`) as first/most-specific match. Added stream glob fallback for plan discovery. Added stream context section to PR template.

## Test Plan
- [x] `npm run build` passes (no TypeScript changes)
- [ ] Stream naming conventions are consistent across all three files
- [ ] Existing single-issue and group flows unchanged (all changes are additive)
- [ ] Plan skill filename convention includes stream variant
- [ ] Impl skill worktree table has stream row as first entry

## Epic
- Parent: #321

---
Generated with Claude Code (Ralph GitHub Plugin)