### PR TITLE
feat: Add per-stream status to pipeline dashboard

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
@@ -324,6 +324,19 @@ export function registerDashboardTools(
         .describe(
           "Days in Done/Canceled before eligible for archive (default: 14)",
         ),
+      streams: z
+        .array(
+          z.object({
+            id: z.string(),
+            issues: z.array(z.number()),
+            sharedFiles: z.array(z.string()),
+            primaryIssue: z.number(),
+          }),
+        )
+        .optional()
+        .describe(
+          "Pre-computed stream assignments from detect_work_streams. When provided, dashboard includes a Streams section.",
+        ),
     },
     async (args) => {
       try {
@@ -402,7 +415,7 @@ export function registerDashboardTools(
         };
 
         // Build dashboard from merged items
-        const dashboard = buildDashboard(allItems, healthConfig);
+        const dashboard = buildDashboard(allItems, healthConfig, undefined, args.streams);
 
         // Strip health if not requested
         if (!args.includeHealth) {


### PR DESCRIPTION
## Summary

Update pipeline dashboard to show per-stream status when stream detection is enabled. Adds optional stream visualization to dashboard output with phase tracking and convergence metrics.

Closes #330

## Changes

- **lib/dashboard.ts**: 
  - Added , , ,  types
  - New  pure function for stream aggregation
  - Extended , ,  with optional Streams section
  
- **dashboard-tools.ts**: 
  - Added optional `streams` parameter to `pipeline_dashboard` tool
  - Wired through to dashboard building logic

- **dashboard.test.ts**: 
  - 16 new test cases across 4 describe blocks
  - Tests: computeStreamSection, buildDashboard with streams, formatMarkdown stream section, formatAscii stream section

## Test Coverage
- ✅ 657 tests passing
- ✅ Stream section rendering with multiple streams
- ✅ Convergence metrics (% ready for next phase)
- ✅ Regression guard: no streams = existing output unchanged
- ✅ Both markdown and ASCII formatters updated

## Features
- Per-stream current phase tracking
- Member count per stream
- Convergence % to next phase
- Works with all dashboard output formats
- Optional parameter — no impact when not provided