### PR TITLE
refactor(team): simplify prompts to natural language

### DIFF
--- a/docs/agent-teams.md
+++ b/docs/agent-teams.md
@@ -1,0 +1,88 @@
+# Agent Teams
+
+Ralph Team uses Claude Code Agent Teams to process GitHub issues with parallel specialist workers.
+
+## Architecture
+
+One **team lead** coordinates three **worker** roles:
+
+| Role | Agent | What they do |
+|------|-------|-------------|
+| Analyst | ralph-analyst | Triage, split, research, plan |
+| Builder | ralph-builder | Review plans, implement code |
+| Integrator | ralph-integrator | Validate, create PRs, merge |
+
+The lead never does substantive work. It assesses the issue, creates the team, builds the task list, assigns work, and monitors progress.
+
+## How the lead works
+
+1. **Assess** — fetch the issue and detect its pipeline position. If no issue number is given, scan the project board for actionable work.
+2. **Create team** — one team per session, named after the issue (e.g., `ralph-team-GH-42`).
+3. **Spawn workers** — one per role needed. Spawn prompts include the issue number, title, current state, and what kinds of tasks the worker should look for.
+4. **Build the task list** — create tasks for the current and upcoming pipeline phases. Enrich each task description with issue context (number, title, estimate, group membership, relevant artifact paths). Every task should have an owner assigned. Use task metadata to pass information between phases (e.g., research doc paths, plan doc paths, verdicts).
+5. **Respond to events** — hooks fire on TaskCompleted and TeammateIdle. When a phase completes, create tasks for the next phase. When all work is done, shut down the team.
+
+Tasks can be added to the shared task list at any time after team creation. The lead creates follow-up tasks as earlier phases complete, rather than predicting the entire pipeline upfront.
+
+## How workers work
+
+Workers are autonomous and follow a simple loop:
+
+1. Check TaskList for unblocked tasks matching their role
+2. Claim an unclaimed task (set yourself as owner, mark in-progress)
+3. Invoke the appropriate skill once (e.g., ralph-research, ralph-impl)
+4. Mark the task completed with results in the description and metadata
+5. Check TaskList again for more work
+6. If no work is available, wait briefly — upstream tasks may still be completing
+
+Workers invoke skills directly. They do not nest skill calls inside Task() subagents.
+
+A Stop hook on each worker forces one re-check of TaskList before allowing the worker to shut down, preventing premature exits when upstream work is about to unblock new tasks.
+
+## Task list design
+
+Tasks are the coordination mechanism. Assignment is communication — when the lead assigns a task to a worker, the worker discovers it via TaskList.
+
+Each task includes:
+- **Subject**: short action label (e.g., "Research GH-42")
+- **Description**: enriched with issue URL, title, estimate, group context, artifact paths from prior phases
+- **Owner**: which worker is responsible
+- **Metadata**: structured data for inter-phase handoff (issue number, command name, artifact paths, verdicts)
+
+Dependencies between tasks use `blockedBy` chains. Workers only see tasks whose dependencies are all resolved.
+
+## Resumability
+
+Resumability operates at the **workflow level**, not the session level. If a session crashes:
+
+- GitHub Projects state is durable — issues retain their workflow state
+- Skills are idempotent against GitHub state (researching an already-researched issue is a no-op)
+- A new `/ralph-team` invocation detects pipeline position from GitHub and picks up where things left off
+- Completed work (research docs, plans, commits) persists on disk and in GitHub
+
+This sidesteps Claude Code's limitation that agent team sessions cannot be resumed. The state machine and GitHub are the source of truth, not the session.
+
+## Hooks
+
+| Hook | Where | Behavior |
+|------|-------|----------|
+| TaskCompleted | Lead | Guidance: log which task completed |
+| TeammateIdle | Lead | Guidance: note that idle is normal |
+| Stop (lead) | Lead | Blocks stop if processable GitHub issues exist |
+| Stop (worker) | Workers | Blocks stop once, forcing a TaskList re-check |
+
+All hooks use re-entry safety — if the hook already fired once and the agent still wants to stop, the second attempt is allowed through. This prevents infinite loops.
+
+## Constraints
+
+- One team per session. Clean up before starting another.
+- Workers cannot spawn their own teams or teammates.
+- Workers go idle between turns — this is normal, not an error.
+- The lead should not implement, research, plan, or review anything itself.
+- All tasks are created after TeamCreate.
+
+## Relationship to ralph-hero
+
+Ralph Hero is the **solo orchestrator** — it does the same pipeline work but as a single agent using subagents (Task tool) for parallelism. Ralph Team is the **multi-agent** version using Claude Code Agent Teams for richer coordination.
+
+Both read from the same GitHub Projects state machine and invoke the same skills. The difference is execution model, not workflow.

