### PR TITLE
docs: add skill architecture design to demo recording research doc

### DIFF
--- a/thoughts/shared/plans/2026-02-24-GH-0379-skill-architecture-design.md
+++ b/thoughts/shared/plans/2026-02-24-GH-0379-skill-architecture-design.md
@@ -66,10 +66,10 @@ Append the `## Skill Architecture Design` section containing:
 **Important**: Append cleanly after existing content with a blank line separator, so #380 and #381 can continue appending.
 
 ### Success Criteria
-- [ ] Automated: `grep -q "## Skill Architecture Design" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
-- [ ] Automated: `grep -q "Mode 1: Autonomous Recording" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
-- [ ] Automated: `grep -q "Mode 2: Interactive Recording" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
-- [ ] Manual: Both modes have clear flows, dependencies are explicit, Artifact Comment Protocol extension is consistent
+- [x] Automated: `grep -q "## Skill Architecture Design" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
+- [x] Automated: `grep -q "Mode 1: Autonomous Recording" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
+- [x] Automated: `grep -q "Mode 2: Interactive Recording" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
+- [x] Manual: Both modes have clear flows, dependencies are explicit, Artifact Comment Protocol extension is consistent
 
 ---
 


### PR DESCRIPTION
## Summary
Implements #379: Add skill architecture design to demo recording research doc.

- Closes #379

## Changes
- Appended `## Skill Architecture Design` section to `thoughts/shared/research/2026-02-22-demo-recording-tools.md`
- Defines Mode 1: Autonomous Recording (asciinema) with 7-step flow, Artifact Comment Protocol extension
- Defines Mode 2: Interactive Recording (OBS + obs-cli) with 9-step flow using AskUserQuestion pacing
- Shared Video Artifact Pipeline with GitHub attachment options comparison table
- Skill File Inventory table (record-demo inline + hook integration autonomous)
- Updated plan checkboxes to mark Phase 1 complete

## Test Plan
- [x] `grep -q "## Skill Architecture Design"` — section present
- [x] `grep -q "Mode 1: Autonomous Recording"` — autonomous mode documented
- [x] `grep -q "Mode 2: Interactive Recording"` — interactive mode documented
- [x] YAML frontmatter still valid after append
- [x] File ends cleanly for #380 and #381 appending

---
Generated with Claude Code (Ralph GitHub Plugin)