### PR TITLE
fix(justfile): move comments before attributes to fix parse error

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -1,12 +1,11 @@
 # Ralph Hero - LLM-powered workflow recipes
 #
 # Usage: just <recipe> [params...]
-# Prerequisites: claude CLI, timeout (coreutils), just >= 1.29
+# Prerequisites: claude CLI, timeout (coreutils), just >= 1.37
 # Optional: mcptools (https://github.com/f/mcptools) for quick-* recipes
 
 set shell := ["bash", "-euc"]
 set dotenv-load
-set min-version := "1.29.0"
 
 # Aliases for frequently-used recipes
 alias t  := triage
@@ -26,63 +25,63 @@ default:
         just --list
     fi
 
-[group('workflow')]
 # Triage a backlog issue - assess validity, close duplicates, route to research
+[group('workflow')]
 triage issue="" budget="1.00" timeout="15m":
     @just _run_skill "triage" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Split a large issue into smaller XS/S sub-issues
+[group('workflow')]
 split issue="" budget="1.00" timeout="15m":
     @just _run_skill "split" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Research an issue - investigate codebase, create findings document
+[group('workflow')]
 research issue="" budget="2.00" timeout="15m":
     @just _run_skill "research" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Create implementation plan from research findings
+[group('workflow')]
 plan issue="" budget="3.00" timeout="15m":
     @just _run_skill "plan" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Review and critique an implementation plan
+[group('workflow')]
 review issue="" budget="2.00" timeout="15m":
     @just _run_skill "review" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Implement an issue following its approved plan
+[group('workflow')]
 impl issue="" budget="5.00" timeout="15m":
     @just _run_skill "impl" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Run project hygiene check - stale items, archive candidates
+[group('workflow')]
 hygiene budget="0.50" timeout="10m":
     @just _run_skill "hygiene" "" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Display pipeline status dashboard with health indicators
+[group('workflow')]
 status budget="0.50" timeout="10m":
     @just _run_skill "status" "" "{{budget}}" "{{timeout}}"
 
-[group('workflow')]
 # Generate and post a project status report
+[group('workflow')]
 report issue="" budget="1.00" timeout="10m":
     @just _run_skill "report" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('orchestrate')]
 # Multi-agent team coordinator - spawns specialist workers
+[group('orchestrate')]
 team issue="" budget="10.00" timeout="30m":
     RALPH_BUDGET="{{budget}}" TIMEOUT="{{timeout}}" ./scripts/ralph-team-loop.sh {{issue}}
 
-[group('orchestrate')]
 # Tree-expansion orchestrator - drives issue through full lifecycle
+[group('orchestrate')]
 hero issue="" budget="10.00" timeout="30m":
     @just _run_skill "hero" "{{issue}}" "{{budget}}" "{{timeout}}"
 
-[group('orchestrate')]
 # Sequential autonomous loop - hygiene, triage, split, research, plan, review, impl
+[group('orchestrate')]
 loop mode="all" review="skip" split="auto" hygiene="auto" budget="5.00" timeout="60m":
     #!/usr/bin/env bash
     set -eu
@@ -91,13 +90,13 @@ loop mode="all" review="skip" split="auto" hygiene="auto" budget="5.00" timeout=
     args="$args --review={{review}} --split={{split}} --hygiene={{hygiene}}"
     RALPH_BUDGET="{{budget}}" TIMEOUT="{{timeout}}" ./scripts/ralph-loop.sh $args
 
-[group('setup')]
 # One-time project setup - create GitHub Project V2 with required fields
+[group('setup')]
 setup budget="1.00" timeout="10m":
     @just _run_skill "setup" "" "{{budget}}" "{{timeout}}"
 
-[group('setup')]
 # Diagnose setup issues - checks env, deps, plugin manifest, and API connectivity
+[group('setup')]
 doctor:
     #!/usr/bin/env bash
     set -eu
@@ -180,9 +179,9 @@ doctor:
     echo "=== Summary: $errors error(s), $warnings warning(s) ==="
     if [ "$errors" -gt 0 ]; then exit 1; fi
 
+# Install global 'ralph' command - run from anywhere after setup
 [group('setup')]
 [confirm('This will install ralph to ~/.local/bin/ralph (overwriting if exists). Continue?')]
