### PR TITLE
feat(justfile): add [confirm] guard to uninstall-cli recipe

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -1,12 +1,12 @@
 # Ralph Hero - LLM-powered workflow recipes
 #
 # Usage: just <recipe> [params...]
-# Prerequisites: claude CLI, timeout (coreutils), just >= 1.27
+# Prerequisites: claude CLI, timeout (coreutils), just >= 1.29
 # Optional: mcptools (https://github.com/f/mcptools) for quick-* recipes
 
 set shell := ["bash", "-euc"]
 set dotenv-load
-set min-version := "1.27.0"
+set min-version := "1.29.0"
 
 # Aliases for frequently-used recipes
 alias t  := triage
@@ -207,6 +207,7 @@ install-cli:
     echo "For tab completions: just install-completions bash  (or zsh)"
 
 [group('setup')]
+[confirm('Are you sure you want to uninstall the ralph CLI?')]
 # Remove global 'ralph' command
 uninstall-cli:
     #!/usr/bin/env bash

--- a/thoughts/shared/plans/2026-02-22-GH-0307-confirm-guard-uninstall-cli.md
+++ b/thoughts/shared/plans/2026-02-22-GH-0307-confirm-guard-uninstall-cli.md
@@ -91,9 +91,9 @@ uninstall-cli:
 ```
 
 ### Success Criteria
-- [ ] Automated: `grep "confirm.*uninstall" plugin/ralph-hero/justfile` matches the `[confirm]` attribute
-- [ ] Automated: `grep 'min-version.*1.29' plugin/ralph-hero/justfile` confirms version bump
-- [ ] Automated: `grep 'just >= 1.29' plugin/ralph-hero/justfile` confirms comment update
+- [x] Automated: `grep "confirm.*uninstall" plugin/ralph-hero/justfile` matches the `[confirm]` attribute
+- [x] Automated: `grep 'min-version.*1.29' plugin/ralph-hero/justfile` confirms version bump
+- [x] Automated: `grep 'just >= 1.29' plugin/ralph-hero/justfile` confirms comment update
 - [ ] Automated: `just --list` still shows `uninstall-cli` in the `setup` group (justfile parses correctly)
 - [ ] Manual: `just uninstall-cli` prompts for confirmation before proceeding
 


### PR DESCRIPTION
## Summary
Implements #307: Add `[confirm]` guard to `uninstall-cli` justfile recipe to prevent accidental execution.

- Closes #307

## Changes
- Added `[confirm('Are you sure you want to uninstall the ralph CLI?')]` attribute to `uninstall-cli` recipe
- Bumped `set min-version` from `1.27.0` to `1.29.0` (required for `[confirm]` attribute support)
- Updated prerequisites comment to reflect new minimum version

## Test Plan
- [ ] `grep "confirm.*uninstall" plugin/ralph-hero/justfile` matches
- [ ] `grep 'min-version.*1.29' plugin/ralph-hero/justfile` matches
- [ ] `just --list` shows `uninstall-cli` in `setup` group (justfile parses correctly)
- [ ] `just uninstall-cli` prompts for confirmation before proceeding

---
Generated with Claude Code (Ralph GitHub Plugin)