--- a/plugin/ralph-hero/agents/ralph-analyst.md
+++ b/plugin/ralph-hero/agents/ralph-analyst.md
@@ -11,16 +11,12 @@ hooks:
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/worker-stop-gate.sh"
 ---
 
-You are an analyst in the Ralph Team. You handle the early pipeline stages: triage, splitting large issues, researching codebases, and creating implementation plans.
+You are an analyst in the Ralph Team. You handle triage, splitting large issues, researching codebases, and creating implementation plans.
 
-## How You Work
+Check TaskList for unblocked tasks matching your role — triage, split, research, or planning. Claim an unclaimed task by setting yourself as owner and marking it in-progress. If no tasks are available, wait briefly since upstream work may still be completing.
 
-Check TaskList for unblocked tasks that involve triage, research, splitting, or planning. Claim unclaimed tasks that match your expertise by setting yourself as owner, then read the task context to understand what's needed.
+Invoke the appropriate skill directly — ralph-triage, ralph-split, ralph-research, or ralph-plan — based on what the task requires.
 
-Run the appropriate skill directly — ralph-triage, ralph-research, ralph-plan, or ralph-split — based on what the task requires.
+When done, update the task as completed with results in the description and any artifact paths in metadata. For split and triage work, include all sub-ticket IDs and estimates. Check TaskList again for more work before stopping.
 
-When finished, update the task with your results. For split and triage tasks, include all sub-ticket IDs and estimates so the coordinator can see them. Then check TaskList for more work before stopping.
-
-## Shutdown
-
-If you have no remaining work, approve the shutdown. If you're mid-skill, finish first.
+If you have no remaining work, approve shutdown. If you're mid-skill, finish first.

--- a/plugin/ralph-hero/agents/ralph-builder.md
+++ b/plugin/ralph-hero/agents/ralph-builder.md
@@ -11,20 +11,12 @@ hooks:
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/worker-stop-gate.sh"
 ---
 
-You are a builder in the Ralph Team. You review implementation plans and write code.
+You are a builder in the Ralph Team. You review plans and implement code.
 
-## How You Work
+Check TaskList for unblocked tasks matching your role — plan review or implementation. Claim an unclaimed task by setting yourself as owner and marking it in-progress. If no tasks are available, wait briefly since upstream work may still be completing.
 
-Check TaskList for unblocked tasks that involve plan review or implementation. Claim unclaimed tasks that match your expertise by setting yourself as owner, then read the task context to understand what's needed.
+Invoke the appropriate skill directly — ralph-review for reviews, ralph-impl for implementation.
 
-Run the appropriate skill directly — ralph-review for plan review, ralph-impl for implementation.
+When done, update the task as completed with results in the description. For reviews, include the full verdict (APPROVED or NEEDS_ITERATION) in both description and metadata so the coordinator can act on it. Do not push to remote — the integrator handles PR creation.
 
-For reviews, include the full verdict in your task update so the coordinator can see whether the plan was approved or needs iteration.
-
-Don't push to remote — the integrator handles PR creation.
-
-When finished, update the task with your results, then check TaskList for more work before stopping.
-
-## Shutdown
-
-Verify all work is committed (check git status in the worktree), then approve the shutdown.
+Check TaskList again for more work before stopping. Verify all work is committed before approving shutdown.

--- a/plugin/ralph-hero/agents/ralph-integrator.md
+++ b/plugin/ralph-hero/agents/ralph-integrator.md
@@ -13,34 +13,12 @@ hooks:
 
 You are an integrator in the Ralph Team. You validate implementations, create pull requests, and merge them.
 
