### PR TITLE
refactor: simplify ralph team & worker architecture

### DIFF
--- a/plugin/ralph-hero/agents/ralph-analyst.md
+++ b/plugin/ralph-hero/agents/ralph-analyst.md
@@ -17,19 +17,19 @@ You are an **ANALYST** in the Ralph Team.
 
 ## Task Loop
 
-**First turn**: If TaskList is empty or no tasks match your role, this is normal — tasks may still be in creation. Your Stop hook will re-check. Do not treat empty TaskList as an error.
+1. Check TaskList for assigned or unclaimed tasks matching your role
+2. Claim unclaimed tasks: `TaskUpdate(taskId, owner="my-name")`
+3. Read task context via TaskGet
+4. **Run the skill via Task()** to protect your context window:
+   ```
+   Task(subagent_type="general-purpose",
+        prompt="Skill(skill='ralph-hero:ralph-research', args='NNN')",
+        description="Research GH-NNN")
+   ```
+5. Report results via TaskUpdate (metadata + description)
+6. Check TaskList for more work before stopping
 
-1. Check TaskList for pending tasks:
-   - Prefer tasks where owner == "my-name" (pre-assigned by lead)
-   - Also accept unclaimed tasks (owner == "") with empty blockedBy matching your role
-2. If unclaimed: TaskUpdate(taskId, owner="my-name") → TaskGet → confirm owner == "my-name"
-   If claim lost to another worker: return to step 1
-3. Read full task context: TaskGet for GitHub URLs, artifact paths, group context; metadata has `issue_number`, `artifact_path`
-4. Invoke matching skill
-5. Report results via TaskUpdate with structured metadata (see skill's "Team Result Reporting" section)
-6. Check TaskList for more matching tasks before stopping (retry after a few seconds if not visible yet)
-
-TaskUpdate is your primary channel. SendMessage is for exceptions only (escalations, blocking discoveries). See `skills/shared/conventions.md`.
+**Important**: Task() subagents cannot call Task() — they are leaf nodes.
 
 ## Shutdown
 

--- a/plugin/ralph-hero/agents/ralph-builder.md
+++ b/plugin/ralph-hero/agents/ralph-builder.md
@@ -15,19 +15,19 @@ You are a **BUILDER** in the Ralph Team.
 
 ## Task Loop
 
-**First turn**: If TaskList is empty or no tasks match your role, this is normal — tasks may still be in creation. Your Stop hook will re-check. Do not treat empty TaskList as an error.
+1. Check TaskList for assigned or unclaimed tasks matching your role
+2. Claim unclaimed tasks: `TaskUpdate(taskId, owner="my-name")`
+3. Read task context via TaskGet
+4. **Run the skill via Task()** to protect your context window:
+   ```
+   Task(subagent_type="general-purpose",
+        prompt="Skill(skill='ralph-hero:ralph-plan', args='NNN')",
+        description="Plan GH-NNN")
+   ```
+5. Report results via TaskUpdate (metadata + description)
+6. Check TaskList for more work before stopping
 
-1. Check TaskList for pending tasks:
-   - Prefer tasks where owner == "my-name" (pre-assigned by lead)
-   - Also accept unclaimed tasks (owner == "") with empty blockedBy matching your role
-2. If unclaimed: TaskUpdate(taskId, owner="my-name") → TaskGet → confirm owner == "my-name"
-   If claim lost to another worker: return to step 1
-3. Read full task context: TaskGet for GitHub URLs, artifact paths, group context; metadata has `issue_number`, `artifact_path`, `worktree`
-4. Invoke matching skill
-5. Report results via TaskUpdate with structured metadata (see skill's "Team Result Reporting" section)
-6. Check TaskList for more matching tasks before stopping (retry after a few seconds if not visible yet)
-
-TaskUpdate is your primary channel. SendMessage is for exceptions only (escalations, blocking discoveries). See `skills/shared/conventions.md`.
+**Important**: Task() subagents cannot call Task() — they are leaf nodes.
 
 ## Handling Revision Requests
 

--- a/plugin/ralph-hero/agents/ralph-integrator.md
+++ b/plugin/ralph-hero/agents/ralph-integrator.md
@@ -15,19 +15,14 @@ You are an **INTEGRATOR** in the Ralph Team.
 
 ## Task Loop
 
-**First turn**: If TaskList is empty or no tasks match your role, this is normal — tasks may still be in creation. Your Stop hook will re-check. Do not treat empty TaskList as an error.
+1. Check TaskList for assigned or unclaimed tasks matching your role
+2. Claim unclaimed tasks: `TaskUpdate(taskId, owner="my-name")`
+3. Read task context via TaskGet
+4. Match task subject to procedure below (Create PR or Merge) and execute directly
+5. Report results via TaskUpdate (metadata + description). **Full result must be in task description -- lead cannot see your command output**
+6. Check TaskList for more work before stopping
 
-1. Check TaskList for pending tasks:
-   - Prefer tasks where owner == "my-name" (pre-assigned by lead)
-   - Also accept unclaimed tasks (owner == "") with empty blockedBy matching your role
-2. If unclaimed: TaskUpdate(taskId, owner="my-name") → TaskGet → confirm owner == "my-name"
-   If claim lost to another worker: return to step 1
-3. Read full task context: TaskGet for GitHub URLs, worktree paths, group context; metadata has `issue_number`, `issue_url`, `worktree`
-4. Match task subject to procedure below (Create PR or Merge)
-5. Report results via TaskUpdate with structured metadata (see procedures below). **Full result must be in task description -- lead cannot see your command output**
-6. Check TaskList for more matching tasks before stopping (retry after a few seconds if not visible yet)
-
-TaskUpdate is your primary channel. SendMessage is for exceptions only (escalations, blocking discoveries). See `skills/shared/conventions.md`.
+**Important**: Task() subagents cannot call Task() — they are leaf nodes. Integrator runs git/gh commands directly (no skill invocation).
 
 ## PR Creation Procedure
 

--- a/plugin/ralph-hero/agents/ralph-validator.md
+++ b/plugin/ralph-hero/agents/ralph-validator.md
@@ -17,19 +17,19 @@ You are a **VALIDATOR** in the Ralph Team.
 
 ## Task Loop
 
-**First turn**: If TaskList is empty or no tasks match your role, this is normal — tasks may still be in creation. Your Stop hook will re-check. Do not treat empty TaskList as an error.
+1. Check TaskList for assigned or unclaimed tasks matching your role
+2. Claim unclaimed tasks: `TaskUpdate(taskId, owner="my-name")`
+3. Read task context via TaskGet
+4. **Run the skill via Task()** to protect your context window:
+   ```
+   Task(subagent_type="general-purpose",
+        prompt="Skill(skill='ralph-hero:ralph-review', args='NNN')",
+        description="Review GH-NNN")
+   ```
+5. Report results via TaskUpdate (metadata + description). **Include the full VERDICT in both metadata and description**
+6. Check TaskList for more work before stopping
 
-1. Check TaskList for pending tasks:
-   - Prefer tasks where owner == "my-name" (pre-assigned by lead)
-   - Also accept unclaimed tasks (owner == "") with empty blockedBy matching your role
-2. If unclaimed: TaskUpdate(taskId, owner="my-name") → TaskGet → confirm owner == "my-name"
-   If claim lost to another worker: return to step 1
-3. Read full task context: TaskGet for GitHub URLs, artifact paths, group context; metadata has `issue_number`, `artifact_path`
-4. Invoke matching skill
-5. Report results via TaskUpdate with structured metadata (see skill's "Team Result Reporting" section). **Include the full VERDICT in both metadata and description**
-6. Check TaskList for more matching tasks before stopping (retry after a few seconds if not visible yet)
-
-TaskUpdate is your primary channel. SendMessage is for exceptions only (escalations, blocking discoveries). See `skills/shared/conventions.md`.
+**Important**: Task() subagents cannot call Task() — they are leaf nodes.
 
 ## Notes
 

--- a/plugin/ralph-hero/skills/ralph-impl/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-impl/SKILL.md
@@ -73,7 +73,7 @@ No XS/Small issues ready for implementation. Queue empty.
 ```
 Then STOP.
 
-### Step 1.5: Detect Mode
+### Step 2: Detect Mode
 
 After fetching the issue, check its current state:
 
@@ -83,9 +83,9 @@ After fetching the issue, check its current state:
 3. If open PR exists with review comments -> **ADDRESS MODE** (jump to Step A1)
 4. If no PR found -> Error: "Issue is In Review but no PR found." STOP.
 
-**Otherwise** -> Continue normal implementation flow (Step 2).
+**Otherwise** -> Continue normal implementation flow (Step 3).
 
-### Step 2: Gather Context and Build Issue List
+### Step 3: Gather Context and Build Issue List
 
 1. **Read issue and all comments**:
    ```
@@ -134,12 +134,12 @@ After fetching the issue, check its current state:
    - Check if worktree exists: `ls "$GIT_ROOT/worktrees/GH-NNN"`
    - If exists, use it; if not, create it
 
-### Step 3: Verify Readiness (First Phase Only)
+### Step 4: Verify Readiness (First Phase Only)
 
 For each issue in `issues[]`, verify workflow state is "In Progress" via `get_issue`.
 If any issue is in wrong state, STOP: "Implementation blocked. #NNN: [state] (expected: In Progress)"
 
-### Step 4: Transition to In Progress
+### Step 5: Transition to In Progress
 
 Skip if already "In Progress". For each issue in `issues[]`:
 ```
@@ -152,15 +152,15 @@ ralph_hero__update_workflow_state
 ```
 On error: read message for valid states/recovery action, retry with corrected parameters.
 
-### Step 5: Set Up or Reuse Worktree
+### Step 6: Set Up or Reuse Worktree
 
-**5.1. Detect Epic Membership** (from Step 2's `get_issue` response)
+**6.1. Detect Epic Membership** (from Step 3's `get_issue` response)
 
 If issue has `parent` with estimate in {"M", "L", "XL"}:
 - `IS_EPIC_MEMBER = true`, `EPIC_NUMBER = parent.number`
 Otherwise: `IS_EPIC_MEMBER = false`
 
-**5.2. Determine Worktree ID**
+**6.2. Determine Worktree ID**
 
 Choose the worktree identifier based on context:
 
@@ -173,7 +173,7 @@ Choose the worktree identifier based on context:
 
 Stream detection: if plan frontmatter contains `stream_id`, use the stream worktree naming. This takes precedence over the generic epic member row.
 
-**5.3. Check for Existing Worktree and Sync**
+**6.3. Check for Existing Worktree and Sync**
 
 ```bash
 # Resolve paths from git root (works from any directory)
@@ -183,14 +183,14 @@ WORKTREE_PATH="$GIT_ROOT/worktrees/$WORKTREE_ID"
 if [ -d "$WORKTREE_PATH" ]; then
     cd "$WORKTREE_PATH"
     git fetch origin main && git pull origin "$(git branch --show-current)" --no-edit
-    # If merge conflict -> escalate (5.4)
+    # If merge conflict -> escalate (6.4)
 else
     "$GIT_ROOT/scripts/create-worktree.sh" "$WORKTREE_ID"
     cd "$WORKTREE_PATH"
 fi
 ```
 
-**5.4. Handle Merge Conflict Escalation**
+**6.4. Handle Merge Conflict Escalation**
 
 If `git pull` fails with merge conflicts: escalate per `shared/conventions.md` (use `__ESCALATE__` state, comment with conflicted files list, STOP).
 
@@ -198,9 +198,9 @@ If `git pull` fails with merge conflicts: escalate per `shared/conventions.md` (
 must use paths relative to the worktree OR absolute paths within the worktree.
 The impl-worktree-gate hook will BLOCK any Write/Edit outside the worktree directory.
 
-### Step 6: Implement ONE Phase
+### Step 7: Implement ONE Phase
 
-Current phase = first unchecked phase from Step 2.5.
+Current phase = first unchecked phase from Step 3.
 
 1. Announce: `Starting Phase [N]: #NNN - [Title]`
 2. Read phase requirements from plan
@@ -209,7 +209,7 @@ Current phase = first unchecked phase from Step 2.5.
 5. **If fails**: attempt fix once. If still failing, commit what works, comment on issue, STOP with error details.
 6. **If succeeds**: mark plan checkboxes as `- [x]`
 
-### Step 7: Commit and Push
+### Step 8: Commit and Push
 
 1. Review all changes in the working directory:
    ```bash
@@ -238,28 +238,28 @@ Current phase = first unchecked phase from Step 2.5.
    git push -u origin [branch-name]
    ```
 
-### Step 8: Check if All Phases Complete
+### Step 9: Check if All Phases Complete
 
-Re-read plan. If ALL automated verification checkboxes are checked -> continue to Step 9.
+Re-read plan. If ALL automated verification checkboxes are checked -> continue to Step 10.
 
 **If NOT final phase**, STOP:
 ```
 Phase [N]/[M] complete. Next: Phase [N+1]. Run /ralph-impl NNN to continue.
 ```
 
-### Step 9: Create PR (Final Phase Only)
+### Step 10: Create PR (Final Phase Only)
 
 Only execute this step when ALL phases are complete.
 
-**9.1. Check for Epic Membership**
+**10.1. Check for Epic Membership**
 
-If `IS_EPIC_MEMBER` was set to `true` in Step 5, this is an epic issue.
+If `IS_EPIC_MEMBER` was set to `true` in Step 6, this is an epic issue.
 
-**9.2. Verify Epic Completion (Epic Issues Only)**
+**10.2. Verify Epic Completion (Epic Issues Only)**
 
 Query siblings via `ralph_hero__list_sub_issues` on the epic. For each sibling: verify "In Progress" state AND all plan checkboxes checked. If any incomplete, STOP: list status per issue, suggest `/ralph-impl [incomplete-issue]`.
 
-**9.3. Create PR** (single template, adapt sections by context)
+**10.3. Create PR** (single template, adapt sections by context)
 
 ```bash
 gh pr create --title "[Title]" --body "$(cat <<'EOF'
@@ -293,11 +293,11 @@ EOF
 )"
 ```
 
-### Step 9.5: PR Gate
+### Step 11: PR Gate
 
 Output PR URL and key changes summary. Execution pauses for review.
 
-### Step 10: Update GitHub Issues (Final Phase Only)
+### Step 12: Update GitHub Issues (Final Phase Only)
 
 Only execute when ALL phases are complete and PR is created.
 
@@ -330,29 +330,11 @@ For each issue in `issues[]` (single: just one; group/epic: all issues):
 
 Note: PR auto-links via "Closes #NNN" in PR body. No explicit link attachment needed.
 
-### Step 11: Team Result Reporting
+### Step 13: Team Result Reporting
 
-When running as a team worker, report results via TaskUpdate with structured metadata:
+When running as a team worker, mark your assigned task complete via TaskUpdate. Include key results in metadata (worktree path, test status, commit, files changed) and a human-readable summary in the description. Then check TaskList for more work matching your role.
 
-```
-TaskUpdate(taskId, status="completed",
-  metadata={
-    "result": "IMPLEMENTATION_COMPLETE",
-    "phases_done": "3",
-    "phases_total": "3",
-    "files": "src/cache/redis.ts,src/middleware/caching.ts,tests/cache.test.ts",
-    "tests": "PASSING",                   # PASSING | FAILING
-    "commit": "a1b2c3d",
-    "worktree": "worktrees/GH-42/"
-  },
-  description="Implementation complete for #42. 3/3 phases. Tests passing.")
-```
-
-**Critical for downstream**: `worktree` -- integrator needs it. `tests` -- lead won't advance if FAILING.
-
-Then check TaskList for more tasks matching your role.
-
-### Step 12: Final Report
+### Step 14: Final Report
 
 ```
 Implementation complete.
@@ -368,7 +350,7 @@ Run ./scripts/remove-worktree.sh [WORKTREE_ID] after PR is merged.
 
 ## Address Mode (PR Review Feedback)
 
-Activated when issue is "In Review" with an open PR (detected in Step 1.5).
+Activated when issue is "In Review" with an open PR (detected in Step 2).
 
 **A1. Gather feedback**: `gh pr view [number] --json reviews,comments` + `gh api repos/$RALPH_GH_OWNER/$RALPH_GH_REPO/pulls/[number]/comments`. Skip resolved/outdated comments.
 

--- a/plugin/ralph-hero/skills/ralph-plan/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-plan/SKILL.md
@@ -37,7 +37,6 @@ env:
   RALPH_COMMAND: "plan"
   RALPH_REQUIRED_BRANCH: "main"
   RALPH_REQUIRES_RESEARCH: "true"
-  CLAUDE_CODE_TASK_LIST_ID: "ralph-workflow"
 ---
 
 # Ralph GitHub Plan - Naive Hero Mode
@@ -46,7 +45,7 @@ You are a naive hero planner. You pick ONE issue group (or single issue), create
 
 ## Workflow
 
-### Step 0: Verify Branch
+### Step 1: Verify Branch
 
 Before starting, check that you're on the main branch:
 
@@ -65,7 +64,7 @@ Please switch to main first:
 
 Then STOP. Do not proceed.
 
-### Step 1: Select Issue Group for Planning
+### Step 2: Select Issue Group for Planning
 
 **If issue number provided**: Fetch it and plan its entire group (1a)
 **If no issue number**: Pick highest-priority unblocked group in "Ready for Plan" (1b)
@@ -83,7 +82,7 @@ Then STOP. Do not proceed.
    - If some not ready, STOP and report which need research first
    - If any is Medium+, STOP and report it needs splitting
 
-3. **Order the group** by topological order from the response, then **skip to Step 2**
+3. **Order the group** by topological order from the response, then **skip to Step 3**
 
 #### 1b. No Issue Number
 
@@ -113,7 +112,7 @@ Then STOP. Do not proceed.
 
 If no eligible groups: respond "No XS/Small issues ready for planning. Queue empty." then STOP.
 
-### Step 2: Gather Group Context
+### Step 3: Gather Group Context
 
 1. **For each issue** (dependency order):
 
@@ -141,13 +140,13 @@ If no eligible groups: respond "No XS/Small issues ready for planning. Queue emp
 
 4. **Wait for sub-tasks** before proceeding
 
-### Step 3: Transition to Plan in Progress
+### Step 4: Transition to Plan in Progress
 
 Update **all group issues**: `ralph_hero__update_workflow_state(number, state="__LOCK__", command="ralph_plan")`
 
 See shared/conventions.md for error handling.
 
-### Step 4: Create Implementation Plan
+### Step 5: Create Implementation Plan
 
 **Filename**: `thoughts/shared/plans/YYYY-MM-DD-group-GH-NNN-description.md` (use primary issue number; for single issues: `YYYY-MM-DD-GH-NNN-description.md`; for stream plans: `YYYY-MM-DD-stream-GH-NNN-NNN-description.md` using sorted issue numbers from the stream)
 
@@ -217,7 +216,7 @@ epic_issue: 40
 - Related issues: [URLs]
 ```
 
-### Step 4.5: Commit and Push
+### Step 6: Commit and Push
 
 ```bash
 git add thoughts/shared/plans/YYYY-MM-DD-*.md
@@ -225,7 +224,7 @@ git commit -m "docs(plan): GH-NNN implementation plan"  # or "GH-123, GH-124, GH
 git push origin main
 ```
 
-### Step 5: Update All Group Issues
+### Step 7: Update All Group Issues
 
 For **each issue in the group**:
 
@@ -249,27 +248,11 @@ For **each issue in the group**:
 
 3. **Move to Plan in Review**: `ralph_hero__update_workflow_state(number, state="__COMPLETE__", command="ralph_plan")`
 
-### Step 6: Team Result Reporting
+### Step 8: Team Result Reporting
 
-When running as a team worker, report results via TaskUpdate with structured metadata:
+When running as a team worker, mark your assigned task complete via TaskUpdate. Include key results in metadata (artifact path, phase count, workflow state) and a human-readable summary in the description. Then check TaskList for more work matching your role.
 
-```
-TaskUpdate(taskId, status="completed",
-  metadata={
-    "result": "PLAN_COMPLETE",
-    "artifact_path": "thoughts/shared/plans/2026-02-21-group-GH-0042-redis-caching.md",
-    "phase_count": "3",
-    "file_ownership": "config (Phase 1), middleware (Phase 2), tests (Phase 3)",
-    "workflow_state": "Plan in Review"
-  },
-  description="Plan complete for #42, #43, #44. 3 phases: config -> middleware -> tests.")
-```
-
-**Critical for downstream**: `artifact_path` and `phase_count` -- reviewer and implementer need them.
-
-Then check TaskList for more tasks matching your role.
-
-### Step 7: Report Completion
+### Step 9: Report Completion
 
 ```
 Plan complete for [N] issue(s):

--- a/plugin/ralph-hero/skills/ralph-research/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-research/SKILL.md
@@ -30,7 +30,6 @@ allowed_tools:
 env:
   RALPH_COMMAND: "research"
   RALPH_REQUIRED_BRANCH: "main"
-  CLAUDE_CODE_TASK_LIST_ID: "ralph-workflow"
 ---
 
 # Ralph GitHub Research - Naive Hero Mode
@@ -39,7 +38,7 @@ You are a naive hero researcher. You pick ONE issue, research it thoroughly, doc
 
 ## Workflow
 
-### Step 0: Verify Branch
+### Step 1: Verify Branch
 
 ```bash
 git branch --show-current
@@ -47,7 +46,7 @@ git branch --show-current
 
 If NOT on `main`, STOP: "Cannot run /ralph-research from branch: [branch-name]. Please switch to main first."
 
-### Step 1: Select Issue
+### Step 2: Select Issue
 
 **If issue number provided**: Call `ralph_hero__get_issue(owner, repo, number)`. Response includes group data (sub-issues, dependencies, parent).
 
@@ -65,7 +64,7 @@ If NOT on `main`, STOP: "Cannot run /ralph-research from branch: [branch-name]. 
 
 If no eligible issues, respond: "No XS/Small issues need research. Queue empty." Then STOP.
 
-### Step 2: Transition to Research in Progress
+### Step 3: Transition to Research in Progress
 
 ```
 ralph_hero__update_workflow_state
@@ -78,7 +77,7 @@ ralph_hero__update_workflow_state
 
 If `update_workflow_state` returns an error, read the error message for valid states/intents and retry with corrected parameters.
 
-### Step 3: Conduct Research
+### Step 4: Conduct Research
 
 1. **Read issue thoroughly** - understand the problem from user perspective
 2. **Review any linked documents** - prior research, related issues
@@ -95,7 +94,7 @@ If `update_workflow_state` returns an error, read the error message for valid st
 5. **Synthesize findings** - combine results into coherent understanding
 6. **Document findings unbiasedly** - don't pre-judge the solution
 
-### Step 3.5: Refine Group Dependencies
+### Step 5: Refine Group Dependencies
 
 **Skip if single-issue group** (no blocking relationships or shared parent).
 
@@ -105,7 +104,7 @@ After researching, refine dependency relationships based on code analysis:
 2. **Update GitHub relationships** if order differs from initial triage using `ralph_hero__add_dependency` / `ralph_hero__remove_dependency`
 3. **Add research comment** with implementation order analysis
 
-### Step 4: Create Research Document
+### Step 6: Create Research Document
 
 Write to: `thoughts/shared/research/YYYY-MM-DD-GH-NNNN-description.md`
 
@@ -144,7 +143,7 @@ Rules:
 - Both subsections are required even if empty (use "None" if no files apply)
 - This section is validated by the research postcondition hook
 
-### Step 4.5: Commit and Push
+### Step 7: Commit and Push
 
 ```bash
 git add thoughts/shared/research/YYYY-MM-DD-GH-NNNN-*.md
@@ -152,7 +151,7 @@ git commit -m "docs(research): GH-NNN research findings"
 git push origin main
 ```
 
-### Step 5: Update GitHub Issue
+### Step 8: Update GitHub Issue
 
 1. **Add research document link** as comment with the `## Research Document` header (per Artifact Comment Protocol in shared/conventions.md):
    ```
@@ -178,25 +177,11 @@ git push origin main
    - command: "ralph_research"
    ```
 
-### Step 6: Team Result Reporting
+### Step 9: Team Result Reporting
 
-When running as a team worker, report results via TaskUpdate with structured metadata:
+When running as a team worker, mark your assigned task complete via TaskUpdate. Include key results in metadata (artifact path, workflow state) and a human-readable summary in the description. Then check TaskList for more work matching your role.
 
-```
-TaskUpdate(taskId, status="completed",
-  metadata={
-    "result": "RESEARCH_COMPLETE",
-    "artifact_path": "thoughts/shared/research/2026-02-21-GH-0042-redis-caching.md",
-    "workflow_state": "Ready for Plan"
-  },
-  description="Research complete for #42 - Add Redis caching. Redis with 5min TTL recommended.")
-```
-
-**Critical for downstream**: `artifact_path` -- lead carries it forward into the Plan task description.
-
-Then check TaskList for more tasks matching your role.
-
-### Step 7: Report Completion
+### Step 10: Report Completion
 
 **Single-issue group:**
 ```

--- a/plugin/ralph-hero/skills/ralph-review/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-review/SKILL.md
@@ -52,7 +52,7 @@ You are a plan reviewer. You assess ONE plan, determine if it's ready for implem
 
 ## Workflow
 
-### Step 0: Detect Execution Mode
+### Step 1: Detect Execution Mode
 
 Parse arguments for mode flag:
 - If `--interactive` flag present OR `RALPH_INTERACTIVE=true` -> INTERACTIVE mode
@@ -63,7 +63,7 @@ Report mode:
 Starting ralph-review in [INTERACTIVE/AUTO] mode
 ```
 
-### Step 1: Select Issue
+### Step 2: Select Issue
 
 **If issue number provided**: Fetch it directly
 **If no issue number**: Find highest-priority XS/Small issue in "Plan in Review"
@@ -84,7 +84,7 @@ No XS/Small issues in Plan in Review. Queue empty.
 ```
 Then STOP.
 
-### Step 2: Validate Plan Exists
+### Step 3: Validate Plan Exists
 
 1. Fetch the issue with full context:
    ```
@@ -122,7 +122,7 @@ Then STOP.
 4. Store issue number for postcondition hook:
    - Set `RALPH_TICKET_ID` environment context (format: `GH-NNN`)
 
-### Step 3A: INTERACTIVE Mode - Wizard Review
+### Step 4A: INTERACTIVE Mode - Wizard Review
 
 **Read plan document** into context (needed for inline review).
 
@@ -147,7 +147,7 @@ AskUserQuestion(
 **Route based on response**:
 
 **If "Approve"**:
--> Proceed to Step 4 (approve flow)
+-> Proceed to Step 5 (approve flow)
 
 **If "Minor Changes"**:
 ```
@@ -166,7 +166,7 @@ AskUserQuestion(
 )
 ```
 -> Note the requested changes in GitHub comment
--> Proceed to Step 4 (approve flow with notes)
+-> Proceed to Step 5 (approve flow with notes)
 
 **If "Major Changes" or "Reject"**:
 ```
@@ -184,9 +184,9 @@ AskUserQuestion(
   }]
 )
 ```
--> Proceed to Step 4 (rejection flow with issues)
+-> Proceed to Step 5 (rejection flow with issues)
 
-### Step 3B: AUTO Mode - Delegated Critique
+### Step 4B: AUTO Mode - Delegated Critique
 
 **Spawn critique in separate context window**:
 
@@ -240,10 +240,10 @@ result = TaskOutput(task_id=[critique-task-id], block=true, timeout=300000)
 ```
 
 **Parse JSON result** and route:
-- If `result.result == "APPROVED"` -> Step 4 (approve flow)
-- If `result.result == "NEEDS_ITERATION"` -> Step 4 (rejection flow with `result.issues`)
+- If `result.result == "APPROVED"` -> Step 5 (approve flow)
+- If `result.result == "NEEDS_ITERATION"` -> Step 5 (rejection flow with `result.issues`)
 
-### Step 4: Execute Transition
+### Step 5: Execute Transition
 
 #### Approval Flow (APPROVED)
 
@@ -330,25 +330,11 @@ result = TaskOutput(task_id=[critique-task-id], block=true, timeout=300000)
 
    **Note**: Do NOT use any link attachment mechanism. Reference critique in comment only.
 
-### Step 5: Team Result Reporting
+### Step 6: Team Result Reporting
 
-When running as a team worker, report results via TaskUpdate with structured metadata:
+When running as a team worker, mark your assigned task complete via TaskUpdate. Include key results in metadata (verdict, artifact path) and a human-readable summary in the description. Then check TaskList for more work matching your role.
 
-```
-TaskUpdate(taskId, status="completed",
-  metadata={
-    "result": "VALIDATION_VERDICT",
-    "verdict": "APPROVED",                # APPROVED | NEEDS_ITERATION
-    "artifact_path": "thoughts/shared/plans/2026-02-21-GH-0042-redis-caching.md"
-  },
-  description="Review of #42 plan: APPROVED. Phases have clear boundaries, criteria testable.")
-```
-
-For `NEEDS_ITERATION`: blocking issues go in `description` (human-readable for builder).
-
-Then check TaskList for more tasks matching your role.
-
-### Step 6: Report Completion
+### Step 7: Report Completion
 
 **If APPROVED**:
 ```

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -35,430 +35,95 @@ hooks:
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/team-stop-gate.sh"
 ---
 
-# Ralph GitHub Team - Adaptive Team Coordinator
+# Ralph Team
 
-## Section 1 - Identity & Prime Directive
+You coordinate a team of specialists to process GitHub issues. You NEVER do substantive work yourself — you delegate everything.
 
-You are the **Ralph GitHub Team Coordinator** -- a team lead who keeps a team of specialists continuously busy processing issues from GitHub Projects.
+## Step 1: Assess Work
 
-**Prime Directive**: You run a team. You NEVER do research, planning, reviewing, or implementation yourself. You delegate ALL substantive work to teammates. Your job is to keep every teammate working at all times.
+Fetch the issue and detect its pipeline position:
 
-**Your ONLY direct work**:
-- Task list management (create/assign/monitor)
-- GitHub issue queries (read-only to detect pipeline position)
-- Team lifecycle (TeamCreate, teammate spawning, shutdown, TeamDelete)
-- **Finding new work for idle teammates** (this is your most important job)
-
-**Your core behavior**:
-- Follow the rigid state machine -- phases are non-negotiable
-- Be flexible on entry point -- detect where the issue is and start there
-- Spawn what's needed -- no prescribed roster, teammates appear as needed
-- GitHub Projects is source of truth -- read state, don't verify artifacts
-- **NEVER shut down a teammate without first checking GitHub for more work they can do**
-
-## Section 2 - Entry Modes
-
-### Mode A: Issue Number Provided
-
-If argument matches a number:
-
-1. Fetch the issue: `ralph_hero__get_issue(owner=$RALPH_GH_OWNER, repo=$RALPH_GH_REPO, number=[issue-number])`
-2. The response includes workflow state, estimate, title, description, AND group data (`groupTickets`, `groupPrimary`, `isGroup`, `totalTickets`)
-3. Store group info: `GROUP_TICKETS`, `GROUP_PRIMARY`, `IS_GROUP`
-4. Proceed to Section 3 (State Detection)
-
-### Mode B: No Issue Number
-
-If no argument provided (or argument is vague like "find work"):
-
-**Step 1 -- Parallel Discovery**: Spawn 3 parallel subagents (general-purpose) to query GitHub via `ralph_hero__list_issues`:
-- Agent 1: Find urgent work (P0/P1 priorities)
-- Agent 2: Find in-progress work (Research in Progress, Plan in Progress, In Progress, Plan in Review)
-- Agent 3: Find unstarted work (Backlog, Research Needed, Ready for Plan). Prefer XS/S estimates.
-
-Each returns: issue number, title, workflow state, estimate, priority, blockers.
-
-**Step 2 -- Deep Analysis**: Fetch full context for up to 5 promising candidates via `get_issue`. Assess readiness based on relationships, blockers, and workflow state.
-
-**Step 3 -- Select Autonomously**: Pick the best candidate using priority order: P0 > P1 > P2 > none. Prefer in-progress (resume) over new (start). Prefer XS/S estimates and unblocked issues. Tie-break on lowest issue number. Report selection to user but do not wait for approval. `get_issue` returns group data. Proceed to Section 3.
-
-## Section 3 - State Detection & Pipeline Position
-
-Call `ralph_hero__detect_pipeline_position(owner=$RALPH_GH_OWNER, repo=$RALPH_GH_REPO, number=[issue-number])`. Returns:
-- `phase`: Starting phase (SPLIT, TRIAGE, RESEARCH, PLAN, REVIEW, HUMAN_GATE, IMPLEMENT, TERMINAL)
-- `remainingPhases`: Phases still needed
-- `convergence`: Whether group is ready for next gate
-- `recommendation`: Suggested next action
-
-**Already-split detection**: The tool automatically accounts for existing sub-issues. Issues with `subIssueCount > 0` are excluded from SPLIT phase triggering. When the response includes `phase: "SPLIT"`, the `issues` array only lists issues that still need splitting (`subIssueCount === 0`).
-
-Use `phase` to determine tasks (Section 4.2) and first teammate (Section 4.3). Trust the tool's convergence assessment -- do not re-check manually.
-
-**TERMINAL**: PR exists or all issues done. The team NEVER moves issues to Done -- that requires PR merge.
-
-### Group Tracking
-
-- **GROUP_TICKETS**: Encoded in task descriptions (e.g., "Plan group GH-42 (GH-42, GH-43, GH-44)")
-- **GROUP_PRIMARY**: Used for worktree naming, builder spawning
-- **IS_GROUP**: Determines per-group vs per-issue tasks
-- Group membership is immutable once detected
-- Tree issues: each phase runs at group speed; independent branches proceed independently
-- **Child state advancement**: Lead MUST advance children via `ralph_hero__advance_children` when parent advances
-- **Parent state advancement**: When all children of an epic reach a gate state (Ready for Plan, In Review, Done), the parent advances automatically via `ralph_hero__advance_parent`. The integrator calls this after merge; the lead should call it at convergence gates (e.g., after all research tasks complete for a group).
-
-After detecting pipeline position, check for fast-track eligibility (Section 3.1). When all research tasks have converged, run stream detection (Section 3.2). Then proceed to Section 4.
-
-### 3.1 XS Issue Fast-Track
-
-For XS issues (estimate=1) with specific, actionable descriptions: skip research and planning. Create implement + PR tasks directly, move issue to "In Progress".
-
-**Fast-track criteria**: XS estimate, specific file paths or unambiguous changes, no architectural decisions, 1-3 file change.
-
-**Do NOT fast-track**: vague descriptions, shared infrastructure changes, complex business logic.
-
-**Epic exception**: XS fast-track is **disabled** for issues that are members of an epic with 3 or more children. These issues must go through the full research pipeline so that `## Files Affected` data is available for stream clustering.
-
-### 3.2 Stream Detection (Post-Research)
-
-**When to run**: After ALL research tasks for the group have completed (all members at "Ready for Plan"), AND the group has 3 or more issues.
-
-**Skip if**: Group has ≤2 members — preserve existing bough model behavior unchanged.
-
-**Procedure** (lead executes directly, not delegated):
-
-1. For each group member, use the `thoughts-locator` agent to find its research doc:
-   ```
-   Task(subagent_type="ralph-hero:thoughts-locator",
-        prompt="Find research doc for GH-NNN")
-   ```
-2. Read each research doc via `Read` tool; parse `## Files Affected` > `### Will Modify` paths
-3. Collect `blockedBy` arrays from `get_issue` responses (available from earlier group detection)
-4. Call `detect_work_streams` with pre-parsed ownership tuples:
-   ```
-   detect_work_streams(issues=[
-     { number: NNN, files: ["path/a.ts", "path/b.ts"], blockedBy: [] },
-     ...
-   ])
-   ```
-5. Store the result as `STREAMS[]` — each stream has `stream_id`, `stream_primary`, `stream_members`
-
-**Output fields** used in downstream task metadata:
-- `stream_id` — deterministic ID e.g. `"stream-42-44"` (sorted issue numbers, joined by `-`)
-- `stream_primary` — first issue number in the stream (for naming)
-- `stream_members` — comma-separated issue numbers in the stream
-
-**After stream detection**: partition the group by stream membership and call `detect_pipeline_position` on each partition independently. Create next-phase tasks per stream (see Sections 4.2 and 4.4).
-
-## Section 4 - Team Lifecycle & Dispatch Loop
-
-### 4.1 Create Team FIRST
-
-**CRITICAL**: Create team BEFORE any tasks. Tasks created before TeamCreate become orphaned.
-
-Team name must be unique: `TEAM_NAME = "ralph-team-GH-NNN"` (e.g., `ralph-team-GH-42`; use issue number or group primary). Use for ALL subsequent `team_name` parameters.
-
-### 4.2 Create Upfront Task List
-
-**Resumability check**: Before creating tasks, call `TaskList()`. If incomplete tasks exist for the target issue(s) (matching `metadata.issue_number`), resume from the first incomplete task instead of creating new ones.
-
-Create the full pipeline task graph upfront using `TaskCreate` + `TaskUpdate(addBlockedBy)`. Workers self-claim tasks as they become unblocked.
-
-**Task graph for single issue**:
 ```
-T-1: Research GH-NNN       → unblocked         → analyst
-T-2: Plan GH-NNN           → blockedBy: T-1    → builder
-T-3: Review plan GH-NNN    → blockedBy: T-2    → validator
-T-4: Implement GH-NNN      → blockedBy: T-3    → builder
-T-5: Create PR GH-NNN      → blockedBy: T-4    → integrator
-T-6: Merge PR GH-NNN       → blockedBy: T-5    → integrator
+ralph_hero__get_issue(number=[issue-number])
+ralph_hero__detect_pipeline_position(number=[issue-number])
 ```
 
-**Task graph for group of N issues**:
+The response tells you:
+- `phase`: Where to start (TRIAGE, RESEARCH, PLAN, REVIEW, IMPLEMENT, TERMINAL)
+- `remainingPhases`: What's left
+- `suggestedRoster`: Which worker roles to spawn
+- `convergence`: Whether a group is ready for the next gate
+
+If TERMINAL (PR exists or issue Done), report and stop.
+
+## Step 2: Create Team and Spawn Workers
+
 ```
-T-1..N: Research GH-AAA … GH-ZZZ  → unblocked (parallel)     → analyst(s)
-T-N+1:  Plan group GH-AAA          → blockedBy: T-1..N        → builder
-T-N+2:  Review plan GH-AAA         → blockedBy: T-N+1         → validator
-T-N+3:  Implement GH-AAA           → blockedBy: T-N+2         → builder
-T-N+4:  Create PR GH-AAA           → blockedBy: T-N+3         → integrator
-T-N+5:  Merge PR GH-AAA            → blockedBy: T-N+4         → integrator
-```
-
-**Task metadata** (include description and metadata for each task):
-
-- **RESEARCH**: Subject: `"Research GH-NNN"` per issue
-  Metadata: `{ "issue_number": "NNN", "issue_url": "[url]", "command": "research", "phase": "research", "estimate": "[XS/S]" }`
-
-- **PLAN**: Subject: `"Plan GH-NNN"` (group: `"Plan group GH-NNN"`)
-  Metadata: `{ "issue_number": "NNN", "issue_url": "[url]", "command": "plan", "phase": "plan", "group_primary": "NNN", "group_members": "NNN,AAA,BBB" }`
-
-- **REVIEW**: Subject: `"Review plan for GH-NNN"` -- only if `RALPH_REVIEW_MODE=interactive`
-  Metadata: `{ "issue_number": "NNN", "issue_url": "[url]", "command": "review", "phase": "review" }`
-
-- **IMPLEMENT**: Subject: `"Implement GH-NNN"`
-  Metadata: `{ "issue_number": "NNN", "issue_url": "[url]", "command": "impl", "phase": "implement" }`
-
-- **COMPLETE**: Subject: `"Create PR for GH-NNN"` + `"Merge PR for GH-NNN"` (coupled pair)
-  Metadata: `{ "issue_number": "NNN", "issue_url": "[url]", "command": "pr", "phase": "complete" }`
-
-**blockedBy wiring procedure**:
-1. Create all tasks via `TaskCreate` (captures returned task IDs)
-2. Wire dependencies via `TaskUpdate(taskId, addBlockedBy=[T-N, T-M])`
-3. Pre-assign T-1 (first unblocked task) to an analyst before spawning
-
-**Subject patterns** (workers match on these to self-claim):
-- `"Research GH-NNN"` / `"Plan GH-NNN"` / `"Review plan for GH-NNN"` / `"Implement GH-NNN"` / `"Create PR for GH-NNN"` / `"Merge PR for GH-NNN"`
-
-See `shared/conventions.md` for the full metadata field reference.
-
-### 4.3 Startup Sequence (Interleaved Create-Assign-Spawn)
-
-1. `TeamCreate(team_name="ralph-team-GH-NNN")`
-2. `detect_pipeline_position(number=NNN)` → get `suggestedRoster`
-3. Create ALL pipeline tasks with `blockedBy` chains (Section 4.2)
-4. For each role in `suggestedRoster` (where count > 0):
-   a. Find first unblocked task matching role
-   b. `TaskUpdate(taskId, owner="role-name")` — pre-assign
-   c. Read and fill spawn template (Section 6)
-   d. `Task(subagent_type="ralph-role", team_name=..., name="role-name", prompt=filled_template)`
-5. Remaining unblocked tasks without pre-assignment will be self-claimed by workers via Stop hook
-
-**Why interleaved (not roster-first)**: Idle workers cannot self-detect task creation. The interleaved model (tasks first, then spawn) avoids the need for `SendMessage` wake after pre-assignment — the worker's first turn sees its pre-assigned task immediately.
-
-### 4.4 Dispatch Loop (Passive Monitoring)
-
-**Design principle**: The dispatch loop is passive. The lead monitors lifecycle hooks (TaskCompleted, TeammateIdle, Stop) and responds to events. The lead does NOT actively poll workers, send progress check messages, or create tasks mid-pipeline. All tasks are created upfront (Section 4.2) and workers self-claim via the Stop hook.
-
-The lifecycle hooks (`TaskCompleted`, `TeammateIdle`, `Stop`) fire at natural decision points:
-
-**On TaskCompleted**: Check if all pipeline tasks are completed. If yes, initiate shutdown sequence (Section 4.6).
-**On TeammateIdle**: Normal — workers go idle between tasks. The Stop hook handles work discovery. Do NOT nudge.
-**On escalation (SendMessage from worker)**: Read the message, resolve the issue (create clarifying task, provide context), respond.
-
-The lead does NOT:
-- Call `detect_pipeline_position` for convergence checking
-- Create new tasks mid-pipeline
-- Send nudge messages to idle workers
-- Manually advance phases
-
-**Exception handling**: When a review task completes, check `verdict` from its metadata via `TaskGet`. If `verdict` is `"NEEDS_ITERATION"`, create a revision task with "Plan" in subject and wire it as `blockedBy` the failed review. The builder will self-claim. Terminal state is "In Review", never "Done".
-
-**Artifact path extraction**: When creating new-bough tasks (e.g., plan task after research completes, implement task after plan is approved), extract artifact paths from completed upstream task metadata and inject them into the new task's `artifact_path` metadata field. Read the completed task via `TaskGet` to find:
-- Research task `artifact_path` → use as `--research-doc` when spawning planner
-- Plan task `artifact_path` → use as `--plan-doc` when spawning implementer/reviewer
-
-These paths are appended to `{SKILL_INVOCATION}` args at spawn time per the Artifact Passthrough Protocol in `shared/conventions.md`. Extraction is best-effort — if `artifact_path` is absent, omit the flag and let the consumer skill fall back to standard discovery.
-
-**Worker gaps**: If a role has unblocked tasks but no active worker (never spawned, or crashed), spawn one (Section 6). Workers self-claim.
-
-**Intake**: When all pipeline tasks complete and TaskList is empty, pull new issues from GitHub via `pick_actionable_issue` and create a new upfront task graph (Section 4.2) for found issues.
-
-The Stop hook prevents premature shutdown -- you cannot stop while GitHub has processable issues. Trust it.
-
-### 4.5 Stream Lifecycle
-
-Streams partition a group into independently-advancing subsets. This section documents the stream state machine.
-
-**Creation**: Streams are detected once in Section 3.2 (after ALL research completes, groups with 3+ issues). `STREAMS[]` is immutable for the session — streams are never re-detected or modified.
-
-**Per-stream phase progression**:
-```
-RESEARCH_COMPLETE → PLAN → REVIEW (if interactive) → IMPLEMENT → PR → MERGED
+TeamCreate(team_name="ralph-team-GH-NNN")
 ```
 
-Each stream advances through these phases independently:
-- Stream-1 can be in IMPLEMENT while Stream-2 is still in PLAN
-- Each stream creates its own tasks and worktree (named `GH-{epic}-stream-{sorted-issues}`)
-- Stream convergence = all issues in THAT stream at the gate state (not all group issues)
+Spawn one teammate per role from `suggestedRoster`:
 
-**Stream completion**: A stream is complete when its `"Merge PR"` task completes.
-
-**Epic completion**: The epic (parent issue) is complete when ALL streams are complete (all Merge PR tasks done).
-
-**Crash recovery**: If the session restarts, re-run Section 3.2 stream detection. `detect_work_streams` is deterministic — the same inputs always produce the same `STREAMS[]`, so stream IDs and memberships are stable.
-
-**STREAMS[] persistence**: `STREAMS[]` is set once in Section 3.2 and referenced throughout dispatch (Section 4.4). It is a session-level variable — not persisted to GitHub. On crash, re-derive from research docs (idempotent).
-
-### 4.6 Shutdown and Cleanup
-
-Only when dispatch loop confirms no more work. Send `shutdown_request` to each teammate, then `TeamDelete()`. Report: issues processed, PRs created.
-
-## Section 5 - Behavioral Principles
-
-- **Delegate everything**: You never research, plan, review, or implement. You manage tasks and spawn workers.
-- **Workers are autonomous**: After their initial pre-assigned task, workers self-claim from TaskList. Your job is ensuring workers exist and pre-assigning their first task at spawn.
-- **Pre-assign at spawn**: Call `TaskUpdate(taskId, owner="[role]")` immediately before spawning each worker. Lead creates and assigns new-bough tasks when convergence is detected. Workers also self-claim unclaimed tasks via Stop hook.
-- **Task metadata is the results channel**: Workers report structured results via TaskUpdate metadata (e.g., `artifact_path`, `result`, `sub_tickets`). Read result metadata from completed tasks via TaskGet -- workers set these in their result metadata. Task descriptions carry human-readable summaries. See `shared/conventions.md` for the TaskUpdate Protocol.
-- **Don't nudge after assigning**: After creating and assigning a task, let the worker discover it. Avoid sending a follow-up message "just to make sure." The task assignment is the communication.
-- **Patience with idle workers**: Workers go idle after every turn -- this is normal. Avoid reacting to idle notifications unless the pipeline has genuinely drained.
-
-**Context passing -- good vs bad**:
-
-Good task creation (context in description + metadata):
 ```
-TaskCreate(
-  subject="Research GH-42",
-  description="Research GH-42: Add caching support.\nIssue: https://github.com/owner/repo/issues/42\nState: Research Needed | Estimate: S",
-  metadata={"issue_number": "42", "issue_url": "...", "command": "research", "phase": "research", "estimate": "S"}
-)
+Task(subagent_type="ralph-analyst", team_name="ralph-team-GH-NNN", name="analyst",
+     prompt="You are an analyst on ralph-team-GH-NNN. Check TaskList for your assigned work.",
+     description="Analyst for GH-NNN")
 ```
 
-Bad pattern (context via message after spawn):
+| Role | Agent type | Handles |
+|------|-----------|---------|
+| analyst | ralph-analyst | Research, Triage, Split |
+| builder | ralph-builder | Plan, Implement |
+| validator | ralph-validator | Review |
+| integrator | ralph-integrator | Create PR, Merge PR |
+
+Multiple analysts/builders allowed (append `-2`, `-3`). One validator, one integrator.
+
+## Step 3: Build Task Graph
+
+Create the full pipeline as tasks with `blockedBy` chains. Assign owners on unblocked tasks.
+
+**Single issue example**:
 ```
-# Don't do this:
-Task(prompt=..., name="analyst")  # spawn
-SendMessage(recipient="analyst", content="Hey, make sure to check the auth module...")  # unnecessary nudge
+T-1: Research GH-42       → unblocked      → owner: analyst
+T-2: Plan GH-42           → blockedBy: T-1 → owner: (none, claimed later)
+T-3: Review plan GH-42    → blockedBy: T-2
+T-4: Implement GH-42      → blockedBy: T-3
+T-5: Create PR for GH-42  → blockedBy: T-4
+T-6: Merge PR for GH-42   → blockedBy: T-5
 ```
 
-Good handoff (let the system handle it):
-```
-TaskUpdate(taskId="3", status="completed",
-  metadata={"result": "RESEARCH_COMPLETE", "artifact_path": "thoughts/shared/research/..."},
-  description="RESEARCH COMPLETE: #42 - Add caching")
-# Stop hook fires -> worker checks TaskList -> claims next task or goes idle
-```
-- **Bias toward action**: When in doubt, check TaskList. When idle, query GitHub. Zero-gap lookahead.
-- **Hooks are your safety net**: Stop hook prevents premature shutdown. State hooks prevent invalid transitions. Trust them.
-- **Escalate and move on**: If stuck, escalate via GitHub comment (`__ESCALATE__` intent) and find other work. Never block on user input.
+**Group** (N issues): N parallel research tasks, then plan/review/implement/PR as a group.
 
-### FORBIDDEN Communication Patterns
-- SendMessage immediately after TaskUpdate(owner=...) — task assignment IS the communication
-- SendMessage with task details in content — put context in TaskCreate description
-- broadcast for anything other than critical blocking issues
-- SendMessage to acknowledge receipt of a task — just start working
-- Creating tasks mid-pipeline — all tasks created upfront (see Section 4.2)
+Each task needs:
+- `subject`: e.g. "Research GH-42"
+- `activeForm`: e.g. "Researching GH-42" (present-continuous of subject)
+- `description`: Issue URL, title, estimate, group context if applicable
+- `metadata`: `{ "issue_number": "42", "command": "research", "phase": "research" }`
 
-## Section 6 - Teammate Spawning
+**Procedure**:
+1. `TaskCreate` all tasks (captures IDs)
+2. `TaskUpdate(taskId, addBlockedBy=[...])` to wire dependencies
+3. `TaskUpdate(taskId, owner="analyst")` to assign unblocked tasks
 
-No prescribed roster -- spawn what's needed. Each teammate receives a minimal prompt from a template.
+Workers discover assigned tasks via TaskList and begin work autonomously.
 
-### Spawn Procedure
+## Step 4: Monitor and Shutdown
 
-1. **Determine role and skill** from the pending task subject:
+The dispatch loop is passive. Hooks fire at decision points:
 
-   | Task subject contains | Role | Skill | Task Verb | Agent type |
-   |----------------------|------|-------|-----------|------------|
-   | "Triage" | analyst | ralph-triage | Triage | ralph-analyst |
-   | "Split" | analyst | ralph-split | Split | ralph-analyst |
-   | "Research" | analyst | ralph-research | Research | ralph-analyst |
-   | "Plan" (not "Review") | builder | ralph-plan | Plan | ralph-builder |
-   | "Review" | validator | ralph-review | Review plan for | ralph-validator |
-   | "Implement" | builder | ralph-impl | Implement | ralph-builder |
-   | "Create PR" | integrator | (none) | Integration task for | ralph-integrator |
-   | "Merge" or "Integrate" | integrator | (none) | Integration task for | ralph-integrator |
+- **TaskCompleted**: Check if all tasks done. If yes, shutdown.
+- **TeammateIdle**: Normal — don't nudge. Workers self-claim via Stop hook.
+- **Escalation (SendMessage)**: Respond and unblock.
 
-2. **Resolve template path**: `Bash("echo $CLAUDE_PLUGIN_ROOT")` to get the plugin root, then read:
-   `Read(file_path="[resolved-root]/templates/spawn/worker.md")`
+When a review completes with `verdict: "NEEDS_ITERATION"`, create a new "Plan GH-NNN" task blocked by the failed review. Builder self-claims.
 
-3. **Substitute placeholders** from the issue context and spawn table:
-   - `{ISSUE_NUMBER}` -> issue number
-   - `{TITLE}` -> issue title
-   - `{TASK_VERB}` -> from spawn table "Task Verb" column
-   - `{TASK_CONTEXT}` -> role-dependent context line:
-     - Triage: `Estimate: {ESTIMATE}.`
-     - Split: `Too large for direct implementation (estimate: {ESTIMATE}).`
-     - Plan/Review: `{GROUP_CONTEXT}` (group line if IS_GROUP, empty if not)
-     - Implement: `{WORKTREE_CONTEXT}` (worktree path if exists, empty if not)
-     - Research/Integrator: empty (line removed)
-   - `{SKILL_INVOCATION}` -> `Skill(skill="ralph-hero:[skill]", args="{ISSUE_NUMBER}")` from spawn table Skill column, with artifact path flags appended when available (see Artifact Passthrough Protocol in `shared/conventions.md`):
-     - Plan: `args="{ISSUE_NUMBER} --research-doc {RESEARCH_PATH}"` (omit flag if no path)
-     - Implement: `args="{ISSUE_NUMBER} --plan-doc {PLAN_PATH}"` (omit flag if no path)
-     - Review: `args="{ISSUE_NUMBER} --plan-doc {PLAN_PATH}"` (omit flag if no path)
-     - Research/Triage/Split: `args="{ISSUE_NUMBER}"` (no artifact flag)
-     - For integrator (no skill): `Check your task subject to determine the operation (Create PR or Merge PR).\nFollow the corresponding procedure in your agent definition.`
-   - `{REPORT_FORMAT}` -> role-specific result format from each worker SKILL.md "Team Result Reporting" section
-   - `{ESTIMATE}` -> issue estimate (only used within `{TASK_CONTEXT}` for triage/split)
-   - `{GROUP_CONTEXT}` -> group line if IS_GROUP, empty if not (only used within `{TASK_CONTEXT}` for plan/review)
-   - `{WORKTREE_CONTEXT}` -> worktree path if exists, empty if not (only used within `{TASK_CONTEXT}` for implement)
+When all tasks complete, `shutdown_request` each teammate, then `TeamDelete()`.
 
-   If a placeholder resolves to an empty string, remove the ENTIRE LINE containing it.
+## Constraints
 
-4. **Spawn**:
-   ```
-   Task(subagent_type="[agent-type-from-table]", team_name=TEAM_NAME, name="[role]",
-        prompt=[resolved template content],
-        description="[Role] GH-NNN")
-   ```
-
-See `shared/conventions.md` "Spawn Template Protocol" for full placeholder reference, authoring rules, and naming conventions.
-
-### Template Integrity
-
-**Template guidance**: The resolved template content should be the primary spawn prompt. Try to keep the prompt close to the template output -- typically 6-8 lines.
-
-**Where to put additional context**:
-- Task descriptions (via TaskCreate) -- GitHub URLs, artifact paths, group membership, worktree paths
-- Task metadata -- Structured key-value pairs that teammates and hooks can parse
-- Avoid putting lengthy analysis, code snippets, or multi-paragraph instructions in the spawn prompt
-
-**Context that belongs in task descriptions, not spawn prompts**:
-- Root cause analysis or investigation guidance
-- File paths or code snippets
-- Architectural context or background sections
-- Research hints or prior findings
-
-**Why**: Agents invoke skills in isolated context windows. The skill's own discovery process (reading GitHub comments, globbing for artifacts) provides canonical context. Task descriptions supplement this with quick-reference metadata.
-
-### Per-Role Instance Limits
-
-- **Analyst**: Up to 3 parallel (`analyst`, `analyst-2`, `analyst-3`)
-- **Builder**: Up to 3 parallel if non-overlapping file ownership (`builder`, `builder-2`, `builder-3`)
-- **Validator**: Single worker (`validator`)
-- **Integrator**: Single worker, serialized on main (`integrator`)
-
-### Worker Lifecycle
-
-- Idle workers auto-claim new tasks from TaskList
-- Nudge idle workers via SendMessage only if idle >2 minutes with unclaimed tasks
-
-### Naming Convention
-
-- Single instance: `"analyst"`, `"builder"`, `"validator"`, `"integrator"`
-- Multiple instances: `"analyst-2"`, `"analyst-3"`, `"builder-2"`, `"builder-3"`
-
-## Section 7 - Lifecycle Hooks
-
-Three hooks (defined in frontmatter) enforce continuous operation:
-- **TaskCompleted**: Triggers dispatch loop with specific next-step guidance
-- **TeammateIdle**: Triggers worker availability check
-- **Stop**: Blocks shutdown while GitHub has processable issues (exit 2). Re-entry safety via `stop_hook_active` prevents infinite loops.
-
-### Human Gates (Exhaustive List)
-
-The team operates autonomously EXCEPT for:
-1. **Cost-incurring actions**: Cloud resource provisioning, API subscriptions
-2. **Security-sensitive actions**: Credential handling, auth system changes
-3. **Explicit user stop request**: User says "stop" or terminates session
-
-Everything else is autonomous. The state machine, hooks, and GitHub Projects provide sufficient guardrails.
-
-## Section 8 - State Machine Enforcement
-
-GitHub Projects is source of truth. Hooks enforce valid transitions at the tool level. The lead's job is routing work to the right skill at the right time -- not re-enforcing what hooks already enforce.
-
-## Section 9 - Known Limitations
-
-- **Idle is normal**: Teammates go idle after every turn. This is expected behavior. Avoid shutting down workers or re-sending messages based solely on idle notifications. If a task appears stalled for more than 5 minutes, check the task description for progress updates before escalating.
-- **Task status may lag**: Check work product directly (Glob, git log). If done, mark it yourself. If not, nudge then replace.
-- **Task list scoping**: All tasks MUST be created AFTER TeamCreate (Section 4.1).
-- **State trusts GitHub**: If workflow state is wrong, behavior will be wrong.
-- **No external momentum**: Dispatch loop + hooks are the only momentum mechanism.
-- **No session resumption**: Committed work survives; teammates are lost. Recovery: new `/ralph-team` with same issue -- state detection resumes.
-- **Hybrid claiming**: Initial tasks are pre-assigned by the lead before spawning. Subsequent tasks use pull-based self-claim with consistent subjects ("Research", "Plan", "Review", "Implement", "Triage", "Split", "Merge"). Workers match on these for self-claim.
-- **Lead name hardcoded**: Always `"team-lead"`. Other names silently dropped.
-- **Messages are fire-and-forget**: If a message doesn't get a response within 2 minutes, try re-sending once, then check the task list or work product directly.
-- **Peer handoff depends on workers existing**: If a stage has no worker (never spawned or crashed), the handoff falls back to the lead. The lead must then spawn a replacement.
-
-## Section 10 - Error Handling
-
-| Scenario | Action |
-|----------|--------|
-| Teammate unresponsive >5 min | Unclaim tasks (TaskUpdate), spawn replacement |
-| Plan rejected 3x | Move to "Human Needed", comment on GitHub, shutdown team |
-| Implementation conflict | Re-analyze file ownership; expand or serialize phases |
-| Unexpected workflow state | "Done"/"Canceled": find other work. "Human Needed": report. Otherwise: escalate via GitHub comment, move to next issue |
-
-See `shared/conventions.md` for escalation protocol, link formatting, and common error handling.
-
-## Environment Variables
-
-Required: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, `RALPH_GH_OWNER`, `RALPH_GH_REPO`, `RALPH_GH_PROJECT_NUMBER`. Set by frontmatter: `RALPH_COMMAND=team`, `RALPH_AUTO_APPROVE=true`.
+- Never do research, planning, reviewing, or implementing yourself
+- Task assignment IS the communication — don't SendMessage after assigning
+- Workers go idle between turns — this is normal
+- All tasks created AFTER TeamCreate
+- If stuck, escalate via GitHub comment (`__ESCALATE__` intent) and move on

--- a/plugin/ralph-hero/skills/ralph-triage/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-triage/SKILL.md
@@ -28,7 +28,6 @@ allowed_tools:
 env:
   RALPH_COMMAND: "triage"
   RALPH_REQUIRED_BRANCH: "main"
-  CLAUDE_CODE_TASK_LIST_ID: "ralph-workflow"
 ---
 
 # Ralph GitHub Triage - Backlog Groomer
@@ -37,7 +36,7 @@ You are a triage specialist. You assess ONE Backlog issue, determine if it's sti
 
 ## Workflow
 
-### Step 0: Verify Branch
+### Step 1: Verify Branch
 
 Before starting, check that you're on the main branch:
 
@@ -56,7 +55,7 @@ Please switch to main first:
 
 Then STOP. Do not proceed.
 
-### Step 1: Select Issue
+### Step 2: Select Issue
 
 **If issue number provided**: Fetch it directly:
 ```
@@ -100,7 +99,7 @@ No untriaged issues in Backlog. Triage complete.
 ```
 Then STOP.
 
-### Step 2: Assess Issue
+### Step 3: Assess Issue
 
 1. **Read issue description and comments thoroughly**
 
@@ -129,7 +128,7 @@ Then STOP.
    - Are there duplicate issues?
    - What's the realistic scope (XS/S/M/L/XL)?
 
-### Step 3: Determine Recommendation
+### Step 4: Determine Recommendation
 
 Choose ONE action:
 
@@ -155,7 +154,7 @@ Choose ONE action:
 - Leave in Backlog for prioritization
 - Add clarifying comment if helpful
 
-### Step 4: Take Action
+### Step 5: Take Action
 
 **If CLOSE:**
 ```
@@ -241,7 +240,7 @@ Add comment: "Moved to Research Needed for investigation."
 Add comment with any clarifications or context discovered.
 Leave workflow state as Backlog.
 
-### Step 4.5: Mark Issue as Triaged
+### Step 6: Mark Issue as Triaged
 
 After completing any action (CLOSE/SPLIT/RE-ESTIMATE/RESEARCH/KEEP), apply the `ralph-triage` label:
 
@@ -255,7 +254,7 @@ ralph_hero__update_issue
 
 **Important**: Preserve existing labels when adding `ralph-triage`. Read the issue's current labels first, then include them all plus `ralph-triage` in the update.
 
-### Step 5: Find and Link Related Issues
+### Step 7: Find and Link Related Issues
 
 After triage action is complete, scan for related issues in Backlog or Research Needed:
 
@@ -334,26 +333,11 @@ After triage action is complete, scan for related issues in Backlog or Research 
    Rationale: [Brief explanation of why these are related]
    ```
 
-### Step 6: Team Result Reporting
+### Step 8: Team Result Reporting
 
-When running as a team worker, report results via TaskUpdate with structured metadata:
+When running as a team worker, mark your assigned task complete via TaskUpdate. Include key results in metadata (action taken, sub-ticket IDs if split) and a human-readable summary in the description. Then check TaskList for more work matching your role.
 
-```
-TaskUpdate(taskId, status="completed",
-  metadata={
-    "result": "TRIAGE_COMPLETE",
-    "action": "SPLIT",                    # CLOSE | SPLIT | RESEARCH | KEEP
-    "sub_tickets": "43,44,45",            # comma-separated, only for SPLIT
-    "sub_estimates": "XS,S,XS"            # parallel to sub_tickets
-  },
-  description="Triaged #42: SPLIT into 3 sub-issues (#43 XS, #44 S, #45 XS)")
-```
-
-**Critical for downstream**: `sub_tickets` -- lead creates follow-up tasks from these IDs.
-
-Then check TaskList for more tasks matching your role.
-
-### Step 7: Report
+### Step 9: Report
 
 ```
 Triage complete for #NNN: [Title]

--- a/plugin/ralph-hero/templates/spawn/worker.md
+++ b/plugin/ralph-hero/templates/spawn/worker.md
@@ -1,6 +1,0 @@
-{TASK_VERB} GH-{ISSUE_NUMBER}: {TITLE}.
-{TASK_CONTEXT}
-
-Invoke: {SKILL_INVOCATION}
-
-Report via TaskUpdate: "{REPORT_FORMAT}"

--- a/thoughts/shared/plans/2026-02-24-simplify-skill-task-instructions.md
+++ b/thoughts/shared/plans/2026-02-24-simplify-skill-task-instructions.md
@@ -1,0 +1,385 @@
+---
+date: 2026-02-24
+status: draft
+github_issues: []
+github_urls: []
+primary_issue: null
+---
+
+# Simplify Ralph Team & Worker Architecture
+
+## Overview
+
+Radical simplification of the ralph-team orchestrator, worker skills, and supporting infrastructure. Remove over-engineering, enforce clear architectural boundaries, delete dead abstractions.
+
+## Current State Analysis
+
+The ralph-team SKILL.md is 460 lines across 10 sections with streams, XS fast-track, spawn templates, placeholder resolution, behavioral principles, forbidden communication patterns, and elaborate metadata schemas. Worker skills have prescriptive TaskUpdate code blocks and static task list IDs that cause cross-session collisions. Worker agents invoke skills inline, consuming their context window.
+
+## Desired End State
+
+- ralph-team SKILL.md is ~80 lines: assess work, spawn team, build task graph, monitor
+- Worker skills have general 3-line team reporting guidance
+- No static task list IDs, no internal TaskCreate in skills
+- No spawn template system (worker.md, placeholder resolution, conventions.md protocol)
+- Worker agents use Task() for skill invocation to protect context
+- Task() subagents are leaf nodes — no nested Task() calls
+
+## What We're NOT Doing
+
+- Changing hook scripts (worker-stop-gate, team-stop-gate, etc.)
+- Changing skill workflow logic (research, plan, impl steps)
+- Changing MCP tools or server code
+
+---
+
+## Phase 1: Clean up worker skills
+
+Remove cross-session collision bugs and over-prescriptive instructions from all worker skills.
+
+### 1a. Remove `CLAUDE_CODE_TASK_LIST_ID` from skill frontmatters
+
+Remove the line `CLAUDE_CODE_TASK_LIST_ID: "ralph-workflow"` from env blocks in:
+- `plugin/ralph-hero/skills/ralph-split/SKILL.md`
+- `plugin/ralph-hero/skills/ralph-research/SKILL.md`
+- `plugin/ralph-hero/skills/ralph-plan/SKILL.md`
+- `plugin/ralph-hero/skills/ralph-triage/SKILL.md`
+
+### 1b. Remove internal TaskCreate/TaskUpdate from ralph-split
+
+**File**: `plugin/ralph-hero/skills/ralph-split/SKILL.md`
+
+- Delete Step 2.5 "Create Split Tasks" entirely (two TaskCreate calls)
+- Remove `analyze_task`/`create_task` TaskUpdate wrapper calls from Steps 3 and 5
+- Keep the actual split work content in those steps
+
+### 1c. Simplify Team Result Reporting across all 6 worker skills
+
+Replace each skill's verbose Team Result Reporting section with:
+
+```markdown
+When running as a team worker, mark your assigned task complete via TaskUpdate. Include key results in metadata and a human-readable summary in the description. Then check TaskList for more work matching your role.
+```
+
+Files: ralph-split, ralph-research, ralph-plan, ralph-impl, ralph-review, ralph-triage
+
+### Success Criteria
+- [x] `grep -r "CLAUDE_CODE_TASK_LIST_ID" plugin/ralph-hero/skills/` returns no results
+- [x] `grep -r "TaskCreate" plugin/ralph-hero/skills/ralph-split/` returns no results
+- [x] No references to `analyze_task` or `create_task` in ralph-split
+- [x] Each skill's Team Result Reporting section is ≤5 lines
+
+---
+
+## Phase 2: Renumber all skill steps to sequential integers
+
+Every skill has accumulated fractional steps (0, 1.5, 2.25, 3.5, 4.5, 9.5) from incremental additions. Renumber all to clean sequential integers.
+
+### Changes Required
+
+For each skill, rename `### Step N:` headers to sequential integers starting at 1. No content changes — just renumber.
+
+**ralph-split** (current → new):
+| Current | New | Title |
+|---------|-----|-------|
+| Step 1 | Step 1 | Select Issue for Splitting |
+| Step 2 | Step 2 | Fetch and Analyze Issue |
+| Step 2.25 | Step 3 | Discover Existing Children |
+| Step 3 | Step 4 | Research Scope |
+| Step 4 | Step 5 | Propose Split |
+| Step 5 | Step 6 | Create or Update Sub-Issues |
+| Step 6 | Step 7 | Establish Dependencies |
+| Step 7 | Step 8 | Update Original Issue |
+| Step 8 | Step 9 | Move Sub-Issues to Appropriate State |
+| Step 9 | Step 10 | Team Result Reporting |
+| Step 10 | Step 11 | Report |
+
+**ralph-research** (current → new):
+| Current | New | Title |
+|---------|-----|-------|
+| Step 0 | Step 1 | Verify Branch |
+| Step 1 | Step 2 | Select Issue |
+| Step 2 | Step 3 | Transition to Research in Progress |
+| Step 3 | Step 4 | Conduct Research |
+| Step 3.5 | Step 5 | Refine Group Dependencies |
+| Step 4 | Step 6 | Create Research Document |
+| Step 4.5 | Step 7 | Commit and Push |
+| Step 5 | Step 8 | Update GitHub Issue |
+| Step 6 | Step 9 | Team Result Reporting |
+| Step 7 | Step 10 | Report Completion |
+
+**ralph-plan** (current → new):
+| Current | New | Title |
+|---------|-----|-------|
+| Step 0 | Step 1 | Verify Branch |
+| Step 1 | Step 2 | Select Issue Group for Planning |
+| Step 2 | Step 3 | Gather Group Context |
+| Step 3 | Step 4 | Transition to Plan in Progress |
+| Step 4 | Step 5 | Create Implementation Plan |
+| Step 4.5 | Step 6 | Commit and Push |
+| Step 5 | Step 7 | Update All Group Issues |
+| Step 6 | Step 8 | Team Result Reporting |
+| Step 7 | Step 9 | Report Completion |
+
+**ralph-triage** (current → new):
+| Current | New | Title |
+|---------|-----|-------|
+| Step 0 | Step 1 | Verify Branch |
+| Step 1 | Step 2 | Select Issue |
+| Step 2 | Step 3 | Assess Issue |
+| Step 3 | Step 4 | Determine Recommendation |
+| Step 4 | Step 5 | Take Action |
+| Step 4.5 | Step 6 | Mark Issue as Triaged |
+| Step 5 | Step 7 | Find and Link Related Issues |
+| Step 6 | Step 8 | Team Result Reporting |
+| Step 7 | Step 9 | Report |
+
+**ralph-impl** (current → new):
+| Current | New | Title |
+|---------|-----|-------|
+| Step 1 | Step 1 | Select Implementation Target |
+| Step 1.5 | Step 2 | Detect Mode |
+| Step 2 | Step 3 | Gather Context and Build Issue List |
+| Step 3 | Step 4 | Verify Readiness (First Phase Only) |
+| Step 4 | Step 5 | Transition to In Progress |
+| Step 5 | Step 6 | Set Up or Reuse Worktree |
+| Step 6 | Step 7 | Implement ONE Phase |
+| Step 7 | Step 8 | Commit and Push |
+| Step 8 | Step 9 | Check if All Phases Complete |
+| Step 9 | Step 10 | Create PR (Final Phase Only) |
+| Step 9.5 | Step 11 | PR Gate |
+| Step 10 | Step 12 | Update GitHub Issues (Final Phase Only) |
+| Step 11 | Step 13 | Team Result Reporting |
+| Step 12 | Step 14 | Final Report |
+
+**ralph-review** (current → new):
+| Current | New | Title |
+|---------|-----|-------|
+| Step 0 | Step 1 | Detect Execution Mode |
+| Step 1 | Step 2 | Select Issue |
+| Step 2 | Step 3 | Validate Plan Exists |
+| Step 3A | Step 4A | INTERACTIVE Mode - Wizard Review |
+| Step 3B | Step 4B | AUTO Mode - Delegated Critique |
+| Step 4 | Step 5 | Execute Transition |
+| Step 5 | Step 6 | Team Result Reporting |
+| Step 6 | Step 7 | Report Completion |
+
+Also fix any internal cross-references (e.g., "see Step 4.5" → "see Step 6").
+
+### Success Criteria
+- [x] No fractional step numbers (0, 1.5, 2.25, 3.5, 4.5, 9.5) in any skill
+- [x] All steps are sequential integers starting at 1
+- [x] Internal cross-references updated to match new numbers
+
+---
+
+## Phase 3: Rewrite ralph-team SKILL.md
+
+Replace the entire 460-line body with ~80 lines covering 4 steps.
+
+**File**: `plugin/ralph-hero/skills/ralph-team/SKILL.md`
+
+**Keep frontmatter as-is** (hooks, env, allowed_tools, model).
+
+**Replace entire body** with:
+
+````markdown
+# Ralph Team
+
+You coordinate a team of specialists to process GitHub issues. You NEVER do substantive work yourself — you delegate everything.
+
+## Step 1: Assess Work
+
+Fetch the issue and detect its pipeline position:
+
+```
+ralph_hero__get_issue(number=[issue-number])
+ralph_hero__detect_pipeline_position(number=[issue-number])
+```
+
+The response tells you:
+- `phase`: Where to start (TRIAGE, RESEARCH, PLAN, REVIEW, IMPLEMENT, TERMINAL)
+- `remainingPhases`: What's left
+- `suggestedRoster`: Which worker roles to spawn
+- `convergence`: Whether a group is ready for the next gate
+
+If TERMINAL (PR exists or issue Done), report and stop.
+
+## Step 2: Create Team and Spawn Workers
+
+```
+TeamCreate(team_name="ralph-team-GH-NNN")
+```
+
+Spawn one teammate per role from `suggestedRoster`:
+
+```
+Task(subagent_type="ralph-analyst", team_name="ralph-team-GH-NNN", name="analyst",
+     prompt="You are an analyst on ralph-team-GH-NNN. Check TaskList for your assigned work.",
+     description="Analyst for GH-NNN")
+```
+
+| Role | Agent type | Handles |
+|------|-----------|---------|
+| analyst | ralph-analyst | Research, Triage, Split |
+| builder | ralph-builder | Plan, Implement |
+| validator | ralph-validator | Review |
+| integrator | ralph-integrator | Create PR, Merge PR |
+
+Multiple analysts/builders allowed (append `-2`, `-3`). One validator, one integrator.
+
+## Step 3: Build Task Graph
+
+Create the full pipeline as tasks with `blockedBy` chains. Assign owners on unblocked tasks.
+
+**Single issue example**:
+```
+T-1: Research GH-42       → unblocked      → owner: analyst
+T-2: Plan GH-42           → blockedBy: T-1 → owner: (none, claimed later)
+T-3: Review plan GH-42    → blockedBy: T-2
+T-4: Implement GH-42      → blockedBy: T-3
+T-5: Create PR for GH-42  → blockedBy: T-4
+T-6: Merge PR for GH-42   → blockedBy: T-5
+```
+
+**Group** (N issues): N parallel research tasks, then plan/review/implement/PR as a group.
+
+Each task needs:
+- `subject`: e.g. "Research GH-42"
+- `activeForm`: e.g. "Researching GH-42" (present-continuous of subject)
+- `description`: Issue URL, title, estimate, group context if applicable
+- `metadata`: `{ "issue_number": "42", "command": "research", "phase": "research" }`
+
+**Procedure**:
+1. `TaskCreate` all tasks (captures IDs)
+2. `TaskUpdate(taskId, addBlockedBy=[...])` to wire dependencies
+3. `TaskUpdate(taskId, owner="analyst")` to assign unblocked tasks
+
+Workers discover assigned tasks via TaskList and begin work autonomously.
+
+## Step 4: Monitor and Shutdown
+
+The dispatch loop is passive. Hooks fire at decision points:
+
+- **TaskCompleted**: Check if all tasks done. If yes, shutdown.
+- **TeammateIdle**: Normal — don't nudge. Workers self-claim via Stop hook.
+- **Escalation (SendMessage)**: Respond and unblock.
+
+When a review completes with `verdict: "NEEDS_ITERATION"`, create a new "Plan GH-NNN" task blocked by the failed review. Builder self-claims.
+
+When all tasks complete, `shutdown_request` each teammate, then `TeamDelete()`.
+
+## Constraints
+
+- Never do research, planning, reviewing, or implementing yourself
+- Task assignment IS the communication — don't SendMessage after assigning
+- Workers go idle between turns — this is normal
+- All tasks created AFTER TeamCreate
+- If stuck, escalate via GitHub comment (`__ESCALATE__` intent) and move on
+````
+
+### Success Criteria
+- [x] ralph-team SKILL.md body is ≤100 lines (excluding frontmatter)
+- [x] No references to: streams, XS fast-track, Mode B, spawn templates, behavioral principles
+- [x] Contains exactly 4 steps: Assess, Create Team, Build Tasks, Monitor
+
+---
+
+## Phase 4: Delete spawn template system
+
+### 3a. Delete template file and directory
+
+- Delete `plugin/ralph-hero/templates/spawn/worker.md`
+- Remove `plugin/ralph-hero/templates/` directory if empty
+
+### 3b. Remove Spawn Template Protocol from conventions.md
+
+**File**: `plugin/ralph-hero/skills/shared/conventions.md`
+
+Delete the entire "Spawn Template Protocol" section, including:
+- Template Location
+- Placeholder Substitution table
+- Group/Worktree/Stream Context Resolution
+- Empty Placeholder Line Removal
+- Resolution Procedure
+
+### 3c. Remove Work Streams section from conventions.md
+
+**File**: `plugin/ralph-hero/skills/shared/conventions.md`
+
+Delete the entire "Work Streams" section, including:
+- Stream ID Format
+- Naming Conventions table
+- Lifecycle description
+
+### Success Criteria
+- [x] `plugin/ralph-hero/templates/spawn/worker.md` does not exist
+- [x] No "Spawn Template Protocol" section in conventions.md
+- [x] No "Work Streams" section in conventions.md
+
+---
+
+## Phase 5: Update worker agents for Task() context protection
+
+Workers use Task() to invoke skills, keeping their own context window clean. Task() subagents are leaf nodes — they cannot call Task() themselves.
+
+### 4a. Update ralph-analyst, ralph-builder, ralph-validator
+
+**Files**:
+- `plugin/ralph-hero/agents/ralph-analyst.md`
+- `plugin/ralph-hero/agents/ralph-builder.md`
+- `plugin/ralph-hero/agents/ralph-validator.md`
+
+Replace the current Task Loop with:
+
+```markdown
+## Task Loop
+
+1. Check TaskList for assigned or unclaimed tasks matching your role
+2. Claim unclaimed tasks: `TaskUpdate(taskId, owner="my-name")`
+3. Read task context via TaskGet
+4. **Run the skill via Task()** to protect your context window:
+   ```
+   Task(subagent_type="general-purpose",
+        prompt="Skill(skill='ralph-hero:ralph-research', args='NNN')",
+        description="Research GH-NNN")
+   ```
+5. Report results via TaskUpdate (metadata + description)
+6. Check TaskList for more work before stopping
+
+**Important**: Task() subagents cannot call Task() — they are leaf nodes.
+```
+
+Remove verbose first-turn disclaimers and claim-lost-to-another-worker flows. Keep role-specific notes (analyst: sub-ticket IDs, builder: revision handling + implementation notes, validator: VERDICT in description).
+
+### 4b. Simplify ralph-integrator task loop header
+
+**File**: `plugin/ralph-hero/agents/ralph-integrator.md`
+
+Integrator runs git/gh commands directly (no skill invocation). Simplify the task loop to match the same 6-step pattern but without the Task() wrapping. Keep PR Creation and Merge procedures as-is.
+
+### Success Criteria
+- [x] All 3 skill-invoking agents (analyst, builder, validator) use `Task()` for skill invocation
+- [x] All agents mention the "no nested Task()" constraint
+- [x] Integrator retains direct command execution
+
+---
+
+## Integration Testing
+
+- [x] `grep -r "CLAUDE_CODE_TASK_LIST_ID" plugin/ralph-hero/skills/` returns no results
+- [x] `grep -r "TaskCreate" plugin/ralph-hero/skills/ralph-split/` returns no results
+- [x] `grep -r "REPORT_FORMAT" plugin/ralph-hero/` returns no results
+- [x] Each skill's Team Result Reporting section is ≤5 lines
+- [x] No fractional step numbers in any skill SKILL.md
+- [x] ralph-team SKILL.md body is ≤100 lines
+- [x] `plugin/ralph-hero/templates/spawn/worker.md` does not exist
+- [x] No "Spawn Template Protocol" in conventions.md
+- [x] No "Work Streams" in conventions.md
+- [x] Worker agents use Task() for skill invocation
+
+## References
+
+- Research: `thoughts/shared/research/2026-02-24-agent-teams-task-list-scoping.md`
+- Root cause analysis from GH-364 ralph-team session
+- disler/IndyDevDan agent team implementations (observability hooks, builder/validator pattern)


### PR DESCRIPTION
## Summary
- Radical simplification of ralph-team orchestrator (460 → 93 lines), worker skills, and supporting infrastructure
- Renumber all 6 worker skill steps to clean sequential integers (removes fractional steps like 0, 1.5, 2.25)
- Delete spawn template system (worker.md, placeholder resolution, conventions.md protocols)
- Update worker agents with Task() context-protected skill invocation pattern

## Changes
- **Phase 1** (prior): Remove `CLAUDE_CODE_TASK_LIST_ID`, internal TaskCreate, verbose team reporting
- **Phase 2**: Renumber all skill steps to sequential integers, fix cross-references
- **Phase 3**: Rewrite ralph-team SKILL.md to 4 steps (Assess, Create Team, Build Tasks, Monitor)
- **Phase 4**: Delete `templates/spawn/worker.md`, remove Spawn Template Protocol and Work Streams from conventions.md
- **Phase 5**: Worker agents (analyst, builder, validator) use `Task()` for skill invocation; all agents document leaf node constraint

## Test plan
- [ ] `grep -r "CLAUDE_CODE_TASK_LIST_ID" plugin/ralph-hero/skills/` returns no results
- [ ] No fractional step numbers in any skill SKILL.md
- [ ] ralph-team SKILL.md body is ≤100 lines
- [ ] `plugin/ralph-hero/templates/spawn/worker.md` does not exist
- [ ] No "Spawn Template Protocol" or "Work Streams" in conventions.md
- [ ] Worker agents use `Task()` for skill invocation with leaf node constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)