### PR TITLE
GH-477: Bug: MCP_VERSION mismatch between cli-dispatch.sh and justfile _mcp_call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
           sed -i "s/ralph-hero-mcp-server@[0-9][0-9.]*/ralph-hero-mcp-server@${NEW_VERSION}/g" \
             plugin/ralph-hero/justfile \
             plugin/ralph-hero/.mcp.json
+          sed -i "s/MCP_VERSION=\"[0-9][0-9.]*\"/MCP_VERSION=\"${NEW_VERSION}\"/g" \
+            plugin/ralph-hero/scripts/cli-dispatch.sh
 
       - name: Commit version bump and tag
         working-directory: .
@@ -143,6 +145,7 @@ jobs:
           if [ "$MCP_CHANGED" = "true" ]; then
             git add plugin/ralph-hero/justfile
             git add plugin/ralph-hero/.mcp.json
+            git add plugin/ralph-hero/scripts/cli-dispatch.sh
           fi
           git commit -m "chore(release): v${NEW_VERSION} [skip ci]"
           git tag "v${NEW_VERSION}"

--- a/plugin/ralph-hero/scripts/cli-dispatch.sh
+++ b/plugin/ralph-hero/scripts/cli-dispatch.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# cli-dispatch.sh — Shared dispatch functions for Ralph CLI
+# Modes: interactive (default), headless (-h), quick (-q)
+
+MCP_VERSION="2.4.95"
+
+# Parse -h/-q/--budget/--timeout flags from args
+# Sets: MODE, ARGS (array), BUDGET, TIMEOUT
+parse_mode() {
+    MODE="${DEFAULT_MODE:-interactive}"
+    ARGS=()
+    BUDGET="${DEFAULT_BUDGET:-2.00}"
+    TIMEOUT="${DEFAULT_TIMEOUT:-15m}"
+
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--headless) MODE="headless" ;;
+            -q|--quick) MODE="quick" ;;
+            --budget=*) BUDGET="${arg#--budget=}" ;;
+            --timeout=*) TIMEOUT="${arg#--timeout=}" ;;
+            *) ARGS+=("$arg") ;;
+        esac
+    done
+}
+
+# Open interactive Claude session with a skill
+run_interactive() {
+    local skill="$1"; shift
+    local cmd="/ralph-hero:${skill}"
+    if [ $# -gt 0 ] && [ -n "$1" ]; then cmd="$cmd $*"; fi
+    echo ">>> Opening: $cmd"
+    exec claude "$cmd"
+}
+
+# Run headless Claude session (print & exit)
+run_headless() {
+    local skill="$1"; shift
+    local cmd="/ralph-hero:${skill}"
+    if [ $# -gt 0 ] && [ -n "$1" ]; then cmd="$cmd $*"; fi
+    echo ">>> Running: $cmd (budget: \$$BUDGET, timeout: $TIMEOUT)"
+    local start_time
+    start_time=$(date +%s)
+    if timeout "$TIMEOUT" claude -p "$cmd" \
+        --max-budget-usd "$BUDGET" \
+        --dangerously-skip-permissions \
+        </dev/null \
+        2>&1; then
+        local elapsed=$(( $(date +%s) - start_time ))
+        echo ">>> Completed (${elapsed}s)"
+    else
+        local exit_code=$?
+        local elapsed=$(( $(date +%s) - start_time ))
+        if [ "$exit_code" -eq 124 ]; then
+            echo ">>> Timed out after $TIMEOUT (${elapsed}s)"
+            echo "    Try increasing: --timeout=30m"
+        else
+            echo ">>> Exited with code $exit_code (${elapsed}s)"
+            echo "    Run: ralph doctor"
+        fi
+    fi
+}
+
+# Direct MCP tool call (instant, no AI)
+run_quick() {
+    local tool="$1"
+    local params="$2"
+    if ! command -v mcp &>/dev/null; then
+        echo "Error: mcptools not installed."
+        echo "Install: brew tap f/mcptools && brew install mcp"
+        echo "   or: go install github.com/f/mcptools/cmd/mcptools@latest"
+        exit 1
+    fi
+    local raw
+    raw=$(mcp call "$tool" --params "$params" \
+        npx -y "ralph-hero-mcp-server@${MCP_VERSION}") || {
+        echo "Error: MCP call to $tool failed." >&2
+        echo "Run: ralph doctor" >&2
+        exit 1
+    }
+    if command -v jq &>/dev/null; then
+        if echo "$raw" | jq -e '.isError // false' > /dev/null 2>&1; then
+            echo "$raw" | jq -r '.content[0].text' >&2
+            exit 1
+        fi
+        echo "$raw" | jq -r '.content[0].text // .' | jq '.' 2>/dev/null \
+            || echo "$raw" | jq -r '.content[0].text // .'
+    else
+        echo "$raw"
+    fi
+}
+
+# Error for unsupported mode
+no_mode() {
+    local command="$1"
+    local mode="$2"
+    echo "Error: '$command' does not support $mode mode."
+    case "$mode" in
+        interactive) echo "Try: ralph $command -h (headless) or ralph $command -q (quick)" ;;
+        headless) echo "Try: ralph $command (interactive) or ralph $command -q (quick)" ;;
+        quick) echo "Try: ralph $command (interactive) or ralph $command -h (headless)" ;;
+    esac
+    exit 1
+}

