### PR TITLE
GH-440: Stamp repository field on DashboardItem via GraphQL query update

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/dashboard.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/dashboard.test.ts
@@ -1282,6 +1282,25 @@ describe("toDashboardItems", () => {
     expect(items[0].projectTitle).toBe("My Board");
   });
 
+  it("stamps repository from content when present", () => {
+    const raw = [
+      makeRawItem({
+        content: {
+          ...makeRawItem().content,
+          repository: { nameWithOwner: "owner/my-repo", name: "my-repo" },
+        },
+      }),
+    ];
+    const items = toDashboardItems(raw);
+    expect(items[0].repository).toBe("owner/my-repo");
+  });
+
+  it("omits repository when content.repository is null", () => {
+    const raw = [makeRawItem()];
+    const items = toDashboardItems(raw);
+    expect(items[0].repository).toBeUndefined();
+  });
+
   it("filters out non-Issue content types", () => {
     const raw = [
       makeRawItem(),

--- a/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
@@ -39,6 +39,7 @@ export interface DashboardItem {
   blockedBy: Array<{ number: number; workflowState: string | null }>;
   projectNumber?: number; // Source project number (multi-project)
   projectTitle?: string; // Human-readable project title (multi-project)
+  repository?: string; // "owner/repo" nameWithOwner format
 }
 
 /** One row in the pipeline snapshot. */

--- a/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
@@ -130,6 +130,7 @@ export interface RawDashboardItem {
     closedAt?: string | null;
     assignees?: { nodes: Array<{ login: string }> };
     trackedInIssues?: { nodes: Array<{ number: number; state: string }> };
+    repository?: { nameWithOwner: string; name: string } | null;
   } | null;
   fieldValues: {
     nodes: Array<{
@@ -182,6 +183,7 @@ export function toDashboardItems(
       blockedBy: [], // blockedBy requires separate queries; omit for now
       ...(projectNumber !== undefined ? { projectNumber } : {}),
       ...(projectTitle !== undefined ? { projectTitle } : {}),
+      ...(r.content.repository ? { repository: r.content.repository.nameWithOwner } : {}),
     });
   }
 
@@ -210,6 +212,7 @@ export const DASHBOARD_ITEMS_QUERY = `query($projectId: ID!, $cursor: String, $f
               updatedAt
               closedAt
               assignees(first: 5) { nodes { login } }
+              repository { nameWithOwner name }
             }
             ... on PullRequest {
               __typename

--- a/thoughts/shared/plans/2026-02-27-GH-0440-stamp-repository-dashboarditem.md
+++ b/thoughts/shared/plans/2026-02-27-GH-0440-stamp-repository-dashboarditem.md
@@ -24,11 +24,11 @@ primary_issue: 440
 ## Desired End State
 
 ### Verification
-- [ ] `DashboardItem` has `repository?: string` field in `nameWithOwner` format
-- [ ] `DASHBOARD_ITEMS_QUERY` fetches `repository { nameWithOwner name }` for Issue type
-- [ ] `toDashboardItems()` stamps `repository` when present using conditional spread
-- [ ] All existing dashboard tests still pass (field is optional)
-- [ ] New test verifies repository stamping from raw item
+- [x] `DashboardItem` has `repository?: string` field in `nameWithOwner` format
+- [x] `DASHBOARD_ITEMS_QUERY` fetches `repository { nameWithOwner name }` for Issue type
+- [x] `toDashboardItems()` stamps `repository` when present using conditional spread
+- [x] All existing dashboard tests still pass (field is optional)
+- [x] New test verifies repository stamping from raw item
 
 ## What We're NOT Doing
 
@@ -136,21 +136,21 @@ The first test verifies that `repository` is stamped as `nameWithOwner` string. 
 
 ### Success Criteria
 
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm test` passes
-- [ ] Automated: `grep -q "repository?: string" plugin/ralph-hero/mcp-server/src/lib/dashboard.ts` exits 0
-- [ ] Automated: `grep -q "repository { nameWithOwner name }" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts` exits 0
-- [ ] Automated: `grep -q "r.content.repository" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts` exits 0
-- [ ] Manual: `DashboardItem` interface has `repository?: string` after `projectTitle`
-- [ ] Manual: `toDashboardItems()` stamps `repository` using same conditional spread pattern as `projectNumber`/`projectTitle`
-- [ ] Manual: `DASHBOARD_ITEMS_QUERY` fetches `repository { nameWithOwner name }` only in Issue fragment (not PR/DraftIssue)
-- [ ] Manual: Existing `makeItem()` helper tests unmodified — all downstream tests pass unchanged
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm test` passes
+- [x] Automated: `grep -q "repository?: string" plugin/ralph-hero/mcp-server/src/lib/dashboard.ts` exits 0
+- [x] Automated: `grep -q "repository { nameWithOwner name }" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts` exits 0
+- [x] Automated: `grep -q "r.content.repository" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts` exits 0
+- [x] Manual: `DashboardItem` interface has `repository?: string` after `projectTitle`
+- [x] Manual: `toDashboardItems()` stamps `repository` using same conditional spread pattern as `projectNumber`/`projectTitle`
+- [x] Manual: `DASHBOARD_ITEMS_QUERY` fetches `repository { nameWithOwner name }` only in Issue fragment (not PR/DraftIssue)
+- [x] Manual: Existing `makeItem()` helper tests unmodified — all downstream tests pass unchanged
 
 ## Integration Testing
 
-- [ ] Run full test suite: `cd plugin/ralph-hero/mcp-server && npm test`
-- [ ] Verify existing `toDashboardItems` tests still pass (projectNumber, projectTitle, non-Issue filtering)
-- [ ] Verify new tests cover: repository present → stamped as nameWithOwner, repository absent → undefined
-- [ ] Verify `buildDashboard` and `formatMarkdown` tests still pass (repository is optional, no behavior change)
+- [x] Run full test suite: `cd plugin/ralph-hero/mcp-server && npm test`
+- [x] Verify existing `toDashboardItems` tests still pass (projectNumber, projectTitle, non-Issue filtering)
+- [x] Verify new tests cover: repository present → stamped as nameWithOwner, repository absent → undefined
+- [x] Verify `buildDashboard` and `formatMarkdown` tests still pass (repository is optional, no behavior change)
 
 ## References
 


### PR DESCRIPTION
## Summary

Add repository data to the pipeline dashboard by fetching and stamping repository information on DashboardItem. This foundational change enables repository grouping in the sibling issue.

Changes:
- Add `repository?: string` (nameWithOwner format) to DashboardItem interface
- Extend DASHBOARD_ITEMS_QUERY Issue fragment to fetch `repository { nameWithOwner name }`
- Update RawDashboardItem.content type to include optional repository
- Stamp repository on each item via conditional spread in toDashboardItems()
- Add 2 test cases verifying repository stamping

All 741 tests passing (2 new tests added).

Closes #440