### PR TITLE
feat(list-issues): add repoFilter for multi-repo boards

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
@@ -126,3 +126,21 @@ describe("list_issues exclude negation filters structural", () => {
     expect(issueToolsSrc).toContain('?? ""');
   });
 });
+
+describe("list_issues repoFilter structural", () => {
+  it("Zod schema includes repoFilter param", () => {
+    expect(issueToolsSrc).toContain("repoFilter: z");
+  });
+
+  it("GraphQL query fetches repository data", () => {
+    expect(issueToolsSrc).toContain("repository { name nameWithOwner }");
+  });
+
+  it("filter logic uses case-insensitive comparison", () => {
+    expect(issueToolsSrc).toContain("args.repoFilter.toLowerCase()");
+  });
+
+  it("supports both name and nameWithOwner formats", () => {
+    expect(issueToolsSrc).toContain('rf.includes("/")');
+  });
+});


### PR DESCRIPTION
## Summary

Implements #428: Add repo filter to list_issues for multi-repo project boards.

- Closes #428

## Changes

- Added `repository { name nameWithOwner }` to the `... on Issue` GraphQL fragment in `list_issues`
- Added optional `repoFilter` parameter to the Zod schema (accepts `'name'` or `'owner/name'` format, case-insensitive)
- Added client-side filter logic following the existing label filter pattern
- Added 4 structural tests verifying parameter, GraphQL fragment, case-insensitive comparison, and format support

## Test Plan

- [x] `npm test` — all 728 tests pass (including 4 new structural tests)
- [x] `npm run build` — compiles without errors
- [ ] Manual: verify `repoFilter` appears in MCP tool discovery schema

---
Generated with Claude Code (Ralph GitHub Plugin)