### PR TITLE
docs(specs): Phase 3 coordination specs (task-schema, team-schema)

### DIFF
--- a/specs/task-schema.md
+++ b/specs/task-schema.md
@@ -1,0 +1,155 @@
+# Task Schema
+
+## Purpose
+
+Defines the schema for TaskCreate/TaskUpdate operations in the Ralph multi-agent workflow, including required fields, metadata conventions, and stop-gate integration.
+
+## Definitions
+
+- **Task**: A unit of work in the Ralph task system, created by the team lead and claimed by workers. Tasks have a subject, description, status, and metadata.
+- **Metadata (input)**: Structured key-value pairs set by the team lead at TaskCreate time. Provides context workers need to execute.
+- **Metadata (output)**: Structured key-value pairs set by workers via TaskUpdate when marking a task complete. Reports results back to the lead.
+- **Blocking Dependency**: A relationship between tasks where one task cannot start until another completes. Expressed via `addBlockedBy` / `addBlocks` arrays of task IDs.
+- **Stop Gate**: A hook that checks whether a worker has remaining work before allowing it to stop. Uses keyword matching against task subjects.
+- **Keyword Matching**: Substring-based matching of task subjects against role-specific keywords to determine which tasks a worker can claim.
+- **Subject Naming Convention**: The requirement that task subjects include specific keywords so stop-gate matching works correctly.
+
+## Requirements
+
+### 1. TaskCreate Required Fields
+
+| Field | Type | Required | Description | Example |
+|-------|------|----------|-------------|---------|
+| `subject` | string | YES | Brief title in imperative form. MUST include GH-NNN for GitHub-linked tasks | "Research GH-468: Scaffold specs" |
+| `description` | string | YES | Full task requirements including issue context, artifact paths, and what the worker needs | *(multiline text)* |
+| `activeForm` | string | YES | Present continuous form shown in spinner during `in_progress` | "Researching GH-468" |
+| `metadata` | object | YES | Structured key-value pairs; lead sets input keys at creation | `{ "issue_number": 468, ... }` |
+
+| Requirement | Enablement |
+|-------------|------------|
+| TaskCreate MUST include all four required fields (subject, description, activeForm, metadata) | `[ ]` not enforced (convention only) |
+| Subject MUST be in imperative form | `[ ]` not enforced |
+
+### 2. Standard Input Metadata
+
+Keys set by the team lead at TaskCreate time. Provides context workers need for execution.
+
+| Key | When Set | Type | Description |
+|-----|----------|------|-------------|
+| `issue_number` | Always | number | GitHub issue number being processed |
+| `issue_url` | Always | string | Full GitHub issue URL |
+| `command` | Always | string | Ralph command this task maps to (e.g., "ralph_research") |
+| `phase` | Always | string | Pipeline phase name (e.g., "research", "plan", "impl") |
+| `estimate` | Always | string | Issue estimate (XS/S) |
+| `group_primary` | Groups | number | Primary issue number of the group |
+| `group_members` | Groups | string | Comma-separated member issue numbers |
+| `artifact_path` | When prior artifact exists | string | Path to research/plan doc from prior phase |
+| `worktree` | Impl tasks | string | Path to worktree directory |
+| `stream_id` | Streams | string | Stream identifier |
+| `stream_primary` | Streams | number | Primary issue of the stream |
+| `stream_members` | Streams | string | Stream member issue numbers |
+| `epic_issue` | Epics | number | Parent epic issue number |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Input metadata MUST include `issue_number`, `issue_url`, `command`, `phase`, and `estimate` for all tasks | `[ ]` not enforced (convention only) |
+| Group-specific keys MUST be set when processing grouped issues | `[ ]` not enforced |
+
+### 3. TaskUpdate Result Schema
+
+Metadata keys that workers MUST set when marking a task complete via `TaskUpdate(status="completed", metadata={...})`. Organized by pipeline phase.
+
+| Phase | Required Metadata Keys | Required Description Content |
+|-------|----------------------|------------------------------|
+| Triage | `action` (RESEARCH/PLAN/CLOSE/SPLIT), `workflow_state` | What action was taken and why |
+| Split | `sub_tickets` (array of numbers), `estimates` | List of sub-issues created with estimates |
+| Research | `artifact_path`, `workflow_state` | Key findings summary, artifact location |
+| Plan | `artifact_path`, `phase_count`, `workflow_state` | Phase summary, artifact location |
+| Review | `result` (APPROVED/NEEDS_ITERATION), `artifact_path` (if AUTO) | Full verdict, critique location if applicable |
+| Impl | `worktree`, `phase_completed`, `pr_url` (if final phase) | Phase summary, PR URL if created |
+| Validate | `result` (PASS/FAIL), `failures` (if FAIL) | Pass/fail verdict with details |
+| PR | `pr_url`, `workflow_state` | PR URL, issue moved to In Review |
+| Merge | `workflow_state` | Issue moved to Done, worktree cleaned |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Workers MUST set phase-appropriate metadata keys when completing a task | `[ ]` not enforced (convention only) |
+| Workers MUST include a meaningful description summarizing results | `[ ]` not enforced |
+| TaskUpdate is the primary reporting channel — workers MUST NOT use SendMessage for routine reporting | `[ ]` not enforced (convention only) |
+
+### 4. Blocking and Dependency Patterns
+
+Tasks can express ordering constraints via blocking relationships.
+
+- `addBlockedBy`: array of task IDs that MUST complete before this task can start
+- `addBlocks`: array of task IDs that this task prevents from starting
+- Within-group blockers define execution order (sequential phases)
+- Cross-group blockers define true blocking (e.g., research blocks planning)
+
+| Requirement | Enablement |
+|-------------|------------|
+| Workers MUST NOT claim tasks where `blockedBy` contains open (non-completed) tasks | `[ ]` not enforced (task system shows visibility but no hook validates claim behavior) |
+| The team lead SHOULD use `addBlockedBy` to express phase ordering within a pipeline | `[ ]` not enforced |
+
+### 5. Subject Naming Convention
+
+Task subjects MUST include role-specific keywords for stop-gate matching to work. The `worker-stop-gate.sh` hook uses substring matching against task subjects to determine if a worker has remaining work.
+
+**Analyst tasks**:
+- "Triage GH-NNN"
+- "Split GH-NNN"
+- "Research GH-NNN: {title}"
+- "Plan GH-NNN: {title}"
+
+**Builder tasks**:
+- "Review plan for #NNN"
+- "Implement #NNN: {title}"
+
+**Integrator tasks**:
+- "Validate #NNN"
+- "Create PR for #NNN"
+- "Merge PR for #NNN"
+
+| Requirement | Enablement |
+|-------------|------------|
+| Task subjects MUST include the role-specific keyword for the target worker | `[ ]` not enforced (convention only — `worker-stop-gate.sh` depends on this but does not validate naming) |
+| Task subjects MUST include the issue number (GH-NNN or #NNN format) | `[ ]` not enforced |
+
+### 6. Worker Stop Gate Integration
+
+`worker-stop-gate.sh` runs before any worker stops. It calls TaskList to check for unblocked tasks matching the worker's role keywords. If matching tasks exist, the stop is blocked.
+
+| Role Prefix | Matched Keywords | Behavior |
+|-------------|-----------------|----------|
+| `analyst*` | "Triage", "Split", "Research", "Plan" | Blocks stop if unblocked task with matching keyword exists |
+| `builder*` | "Review", "Implement" | Blocks stop if unblocked task with matching keyword exists |
+| `integrator*` | "Validate", "Create PR", "Merge", "Integrate" | Blocks stop if unblocked task with matching keyword exists |
+
+The `$TEAMMATE` environment variable provides the worker's name (set from the `name` field in `Task()` spawn). The role prefix is matched against `$TEAMMATE`.
+
+| Requirement | Enablement |
+|-------------|------------|
+| Workers MUST check TaskList for unblocked matching tasks before stopping | `[x]` `worker-stop-gate.sh` (registered in all 3 agent Stop hooks) |
+| Worker names MUST use role prefixes (`analyst*`, `builder*`, `integrator*`) for stop gate matching | `[ ]` not enforced (convention only) |
+
+### 7. TaskCompleted Hook
+
+`team-task-completed.sh` fires when any teammate marks a task completed. It provides advisory guidance to the team lead for follow-up task creation.
+
+The hook:
+- Reads the completed task's metadata and description
+- Suggests next-phase task creation (e.g., after research completes, suggest creating a plan task)
+- Handles review rejections (suggest creating new plan task)
+- Handles validation failures (suggest creating new impl task)
+- Always exits 0 (never blocks completion)
+
+| Requirement | Enablement |
+|-------------|------------|
+| The TaskCompleted hook MUST fire on task completion | `[x]` `team-task-completed.sh` (registered in ralph-team SKILL.md TaskCompleted hook) |
+| The hook MUST be advisory only (exit 0, never block) | `[x]` `team-task-completed.sh` (always exits 0) |
+
+## Cross-References
+
+- [skill-io-contracts.md](skill-io-contracts.md) — Command-level result schemas and per-skill postconditions
+- [agent-permissions.md](agent-permissions.md) — Which agents run which skills (determines which task types each worker handles)
+- [team-schema.md](team-schema.md) — TeamCreate ordering, worker spawn protocol, shutdown sequence

--- a/specs/team-schema.md
+++ b/specs/team-schema.md
@@ -1,0 +1,175 @@
+# Team Schema
+
+## Purpose
+
+Defines the schema for team creation, worker spawning, role contracts, and shutdown protocol in the Ralph multi-agent workflow.
+
+## Definitions
+
+- **Team**: A coordinated group of agents (one lead + N workers) operating on a shared TaskList scope. Created via TeamCreate, destroyed via TeamDelete.
+- **Team Lead**: The orchestrating agent that creates the team, spawns workers, creates tasks, and manages shutdown. Runs the ralph-team skill.
+- **Worker**: An autonomous agent spawned into a team. Claims tasks from TaskList, executes skills, reports results via TaskUpdate.
+- **Roster**: The set of workers spawned for a team session. Sized based on pipeline position and workload.
+- **Spawn Protocol**: The process of creating a worker via `Task()` with required parameters (subagent_type, team_name, name, prompt).
+- **Sub-Agent Isolation**: The rule that internal sub-tasks spawned within a skill MUST NOT be added to the team's TaskList scope.
+- **Shutdown**: The orderly process of collecting results, writing a post-mortem, dismissing workers, and destroying the team.
+- **Post-Mortem**: A markdown report capturing all session results, written before TeamDelete destroys ephemeral task data.
+
+## Requirements
+
+### 1. TeamCreate Ordering
+
+| Requirement | Enablement |
+|-------------|------------|
+| TeamCreate MUST be called before any TaskCreate | `[ ]` not enforced (convention enforced by ralph-team skill prompt only) |
+| Workers are spawned as part of team creation; tasks are assigned after the team exists | `[ ]` not enforced |
+
+### 2. Roster Sizing
+
+Guidelines for worker allocation based on pipeline position.
+
+**Recommended roster by pipeline position**:
+
+| Pipeline Position | Recommended Workers |
+|------------------|---------------------|
+| Backlog / Research Needed | 1 analyst |
+| Ready for Plan | 1 analyst + 1 builder |
+| In Progress | 1 builder + 1 integrator |
+| Full pipeline | 1 analyst + 1 builder + 1 integrator |
+
+**Maximum parallel instances per role**:
+
+| Role | Max Instances | Rationale |
+|------|--------------|-----------|
+| Analyst | 3 | Parallel per issue; read-only + docs, no contention |
+| Builder | 3 | Parallel per issue; worktree isolation prevents conflicts |
+| Integrator | 1 | Serialized on main branch for merges |
+
+Source: GH-0044 worker scope boundaries research + GH-451 post-mortem evidence (actual session: 1 analyst + 1 builder + 1 integrator for XL issue split into 6 sub-issues).
+
+| Requirement | Enablement |
+|-------------|------------|
+| Integrator instances SHOULD be limited to 1 per team | `[ ]` not enforced (team lead decides) |
+| Roster size SHOULD match the pipeline position guidelines | `[ ]` not enforced |
+
+### 3. Worker Spawn Protocol
+
+Workers are spawned via `Task()` call with specific parameters:
+
+```
+Task(
+  subagent_type="ralph-analyst",   # matches agents/ralph-analyst.md filename
+  team_name=TEAM_NAME,             # binds worker to this team's TaskList scope
+  name="analyst",                   # becomes $TEAMMATE for stop gate matching
+  prompt="..."                      # spawn prompt with required fields
+)
+```
+
+The `name` field MUST use a role prefix (`analyst*`, `builder*`, `integrator*`) for stop-gate keyword matching to work. Names like "analyst-1" or "builder-primary" are valid; "worker-1" is not.
+
+**Required spawn prompt fields per role**:
+
+| Field | Analyst | Builder | Integrator |
+|-------|---------|---------|------------|
+| Issue number | YES | YES | YES |
+| Issue title | YES | YES | YES |
+| Current workflow state | YES | YES | YES |
+| Task subjects to look for | YES | YES | YES |
+| Skill(s) to invoke | YES | YES | YES |
+| How to report results | YES | YES | YES |
+
+| Requirement | Enablement |
+|-------------|------------|
+| Worker `name` MUST use a role prefix (analyst*, builder*, integrator*) | `[ ]` not enforced (convention only) |
+| Spawn prompts MUST include all 6 required fields | `[ ]` not enforced |
+| `team_name` MUST be set to bind the worker to the team's TaskList scope | `[ ]` not enforced |
+
+### 4. Worker Role Contracts
+
+Each role handles specific pipeline phases and has access to specific skills.
+
+| Role | Handled Phases | Available Skills | Model |
+|------|---------------|-----------------|-------|
+| Analyst | Triage, Split, Research, Plan | ralph-triage, ralph-split, ralph-research, ralph-plan | sonnet |
+| Builder | Plan review, Implementation | ralph-review, ralph-impl | sonnet |
+| Integrator | Validation, PR creation, Merge | ralph-val, ralph-pr, ralph-merge | haiku |
+
+**Worker autonomy rules**:
+1. Check TaskList for unblocked tasks matching role keywords
+2. Self-assign: set `owner` and `status: in_progress`
+3. Invoke the appropriate skill
+4. Report results via TaskUpdate (metadata + description)
+5. Check TaskList again before stopping
+
+**Communication discipline**: Workers MUST NOT send SendMessage for routine reporting — TaskUpdate is the primary communication channel. SendMessage is reserved for escalations (blockers, errors requiring lead intervention) and responses to direct questions from the lead.
+
+| Requirement | Enablement |
+|-------------|------------|
+| Workers MUST check TaskList before stopping | `[x]` `worker-stop-gate.sh` (blocks stop if unblocked matching tasks exist) |
+| Workers MUST NOT invoke mutating tools outside of a skill context | `[x]` `require-skill-context.sh` (blocks mutating calls outside skill context) |
+| Workers MUST NOT use SendMessage for routine status reporting | `[ ]` not enforced (convention only) |
+| Workers MUST report results via TaskUpdate metadata and description | `[ ]` not enforced |
+
+### 5. Sub-Agent Team Isolation
+
+Internal sub-tasks spawned via `Task()` within a skill MUST NOT pass `team_name`. Internal sub-agents are research helpers, not team workers. Passing `team_name` would pollute the team's TaskList scope, causing confusion for workers checking TaskList.
+
+```
+# CORRECT — internal sub-agent, no team binding
+Task(subagent_type="codebase-locator", prompt="Find files related to...")
+
+# INCORRECT — pollutes team's TaskList with internal sub-agent tasks
+Task(subagent_type="codebase-locator", team_name=TEAM_NAME, prompt="Find files...")
+```
+
+| Requirement | Enablement |
+|-------------|------------|
+| Internal sub-tasks spawned within a skill MUST NOT pass `team_name` | `[ ]` not enforced (convention only) |
+
+### 6. Shutdown Protocol
+
+Step-by-step shutdown sequence for the team lead:
+
+1. **Collect session data**: Call TaskList, then TaskGet on each task. Extract issues processed, PRs created, worker assignments, errors.
+2. **Write post-mortem**: Create `thoughts/shared/reports/YYYY-MM-DD-ralph-team-{team-name}.md` (see Section 7 for template).
+3. **Commit and push**: `git commit -m "docs(report): {team-name} session post-mortem"`
+4. **Send shutdown to each teammate**: `SendMessage(type="shutdown_request", recipient=teammate)`
+5. **Wait for confirmations**: Workers approve (if idle/done) or reject (if mid-skill). Handle rejections.
+6. **Call TeamDelete()**: Removes task list and team config. Task data is destroyed.
+
+| Requirement | Enablement |
+|-------------|------------|
+| The team lead MUST NOT stop while processable issues remain on the board | `[x]` `team-stop-gate.sh` (blocks lead stop if processable issues remain) |
+| Post-mortem MUST be written and committed BEFORE TeamDelete is called | `[ ]` not enforced (convention only — task data is ephemeral, destroyed by TeamDelete) |
+| Shutdown requests MUST be sent to all teammates before TeamDelete | `[ ]` not enforced |
+
+### 7. Post-Mortem Requirements
+
+Post-mortem reports are the only persistent artifact from a team session. Task data is ephemeral and destroyed by TeamDelete.
+
+**Required sections**:
+
+| Section | Content |
+|---------|---------|
+| Date | Session date |
+| Summary | One-line outcome description |
+| Issues Processed | Table: Issue number, title, estimate, outcome, PR |
+| Worker Summary | Table: Worker name, tasks completed (list of task subjects) |
+| Key Metrics | *(optional)* PRs merged, tests passing, other measurable outcomes |
+| Notes | Escalations, errors, anything notable |
+
+**Commit message pattern**: `docs(report): {team-name} session post-mortem`
+
+**File path pattern**: `thoughts/shared/reports/YYYY-MM-DD-ralph-team-{team-name}.md`
+
+| Requirement | Enablement |
+|-------------|------------|
+| Post-mortem MUST include Issues Processed and Worker Summary tables | `[ ]` not enforced (convention only) |
+| Post-mortem MUST be committed with the standard commit message pattern | `[ ]` not enforced |
+| Post-mortem MUST capture all session results before TeamDelete destroys task data | `[ ]` not enforced |
+
+## Cross-References
+
+- [task-schema.md](task-schema.md) — TaskCreate/TaskUpdate fields, metadata keys, stop-gate integration
+- [agent-permissions.md](agent-permissions.md) — Per-agent tool whitelists and PreToolUse gates
+- [skill-io-contracts.md](skill-io-contracts.md) — Per-skill contracts that workers execute


### PR DESCRIPTION
## Summary

- Add `specs/task-schema.md` — TaskCreate required fields, standard input/output metadata tables by phase, blocking/dependency patterns, subject naming convention, worker stop-gate integration, and TaskCompleted hook (7 requirement sections)
- Add `specs/team-schema.md` — TeamCreate ordering, roster sizing guidelines with evidence from GH-0044 and GH-451, worker spawn protocol, role contracts, sub-agent team isolation rule, step-by-step shutdown protocol, and post-mortem requirements (7 requirement sections)
- All enablement checkboxes verified against actual hook enforcement

Closes #470

## Test plan

- [ ] Verify `specs/task-schema.md` exists with Purpose, Requirements, Cross-References sections
- [ ] Verify all 7 requirement sections present (TaskCreate fields, input metadata, output metadata, blocking, subject naming, stop gate, TaskCompleted)
- [ ] Verify stop-gate keyword table covers all 3 roles (analyst, builder, integrator)
- [ ] Verify `specs/team-schema.md` exists with Purpose, Requirements, Cross-References sections
- [ ] Verify all 7 requirement sections present (TeamCreate ordering, roster sizing, spawn protocol, role contracts, sub-agent isolation, shutdown, post-mortem)
- [ ] Verify shutdown protocol has all 6 steps with post-mortem-before-TeamDelete ordering
- [ ] Verify roster sizing table includes role limits with rationale
- [ ] Verify enablement checkboxes match actual enforcement
- [ ] Verify cross-references to Phase 1 specs are present and consistent
- [ ] Verify no duplicate content between task-schema.md and skill-io-contracts.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)