### PR TITLE
feat(team): Enforce skill context for worker agents (GH-417)

### DIFF
--- a/plugin/ralph-hero/agents/ralph-analyst.md
+++ b/plugin/ralph-hero/agents/ralph-analyst.md
@@ -5,6 +5,11 @@ tools: Read, Write, Glob, Grep, Skill, Bash, TaskList, TaskGet, TaskUpdate, Send
 model: sonnet
 color: green
 hooks:
+  PreToolUse:
+    - matcher: "ralph_hero__update_workflow_state|ralph_hero__update_issue|ralph_hero__update_estimate|ralph_hero__update_priority|ralph_hero__create_issue|ralph_hero__create_comment|ralph_hero__add_sub_issue|ralph_hero__add_dependency|ralph_hero__remove_dependency"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/require-skill-context.sh"
   Stop:
     - hooks:
         - type: command

--- a/plugin/ralph-hero/agents/ralph-builder.md
+++ b/plugin/ralph-hero/agents/ralph-builder.md
@@ -5,6 +5,11 @@ tools: Read, Write, Edit, Bash, Glob, Grep, Skill, TaskList, TaskGet, TaskUpdate
 model: sonnet
 color: cyan
 hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/require-skill-context.sh"
   Stop:
     - hooks:
         - type: command

--- a/plugin/ralph-hero/hooks/scripts/hygiene-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/hygiene-postcondition.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Postcondition for ralph-hygiene: warn-only, permissive check.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+if [[ "${RALPH_COMMAND:-}" != "hygiene" ]]; then
+  allow
+fi
+
+# Lightweight check — warn only, don't block
+allow

--- a/plugin/ralph-hero/hooks/scripts/merge-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/merge-postcondition.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Postcondition for ralph-merge: verify PR was merged.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+if [[ "${RALPH_COMMAND:-}" != "merge" ]]; then
+  allow
+fi
+
+ticket_id="${RALPH_TICKET_ID:-}"
+if [[ -z "$ticket_id" ]]; then
+  allow
+fi
+
+# Check if the PR for this branch is in merged state
+pr_state=$(gh pr list --repo "${RALPH_GH_OWNER}/${RALPH_GH_REPO}" --head "feature/${ticket_id}" --state merged --json number --jq 'length' 2>/dev/null || echo "0")
+if [[ "$pr_state" -gt 0 ]]; then
+  allow
+fi
+
+warn "PR for feature/${ticket_id} does not appear to be merged. Merge may have failed or PR may not be ready."

--- a/plugin/ralph-hero/hooks/scripts/merge-state-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/merge-state-gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# State gate for ralph-merge skill.
+# Allows: Done, Human Needed. advance_parent calls pass through.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+tool_name=$(get_field ".tool_name" 2>/dev/null || echo "")
+# advance_parent computes target state server-side — allow unconditionally
+if [[ "$tool_name" == *"advance_parent"* ]]; then
+  allow
+fi
+
+new_state=$(get_field ".tool_input.state" 2>/dev/null || get_field ".tool_input.targetState" 2>/dev/null || echo "")
+if [[ -z "$new_state" ]]; then
+  allow
+fi
+
+valid="${RALPH_VALID_OUTPUT_STATES:-Done,Human Needed}"
+if validate_state "$new_state" "$valid"; then
+  allow_with_context "Merge state transition to '$new_state' is valid."
+fi
+
+block "Invalid state transition for merge: '$new_state'
+Valid output states: $valid"

--- a/plugin/ralph-hero/hooks/scripts/pr-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/pr-postcondition.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Postcondition for ralph-pr: verify PR was created.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+if [[ "${RALPH_COMMAND:-}" != "pr" ]]; then
+  allow
+fi
+
+ticket_id="${RALPH_TICKET_ID:-}"
+if [[ -z "$ticket_id" ]]; then
+  allow
+fi
+
+# Check if a PR exists for the feature branch
+pr_url=$(gh pr list --repo "${RALPH_GH_OWNER}/${RALPH_GH_REPO}" --head "feature/${ticket_id}" --json url --jq '.[0].url' 2>/dev/null || echo "")
+if [[ -n "$pr_url" ]]; then
+  allow
+fi
+
+warn "No PR found for feature/${ticket_id}. PR creation may have failed."

