### PR TITLE
feat(worktree): stacked branch strategy for parallel implementations

### DIFF
--- a/plugin/ralph-hero/agents/ralph-integrator.md
+++ b/plugin/ralph-hero/agents/ralph-integrator.md
@@ -25,3 +25,20 @@ For PR creation, invoke ralph-pr with the issue number. The skill handles fetchi
 For merging, invoke ralph-merge with the issue number. The skill verifies PR readiness, merges, cleans up the worktree, moves issues to "Done", advances the parent if applicable, and posts a completion comment. If the PR is not ready, the skill will report status and you can retry later.
 
 Check TaskList again for more work before stopping. If you receive a notification about a task you just completed yourself (self-notification from TaskUpdate), ignore it — do not start a new turn or check TaskList again for that notification alone. Approve shutdown unless you're mid-merge or mid-validation.
+
+## Stacked Branch Handling
+
+When merging a PR for an issue that has downstream stacked branches (indicated by task metadata `base_branch` pointing to the merged branch):
+
+1. After merging the upstream PR, identify any in-progress or pending implementation tasks whose `base_branch` references the just-merged branch name
+2. For each downstream branch:
+   ```bash
+   git checkout feature/GH-NNN-downstream
+   git fetch origin main
+   git rebase origin/main
+   git push --force-with-lease
+   ```
+3. If the downstream PR already exists, update its base: `gh pr edit NNN --base main`
+4. Use `--force-with-lease` (never bare `--force`) for safety
+
+This step is only needed when streams detected overlapping files and created stacked task chains. For independent streams, no action is needed after merge.

--- a/plugin/ralph-hero/skills/ralph-impl/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-impl/SKILL.md
@@ -169,6 +169,10 @@ Choose the worktree identifier based on context:
 
 Stream detection: if plan frontmatter contains `stream_id`, use the stream worktree naming. This takes precedence over the generic epic member row.
 
+**Base branch detection**: If the task description or plan frontmatter contains a `base_branch` value (set by the team lead via stream detection), store it:
+- `BASE_BRANCH_ARG="$base_branch"` (e.g., `feature/GH-42`)
+- If no `base_branch` found: `BASE_BRANCH_ARG=""` (default to origin/main)
+
 **6.3. Check for Existing Worktree and Sync**
 
 ```bash
@@ -181,10 +185,26 @@ if [ -d "$WORKTREE_PATH" ]; then
     git fetch origin main && git pull origin "$(git branch --show-current)" --no-edit
     # If merge conflict -> escalate (6.4)
 else
-    "$GIT_ROOT/scripts/create-worktree.sh" "$WORKTREE_ID"
+    "$GIT_ROOT/scripts/create-worktree.sh" "$WORKTREE_ID" "" "$BASE_BRANCH_ARG"
     cd "$WORKTREE_PATH"
 fi
 ```
+
+**6.3a. Rebase onto main if predecessor merged**
+
+When `BASE_BRANCH_ARG` is set (stacked branch), check if the predecessor branch has been merged to main:
+```bash
+if [[ -n "$BASE_BRANCH_ARG" ]]; then
+  git fetch origin main
+  # Check if predecessor's commits are already in main
+  if git merge-base --is-ancestor "origin/$BASE_BRANCH_ARG" origin/main 2>/dev/null; then
+    echo "Predecessor branch $BASE_BRANCH_ARG merged to main. Rebasing..."
+    git rebase origin/main
+  fi
+fi
+```
+
+This handles the case where the team lead created a stacked task but the predecessor merged before implementation started. The worktree was created from the predecessor branch, but since that's now in main, rebase to avoid a redundant merge base.
 
 **6.4. Handle Merge Conflict Escalation**
 

--- a/plugin/ralph-hero/skills/ralph-team/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-team/SKILL.md
@@ -98,7 +98,7 @@ When creating implementation tasks for a group with 2+ issues:
    - Task owner: assigned to the builder for that stream (`builder` → stream-1, `builder-2` → stream-2, `builder-3` → stream-3)
    - Within a stream: sequential `blockedBy` chain (second task blocked by first)
    - Across streams: no `blockedBy` (parallel execution)
-   - Task description must include `base_branch` if stacked branches apply (set by GH-465 plumbing)
+   - Task description must include `base_branch` if stacked branches apply: set `base_branch` to the predecessor's branch name (e.g., `feature/GH-42`). This tells the builder to create its worktree stacked on the predecessor branch instead of main. Issues in independent streams or standalone issues should not have `base_branch` set.
 
 6. **Single-stream fallback**: If `totalStreams == 1` or only 1 issue, skip stream tagging. Create implementation tasks as today — the existing single builder handles them sequentially.
 

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 # Create a git worktree for isolated feature development
 #
-# Usage: ./scripts/create-worktree.sh TICKET-ID [branch-name]
+# Usage: ./scripts/create-worktree.sh TICKET-ID [branch-name] [base-branch-override]
 #
 # Examples:
 #   ./scripts/create-worktree.sh GH-42
 #   ./scripts/create-worktree.sh GH-42 my-custom-branch
+#   ./scripts/create-worktree.sh GH-43 "" feature/GH-42  # Stack on GH-42's branch
 
 set -e
 
 TICKET_ID="${1:?Usage: $0 TICKET_ID [BRANCH_NAME]}"
 BRANCH_NAME="${2:-feature/$TICKET_ID}"
+BASE_BRANCH_OVERRIDE="${3:-}"
 
 # Always resolve from git root to handle being called from any directory
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -36,6 +38,19 @@ if ! git rev-parse --verify "$BASE_BRANCH" &>/dev/null; then
   if ! git rev-parse --verify "$BASE_BRANCH" &>/dev/null; then
     echo "Error: Could not find origin/main or origin/master"
     exit 1
