### PR TITLE
fix(justfile): resolve WSL2 shebang permission denied errors

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -6,6 +6,7 @@
 
 set shell := ["bash", "-euc"]
 set dotenv-load
+set tempdir := "/tmp"
 
 # Aliases for frequently-used recipes
 alias t  := triage
@@ -15,6 +16,7 @@ alias i  := impl
 alias s  := status
 alias sp := split
 alias h  := hygiene
+alias issue := quick-info
 
 # Browse and run a recipe interactively (falls back to --list without fzf)
 default:
@@ -176,6 +178,21 @@ doctor:
         echo "SKIP: mcptools or RALPH_HERO_GITHUB_TOKEN not available"
         echo ""
     fi
+    echo "--- WSL2 Compatibility ---"
+    if grep -qi microsoft /proc/version 2>/dev/null; then
+        echo "  WSL2 detected"
+        tempdir="${JUST_TEMPDIR:-/tmp}"
+        if mount | grep -q "on $tempdir.*noexec"; then
+            echo "WARN: $tempdir is mounted noexec — shebang recipes will fail"
+            echo "      Fix: export JUST_TEMPDIR=/tmp"
+            warnings=$((warnings + 1))
+        else
+            echo "  OK: tempdir ($tempdir) supports exec"
+        fi
+    else
+        echo "  OK: Not WSL2 (no shebang restrictions)"
+    fi
+    echo ""
     echo "=== Summary: $errors error(s), $warnings warning(s) ==="
     if [ "$errors" -gt 0 ]; then exit 1; fi
 

--- a/thoughts/shared/plans/2026-02-26-GH-0410-fix-justfile-shebang-wsl2.md
+++ b/thoughts/shared/plans/2026-02-26-GH-0410-fix-justfile-shebang-wsl2.md
@@ -115,8 +115,8 @@ fi
 ```
 
 ### Success Criteria
-- [ ] Automated: `just --justfile plugin/ralph-hero/justfile --evaluate 2>&1` exits 0 (justfile parses correctly)
-- [ ] Automated: `just --justfile plugin/ralph-hero/justfile --list 2>&1 | grep -q issue` (issue alias appears in list)
+- [x] Automated: `just --justfile plugin/ralph-hero/justfile --evaluate 2>&1` exits 0 (justfile parses correctly)
+- [x] Automated: `just --justfile plugin/ralph-hero/justfile --list 2>&1 | grep -q issue` (issue alias appears in list)
 - [ ] Manual: Run `ralph hero` on WSL2 — should not get "Permission denied (os error 13)"
 - [ ] Manual: Run `ralph issue 410` — should return issue details
 - [ ] Manual: Run `ralph doctor` on WSL2 — should show WSL2 compatibility section
@@ -124,8 +124,8 @@ fi
 ---
 
 ## Integration Testing
-- [ ] `just --justfile plugin/ralph-hero/justfile --list` shows all recipes including `issue` alias
-- [ ] `just --justfile plugin/ralph-hero/justfile --evaluate` parses without errors
+- [x] `just --justfile plugin/ralph-hero/justfile --list` shows all recipes including `issue` alias
+- [x] `just --justfile plugin/ralph-hero/justfile --evaluate` parses without errors
 - [ ] Workflow recipes (`triage`, `research`, `plan`, `impl`, `hero`) still work via `_run_skill`
 - [ ] Quick recipes (`quick-status`, `quick-issue`) still work via `_mcp_call`
 - [ ] `doctor` recipe runs to completion and shows WSL2 section


### PR DESCRIPTION
## Summary

- Adds `set tempdir := "/tmp"` directive to redirect temp file creation to an exec-mounted filesystem, fixing `Permission denied (os error 13)` on WSL2 2.5.7+
- Adds `issue` alias for `quick-info` recipe so `ralph issue <number>` works
- Adds WSL2 compatibility diagnostic to `doctor` recipe

Closes #410

## Test plan
- [x] `just --justfile plugin/ralph-hero/justfile --evaluate` exits 0 (justfile parses correctly)
- [x] `just --justfile plugin/ralph-hero/justfile --list` shows `issue` alias on `quick-info`
- [x] WSL2 diagnostic section present in `doctor` recipe
- [ ] Manual: `ralph hero` succeeds on WSL2 (no "Permission denied" error)
- [ ] Manual: `ralph issue 410` returns issue details on WSL2

🤖 Generated with [Claude Code](https://claude.com/claude-code)