### PR TITLE
GH-438: Change resolveRepoFromProject() 2+ repos branch from error to warning

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/lib/helpers.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/helpers.ts
@@ -415,9 +415,9 @@ export async function queryProjectRepositories(
  * - If client.config.repo is already set → return it (env var takes precedence)
  * - If exactly 1 repo linked → use it, cache in client.config.repo
  * - If 0 repos linked → throw with bootstrap instructions
- * - If 2+ repos linked → throw with list of repos and hint to set RALPH_GH_REPO
+ * - If 2+ repos linked → warn and return undefined, leaving client.config.repo unset
  */
-export async function resolveRepoFromProject(client: GitHubClient): Promise<string> {
+export async function resolveRepoFromProject(client: GitHubClient): Promise<string | undefined> {
   if (client.config.repo) return client.config.repo;
 
   const projectNumber = client.config.projectNumber;
@@ -449,10 +449,12 @@ export async function resolveRepoFromProject(client: GitHubClient): Promise<stri
   }
 
   const repoList = result.repos.map(r => r.nameWithOwner).join(", ");
-  throw new Error(
-    `Multiple repos linked to project: ${repoList}. ` +
-    "Set RALPH_GH_REPO to select which repo to use as default."
+  console.error(
+    `[ralph-hero] Multiple repos linked to project: ${repoList}. ` +
+    `Set RALPH_GH_REPO to select the default repo. ` +
+    `Read-only tools will work; write tools require an explicit repo param.`
   );
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/thoughts/shared/plans/2026-02-27-GH-0438-resolve-repo-warning.md
+++ b/thoughts/shared/plans/2026-02-27-GH-0438-resolve-repo-warning.md
@@ -24,11 +24,11 @@ primary_issue: 438
 ## Desired End State
 
 ### Verification
-- [ ] `resolveRepoFromProject()` returns `undefined` (not throws) when 2+ repos linked
-- [ ] A warning is logged listing the linked repos
-- [ ] Function return type is `Promise<string | undefined>`
-- [ ] Startup completes without error for multi-repo projects
-- [ ] Existing test updated to verify warning + undefined return
+- [x] `resolveRepoFromProject()` returns `undefined` (not throws) when 2+ repos linked
+- [x] A warning is logged listing the linked repos
+- [x] Function return type is `Promise<string | undefined>`
+- [x] Startup completes without error for multi-repo projects
+- [x] Existing test updated to verify warning + undefined return
 
 ## What We're NOT Doing
 
@@ -145,19 +145,19 @@ With:
 
 ### Success Criteria
 
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm test` passes
-- [ ] Automated: `grep -q "return undefined" plugin/ralph-hero/mcp-server/src/lib/helpers.ts` exits 0
-- [ ] Automated: `grep -q "Promise<string | undefined>" plugin/ralph-hero/mcp-server/src/lib/helpers.ts` exits 0
-- [ ] Automated: `grep -q "warns and returns undefined" plugin/ralph-hero/mcp-server/src/__tests__/repo-inference.test.ts` exits 0
-- [ ] Manual: The 0-repos and 1-repo branches are unchanged
-- [ ] Manual: No changes to `index.ts`, `resolveConfig()`, or any tool files
-- [ ] Manual: Console warning includes the repo list and guidance about RALPH_GH_REPO
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm test` passes
+- [x] Automated: `grep -q "return undefined" plugin/ralph-hero/mcp-server/src/lib/helpers.ts` exits 0
+- [x] Automated: `grep -q "Promise<string | undefined>" plugin/ralph-hero/mcp-server/src/lib/helpers.ts` exits 0
+- [x] Automated: `grep -q "warns and returns undefined" plugin/ralph-hero/mcp-server/src/__tests__/repo-inference.test.ts` exits 0
+- [x] Manual: The 0-repos and 1-repo branches are unchanged
+- [x] Manual: No changes to `index.ts`, `resolveConfig()`, or any tool files
+- [x] Manual: Console warning includes the repo list and guidance about RALPH_GH_REPO
 
 ## Integration Testing
 
-- [ ] Run full test suite: `cd plugin/ralph-hero/mcp-server && npm test`
-- [ ] Verify existing tests for 0-repos and 1-repo branches still pass unchanged
-- [ ] Verify the new test correctly checks both the return value and the console.error call
+- [x] Run full test suite: `cd plugin/ralph-hero/mcp-server && npm test`
+- [x] Verify existing tests for 0-repos and 1-repo branches still pass unchanged
+- [x] Verify the new test correctly checks both the return value and the console.error call
 
 ## References
 


### PR DESCRIPTION
## Summary

Change multi-repo resolution to warn instead of error when 2+ repos are linked. This enables read-only tools to continue working while requiring explicit repo specification for write tools.

Changes:
- Update resolveRepoFromProject() return type to Promise<string | undefined>
- Replace throw with console.error + return undefined at 2+ repos branch
- Update test to verify warning + undefined return instead of throw
- Warning message lists all linked repos and suggests RALPH_GH_REPO setting

All 732 tests passing.

Closes #438