### PR TITLE
GH-366: Add post-mortem reflection step to ralph-team shutdown

### DIFF
--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -4,6 +4,7 @@ argument-hint: "[issue-number]"
 model: sonnet
 allowed-tools:
   - Read
+  - Write
   - Glob
   - Bash
   - Task
@@ -60,4 +61,57 @@ Hooks fire when tasks complete or teammates go idle. When a task completes, deci
 
 Workers going idle between turns is normal — don't nudge them. Task assignment is the communication mechanism.
 
-When all tasks are complete, shut down each teammate and delete the team.
+## Shut Down
+
+When all tasks are complete:
+
+### 1. Write Post-Mortem
+
+Before shutting down teammates or deleting the team, collect session results and write a report.
+
+**Collect data**: Call `TaskList`, then `TaskGet` on each task. Extract from task metadata and descriptions:
+- Issues processed (issue_number, title, estimate, final workflow state)
+- PRs created (artifact_path or PR URLs from integrator tasks)
+- Worker assignments (task owner → task subjects)
+- Errors or escalations (tasks with failed results, Human Needed states)
+
+**Write report** to `thoughts/shared/reports/YYYY-MM-DD-ralph-team-{team-name}.md`:
+
+```markdown
+# Ralph Team Session Report: {team-name}
+
+**Date**: YYYY-MM-DD
+
+## Issues Processed
+
+| Issue | Title | Estimate | Outcome | PR |
+|-------|-------|----------|---------|-----|
+| #NNN | [title] | XS | Done | #PR |
+
+## Worker Summary
+
+| Worker | Tasks Completed |
+|--------|----------------|
+| analyst | [task subjects] |
+| builder | [task subjects] |
+| integrator | [task subjects] |
+
+## Notes
+
+[Escalations, errors, or anything notable from the session]
+```
+
+Commit and push the report:
+```bash
+git add thoughts/shared/reports/YYYY-MM-DD-ralph-team-*.md
+git commit -m "docs(report): {team-name} session post-mortem"
+git push origin main
+```
+
+### 2. Shut Down Teammates
+
+Send shutdown to each teammate. Wait for all to confirm.
+
+### 3. Delete Team
+
+Call `TeamDelete()`. This removes the task list and team config.

--- a/thoughts/shared/plans/2026-02-27-GH-0366-ralph-team-post-mortem.md
+++ b/thoughts/shared/plans/2026-02-27-GH-0366-ralph-team-post-mortem.md
@@ -24,11 +24,11 @@ primary_issue: 366
 ## Desired End State
 
 ### Verification
-- [ ] `ralph-team/SKILL.md` includes a "Write Post-Mortem" section before shutdown
-- [ ] Post-mortem template specifies `thoughts/shared/reports/` as output directory
-- [ ] Post-mortem collects: issues processed, PRs created, worker summary, errors
-- [ ] TeamDelete is called AFTER post-mortem is written
-- [ ] `Write` tool is present in allowed-tools (must be added — not present in current version)
+- [x] `ralph-team/SKILL.md` includes a "Write Post-Mortem" section before shutdown
+- [x] Post-mortem template specifies `thoughts/shared/reports/` as output directory
+- [x] Post-mortem collects: issues processed, PRs created, worker summary, errors
+- [x] TeamDelete is called AFTER post-mortem is written
+- [x] `Write` tool is present in allowed-tools (must be added — not present in current version)
 
 ## What We're NOT Doing
 
@@ -140,20 +140,20 @@ Call `TeamDelete()`. This removes the task list and team config.
 
 ### Success Criteria
 
-- [ ] Automated: `grep -q "Write Post-Mortem" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
-- [ ] Automated: `grep -q "thoughts/shared/reports/" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
-- [ ] Automated: `grep -q "TeamDelete" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
-- [ ] Automated: `grep -c "Shut Down" plugin/ralph-hero/skills/ralph-team/SKILL.md` returns at least 1
-- [ ] Automated: `grep -q "Write" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
-- [ ] Manual: `Write` is present in the `allowed-tools` frontmatter list
-- [ ] Manual: Post-mortem step appears BEFORE TeamDelete in the document
-- [ ] Manual: No other skill or agent files are modified
+- [x] Automated: `grep -q "Write Post-Mortem" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
+- [x] Automated: `grep -q "thoughts/shared/reports/" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
+- [x] Automated: `grep -q "TeamDelete" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
+- [x] Automated: `grep -c "Shut Down" plugin/ralph-hero/skills/ralph-team/SKILL.md` returns at least 1
+- [x] Automated: `grep -q "Write" plugin/ralph-hero/skills/ralph-team/SKILL.md` exits 0
+- [x] Manual: `Write` is present in the `allowed-tools` frontmatter list
+- [x] Manual: Post-mortem step appears BEFORE TeamDelete in the document
+- [x] Manual: No other skill or agent files are modified
 
 ## Integration Testing
 
-- [ ] Verify `ralph-team/SKILL.md` is valid markdown (no broken code fences)
-- [ ] Verify the post-mortem template in the plan uses standard markdown table syntax
-- [ ] Verify the shutdown sequence is: Write Post-Mortem → Shut Down Teammates → Delete Team (correct ordering)
+- [x] Verify `ralph-team/SKILL.md` is valid markdown (no broken code fences)
+- [x] Verify the post-mortem template in the plan uses standard markdown table syntax
+- [x] Verify the shutdown sequence is: Write Post-Mortem → Shut Down Teammates → Delete Team (correct ordering)
 
 ## References
 


### PR DESCRIPTION
## Summary

Add post-mortem reflection step before team shutdown. The team lead now writes a session report with task summary, worker assignments, and issues processed before deleting the team.

Changes:
- Add `Write` to allowed-tools in ralph-team skill
- Replace one-liner shutdown with structured Shut Down section with post-mortem step

Closes #366