### PR TITLE
fix(mcp): split save_issue into closeIssue/reopenIssue/updateIssue mutations

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/save-issue.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/save-issue.test.ts
@@ -236,9 +236,33 @@ describe("save_issue structural", () => {
     expect(issueToolsSrc).toContain("WORKFLOW_STATE_TO_STATUS");
   });
 
-  it("supports issueState with state and stateReason in mutation", () => {
-    expect(issueToolsSrc).toContain("$state: IssueState");
+  it("uses closeIssue mutation with stateReason for closing", () => {
+    expect(issueToolsSrc).toContain("closeIssue(input:");
     expect(issueToolsSrc).toContain("$stateReason: IssueClosedStateReason");
+  });
+
+  it("uses reopenIssue mutation for reopening (no stateReason)", () => {
+    expect(issueToolsSrc).toContain("reopenIssue(input:");
+    // reopenIssue should NOT reference stateReason
+    const reopenBlock = issueToolsSrc.slice(
+      issueToolsSrc.indexOf("reopenIssue(input:"),
+      issueToolsSrc.indexOf("reopenIssue(input:") + 200,
+    );
+    expect(reopenBlock).not.toContain("stateReason");
+  });
+
+  it("updateIssue mutation does not include state or stateReason", () => {
+    // Find the updateIssue mutation input block
+    const updateIdx = issueToolsSrc.indexOf("updateIssue(input:");
+    expect(updateIdx).toBeGreaterThan(-1);
+    const updateBlock = issueToolsSrc.slice(updateIdx, updateIdx + 300);
+    expect(updateBlock).not.toContain("stateReason");
+    // state should not be in updateIssue input (it's handled by closeIssue/reopenIssue)
+    expect(updateBlock).not.toContain("$state");
+  });
+
+  it("does not assign REOPENED as stateReason", () => {
+    expect(issueToolsSrc).not.toContain('"REOPENED"');
   });
 
   it("supports field clearing via clearProjectV2ItemFieldValue", () => {

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -1160,7 +1160,7 @@ export function registerIssueTools(
 
         // 2. Determine if we need to close/reopen the issue
         let targetState: "OPEN" | "CLOSED" | undefined;
-        let stateReason: "COMPLETED" | "NOT_PLANNED" | "REOPENED" | undefined;
+        let stateReason: "COMPLETED" | "NOT_PLANNED" | undefined;
 
         if (args.issueState === "CLOSED") {
           targetState = "CLOSED";
@@ -1170,7 +1170,7 @@ export function registerIssueTools(
           stateReason = "NOT_PLANNED";
         } else if (args.issueState === "OPEN") {
           targetState = "OPEN";
-          stateReason = "REOPENED";
+          // reopenIssue mutation has no stateReason parameter
         }
 
         // Auto-close: if workflowState is terminal and issueState not explicitly set
@@ -1180,69 +1180,104 @@ export function registerIssueTools(
           changes.autoClose = true;
         }
 
-        // 3. Issue-object mutation (title, body, labels, assignees, state)
-        const needsIssueMutation = hasIssueFields || targetState !== undefined;
+        // 3. Issue state mutations (close/reopen) - use dedicated mutations
+        const hasMetadataFields = args.title !== undefined || args.body !== undefined ||
+          args.labels !== undefined || args.assignees !== undefined;
+        const needsIssueMutation = hasMetadataFields || targetState !== undefined;
+
         if (needsIssueMutation) {
           const issueId = await resolveIssueNodeId(client, owner, repo, args.number);
 
-          // Resolve label IDs if provided
-          let labelIds: string[] | undefined;
-          if (args.labels) {
-            const labelResult = await client.query<{
-              repository: {
-                labels: { nodes: Array<{ id: string; name: string }> };
+          // 3a. Close issue (uses closeIssue mutation which accepts stateReason)
+          if (targetState === "CLOSED") {
+            await client.mutate<{
+              closeIssue: {
+                issue: { number: number; state: string; stateReason: string | null };
               };
             }>(
-              `query($owner: String!, $repo: String!) {
-                repository(owner: $owner, name: $repo) {
-                  labels(first: 100) {
-                    nodes { id name }
-                  }
+              `mutation($issueId: ID!, $stateReason: IssueClosedStateReason) {
+                closeIssue(input: { issueId: $issueId, stateReason: $stateReason }) {
+                  issue { number state stateReason }
                 }
               }`,
-              { owner, repo },
-              { cache: true, cacheTtlMs: 5 * 60 * 1000 },
+              { issueId, stateReason: stateReason ?? null },
             );
-            const allLabels = labelResult.repository.labels.nodes;
-            labelIds = args.labels
-              .map((name) => allLabels.find((l) => l.name === name)?.id)
-              .filter((id): id is string => id !== undefined);
+            if (args.issueState !== undefined) changes.issueState = args.issueState;
           }
 
-          await client.mutate<{
-            updateIssue: {
-              issue: { number: number; title: string; url: string; state: string; stateReason: string | null };
-            };
-          }>(
-            `mutation($issueId: ID!, $title: String, $body: String, $labelIds: [ID!], $assigneeIds: [ID!], $state: IssueState, $stateReason: IssueClosedStateReason) {
-              updateIssue(input: {
-                id: $issueId,
-                title: $title,
-                body: $body,
-                labelIds: $labelIds,
-                assigneeIds: $assigneeIds,
-                state: $state,
-                stateReason: $stateReason
-              }) {
-                issue { number title url state stateReason }
-              }
-            }`,
-            {
-              issueId,
-              title: args.title ?? null,
-              body: args.body ?? null,
-              labelIds: labelIds ?? null,
-              assigneeIds: null, // Would need username -> ID resolution
-              state: targetState ?? null,
-              stateReason: stateReason ?? null,
-            },
-          );
+          // 3b. Reopen issue (uses reopenIssue mutation, no stateReason)
+          if (targetState === "OPEN") {
+            await client.mutate<{
+              reopenIssue: {
+                issue: { number: number; state: string };
+              };
+            }>(
+              `mutation($issueId: ID!) {
+                reopenIssue(input: { issueId: $issueId }) {
+                  issue { number state }
+                }
+              }`,
+              { issueId },
+            );
+            if (args.issueState !== undefined) changes.issueState = args.issueState;
+          }
 
-          if (args.title !== undefined) changes.title = args.title;
-          if (args.body !== undefined) changes.body = "(updated)";
-          if (args.labels !== undefined) changes.labels = args.labels;
-          if (args.assignees !== undefined) changes.assignees = args.assignees;
-          if (args.issueState !== undefined) changes.issueState = args.issueState;
+          // 3c. Metadata update (uses updateIssue, NO state/stateReason fields)
+          if (hasMetadataFields) {
+            // Resolve label IDs if provided
+            let labelIds: string[] | undefined;
+            if (args.labels) {
+              const labelResult = await client.query<{
+                repository: {
+                  labels: { nodes: Array<{ id: string; name: string }> };
+                };
+              }>(
+                `query($owner: String!, $repo: String!) {
+                  repository(owner: $owner, name: $repo) {
+                    labels(first: 100) {
+                      nodes { id name }
+                    }
+                  }
+                }`,
+                { owner, repo },
+                { cache: true, cacheTtlMs: 5 * 60 * 1000 },
+              );
+              const allLabels = labelResult.repository.labels.nodes;
+              labelIds = args.labels
+                .map((name) => allLabels.find((l) => l.name === name)?.id)
+                .filter((id): id is string => id !== undefined);
+            }
+
+            await client.mutate<{
+              updateIssue: {
+                issue: { number: number; title: string; url: string };
+              };
+            }>(
+              `mutation($issueId: ID!, $title: String, $body: String, $labelIds: [ID!], $assigneeIds: [ID!]) {
+                updateIssue(input: {
+                  id: $issueId,
+                  title: $title,
+                  body: $body,
+                  labelIds: $labelIds,
+                  assigneeIds: $assigneeIds
+                }) {
+                  issue { number title url }
+                }
+              }`,
+              {
+                issueId,
+                title: args.title ?? null,
+                body: args.body ?? null,
+                labelIds: labelIds ?? null,
+                assigneeIds: null, // Would need username -> ID resolution
+              },
+            );
+
+            if (args.title !== undefined) changes.title = args.title;
+            if (args.body !== undefined) changes.body = "(updated)";
+            if (args.labels !== undefined) changes.labels = args.labels;
+            if (args.assignees !== undefined) changes.assignees = args.assignees;
+          }
         }
 
         // 4. Project-field mutations (aliased batch for workflow state + status sync + estimate + priority)

--- a/thoughts/shared/plans/2026-03-01-GH-0483-save-issue-terminal-state-stateReason-bug.md
+++ b/thoughts/shared/plans/2026-03-01-GH-0483-save-issue-terminal-state-stateReason-bug.md
@@ -269,8 +269,8 @@ it("does not assign REOPENED as stateReason", () => {
 ```
 
 ### Success Criteria
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm run build` succeeds with no errors
-- [ ] Automated: `cd plugin/ralph-hero/mcp-server && npm test` -- all tests pass including new structural tests
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm run build` succeeds with no errors
+- [x] Automated: `cd plugin/ralph-hero/mcp-server && npm test` -- all tests pass including new structural tests
 - [ ] Manual: Call `save_issue(number=<test-issue>, workflowState="Done", command="ralph_impl")` -- issue closes with `stateReason: COMPLETED` in GitHub UI
 - [ ] Manual: Call `save_issue(number=<test-issue>, issueState="OPEN")` -- issue reopens successfully
 - [ ] Manual: Call `save_issue(number=<test-issue>, issueState="CLOSED_NOT_PLANNED")` -- issue closes with `stateReason: NOT_PLANNED` in GitHub UI
@@ -278,8 +278,8 @@ it("does not assign REOPENED as stateReason", () => {
 ---
 
 ## Integration Testing
-- [ ] Build passes: `npm run build` in `plugin/ralph-hero/mcp-server`
-- [ ] All tests pass: `npm test` in `plugin/ralph-hero/mcp-server`
+- [x] Build passes: `npm run build` in `plugin/ralph-hero/mcp-server`
+- [x] All tests pass: `npm test` in `plugin/ralph-hero/mcp-server`
 - [ ] End-to-end: `save_issue` with terminal `workflowState` succeeds (previously failed)
 - [ ] End-to-end: `save_issue` with metadata + terminal state succeeds (combined operation)
 - [ ] No regression: `save_issue` with only metadata fields (title, labels) still works


### PR DESCRIPTION
## Summary

Fixes #483: `save_issue` fails on terminal state transitions because `stateReason` is passed to `UpdateIssueInput`, which doesn't accept it.

- Closes #483

## Changes

- **`closeIssue` mutation** for closing issues (accepts `stateReason: COMPLETED | NOT_PLANNED`)
- **`reopenIssue` mutation** for reopening issues (no `stateReason` parameter)
- **`updateIssue` mutation** now only handles metadata (title, body, labels, assignees) — no `state` or `stateReason`
- Removed invalid `"REOPENED"` from `stateReason` type union (not a valid `IssueClosedStateReason`)
- Updated structural tests to verify correct mutation separation
- Added new tests: `reopenIssue` has no `stateReason`, `updateIssue` has no state fields, no `"REOPENED"` literal

## Test Plan

- [x] `npm run build` — no type errors
- [x] `npm test` — all 725 tests pass (29 save-issue tests including 4 new structural tests)
- [ ] Manual: `save_issue(number=N, workflowState="Done", command="ralph_impl")` closes with `stateReason: COMPLETED`
- [ ] Manual: `save_issue(number=N, issueState="OPEN")` reopens successfully
- [ ] Manual: `save_issue(number=N, issueState="CLOSED_NOT_PLANNED")` closes with `stateReason: NOT_PLANNED`

---
Generated with Claude Code (Ralph GitHub Plugin)