### PR TITLE
fix: justfile parse error + add justfile to release triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
       - 'plugin/ralph-hero/hooks/**'
       - 'plugin/ralph-hero/scripts/**'
       - 'plugin/ralph-hero/templates/**'
+      - 'plugin/ralph-hero/justfile'
   workflow_dispatch:
     inputs:
       bump:


### PR DESCRIPTION
## Summary
- Fixes justfile parse error by moving comments before attributes (GH-394)
- Adds `plugin/ralph-hero/justfile` to the release workflow's `paths` filter so justfile changes trigger a new versioned release

## Context
Previously, changes to the justfile didn't trigger a release because it wasn't in the `paths` list in `release.yml`. This meant plugin users couldn't get the fix via version upgrade.

## Test plan
- [ ] CI passes
- [ ] After merge, release workflow triggers and creates a new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)