--- a/plugin/ralph-hero/hooks/scripts/pr-state-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/pr-state-gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# State gate for ralph-pr skill.
+# Allows: In Review, Human Needed
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+new_state=$(get_field ".tool_input.state" 2>/dev/null || get_field ".tool_input.targetState" 2>/dev/null || echo "")
+if [[ -z "$new_state" ]]; then
+  allow
+fi
+
+valid="${RALPH_VALID_OUTPUT_STATES:-In Review,Human Needed}"
+if validate_state "$new_state" "$valid"; then
+  allow_with_context "PR state transition to '$new_state' is valid."
+fi
+
+block "Invalid state transition for PR creation: '$new_state'
+Valid output states: $valid"

--- a/plugin/ralph-hero/hooks/scripts/report-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/report-postcondition.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Postcondition for ralph-report: warn-only, permissive check.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+if [[ "${RALPH_COMMAND:-}" != "report" ]]; then
+  allow
+fi
+
+# Lightweight check — warn only, don't block
+allow

--- a/plugin/ralph-hero/hooks/scripts/require-skill-context.sh
+++ b/plugin/ralph-hero/hooks/scripts/require-skill-context.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Blocks tool calls that require skill context.
+# Used as a PreToolUse hook on worker agent definitions.
+#
+# When a worker invokes a skill with context: fork, the skill's
+# SessionStart hook sets RALPH_COMMAND via set-skill-env.sh.
+# If RALPH_COMMAND is empty, the tool call is happening outside
+# a skill and should be blocked.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+
+read_input
+
+command="${RALPH_COMMAND:-}"
+if [[ -n "$command" ]]; then
+  allow
+fi
+
+tool_name=$(get_field ".tool_name" 2>/dev/null || echo "unknown")
+block "This tool requires skill context.
+
+$tool_name cannot be called directly — invoke the appropriate skill instead.
+Skills set RALPH_COMMAND via SessionStart hooks, which enables tool access.
+
+Available skills: ralph-triage, ralph-split, ralph-research, ralph-plan,
+ralph-review, ralph-impl, ralph-val, ralph-pr, ralph-merge"

--- a/plugin/ralph-hero/hooks/scripts/setup-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/setup-postcondition.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Postcondition for ralph-setup: warn-only, permissive check.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+if [[ "${RALPH_COMMAND:-}" != "setup" ]]; then
+  allow
+fi
+
+# Lightweight check — warn only, don't block
+allow

--- a/plugin/ralph-hero/hooks/scripts/status-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/status-postcondition.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Postcondition for ralph-status: warn-only, permissive check.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+read_input
+
+if [[ "${RALPH_COMMAND:-}" != "status" ]]; then
+  allow
+fi
+
+# Lightweight check — warn only, don't block
+allow

--- a/plugin/ralph-hero/skills/ralph-hygiene/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-hygiene/SKILL.md
@@ -8,6 +8,10 @@ hooks:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=hygiene RALPH_REQUIRED_BRANCH=main"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hygiene-postcondition.sh"
 ---
 
 # Ralph GitHub Hygiene - Board Cleanup