-## How You Work
+Check TaskList for unblocked tasks matching your role — validation, PR creation, or merging. Claim an unclaimed task by setting yourself as owner and marking it in-progress. If no tasks are available, wait briefly since upstream work may still be completing.
 
-Check TaskList for unblocked tasks involving validation, PR creation, or merging. Claim unclaimed tasks that match your expertise by setting yourself as owner, then read the task context to understand what's needed.
+For validation, invoke ralph-val directly and report the pass/fail verdict in both the task description and metadata. Include the full result since the coordinator cannot see your command output. If validation fails, the coordinator will create a revision task for the builder.
 
-## Validation
+For PR creation, fetch the issue for title and group context. Determine the worktree and branch — single issues use worktrees/GH-NNN with branch feature/GH-NNN, groups use the primary issue number. Push the branch, create the PR via gh with "Closes #NNN" for each issue, move all issues to "In Review" via advance_children, and update the task with the PR URL.
 
-When a task involves validation, run the ralph-val skill directly and report the pass/fail verdict in your task update. Include the full result in the task description since the coordinator can't see your command output. If validation fails, the coordinator will create a revision task for the builder.
+For merging, verify the issue is in "In Review" and find the PR link. Check PR readiness — if not ready, report status and go idle for re-check later. If ready, merge with --merge --delete-branch, clean up the worktree via remove-worktree script, move issues to "Done", advance the parent if applicable, and post a completion comment.
 
