### PR TITLE
feat(mcp): expose draftIssueId in list_project_items

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/project-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/project-tools.test.ts
@@ -115,6 +115,20 @@ describe("list_project_items repository info structural", () => {
     expect(draftIssueBlock).toBeDefined();
     expect(draftIssueBlock).not.toContain("repository");
   });
+
+  it("DraftIssue GraphQL fragment includes id field for DI_* content node ID", () => {
+    const draftIssueBlock = projectToolsSrc.match(/\.\.\. on DraftIssue \{[^}]+\}/)?.[0];
+    expect(draftIssueBlock).toBeDefined();
+    expect(draftIssueBlock).toContain("id");
+  });
+
+  it("response mapping includes draftIssueId field", () => {
+    expect(projectToolsSrc).toContain("draftIssueId:");
+  });
+
+  it("draftIssueId is conditional on DRAFT_ISSUE type", () => {
+    expect(projectToolsSrc).toContain('item.type === "DRAFT_ISSUE"');
+  });
 });
 
 describe("list_project_items exclude negation filters structural", () => {

--- a/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
@@ -928,6 +928,7 @@ export function registerProjectTools(
                         repository { nameWithOwner name owner { login } }
                       }
                       ... on DraftIssue {
+                        id
                         title
                         body
                       }
@@ -1062,6 +1063,7 @@ export function registerProjectTools(
           return {
             itemId: item.id,
             type: item.type,
+            draftIssueId: item.type === "DRAFT_ISSUE" ? (content?.id as string) ?? null : null,
             number: content?.number,
             title: content?.title,
             state: content?.state,

--- a/plugin/ralph-hero/mcp-server/src/types.ts
+++ b/plugin/ralph-hero/mcp-server/src/types.ts
@@ -131,6 +131,7 @@ export interface ProjectV2Item {
 
 export interface DraftIssue {
   __typename: "DraftIssue";
+  id: string;
   title: string;
   body: string;
 }

--- a/thoughts/shared/plans/2026-02-23-GH-0311-draft-issue-list-support.md
+++ b/thoughts/shared/plans/2026-02-23-GH-0311-draft-issue-list-support.md
@@ -104,7 +104,7 @@ export interface DraftIssue {
 **Changes**: If a DraftIssue structural test exists, verify `id` field is present. Otherwise follow existing pattern.
 
 ### Success Criteria
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm run build && npm test`
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm run build && npm test`
 - [ ] Manual: Call `list_project_items` with `itemType: "DRAFT_ISSUE"` and verify `draftIssueId` (DI_*) appears in response
 - [ ] Manual: Verify non-draft items have `draftIssueId: null`
 


### PR DESCRIPTION
## Summary
- Closes #311

Adds `draftIssueId` (DI_* content node ID) to `list_project_items` response, enabling the `list → update_draft_issue` workflow. Archive/remove `projectItemId` bypass and `create_draft_issue` DI_ return were already implemented in PR #372 (GH-363).

## Changes
- **`project-tools.ts`**: Added `id` to DraftIssue GraphQL fragment; added `draftIssueId` field to formatted response (conditional on `DRAFT_ISSUE` type, `null` for other types)
- **`types.ts`**: Added `id` field to `DraftIssue` interface
- **`project-tools.test.ts`**: Added structural tests for DraftIssue `id` in fragment, `draftIssueId` in response, and type-conditional logic

## Test Plan
- [x] `npm run build` passes
- [x] `npm test` passes (721 tests, 32 suites)
- [ ] Manual: `list_project_items` with `itemType: "DRAFT_ISSUE"` returns `draftIssueId`
- [ ] Manual: Non-draft items have `draftIssueId: null`

---
Generated with Claude Code (Ralph GitHub Plugin)