### PR TITLE
docs(specs): Phase 2 lifecycle and document protocol specs

### DIFF
--- a/specs/document-protocols.md
+++ b/specs/document-protocols.md
@@ -1,0 +1,137 @@
+# Document Protocols
+
+## Purpose
+
+Defines content structure, quality criteria, and enforcement status for documents produced by Ralph skills — research, plan, and review/critique.
+
+## Definitions
+
+- **Research Document**: Investigation output created by ralph_research. Analyzes codebase, extracts data, and recommends next steps.
+- **Plan Document**: Implementation specification created by ralph_plan. Defines phased changes with success criteria.
+- **Critique Document**: Review output created by ralph_review (AUTO mode). Contains verdict and findings.
+- **Phase Structure**: Plan documents organize work into numbered phases (`## Phase N: Title`), each with its own success criteria.
+- **Convergence Verification**: For group plans, validation that all grouped issues are addressed coherently before proceeding.
+- **Artifact Comment**: A GitHub issue comment posted after document creation, containing a header and blob URL linking to the committed document.
+
+## Requirements
+
+### 1. Research Documents
+
+**Required sections**:
+- Frontmatter block (YAML)
+- Problem statement
+- Current state analysis
+- Key discoveries with `file:line` references
+- Potential approaches (pros/cons)
+- Risks
+- Recommended next steps
+- `## Files Affected` section with `### Will Modify` and `### Will Read (Dependencies)` subsections
+
+**Frontmatter schema**: See [artifact-metadata.md](artifact-metadata.md) for the research frontmatter schema. Required fields: `date`, `github_issue`, `github_url`, `status: complete`, `type: research`.
+
+| Requirement | Enablement |
+|-------------|------------|
+| Research documents MUST contain a `## Files Affected` section | `[x]` `research-postcondition.sh` |
+| Research documents MUST be committed and pushed before linking | `[x]` `research-postcondition.sh` |
+| Research documents MUST NOT duplicate an existing research artifact for the same issue | `[x]` `pre-artifact-validator.sh` |
+| Research documents MUST contain frontmatter with `github_issue` and `status` fields | `[ ]` not enforced (declared in `artifact_types.research.validates` but no hook validates schema) |
+| Research documents MUST contain all required sections (problem statement, analysis, discoveries, approaches, risks, next steps) | `[ ]` not enforced |
+| An Artifact Comment with `## Research Document` header MUST be posted after creation | `[ ]` not enforced (`artifact-discovery.sh` warns only, does not block) |
+
+**Quality criteria** (from quality-standards.md):
+1. **Depth** — problem understood from user perspective, root cause analysis
+2. **Feasibility** — existing codebase patterns identified
+3. **Risk** — edge cases and failure modes identified
+4. **Actionability** — recommendations with `file:line` references
+
+| Requirement | Enablement |
+|-------------|------------|
+| Research documents SHOULD meet all four quality dimensions | `[ ]` not enforced (skill-prompt guidance only) |
+
+### 2. Plan Documents
+
+**Required sections**:
+- Frontmatter block (YAML)
+- Overview with phase table
+- Current state analysis
+- Desired end state with verification criteria
+- "What We're NOT Doing" section
+- Per-phase sections (`## Phase N: Title` pattern)
+- Success criteria per phase (`- [ ] Automated:` / `- [ ] Manual:` format)
+- Integration testing section
+- References
+
+**Frontmatter schema**: See [artifact-metadata.md](artifact-metadata.md) for the three plan frontmatter variants (single issue, group, stream). Required fields vary by variant; all include `date`, `status: draft`, `github_issues`, `github_urls`, `primary_issue`.
+
+**Research prerequisite**: A research document MUST be attached to the issue before a plan can be created.
+
+| Requirement | Enablement |
+|-------------|------------|
+| Plan documents MUST be committed before the skill completes | `[x]` `plan-postcondition.sh` |
+| A research document MUST exist before plan creation | `[x]` `plan-research-required.sh` |
+| Plan documents MUST NOT duplicate an existing plan artifact for the same issue | `[x]` `pre-artifact-validator.sh` |
+| Plan documents MUST use `## Phase N:` header pattern for each phase | `[ ]` not enforced (`plan-verify-doc.sh` is ORPHANED — not registered in any hooks.json or SKILL.md) |
+| Each phase MUST have success criteria in `- [ ] Automated:` / `- [ ] Manual:` format | `[ ]` not enforced |
+| Plan documents MUST contain frontmatter with required fields | `[ ]` not enforced |
+| An Artifact Comment with `## Implementation Plan` header MUST be posted after creation | `[ ]` not enforced (`artifact-discovery.sh` warns only) |
+
+**Quality criteria** (from quality-standards.md):
+1. **Completeness** — all requirements addressed
+2. **Feasibility** — implementable with existing patterns
+3. **Clarity** — success criteria are specific and testable
+4. **Scope** — boundaries clearly defined
+
+| Requirement | Enablement |
+|-------------|------------|
+| Plan documents SHOULD meet all four quality dimensions | `[ ]` not enforced (skill-prompt guidance only) |
+
+### 3. Review/Critique Documents
+
+**Required sections**:
+- Frontmatter block (YAML)
+- Verdict (APPROVED or NEEDS_ITERATION)
+- Critique/findings
+
+**Frontmatter schema**: See [artifact-metadata.md](artifact-metadata.md) for the critique frontmatter schema. Required fields: `date`, `github_issue`, `github_url` (if applicable), `status: complete` (if applicable), `type: critique`.
+
+**Verdict values**: APPROVED transitions the issue to In Progress. NEEDS_ITERATION transitions to Ready for Plan and adds `needs-iteration` label.
+
+**AUTO vs INTERACTIVE modes**:
+- **AUTO**: Critique document MUST be created and committed. `review-postcondition.sh` blocks if missing.
+- **INTERACTIVE**: No critique document required. Human reviews the plan directly.
+
+| Requirement | Enablement |
+|-------------|------------|
+| In AUTO mode, a critique document MUST be created and committed | `[x]` `review-postcondition.sh` |
+| Critique documents MUST NOT duplicate an existing critique for the same issue | `[x]` `review-no-dup.sh` |
+| Critique frontmatter SHOULD include `status`, `github_issue`, and `type` fields | `[x]` `review-verify-doc.sh` (warns on missing fields, does not block — partial enforcement) |
+| Critique documents MUST contain a verdict section (APPROVED or NEEDS_ITERATION) | `[ ]` not enforced |
+| An Artifact Comment with `## Plan Critique` header MUST be posted after creation | `[ ]` not enforced |
+
+### 4. Convergence Verification (Group Plans)
+
+For group plans (multiple issues planned together), convergence verification ensures all grouped issues are addressed coherently.
+
+| Requirement | Enablement |
+|-------------|------------|
+| Group plans SHOULD have convergence verified before proceeding to `Plan in Progress` | `[ ]` warns only (`convergence-gate.sh` warns on missing `RALPH_CONVERGENCE_VERIFIED`, does not block) |
+| Full convergence check is available via `ralph_hero__check_convergence` MCP tool | `[x]` `check_convergence` tool |
+
+### 5. Document Quality Dimensions
+
+Quality criteria are defined in `quality-standards.md` and referenced by skill prompts. They are not machine-enforced.
+
+| Document Type | Quality Dimensions |
+|--------------|-------------------|
+| Research | Depth, Feasibility, Risk, Actionability |
+| Plan | Completeness, Feasibility, Clarity, Scope |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Skills SHOULD evaluate documents against their type-specific quality dimensions | `[ ]` not enforced (quality is skill-prompt guidance only) |
+
+## Cross-References
+
+- [artifact-metadata.md](artifact-metadata.md) — File naming patterns, frontmatter schemas, Artifact Comment Protocol
+- [skill-io-contracts.md](skill-io-contracts.md) — Which skills produce which documents (postconditions)
+- [issue-lifecycle.md](issue-lifecycle.md) — State transitions that trigger document creation (e.g., Research Needed triggers research, Ready for Plan triggers planning)