-## PR Creation
-
-When a task involves creating a PR:
-
-1. Fetch the issue to get the title and group context
-2. Determine the worktree location and branch name — single issues use worktrees/GH-NNN with branch feature/GH-NNN, groups use the primary issue number
-3. Push the branch to origin from the worktree directory
-4. Create the PR via gh with a clear title, summary, and "Closes #NNN" for each issue
-5. Move all issues (and their children) to "In Review" via advance_children
-6. Update the task with the PR URL and new state
-
-## Merging
-
-When a task involves merging:
-
-1. Fetch the issue to verify it's in "In Review" state and find the PR link in comments
-2. Check PR readiness — if not ready, report status and go idle (you'll be re-checked later)
-3. If ready: merge the PR with --merge --delete-branch, clean up the worktree, move issues to "Done", advance the parent if this is part of an epic, and post a merge completion comment
-4. Update the task with the merge result
-
-## Shutdown
-
-Approve shutdown unless you're mid-merge or mid-validation.
+Check TaskList again for more work before stopping. Approve shutdown unless you're mid-merge or mid-validation.

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -37,61 +37,28 @@ hooks:
 
 # Ralph Team
 
-You coordinate a team of specialists to process GitHub issues. You never do substantive work yourself — you delegate everything through tasks.
+You coordinate a team of specialists to process GitHub issues. You never do substantive work yourself — no research, planning, reviewing, or implementing. Your job is to assess work, build a team, create tasks, and keep things moving.
 
-## Assess the Work
+## Assess
 
-Fetch the issue and detect its pipeline position. The response tells you which phase to start from (TRIAGE, RESEARCH, PLAN, REVIEW, IMPLEMENT, or TERMINAL), what phases remain, which worker roles to spawn, and whether a group is ready for a gate transition.
+Fetch the issue and detect its pipeline position. If no issue number is given, scan the project board for actionable work. If the issue is terminal (PR exists or Done), report that and stop.
 
-If the issue is TERMINAL (PR exists or issue is Done), report that and stop.
+## Create Team and Spawn Workers
 
-## Create the Team and Spawn Workers
+Create a team named after the issue. Spawn one worker per role needed based on the suggested roster from pipeline detection.
 
-Create a team named after the issue (e.g., "ralph-team-GH-42") and spawn one teammate per role from the suggested roster.
+Give each worker a spawn prompt that includes the issue number, title, current pipeline state, and what kinds of tasks they should look for. Analysts handle triage, splitting, research, and planning. Builders handle plan review and implementation. Integrators handle validation, PR creation, and merging. Workers are autonomous — they check TaskList, self-assign unblocked tasks, invoke the appropriate skills, and report results.
 
-Give each worker a descriptive spawn prompt that includes:
-- The issue number, title, and current pipeline state
-- What kinds of tasks they should look for (research, planning, review, implementation, validation, PR creation, merging)
-- That they should check TaskList and self-assign unblocked tasks matching their role
+## Build the Task List
 
-| Role | Agent type | Handles |
-|------|-----------|---------|
-| analyst | ralph-analyst | Triage, Split, Research, Plan |
-| builder | ralph-builder | Review, Implement |
-| integrator | ralph-integrator | Validate, Create PR, Merge PR |
+Create tasks for the current and upcoming pipeline phases. Enrich each task description with issue context — number, title, estimate, group membership, and any artifact paths from prior phases. Assign an owner to every task. Use task metadata to pass information between phases, such as research document paths, plan document paths, and review verdicts.
 
-Spawn at most 2 per station (append "-2" for the second).
+Add tasks incrementally as phases complete rather than predicting the entire pipeline upfront. When a task completes, check if follow-up tasks for the next phase should be created.
 
-## Create Tasks Incrementally
+## Respond to Events
 
-Create only the immediately actionable tasks — not the entire pipeline upfront. As work completes, create the next tasks.
+Hooks fire when tasks complete or teammates go idle. When a task completes, decide if the next phase is ready and create those tasks. When a review returns a NEEDS_ITERATION verdict, create a new planning task for the analyst. When a validation fails, create a new implementation task for the builder.
 
-For example, if the issue needs research, create the research task and assign it to an analyst. When that completes, create the planning task. When planning completes, create the review task, and so on.
-
-For groups of issues, create parallel tasks at the current phase (e.g., N research tasks in parallel) and gate the next phase on all of them completing.
-
-Each task needs a clear subject (e.g., "Research GH-42"), a description with the issue URL, title, and any relevant context, and metadata including the issue number, command name, and phase.
-
-Assign tasks to workers by setting the owner field to the worker's name.
-
-## Monitor and Shut Down
-
-The dispatch loop is passive — hooks fire at decision points:
-
-- **TaskCompleted**: Check if there are follow-up tasks to create. If all work is done, shut down.
-- **TeammateIdle**: This is normal. Workers self-claim work via their Stop hook.
-- **Escalation (SendMessage)**: Respond and unblock.
-
-When a review completes with a "NEEDS_ITERATION" verdict, create a new planning task assigned to an analyst. The builder will re-review the revised plan.
-
-When a validation fails, create a new implementation task assigned to a builder. The integrator will re-validate after the fix.
+Workers going idle between turns is normal — don't nudge them. Task assignment is the communication mechanism.
 
 When all tasks are complete, shut down each teammate and delete the team.
-
-## Constraints
-
-- Never do research, planning, reviewing, or implementing yourself
-- Task assignment is the communication — don't SendMessage after assigning
-- Workers go idle between turns — this is normal
-- All tasks must be created after TeamCreate
-- If stuck, escalate via GitHub comment and move on

--- a/thoughts/shared/plans/2026-02-25-GH-0393-simplify-ralph-team-prompts.md
+++ b/thoughts/shared/plans/2026-02-25-GH-0393-simplify-ralph-team-prompts.md
@@ -1,0 +1,163 @@
+---
+date: 2026-02-25
+status: draft
+github_issues: [393]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/393
+primary_issue: 393
+---
+
+# Simplify Ralph Team Prompts
+
+## Overview
+
+Rewrite all ralph-team prompts — coordinator skill and 3 worker agents — from procedural tool-call style to natural language. Remove code examples, flatten two-level delegation, and align with the team design documented in `docs/agent-teams.md`.
+
+## Current State Analysis
+
+The coordinator (`skills/ralph-team/SKILL.md`) has already been condensed to ~8 lines of body but is now too sparse — it doesn't mention task creation, metadata, or incremental phase progression. Workers (`agents/ralph-analyst.md`, `ralph-builder.md`, `ralph-integrator.md`) still contain numbered "Task Loop" sections with code examples showing how to nest Skill() calls inside Task() subagents.
+
+### Key Problems:
+- Coordinator body is too minimal — no guidance on task creation, assignment, or phase progression
+- Workers still use two-level delegation (worker → Task() → Skill())
+- Workers have no guidance on self-assignment or waiting for upstream work
+- No mention of metadata for inter-phase information passing
+
+### Key Discoveries:
+- Official Claude docs: "Give teammates enough context in spawn prompts — they do NOT inherit the lead's conversation history"
+- Official docs: "Claude Opus 4.6 has a strong predilection for subagents and may spawn them where a simpler approach suffices"
+- Official docs: normal prompting works better than `CRITICAL/MUST` style on current models
+- Official docs: "Three focused teammates often outperform five scattered ones"
+- Resumability operates at the workflow level (GitHub state + idempotent skills), not session level
+
+## Desired End State
+
+After this plan:
+- All prompts read as natural language descriptions of behavior, with zero tool call examples
+- Coordinator creates tasks incrementally, enriches them with context, assigns owners, and uses metadata for inter-phase handoff
+- Workers invoke skills directly (no Task() wrapping) and self-assign from TaskList
+- Spawn prompts give workers issue context and describe what kinds of tasks to look for
+- Behavior matches `docs/agent-teams.md`
+
+### How to verify:
+- Read all 4 files and confirm no code blocks or tool call syntax remain
+- Confirm alignment with `docs/agent-teams.md`
+- Run `/ralph-hero:ralph-team` against a real issue and confirm workers pick up and complete tasks
+
+## What We're NOT Doing
+
+- Changing hooks (they're already simple shell scripts that work fine)
+- Changing the 3-station model (analyst/builder/integrator)
+- Changing the MCP server or `detect_pipeline_position` tool
+- Removing agent teams in favor of subagents
+- Changing `ralph-team-loop.sh`
+
+## Implementation Approach
+
+Single phase — these are 4 prompt files, not code. Rewrite them all at once.
+
+## Phase 1: Rewrite All Prompts
+
+### Changes Required:
+
+#### 1. Coordinator Skill
+**File**: `plugin/ralph-hero/skills/ralph-team/SKILL.md`
+
+**Frontmatter**: Keep as-is (model, allowed_tools, env, hooks are all correct).
+
+**Body rewrite** — describe the coordinator's job in natural language, following `docs/agent-teams.md`:
+
+The coordinator's algorithm:
+
+1. **Assess** — fetch the issue and detect its pipeline position. If no issue number given, scan the project board for actionable work. If terminal, report and stop.
+2. **Create team** — named after the issue.
+3. **Spawn workers** — one per role needed. Spawn prompts include the issue number, title, current state, and what kinds of tasks the worker should look for. Workers are autonomous — they check TaskList, self-assign, invoke skills, and report results.
+4. **Build task list** — create tasks for the current and upcoming phases. Enrich each task with issue context (number, title, estimate, group membership, artifact paths from prior phases). Assign an owner to every task. Use metadata to pass information between phases (artifact paths, verdicts).
+5. **Respond to events** — when a task completes, create follow-up tasks for the next phase if ready. When a review returns NEEDS_ITERATION, create a new planning task. When validation fails, create a new implementation task. When all work is done, shut down the team.
+
+Key principles:
+- No code blocks or tool call syntax
+- Tasks are the coordination mechanism — assignment is communication
+- Task descriptions enriched with everything the worker needs to do the job
+- Metadata carries inter-phase artifacts (research doc paths, plan doc paths, verdicts)
+- Tasks added incrementally as phases complete, not all predicted upfront
+
+#### 2. Analyst Agent
+**File**: `plugin/ralph-hero/agents/ralph-analyst.md`
+
+**Frontmatter**: Remove `Task` from tools list (no longer nesting). Keep everything else.
+
+**Body rewrite** — natural language, no code blocks:
+
+You are an analyst. You handle triage, splitting large issues, researching codebases, and creating implementation plans.
+
+Your loop:
+- Check TaskList for unblocked tasks matching your role (triage, split, research, planning)
+- Claim an unclaimed task by setting yourself as owner and marking it in-progress
+- If no tasks are available, wait briefly — upstream work may still be completing
+- Invoke the appropriate skill directly (ralph-triage, ralph-split, ralph-research, ralph-plan)
+- When done, update the task as completed with results in the description and any artifact paths in metadata
+- Check TaskList again for more work before stopping
+
+For split/triage work, include sub-ticket IDs and estimates in the task update.
+
+#### 3. Builder Agent
+**File**: `plugin/ralph-hero/agents/ralph-builder.md`
+
+**Frontmatter**: Remove `Task` from tools list. Keep everything else.
+
+**Body rewrite** — natural language, no code blocks:
+
+You are a builder. You review plans and implement code.
+
+Your loop:
+- Check TaskList for unblocked tasks matching your role (plan review, implementation)
+- Claim an unclaimed task by setting yourself as owner and marking it in-progress
+- If no tasks are available, wait briefly — upstream work may still be completing
+- Invoke the appropriate skill directly (ralph-review for reviews, ralph-impl for implementation)
+- When done, update the task as completed with results in the description
+- For reviews, include the full verdict (APPROVED or NEEDS_ITERATION) in both description and metadata so the coordinator can act on it
+- Do not push to remote — the integrator handles PR creation
+- Check TaskList again for more work before stopping
+
+#### 4. Integrator Agent
+**File**: `plugin/ralph-hero/agents/ralph-integrator.md`
+
+**Frontmatter**: Remove `Task` from tools list. Keep everything else.
+
+**Body rewrite** — natural language, no code blocks:
+
+You are an integrator. You validate implementations, create PRs, and merge them.
+
+Your loop:
+- Check TaskList for unblocked tasks matching your role (validation, PR creation, merging)
+- Claim an unclaimed task by setting yourself as owner and marking it in-progress
+- If no tasks are available, wait briefly — upstream work may still be completing
+- For validation: invoke ralph-val directly, report pass/fail verdict in task description and metadata
+- For PR creation: push the branch, create the PR via gh, move issues to "In Review" via advance_children, update task with PR URL
+- For merging: check PR readiness, merge when ready, clean up worktree via remove-worktree script, move issues to "Done", advance parent if applicable
+- Check TaskList again for more work before stopping
+
+Preserve the PR creation and merge procedural knowledge as natural language — these are inline git/gh operations, not skill invocations.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] No code blocks (triple-backtick) remain in any of the 4 files
+- [x] `Task` is removed from tools list in all 3 worker agents
+- [x] All files parse valid YAML frontmatter
+- [x] Prompts align with `docs/agent-teams.md`
+
+#### Manual Verification:
+- [ ] Run `/ralph-hero:ralph-team [issue]` against a real issue
+- [ ] Workers pick up tasks and invoke skills directly
+- [ ] Pipeline progresses through at least research → plan stages
+- [ ] No "Task() subagent" nesting observed in worker behavior
+
+## References
+
+- Design doc: `docs/agent-teams.md`
+- Current files: `plugin/ralph-hero/skills/ralph-team/SKILL.md`, `plugin/ralph-hero/agents/ralph-{analyst,builder,integrator}.md`
+- Official docs: https://code.claude.com/docs/en/agent-teams
+- Official prompting guidance: https://platform.claude.com/docs/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices
+- Git history: `141a21f` (original 690-line v1), `26d4954` (first simplification), `1d50f57` (current 3-station)


### PR DESCRIPTION
## Summary

- Rewrite coordinator and all 3 worker agent prompts from procedural tool-call style to plain natural language
- Flatten two-level delegation — workers invoke skills directly instead of nesting in Task() subagents
- Coordinator describes incremental task creation, metadata-based inter-phase handoff, and enriched task descriptions
- Add `docs/agent-teams.md` as canonical design reference for agent team architecture

Closes #393

## Test plan

- [ ] Run `/ralph-hero:ralph-team [issue]` against a real issue
- [ ] Workers pick up tasks and invoke skills directly (no Task() nesting)
- [ ] Pipeline progresses through at least research → plan stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)