--- a/plugin/ralph-hero/skills/ralph-merge/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-merge/SKILL.md
@@ -1,0 +1,151 @@
+---
+description: Merge an approved pull request — checks PR readiness, merges, cleans up worktree, moves issues to Done. Use when you want to merge a PR for a completed issue.
+argument-hint: <issue-number> [--pr-url url]
+context: fork
+model: haiku
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=merge RALPH_VALID_OUTPUT_STATES='Done,Human Needed'"
+  PreToolUse:
+    - matcher: "ralph_hero__update_workflow_state|ralph_hero__advance_children|ralph_hero__advance_parent"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/merge-state-gate.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/merge-postcondition.sh"
+allowed-tools:
+  - Read
+  - Glob
+  - Bash
+  - ralph_hero__get_issue
+  - ralph_hero__list_sub_issues
+  - ralph_hero__advance_children
+  - ralph_hero__advance_parent
+  - ralph_hero__update_workflow_state
+  - ralph_hero__create_comment
+---
+
+# Ralph Merge
+
+Merge an approved pull request and move issues to Done.
+
+## Step 1: Parse Arguments
+
+Extract issue number and optional `--pr-url` flag from args:
+
+```
+args: "NNN"                         -> issue_number=NNN, pr_url=nil
+args: "NNN --pr-url https://..."    -> issue_number=NNN, pr_url=provided
+```
+
+Export: `export RALPH_TICKET_ID="GH-NNN"`
+
+## Step 2: Fetch Issue
+
+```
+ralph_hero__get_issue(number=NNN)
+```
+
+Verify the issue is in "In Review" state. If not, output:
+
+```
+MERGE BLOCKED
+Issue: #NNN
+Current state: [state]
+Required state: In Review
+```
+
+And stop.
+
+## Step 3: Find Pull Request
+
+If `--pr-url` was provided, use it directly.
+
+Otherwise:
+
+```bash
+gh pr list --head feature/GH-NNN --json number,url,state --jq '.[0]'
+```
+
+If no PR found, report and stop.
+
+## Step 4: Check PR Readiness
+
+```bash
+gh pr view NNN --json mergeable,reviewDecision,state
+```
+
+Check:
+- `state` is `OPEN`
+- `mergeable` is `MERGEABLE`
+- `reviewDecision` is `APPROVED` or null (no review required)
+
+If not ready, output status and stop:
+
+```
+MERGE NOT READY
+Issue: #NNN
+PR: #NNN
+Mergeable: [status]
+Review: [status]
+State: [state]
+```
+
+The integrator will retry when ready.
+
+## Step 5: Merge PR
+
+```bash
+gh pr merge NNN --merge --delete-branch
+```
+
+If merge fails, report the error and stop.
+
+## Step 6: Clean Up Worktree
+
+```bash
+./scripts/remove-worktree.sh GH-NNN
+```
+
+Run from the project root. If cleanup fails, warn but continue — the merge was successful.
+
+## Step 7: Move Issues to Done
+
+```
+ralph_hero__advance_children(parentNumber=NNN, targetState="Done")
+```
+
+Or for a standalone issue:
+
+```
+ralph_hero__update_workflow_state(number=NNN, state="Done")
+```
+
+## Step 8: Advance Parent
+
+If applicable:
+
+```
+ralph_hero__advance_parent(childNumber=NNN)
+```
+
+## Step 9: Post Completion Comment
+
+```
+ralph_hero__create_comment(number=NNN, body="## Merged\n\nPR merged successfully. Issue moved to Done.")
+```
+
+## Step 10: Report Result
+
+Output completion status:
+
+```
+MERGED
+Issue: #NNN
+PR: https://github.com/owner/repo/pull/NNN
+State: Done
+```

--- a/plugin/ralph-hero/skills/ralph-pr/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-pr/SKILL.md
@@ -1,0 +1,128 @@
+---
+description: Create a pull request for a completed implementation — pushes branch, creates PR via gh, moves issues to In Review. Use when you want to create a PR for a completed issue.
+argument-hint: <issue-number> [--worktree path]
+context: fork
+model: haiku
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=pr RALPH_VALID_OUTPUT_STATES='In Review,Human Needed'"
+  PreToolUse:
+    - matcher: "ralph_hero__update_workflow_state|ralph_hero__advance_children"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pr-state-gate.sh"
+  PostToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/impl-verify-pr.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pr-postcondition.sh"
+allowed-tools:
+  - Read
+  - Glob
+  - Bash
+  - ralph_hero__get_issue
+  - ralph_hero__list_sub_issues
+  - ralph_hero__advance_children
+  - ralph_hero__update_workflow_state
+  - ralph_hero__create_comment
+---
+
+# Ralph PR
+
+Create a pull request for a completed implementation and move issues to In Review.
+
+## Step 1: Parse Arguments
+
+Extract issue number and optional `--worktree` flag from args:
+
+```
+args: "NNN"                           -> issue_number=NNN, worktree=nil
+args: "NNN --worktree path/to/dir"   -> issue_number=NNN, worktree=path
+```
+
+Export: `export RALPH_TICKET_ID="GH-NNN"`
+
+## Step 2: Fetch Issue
+
+```
+ralph_hero__get_issue(number=NNN)
+```
+
+Get issue title, state, group context, and sub-issues.
+
+## Step 3: Determine Worktree and Branch
+
+If `--worktree` was provided, use that path directly.
+
+Otherwise, check `worktrees/GH-NNN` relative to the git root.
+
+For group issues (with sub-issues), use the primary issue number for the branch name.
+
+Branch name: `feature/GH-NNN`
+
+If no worktree exists, output an error and stop.
+
+## Step 4: Push Branch
+
+From the worktree directory:
+
+```bash
+git push -u origin feature/GH-NNN
+```
+
+If push fails, report the error and stop.
+
+## Step 5: Create Pull Request
+
+```bash
+gh pr create \
+  --title "GH-NNN: [issue title]" \
+  --body "## Summary
+
+[Brief description from issue]
+
+Closes #NNN" \
+  --head feature/GH-NNN \
+  --base main
+```
+
+For group issues, include `Closes #NNN` for each sub-issue in the body.
+
+Capture the PR URL from the output.
+
+## Step 6: Move Issues to In Review
+
+```
+ralph_hero__advance_children(parentNumber=NNN, targetState="In Review")
+```
+
+Or for a standalone issue:
+
+```
+ralph_hero__update_workflow_state(number=NNN, state="In Review")
+```
+
+## Step 7: Post Comment
+
+Post a comment on the issue with the PR URL:
+
+```
+ralph_hero__create_comment(number=NNN, body="## Pull Request\n\nPR created: [PR URL]\n\nIssue moved to In Review.")
+```
+
+## Step 8: Report Result
+
+Output the PR URL for the caller:
+
+```
+PR CREATED
+Issue: #NNN
+PR: https://github.com/owner/repo/pull/NNN
+State: In Review
+```

