### PR TITLE
GH-365: Centralize project quality standards and embed them in plan phases

### DIFF
--- a/plugin/ralph-hero/skills/ralph-plan/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-plan/SKILL.md
@@ -284,20 +284,7 @@ Profiles set default filters. Explicit params override profile defaults.
 
 ## Planning Quality Guidelines
 
-Good plans have:
-- Clear phases with specific file changes
-- Testable success criteria for each phase
-- Explicit scope boundaries (what we're NOT doing)
-- References to existing code patterns to follow
-- For groups: explicit dependencies between phases
-- For groups: integration testing section
-
-Avoid:
-- Vague descriptions like "update the code"
-- Missing success criteria
-- Unbounded scope
-- Ignoring existing patterns in the codebase
-- For groups: unclear phase ordering or dependencies
+See [shared/quality-standards.md](../shared/quality-standards.md) for canonical plan quality dimensions (Completeness, Feasibility, Clarity, Scope) and group-specific requirements.
 
 ## Link Formatting
 

--- a/plugin/ralph-hero/skills/ralph-research/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-research/SKILL.md
@@ -221,9 +221,7 @@ Profiles set default filters. Explicit params override profile defaults.
 
 ## Research Quality
 
-Focus on: understanding the problem deeply, finding existing codebase patterns to leverage, identifying risks and edge cases, providing actionable recommendations.
-
-Avoid: premature solutioning, over-engineering suggestions, ignoring existing patterns, vague findings.
+See [shared/quality-standards.md](../shared/quality-standards.md) for canonical research quality dimensions (Depth, Feasibility, Risk, Actionability) and anti-patterns.
 
 ## Escalation & Link Formatting
 

--- a/plugin/ralph-hero/skills/ralph-review/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-review/SKILL.md
@@ -396,17 +396,7 @@ Profiles set default filters. Explicit params override profile defaults.
 
 ## Quality Guidelines
 
-**Focus on**:
-- Plan completeness (all phases defined)
-- Success criteria specificity (testable)
-- Scope boundaries (what we're NOT doing)
-- Technical feasibility (files exist, patterns valid)
-
-**Avoid**:
-- Rubber-stamping without analysis
-- Over-critiquing minor style issues
-- Blocking on subjective preferences
-- Creating critique without actionable feedback
+See [shared/quality-standards.md](../shared/quality-standards.md) for canonical plan quality dimensions and review anti-patterns.
 
 ## Link Formatting
 

--- a/plugin/ralph-hero/skills/shared/quality-standards.md
+++ b/plugin/ralph-hero/skills/shared/quality-standards.md
@@ -1,0 +1,52 @@
+# Quality Standards
+
+Canonical quality criteria referenced by ralph-plan, ralph-review, and ralph-research.
+
+## Plan Quality Dimensions
+
+Plans are evaluated on four dimensions (matching ralph-review AUTO critique):
+
+1. **Completeness** — All phases defined with specific file changes and clear descriptions
+2. **Feasibility** — Referenced files exist; patterns are valid and follow existing codebase conventions
+3. **Clarity** — Success criteria are specific and testable (`- [ ] Automated:` / `- [ ] Manual:` format)
+4. **Scope** — "What we're NOT doing" section is explicit and well-bounded
+
+### Group-Specific Requirements
+
+For multi-issue group plans, also verify:
+- Phase dependencies are explicit (each phase states what it creates for the next)
+- Integration testing section covers cross-phase interactions
+
+### Plan Anti-Patterns
+
+Avoid:
+- Vague descriptions like "update the code"
+- Missing or untestable success criteria
+- Unbounded scope without explicit exclusions
+- Ignoring existing patterns in the codebase
+- For groups: unclear phase ordering or missing dependencies
+
+## Research Quality Dimensions
+
+Research documents are evaluated on:
+
+1. **Depth** — Problem understood from user perspective with root cause analysis
+2. **Feasibility** — Existing codebase patterns identified to leverage
+3. **Risk** — Edge cases and failure modes identified
+4. **Actionability** — Recommendations are concrete with file:line references
+
+### Research Anti-Patterns
+
+Avoid:
+- Premature solutioning before understanding the problem
+- Over-engineering suggestions beyond issue scope
+- Ignoring existing patterns in the codebase
+- Vague findings without concrete file references
+
+## Review Anti-Patterns
+
+When reviewing plans or research, avoid:
+- Rubber-stamping without analysis
+- Over-critiquing minor style issues
+- Blocking on subjective preferences
+- Creating critique without actionable feedback

--- a/thoughts/shared/plans/2026-02-27-GH-0365-centralize-quality-standards.md
+++ b/thoughts/shared/plans/2026-02-27-GH-0365-centralize-quality-standards.md
@@ -32,11 +32,11 @@ The ralph-review AUTO mode critique prompt (`SKILL.md:196-200`) uses 4 named dim
 ## Desired End State
 
 ### Verification
-- [ ] `plugin/ralph-hero/skills/shared/quality-standards.md` exists with canonical quality dimensions
-- [ ] `ralph-plan/SKILL.md` Quality section references shared standard
-- [ ] `ralph-review/SKILL.md` Quality section references shared standard
-- [ ] `ralph-research/SKILL.md` Quality section references shared standard
-- [ ] All 4 files are syntactically valid markdown
+- [x] `plugin/ralph-hero/skills/shared/quality-standards.md` exists with canonical quality dimensions
+- [x] `ralph-plan/SKILL.md` Quality section references shared standard
+- [x] `ralph-review/SKILL.md` Quality section references shared standard
+- [x] `ralph-research/SKILL.md` Quality section references shared standard
+- [x] All 4 files are syntactically valid markdown
 
 ## What We're NOT Doing
 
@@ -213,20 +213,20 @@ See [shared/quality-standards.md](../shared/quality-standards.md) for canonical 
 
 ### Success Criteria
 
-- [ ] Automated: `test -f plugin/ralph-hero/skills/shared/quality-standards.md` exits 0
-- [ ] Automated: `grep -q "quality-standards.md" plugin/ralph-hero/skills/ralph-plan/SKILL.md` exits 0
-- [ ] Automated: `grep -q "quality-standards.md" plugin/ralph-hero/skills/ralph-review/SKILL.md` exits 0
-- [ ] Automated: `grep -q "quality-standards.md" plugin/ralph-hero/skills/ralph-research/SKILL.md` exits 0
-- [ ] Automated: `grep -c "Completeness" plugin/ralph-hero/skills/shared/quality-standards.md` returns at least 1
-- [ ] Automated: `grep -c "Feasibility" plugin/ralph-hero/skills/shared/quality-standards.md` returns at least 1
-- [ ] Manual: ralph-review AUTO mode inline prompt (lines 196-200) is unchanged
-- [ ] Manual: No other skill files are modified
+- [x] Automated: `test -f plugin/ralph-hero/skills/shared/quality-standards.md` exits 0
+- [x] Automated: `grep -q "quality-standards.md" plugin/ralph-hero/skills/ralph-plan/SKILL.md` exits 0
+- [x] Automated: `grep -q "quality-standards.md" plugin/ralph-hero/skills/ralph-review/SKILL.md` exits 0
+- [x] Automated: `grep -q "quality-standards.md" plugin/ralph-hero/skills/ralph-research/SKILL.md` exits 0
+- [x] Automated: `grep -c "Completeness" plugin/ralph-hero/skills/shared/quality-standards.md` returns at least 1
+- [x] Automated: `grep -c "Feasibility" plugin/ralph-hero/skills/shared/quality-standards.md` returns at least 1
+- [x] Manual: ralph-review AUTO mode inline prompt (lines 196-200) is unchanged
+- [x] Manual: No other skill files are modified
 
 ## Integration Testing
 
-- [ ] Verify `quality-standards.md` relative links work from each skill file's location (`../shared/quality-standards.md`)
-- [ ] Verify the ralph-review AUTO critique prompt (lines 196-200) still contains the 4 inline dimensions
-- [ ] Verify `ralph-impl` checkpoint consumption is unaffected (no changes to that file)
+- [x] Verify `quality-standards.md` relative links work from each skill file's location (`../shared/quality-standards.md`)
+- [x] Verify the ralph-review AUTO critique prompt (lines 196-200) still contains the 4 inline dimensions
+- [x] Verify `ralph-impl` checkpoint consumption is unaffected (no changes to that file)
 
 ## References
 


### PR DESCRIPTION
## Summary

Centralize quality standards across plan, review, and research skills into a single shared document (quality-standards.md) that defines canonical quality dimensions for plans, reviews, and research.

Closes #365