### PR TITLE
feat(mcp): add draft issue lifecycle tools

### DIFF
--- a/thoughts/shared/plans/2026-02-23-GH-0363-draft-issue-lifecycle-tools.md
+++ b/thoughts/shared/plans/2026-02-23-GH-0363-draft-issue-lifecycle-tools.md
@@ -165,7 +165,7 @@ query($itemId: ID!) {
 - Repository ID query has required fields (`owner`, `name`)
 
 ### Success Criteria
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm run build && npm test`
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm run build && npm test`
 - [ ] Manual: Verify `archive_item` with `projectItemId` param archives a draft issue
 - [ ] Manual: Verify `remove_from_project` with `projectItemId` param removes a draft issue
 - [ ] Manual: Verify `convert_draft_issue` converts a draft to a real issue (with classic PAT)


### PR DESCRIPTION
## Summary
- Closes #363

Extends draft issue lifecycle management in the MCP server:
- `archive_item` and `remove_from_project` now accept optional `projectItemId` (PVTI_) as alternative to `number`, enabling operations on draft items
- New `convert_draft_issue` tool wraps `convertProjectV2DraftIssueItemToIssue` mutation (with fine-grained PAT caveat documented)
- `create_draft_issue` now returns both `projectItemId` (PVTI_) and `draftIssueId` (DI_) so callers can immediately use `update_draft_issue`

## Changes
- **`archive_item`**: Added optional `projectItemId` param, one-of validation with `number`, skip `resolveProjectItemId` when using direct ID
- **`remove_from_project`**: Same pattern, plus warning about permanent deletion for drafts in description, conditional cache invalidation
- **`convert_draft_issue`** (new): Accepts `projectItemId` + optional `repositoryId` (auto-fetched), calls convert mutation
- **`create_draft_issue`**: Added post-creation query to fetch DI_ content node ID, returns in response
- **Tests**: Added mutation structure tests for convert mutation, repo ID query, draft content query, and dual-identifier validation

## Test Plan
- [x] `npm run build` passes
- [x] `npm test` passes (718 tests, 32 suites)
- [ ] Manual: archive a draft via `projectItemId`
- [ ] Manual: remove a draft via `projectItemId`
- [ ] Manual: convert draft to real issue (classic PAT)
- [ ] Manual: create draft and verify both IDs returned

---
Generated with Claude Code (Ralph GitHub Plugin)