--- a/plugin/ralph-hero/skills/ralph-report/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-report/SKILL.md
@@ -1,12 +1,17 @@
 ---
 description: Generate and post a project status report. Queries pipeline dashboard with velocity metrics, composes a markdown report, auto-determines health status (ON_TRACK/AT_RISK/OFF_TRACK), and posts via GitHub Projects V2 status updates.
 argument-hint: "[optional: --dry-run] [optional: --window N] [optional: --status ON_TRACK|AT_RISK|OFF_TRACK]"
+context: fork
 model: sonnet
 hooks:
   SessionStart:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=report"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/report-postcondition.sh"
 ---
 
 # Ralph Project Report

--- a/plugin/ralph-hero/skills/ralph-setup/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-setup/SKILL.md
@@ -1,12 +1,17 @@
 ---
 description: One-time setup for Ralph GitHub workflow - creates GitHub Project V2 with required custom fields, workflow states, priorities, estimates, and configuration. Use when setting up a new repository for Ralph, configuring GitHub Projects, or troubleshooting missing workflow states.
 argument-hint: "[project-number]"
+context: fork
 model: haiku
 hooks:
   SessionStart:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=setup"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/setup-postcondition.sh"
 ---
 
 # Ralph GitHub Setup

--- a/plugin/ralph-hero/skills/ralph-status/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-status/SKILL.md
@@ -1,12 +1,17 @@
 ---
 description: Display pipeline status dashboard with health indicators. Shows issue counts per workflow phase, identifies stuck issues, WIP violations, and blocked dependencies. First read-only skill - no state changes.
 argument-hint: "[optional: markdown|ascii|json]"
+context: fork
 model: haiku
 hooks:
   SessionStart:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=status"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/status-postcondition.sh"
 ---
 
 # Ralph Pipeline Status


### PR DESCRIPTION
## Summary

- Add `require-skill-context.sh` hook to block worker agents from calling substantive tools outside a skill context (`RALPH_COMMAND` must be set)
- Add `PreToolUse` hooks to analyst (MCP mutating tools), builder (`Write`/`Edit`), and integrator (MCP mutating tools)
- New `ralph-pr` skill: push branch, create PR via `gh`, advance issues to In Review with state gate + postcondition
- New `ralph-merge` skill: verify readiness, merge PR, clean up worktree, advance to Done with state gate + postcondition
- Update integrator prompt to invoke `ralph-val`, `ralph-pr`, `ralph-merge` as skills
- Frontmatter parity: add `context: fork` + `Stop` postconditions to hygiene, setup, report, status skills

## Test plan

- [ ] Analyst attempts to call `update_workflow_state` directly — should be blocked with skill guidance message
- [ ] Analyst invokes `ralph-research` skill — `RALPH_COMMAND=research` set, tools allowed inside skill fork
- [ ] Builder attempts `Write` directly — should be blocked
- [ ] Builder invokes `ralph-impl` skill — `Write`/`Edit` work inside skill fork
- [ ] Integrator invokes `ralph-pr` — PR creation works through skill with state gates
- [ ] Integrator invokes `ralph-merge` — merge flow works through skill
- [ ] CI build + tests pass

Closes #417, #418, #419, #420, #421, #422, #423, #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)