--- a/specs/issue-lifecycle.md
+++ b/specs/issue-lifecycle.md
@@ -1,0 +1,221 @@
+# Issue Lifecycle
+
+## Purpose
+
+Governs the issue state machine, valid transitions, lock protocol, semantic intents, and Status sync for the Ralph workflow.
+
+## Definitions
+
+- **Workflow State**: The current position of an issue in the Ralph pipeline, stored as a custom field on the GitHub Projects V2 board. One of 11 defined states.
+- **Lock State**: A workflow state indicating exclusive ownership by an agent. Other agents MUST NOT claim an issue in a lock state.
+- **Terminal State**: A workflow state with no outbound transitions. The issue is complete or canceled.
+- **Semantic Intent**: An abstract action (e.g., `__COMPLETE__`) that resolves to a concrete state based on which skill is executing.
+- **Status Sync**: One-way, best-effort mapping from workflow states to the GitHub Projects default Status field (Todo / In Progress / Done).
+- **Parent Gate State**: A workflow state that triggers parent issue advancement checks when all children reach it.
+
+## Requirements
+
+### 1. Workflow States
+
+All 11 workflow states defined in the Ralph state machine.
+
+| State | Description | Lock | Terminal | Requires Human |
+|-------|-------------|------|----------|----------------|
+| Backlog | Ticket awaiting triage | | | |
+| Research Needed | Needs investigation before planning | | | |
+| Research in Progress | Research actively underway | yes | | |
+| Ready for Plan | Research complete, ready for planning | | | |
+| Plan in Progress | Plan actively being created | yes | | |
+| Plan in Review | Plan awaiting human approval | | | yes |
+| In Progress | Implementation actively underway | yes | | |
+| In Review | PR created, awaiting code review | | | yes |
+| Human Needed | Escalated, requires human intervention | | | yes |
+| Done | Ticket completed | | yes | |
+| Canceled | Ticket canceled/superseded | | yes | |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Issues MUST be in exactly one workflow state at all times | `[ ]` not enforced |
+| State names MUST match exactly (case-sensitive) | `[x]` `workflow-states.ts` via `VALID_STATES` |
+
+### 2. Valid Transitions
+
+Every non-terminal state has a defined set of allowed outbound transitions. No transitions are valid from terminal states.
+
+| From | Allowed To |
+|------|------------|
+| Backlog | Research Needed, Ready for Plan, Done, Canceled |
+| Research Needed | Research in Progress, Ready for Plan, Human Needed |
+| Research in Progress | Ready for Plan, Human Needed |
+| Ready for Plan | Plan in Progress, Human Needed |
+| Plan in Progress | Plan in Review, Human Needed |
+| Plan in Review | In Progress, Ready for Plan, Human Needed |
+| In Progress | In Review, Human Needed |
+| In Review | Done, In Progress, Human Needed |
+| Human Needed | Backlog, Research Needed, Ready for Plan, In Progress |
+| Done | *(none — terminal)* |
+| Canceled | *(none — terminal)* |
+
+| Requirement | Enablement |
+|-------------|------------|
+| State transitions MUST follow the allowed transition table | `[x]` `auto-state.sh` via `ralph-state-machine.json` lookup |
+| Transitions not listed in the table MUST be rejected | `[x]` per-command state gate hooks |
+
+### 3. State Ownership by Skill
+
+Which skills produce which states, and which states skills require as input.
+
+**State production** (which skills can set which states):
+
+| State Produced | Skill(s) Responsible |
+|---------------|----------------------|
+| Backlog | ralph_triage, ralph_split |
+| Research Needed | ralph_triage |
+| Research in Progress | ralph_research (lock acquire) |
+| Ready for Plan | ralph_research |
+| Plan in Progress | ralph_plan (lock acquire) |
+| Plan in Review | ralph_plan, ralph_review (rejection bounce) |
+| In Progress | ralph_review (approval), ralph_impl |
+| In Review | ralph_impl |
+| Human Needed | any skill via `__ESCALATE__` |
+| Done | ralph_triage, ralph_impl, ralph_merge |
+| Canceled | ralph_triage |
+
+**Skill input state requirements** (preconditions):
+
+| Skill | Required Input State(s) |
+|-------|------------------------|
+| ralph_triage | Backlog |
+| ralph_split | Backlog, Research Needed |
+| ralph_research | Research Needed |
+| ralph_plan | Ready for Plan |
+| ralph_review | Plan in Review |
+| ralph_impl | Plan in Review, In Progress |
+| ralph_merge | In Review |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Skills MUST only produce states listed in their production table | `[x]` per-command state gate hooks (`triage-state-gate.sh`, `research-state-gate.sh`, `plan-state-gate.sh`, `review-state-gate.sh`, `impl-state-gate.sh`, `merge-state-gate.sh`, `pr-state-gate.sh`) |
+| Skills MUST NOT execute unless the issue is in a valid input state | `[x]` per-command state gate hooks |
+
+### 4. Lock State Protocol
+
+Lock states prevent concurrent claim by multiple agents. Three lock states exist.
+
+| Lock State | Acquired From | By Command | Released To (success) | Released To (failure) | Released To (escalation) |
+|------------|--------------|-----------|----------------------|----------------------|-----------------------------|
+| Research in Progress | Research Needed | ralph_research | Ready for Plan | Research Needed | Human Needed |
+| Plan in Progress | Ready for Plan | ralph_plan | Plan in Review | Ready for Plan | Human Needed |
+| In Progress | Plan in Review | ralph_impl | In Review | *(stays In Progress)* | Human Needed |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Agents MUST NOT claim an issue that is in a lock state | `[ ]` not enforced (convention: agents check lock states before claiming) |
+| Lock acquisition MUST transition from the correct source state | `[x]` `auto-state.sh` |
+| Lock release on success MUST transition to the correct target state | `[x]` per-command state gate hooks |
+| Lock release on failure MUST return to the pre-lock state (except In Progress) | `[ ]` not enforced (skill-level convention) |
+
+### 5. Semantic Intents
+
+Abstract intents resolve to concrete states based on the executing skill.
+
+| Intent | ralph_research | ralph_plan | ralph_impl | ralph_review | ralph_split | ralph_merge | all commands |
+|--------|---------------|------------|------------|--------------|-------------|-------------|--------------|
+| `__LOCK__` | Research in Progress | Plan in Progress | In Progress | — | — | — | — |
+| `__COMPLETE__` | Ready for Plan | Plan in Review | In Review | In Progress | Backlog | Done | — |
+| `__ESCALATE__` | — | — | — | — | — | — | Human Needed |
+| `__CLOSE__` | — | — | — | — | — | — | Done |
+| `__CANCEL__` | — | — | — | — | — | — | Canceled |
+
+**Triage-specific actions** (ralph_triage has multiple output paths not captured by semantic intents):
+
+| Action | Resolved State |
+|--------|---------------|
+| RESEARCH | Research Needed |
+| PLAN | Ready for Plan |
+| CLOSE | Done |
+| KEEP | *(no state change)* |
+| SPLIT | *(delegates to ralph_split)* |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Skills MUST use semantic intents when setting workflow state via `save_issue` | `[ ]` not enforced (convention only) |
+| `__ESCALATE__` MUST resolve to Human Needed for all commands | `[x]` `ralph-state-machine.json` definition |
+
+### 6. Status Sync
+
+One-way, best-effort mapping from workflow states to the GitHub Projects default Status field.
+
+| Workflow State | GitHub Status |
+|---------------|--------------|
+| Backlog | Todo |
+| Research Needed | Todo |
+| Ready for Plan | Todo |
+| Plan in Review | Todo |
+| Research in Progress | In Progress |
+| Plan in Progress | In Progress |
+| In Progress | In Progress |
+| In Review | In Progress |
+| Done | Done |
+| Canceled | Done |
+| Human Needed | Done |
+
+**Rationale**: Todo = work not yet actively started (queued states). In Progress = work actively being processed (lock states + review). Done = terminal/escalated states (no automated progression).
+
+| Requirement | Enablement |
+|-------------|------------|
+| `save_issue` MUST sync Status when setting workflowState | `[x]` `workflow-states.ts` via `WORKFLOW_STATE_TO_STATUS` mapping in `issue-tools.ts` |
+| `batch_update` and `advance_issue` MUST also sync Status | `[x]` `workflow-states.ts` |
+| Status sync MUST be best-effort: silently skip if Status field is missing or has non-standard options | `[x]` `workflow-states.ts` |
+
+### 7. Issue Creation
+
+| Requirement | Enablement |
+|-------------|------------|
+| Issues MUST have a title at creation | `[ ]` not enforced (GitHub API requires title) |
+| Estimate, priority, and workflowState MUST be set via project fields after creation | `[ ]` not enforced |
+| New issues created by ralph_split MUST start in Backlog | `[x]` `triage-state-gate.sh` |
+
+### 8. Close/Reopen Semantics
+
+| Requirement | Enablement |
+|-------------|------------|
+| Done and Canceled are terminal states — no outbound transitions are valid | `[x]` `ralph-state-machine.json` (empty `allowed_transitions`) |
+| Human Needed is NOT terminal — it can return to Backlog, Research Needed, Ready for Plan, or In Progress | `[x]` `ralph-state-machine.json` |
+| Only a human MAY transition issues out of Human Needed | `[ ]` not enforced (convention only) |
+
+### 9. Parent Gate States
+
+When all children of a parent issue reach a gate state, the parent issue advancement check triggers.
+
+| Gate State | Trigger |
+|-----------|---------|
+| Ready for Plan | All children researched — parent can advance to planning |
+| In Review | All children implemented — parent can advance to review |
+| Done | All children complete — parent can close |
+
+| Requirement | Enablement |
+|-------------|------------|
+| `advance_issue` MUST check parent gate states when a child reaches Ready for Plan, In Review, or Done | `[x]` `workflow-states.ts` via `PARENT_GATE_STATES` |
+| Parent advancement MUST only occur when ALL children reach the gate state | `[x]` `relationship-tools.ts` |
+
+### 10. State Ordering
+
+Canonical pipeline order defines left-to-right progression through the workflow.
+
+```
+Backlog → Research Needed → Research in Progress → Ready for Plan → Plan in Progress → Plan in Review → In Progress → In Review → Done
+```
+
+States not in the canonical order: Canceled, Human Needed. These are off-pipeline states with special semantics.
+
+| Requirement | Enablement |
+|-------------|------------|
+| Pipeline position comparisons MUST use the canonical state ordering | `[x]` `workflow-states.ts` via `STATE_ORDER`, `stateIndex()`, `compareStates()` |
+| States not in STATE_ORDER MUST return -1 from `stateIndex()` | `[x]` `workflow-states.ts` |
+
+## Cross-References
+
+- [skill-io-contracts.md](skill-io-contracts.md) — Per-skill preconditions and postconditions that reference workflow states
+- [agent-permissions.md](agent-permissions.md) — Which agents run which skills (and therefore which state transitions they can trigger)
+- [document-protocols.md](document-protocols.md) — Document creation requirements triggered by state transitions


