### PR TITLE
feat(justfile): add [confirm] guards to install-cli and install-completions

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -181,6 +181,7 @@ doctor:
     if [ "$errors" -gt 0 ]; then exit 1; fi
 
 [group('setup')]
+[confirm('This will install ralph to ~/.local/bin/ralph (overwriting if exists). Continue?')]
 # Install global 'ralph' command - run from anywhere after setup
 install-cli:
     #!/usr/bin/env bash
@@ -231,6 +232,7 @@ uninstall-cli:
     fi
 
 [group('setup')]
+[confirm('This will install shell completions (overwriting if exists). Continue?')]
 # Install shell completions for the global 'ralph' command
 install-completions shell="bash":
     #!/usr/bin/env bash

--- a/thoughts/shared/plans/2026-02-22-GH-0307-confirm-guard-uninstall-cli.md
+++ b/thoughts/shared/plans/2026-02-22-GH-0307-confirm-guard-uninstall-cli.md
@@ -146,7 +146,7 @@ install-completions shell="bash":
 ```
 
 ### Success Criteria
-- [ ] Automated: `grep -c "\[confirm(" plugin/ralph-hero/justfile` returns `3` (all three recipes guarded)
+- [x] Automated: `grep -c "\[confirm(" plugin/ralph-hero/justfile` returns `3` (all three recipes guarded)
 - [ ] Automated: `just --list` still shows all recipes correctly
 - [ ] Manual: `just install-cli` prompts for confirmation before proceeding
 - [ ] Manual: `just install-completions` prompts for confirmation before proceeding


### PR DESCRIPTION
## Summary
Implements #308: Add `[confirm]` guards to `install-cli` and `install-completions` justfile recipes to prevent accidental file overwrites.

- Closes #308

## Changes
- Added `[confirm('This will install ralph to ~/.local/bin/ralph (overwriting if exists). Continue?')]` to `install-cli` recipe
- Added `[confirm('This will install shell completions (overwriting if exists). Continue?')]` to `install-completions` recipe
- Builds on #307 (merged) which bumped `min-version` to 1.29.0 and added `[confirm]` to `uninstall-cli`

## Test Plan
- [ ] `grep -c "\[confirm(" plugin/ralph-hero/justfile` returns `3` (all three setup recipes guarded)
- [ ] `just --list` shows all recipes correctly
- [ ] `just install-cli` prompts for confirmation before proceeding
- [ ] `just install-completions` prompts for confirmation before proceeding

---
Generated with Claude Code (Ralph GitHub Plugin)