### PR TITLE
GH-479: Bug: `doctor` health check doesn't increment error counter on API failure

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -381,6 +381,11 @@ _mcp_call tool params:
     raw=$(mcp call "{{tool}}" --params '{{params}}' \
         npx -y ralph-hero-mcp-server@2.4.97)
     if command -v jq &>/dev/null; then
+        if ! echo "$raw" | jq -e '.' > /dev/null 2>&1; then
+            echo "Error: MCP server returned invalid response" >&2
+            echo "$raw" >&2
+            exit 1
+        fi
         if echo "$raw" | jq -e '.isError // false' > /dev/null 2>&1; then
             echo "$raw" | jq -r '.content[0].text' >&2
             exit 1

--- a/thoughts/shared/plans/2026-03-01-GH-0479-doctor-error-counter-fix.md
+++ b/thoughts/shared/plans/2026-03-01-GH-0479-doctor-error-counter-fix.md
@@ -17,8 +17,8 @@ estimate: XS
 
 ### Automated Verification
 
-- [ ] `just doctor` with valid env vars completes and shows health check output
-- [ ] Modifying `_mcp_call` to test invalid response: `echo "not json" | jq -e '.' > /dev/null 2>&1` returns non-zero
+- [x] `just doctor` with valid env vars completes and shows health check output
+- [x] Modifying `_mcp_call` to test invalid response: `echo "not json" | jq -e '.' > /dev/null 2>&1` returns non-zero
 
 ## File Ownership Summary
 


### PR DESCRIPTION
## Summary

Fixed bug where `doctor` recipe's API Health Check failed silently without incrementing the error counter.

The issue was in the `_mcp_call` recipe - without explicit JSON validation, a three-stage jq pipeline could exit with code 0 even when the middle jq failed.

## Fix

Added JSON validation guard in `_mcp_call` recipe to exit non-zero when MCP server returns invalid/non-JSON response. This allows the `doctor` recipe's error handling to properly detect and count failures.

Closes #479