-# Install global 'ralph' command - run from anywhere after setup
 install-cli:
     #!/usr/bin/env bash
     set -eu
@@ -207,9 +206,9 @@ install-cli:
     echo "  ralph team 42"
     echo "For tab completions: just install-completions bash  (or zsh)"
 
+# Remove global 'ralph' command
 [group('setup')]
 [confirm('Are you sure you want to uninstall the ralph CLI?')]
-# Remove global 'ralph' command
 uninstall-cli:
     #!/usr/bin/env bash
     set -eu
@@ -231,9 +230,9 @@ uninstall-cli:
         echo "Nothing to uninstall -- ralph CLI was not installed."
     fi
 
+# Install shell completions for the global 'ralph' command
 [group('setup')]
 [confirm('This will install shell completions (overwriting if exists). Continue?')]
-# Install shell completions for the global 'ralph' command
 install-completions shell="bash":
     #!/usr/bin/env bash
     set -eu
@@ -259,37 +258,37 @@ install-completions shell="bash":
             ;;
     esac
 
-[group('setup')]
 # Generate shell tab completions (bash, zsh, fish, powershell, elvish)
+[group('setup')]
 completions shell="bash":
     @just --completions {{shell}}
 
-[group('quick')]
 # Pipeline status dashboard - instant, no API cost
+[group('quick')]
 quick-status format="markdown":
     @just _mcp_call "ralph_hero__pipeline_dashboard" \
         '{"format":"{{format}}","includeHealth":true}'
 
-[group('quick')]
 # Move issue to a workflow state - instant, no API cost
+[group('quick')]
 quick-move issue state:
     @just _mcp_call "ralph_hero__update_workflow_state" \
         '{"number":{{issue}},"state":"{{state}}","command":"ralph_cli"}'
 
-[group('quick')]
 # Find next actionable issue by workflow state - instant, no API cost
+[group('quick')]
 quick-pick state="Research Needed" max-estimate="S":
     @just _mcp_call "ralph_hero__pick_actionable_issue" \
         '{"workflowState":"{{state}}","maxEstimate":"{{max-estimate}}"}'
 
-[group('quick')]
 # Assign issue to a GitHub user - instant, no API cost
+[group('quick')]
 quick-assign issue user:
     @just _mcp_call "ralph_hero__update_issue" \
         '{"number":{{issue}},"assignees":["{{user}}"]}'
 
-[group('quick')]
 # Create a new issue with project fields - instant, no API cost
+[group('quick')]
 quick-issue title label="" priority="" estimate="" state="Backlog":
     #!/usr/bin/env bash
     set -eu
@@ -300,20 +299,20 @@ quick-issue title label="" priority="" estimate="" state="Backlog":
     params="$params,\"workflowState\":\"{{state}}\"}"
     just _mcp_call "ralph_hero__create_issue" "$params"
 
-[group('quick')]
 # Get full issue details with project fields - instant, no API cost
+[group('quick')]
 quick-info issue:
     @just _mcp_call "ralph_hero__get_issue" \
         '{"number":{{issue}}}'
 
-[group('quick')]
 # Add a comment to an issue - instant, no API cost
+[group('quick')]
 quick-comment issue body:
     @just _mcp_call "ralph_hero__create_comment" \
         '{"number":{{issue}},"body":"{{body}}"}'
 
-[group('quick')]
 # Create a draft issue on the project board (no GitHub issue, just a card)
+[group('quick')]
 quick-draft title priority="" estimate="" state="Backlog":
     #!/usr/bin/env bash
     set -eu


### PR DESCRIPTION
## Summary

- Move `# description` comments **before** `[group()]`/`[confirm()]` attributes instead of between attributes and recipe names, fixing a parse error on all just versions
- Remove non-existent `set min-version := "1.29.0"` setting (proposed in casey/just#2290 but never implemented)
- Update prerequisite comment from `just >= 1.29` to `just >= 1.37` (when `[group()]` was introduced)

Closes #394

## Test plan

- [x] `just --list` shows all 35 recipes with correct grouping and descriptions
- [ ] `just doctor` runs successfully
- [ ] `just status` invokes the skill correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)