### PR TITLE
fix(mcp): add cwd to prevent npx binary resolution failure

### DIFF
--- a/plugin/ralph-hero/.mcp.json
+++ b/plugin/ralph-hero/.mcp.json
@@ -3,6 +3,7 @@
     "ralph-github": {
       "command": "npx",
       "args": ["-y", "ralph-hero-mcp-server@2.4.66"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}",
       "env": {
         "RALPH_GH_OWNER": "${RALPH_GH_OWNER:-cdubiel08}",
         "RALPH_GH_REPO": "${RALPH_GH_REPO:-ralph-hero}",


### PR DESCRIPTION
## Summary
- Add `cwd: ${CLAUDE_PLUGIN_ROOT}` to `.mcp.json` to fix npx failing to resolve the `ralph-hero-mcp-server` binary

## Root Cause
`npx` was launching from the `mcp-server/` subdirectory, whose `package.json` defines the same package name (`ralph-hero-mcp-server`). npx saw the local project instead of installing to its cache, resulting in `sh: 1: ralph-hero-mcp-server: not found`.

## Test plan
- [ ] Restart Claude Code after merge and verify MCP server starts
- [ ] Confirm `ralph_hero__*` tools are available in session

🤖 Generated with [Claude Code](https://claude.com/claude-code)