### PR DESCRIPTION
## Summary

- Add `specs/issue-lifecycle.md` — full 11-state machine with transition table, lock protocol, semantic intents, Status sync mapping, parent gate states, and state ordering (10 requirement sections)
- Add `specs/document-protocols.md` — research, plan, and review/critique document requirements with convergence verification and quality dimensions (5 requirement sections)
- All enablement checkboxes verified against actual hook enforcement; orphaned scripts (`plan-verify-doc.sh`, `plan-no-dup.sh`) correctly marked as not enforced

Closes #469

## Test plan

- [ ] Verify `specs/issue-lifecycle.md` exists with Purpose, Requirements, Cross-References sections
- [ ] Verify all 11 workflow states present in state table
- [ ] Verify transition table matches `ralph-state-machine.json`
- [ ] Verify Status sync mapping matches `WORKFLOW_STATE_TO_STATUS` in `workflow-states.ts`
- [ ] Verify `specs/document-protocols.md` exists with Purpose, Requirements, Cross-References sections
- [ ] Verify research, plan, and review sections all present
- [ ] Verify enablement checkboxes match actual hook enforcement
- [ ] Verify no orphaned scripts cited as `[x]` enforcers
- [ ] Verify cross-references to Phase 1 specs are present and consistent
- [ ] Verify 7 total files in `specs/` directory (README + 4 Phase 1 + 2 Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)