--- a/thoughts/shared/plans/2026-03-01-GH-0477-mcp-version-mismatch-fix.md
+++ b/thoughts/shared/plans/2026-03-01-GH-0477-mcp-version-mismatch-fix.md
@@ -22,10 +22,10 @@ primary_issue: 477
 
 ## Desired End State
 ### Verification
-- [ ] `cli-dispatch.sh` line 5 reads `MCP_VERSION="2.4.95"`
-- [ ] `release.yml` has a sed targeting `MCP_VERSION="X.Y.Z"` format in `cli-dispatch.sh`
-- [ ] `release.yml` git add step includes `cli-dispatch.sh` (conditionally, when MCP changed)
-- [ ] All three version locations (`cli-dispatch.sh`, `justfile`, `.mcp.json`) report the same version
+- [x] `cli-dispatch.sh` line 5 reads `MCP_VERSION="2.4.95"`
+- [x] `release.yml` has a sed targeting `MCP_VERSION="X.Y.Z"` format in `cli-dispatch.sh`
+- [x] `release.yml` git add step includes `cli-dispatch.sh` (conditionally, when MCP changed)
+- [x] All three version locations (`cli-dispatch.sh`, `justfile`, `.mcp.json`) report the same version
 
 ## What We're NOT Doing
 - Not unifying the version format across files (Option B from research) — preserving the named `MCP_VERSION` variable is preferable for readability
@@ -64,16 +64,16 @@ git add plugin/ralph-hero/scripts/cli-dispatch.sh
 After line 145 (`git add plugin/ralph-hero/.mcp.json`).
 
 ### Success Criteria
-- [ ] Automated: `grep -q 'MCP_VERSION="2.4.95"' plugin/ralph-hero/scripts/cli-dispatch.sh`
-- [ ] Automated: `grep -q 'MCP_VERSION=\\"' .github/workflows/release.yml` (new sed pattern present)
-- [ ] Automated: `grep -q 'cli-dispatch.sh' .github/workflows/release.yml` (file in git add list)
-- [ ] Manual: All three version locations agree: `grep -oP '(?<=@|=")[0-9.]+' plugin/ralph-hero/scripts/cli-dispatch.sh plugin/ralph-hero/justfile plugin/ralph-hero/.mcp.json`
+- [x] Automated: `grep -q 'MCP_VERSION="2.4.95"' plugin/ralph-hero/scripts/cli-dispatch.sh`
+- [x] Automated: `grep -q 'MCP_VERSION=\\"' .github/workflows/release.yml` (new sed pattern present)
+- [x] Automated: `grep -q 'cli-dispatch.sh' .github/workflows/release.yml` (file in git add list)
+- [x] Manual: All three version locations agree: `grep -oP '(?<=@|=")[0-9.]+' plugin/ralph-hero/scripts/cli-dispatch.sh plugin/ralph-hero/justfile plugin/ralph-hero/.mcp.json`
 
 ---
 
 ## Integration Testing
-- [ ] Verify `ralph doctor -q` works with the updated version
-- [ ] Verify release workflow YAML is syntactically valid: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+- [x] Verify `ralph doctor -q` works with the updated version
+- [x] Verify release workflow YAML is syntactically valid: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
 
 ## References
 - Research: [GH-0477 research](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-03-01-GH-0477-mcp-version-mismatch-cli-dispatch.md)


### PR DESCRIPTION
## Summary

`cli-dispatch.sh` hardcodes `MCP_VERSION="2.4.88"` (line 5) while the justfile and `.mcp.json` use `@2.4.95`. Quick-mode commands routed through `run_quick()` in `cli-dispatch.sh` spawn the old MCP server version.

## Changes

1. `cli-dispatch.sh` line 5: MCP_VERSION="2.4.88" → "2.4.95"
2. `release.yml`: Added sed pattern for MCP_VERSION="X.Y.Z" format
3. `release.yml`: Added cli-dispatch.sh to git add step

This ensures the release workflow properly updates the MCP_VERSION in cli-dispatch.sh during future releases.

Closes #477