+  fi
+fi
+
+# Apply base branch override if specified (for stacked branches)
+if [[ -n "$BASE_BRANCH_OVERRIDE" ]]; then
+  echo "Using base branch override: $BASE_BRANCH_OVERRIDE"
+  git fetch origin "$BASE_BRANCH_OVERRIDE" 2>/dev/null || true
+  if git rev-parse --verify "origin/$BASE_BRANCH_OVERRIDE" &>/dev/null; then
+    BASE_BRANCH="origin/$BASE_BRANCH_OVERRIDE"
+  elif git rev-parse --verify "$BASE_BRANCH_OVERRIDE" &>/dev/null; then
+    BASE_BRANCH="$BASE_BRANCH_OVERRIDE"
+  else
+    echo "Warning: Base branch override '$BASE_BRANCH_OVERRIDE' not found, using $BASE_BRANCH"
   fi
 fi
 

--- a/thoughts/shared/plans/2026-03-01-GH-0465-stacked-branch-strategy.md
+++ b/thoughts/shared/plans/2026-03-01-GH-0465-stacked-branch-strategy.md
@@ -25,11 +25,11 @@ The stream detection infrastructure already exists — `detect_stream_positions`
 ## Desired End State
 
 ### Verification
-- [ ] `create-worktree.sh` accepts an optional 3rd argument (`BASE_BRANCH_OVERRIDE`) and creates worktrees from that branch when provided
-- [ ] `ralph-impl` reads `base_branch` from task context and passes it to `create-worktree.sh`
-- [ ] `ralph-impl` runs `git rebase origin/main` when starting a stream-sequential issue whose predecessor has merged
-- [ ] Integrator agent documentation includes rebase guidance for stacked branches
-- [ ] Existing behavior (branching from `origin/main`) unchanged when no base branch is specified
+- [x] `create-worktree.sh` accepts an optional 3rd argument (`BASE_BRANCH_OVERRIDE`) and creates worktrees from that branch when provided
+- [x] `ralph-impl` reads `base_branch` from task context and passes it to `create-worktree.sh`
+- [x] `ralph-impl` runs `git rebase origin/main` when starting a stream-sequential issue whose predecessor has merged
+- [x] Integrator agent documentation includes rebase guidance for stacked branches
+- [x] Existing behavior (branching from `origin/main`) unchanged when no base branch is specified
 
 ## What We're NOT Doing
 - Stream detection in `ralph-team` — that's GH-488
@@ -170,13 +170,13 @@ When creating implementation tasks for issues within the same work stream (detec
 This is a lightweight touch — GH-488 will add the full stream detection logic. This note ensures the contract between team lead and builder is documented now.
 
 ### Success Criteria
-- [ ] Automated: `./scripts/create-worktree.sh GH-test-stacked "" feature/main` creates a worktree from `origin/main` (override resolves to the branch)
-- [ ] Automated: `./scripts/create-worktree.sh GH-test-default` creates from `origin/main` (no override, backward compatible)
-- [ ] Automated: `./scripts/create-worktree.sh GH-test-missing "" nonexistent-branch` falls back to `origin/main` with a warning
-- [ ] Manual: `ralph-impl` SKILL.md contains base_branch detection in Step 6.2 and passes it in Step 6.3
-- [ ] Manual: `ralph-impl` SKILL.md contains Step 6.3a rebase-on-predecessor-merged logic
-- [ ] Manual: `ralph-integrator.md` contains stacked branch rebase guidance
-- [ ] Manual: `ralph-team/SKILL.md` documents `base_branch` metadata contract
+- [x] Automated: `./scripts/create-worktree.sh GH-test-stacked "" feature/main` creates a worktree from `origin/main` (override resolves to the branch)
+- [x] Automated: `./scripts/create-worktree.sh GH-test-default` creates from `origin/main` (no override, backward compatible)
+- [x] Automated: `./scripts/create-worktree.sh GH-test-missing "" nonexistent-branch` falls back to `origin/main` with a warning
+- [x] Manual: `ralph-impl` SKILL.md contains base_branch detection in Step 6.2 and passes it in Step 6.3
+- [x] Manual: `ralph-impl` SKILL.md contains Step 6.3a rebase-on-predecessor-merged logic
+- [x] Manual: `ralph-integrator.md` contains stacked branch rebase guidance
+- [x] Manual: `ralph-team/SKILL.md` documents `base_branch` metadata contract
 
 ---
 


### PR DESCRIPTION
## Summary
- Closes #465

Enables stacked branches for overlapping-file implementations. When stream detection identifies issues that share files, builders can now create worktrees based on predecessor branches instead of origin/main, preventing predictable merge conflicts.

## Changes
- **`scripts/create-worktree.sh`** — Added optional 3rd arg `BASE_BRANCH_OVERRIDE` with graceful fallback to origin/main
- **`plugin/ralph-hero/skills/ralph-impl/SKILL.md`** — Added base_branch detection in Step 6.2, passes to create-worktree.sh in Step 6.3, added Step 6.3a for rebase-on-predecessor-merged
- **`plugin/ralph-hero/agents/ralph-integrator.md`** — Added "Stacked Branch Handling" section with cascade rebase guidance
- **`plugin/ralph-hero/skills/ralph-team/SKILL.md`** — Documented `base_branch` metadata contract for stream-based task creation

## Test Plan
- [x] `create-worktree.sh` with no override — branches from origin/main (backward compatible)
- [x] `create-worktree.sh` with valid override — branches from specified branch
- [x] `create-worktree.sh` with invalid override — falls back to origin/main with warning
- [ ] End-to-end: ralph-team session with overlapping-file streams uses stacked branches

---
Generated with Claude Code (Ralph GitHub Plugin)