### PR TITLE
docs: add artifact pipeline specification to demo recording research doc

### DIFF
--- a/thoughts/shared/plans/2026-02-24-GH-0380-artifact-pipeline-specification.md
+++ b/thoughts/shared/plans/2026-02-24-GH-0380-artifact-pipeline-specification.md
@@ -66,10 +66,10 @@ Append the `## Artifact Pipeline Specification` section containing:
 **Important**: Append cleanly so #381 can continue appending.
 
 ### Success Criteria
-- [ ] Automated: `grep -q "## Artifact Pipeline Specification" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
-- [ ] Automated: `grep -q "Autonomous Mode Pipeline" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
-- [ ] Automated: `grep -q "## Demo Recording" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
-- [ ] Manual: Pipeline flows are clear, comment templates are consistent with existing protocol
+- [x] Automated: `grep -q "## Artifact Pipeline Specification" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
+- [x] Automated: `grep -q "Autonomous Mode Pipeline" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
+- [x] Automated: `grep -q "## Demo Recording" thoughts/shared/research/2026-02-22-demo-recording-tools.md`
+- [x] Manual: Pipeline flows are clear, comment templates are consistent with existing protocol
 
 ---
 


### PR DESCRIPTION
## Summary
Implements #380: Add artifact pipeline specification to demo recording research doc.

- Closes #380

## Changes
- Appended `## Artifact Pipeline Specification` section to `thoughts/shared/research/2026-02-22-demo-recording-tools.md`
- File lifecycle diagram with recording → conversion → upload → comment link flow
- Autonomous mode pipeline: asciinema → agg → gh api → create_comment
- Interactive mode pipeline: obs-cli → ffmpeg trim/thumbnail → gh release upload → create_comment
- `## Demo Recording` Artifact Comment Protocol extension with comment format templates for both modes
- Storage & cleanup table with gitignore entry for `recordings/`
- Updated plan checkboxes to mark Phase 1 complete

## Test Plan
- [x] `grep -q "## Artifact Pipeline Specification"` — section present
- [x] `grep -q "Autonomous Mode Pipeline"` — autonomous pipeline documented
- [x] `grep -q "## Demo Recording"` — protocol extension documented
- [x] YAML frontmatter still valid after append
- [x] File ends cleanly for #381 appending

---
Generated with Claude Code (Ralph GitHub Plugin)