### PR TITLE
GH-480: Add `/hello` session briefing command with actionable insights

### DIFF
--- a/plugin/ralph-hero/skills/ralph-hello/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-hello/SKILL.md
@@ -11,6 +11,9 @@ hooks:
 allowed-tools:
   - Read
   - Bash
+  - Skill
+  - ralph_hero__pipeline_dashboard
+  - ralph_hero__project_hygiene
 ---
 
 # Ralph Session Briefing

--- a/specs/skill-io-contracts.md
+++ b/specs/skill-io-contracts.md
@@ -58,6 +58,7 @@ Defines the inputs, outputs, preconditions, and postconditions for every `ralph-
 | `ralph-report` | read-only | (no state changes) | — | — | Status update posted |
 | `ralph-hygiene` | read-only | (no state changes) | — | main branch | Archive candidates report |
 | `ralph-setup` | — | — | — | — | GitHub Project V2 configuration |
+| `ralph-hello` | read-only | (no state changes) | — | — | Briefing output, routes to skills |
 
 ### Precondition Enforcement
 

--- a/specs/skill-permissions.md
+++ b/specs/skill-permissions.md
@@ -16,22 +16,22 @@ Defines the tool access matrix for every `ralph-*` skill and the plugin-level ho
 
 Each cell: **allow** = tool is in `allowed-tools`, **—** = tool is not listed (blocked by runtime).
 
-| Tool | triage | split | research | plan | impl | review | hero | team | merge | pr | val | status | report | hygiene | setup |
-|------|--------|-------|----------|------|------|--------|------|------|-------|----|----|--------|--------|---------|-------|
-| Read | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | — | — | — | — |
-| Write | — | — | allow | allow | allow | allow | — | allow | — | — | — | — | — | — | — |
-| Edit | — | — | — | — | allow | — | — | — | — | — | — | — | — | — | — |
-| Glob | allow | allow | allow | allow | allow | allow | allow | — | allow | allow | allow | — | — | — | — |
-| Grep | allow | allow | allow | allow | allow | allow | allow | — | — | — | allow | — | — | — | — |
-| Bash | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | — | — | — | — |
-| Task | allow | allow | allow | allow | allow | allow | allow | allow | — | — | allow | — | — | — | — |
-| Skill | — | — | — | — | — | — | allow | allow | allow | — | — | — | — | — | — |
-| WebSearch | allow | — | allow | — | — | — | — | — | — | — | — | — | — | — | — |
-| WebFetch | — | — | allow | — | — | — | — | — | — | — | — | — | — | — | — |
-| TaskCreate/List/Get/Update | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — |
-| SendMessage | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — |
-| TeamCreate/Delete | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — |
-| MCP tools (ralph_hero__*) | indirect | indirect | indirect | indirect | indirect | indirect | indirect | indirect | direct | direct | — | — | — | — | — |
+| Tool | triage | split | research | plan | impl | review | hero | team | merge | pr | val | status | report | hygiene | setup | hello |
+|------|--------|-------|----------|------|------|--------|------|------|-------|----|----|--------|--------|---------|-------|-------|
+| Read | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | — | — | — | — | allow |
+| Write | — | — | allow | allow | allow | allow | — | allow | — | — | — | — | — | — | — | — |
+| Edit | — | — | — | — | allow | — | — | — | — | — | — | — | — | — | — | — |
+| Glob | allow | allow | allow | allow | allow | allow | allow | — | allow | allow | allow | — | — | — | — | — |
+| Grep | allow | allow | allow | allow | allow | allow | allow | — | — | — | allow | — | — | — | — | — |
+| Bash | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | allow | — | — | — | — | allow |
+| Task | allow | allow | allow | allow | allow | allow | allow | allow | — | — | allow | — | — | — | — | — |
+| Skill | — | — | — | — | — | — | allow | allow | allow | — | — | — | — | — | — | allow |
+| WebSearch | allow | — | allow | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| WebFetch | — | — | allow | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| TaskCreate/List/Get/Update | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — | — |
+| SendMessage | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — | — |
+| TeamCreate/Delete | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — | — |
+| MCP tools (ralph_hero__*) | indirect | indirect | indirect | indirect | indirect | indirect | indirect | indirect | direct | direct | — | — | — | — | — | direct |
 
 **Note on MCP tools**: Most skills access `ralph_hero__*` tools indirectly through Bash/Task delegation. `ralph-merge` and `ralph-pr` have direct MCP tool access in their `allowed-tools`.
 

--- a/thoughts/shared/plans/2026-03-03-GH-0480-hello-session-briefing.md
+++ b/thoughts/shared/plans/2026-03-03-GH-0480-hello-session-briefing.md
@@ -195,15 +195,15 @@ Session briefing complete. [N] insight(s) acted on.
 
 ## Code Review Findings (v1 follow-ups)
 
-Issues identified during code review that scored 75/100 confidence. Not blocking for v1 but should be addressed:
+Issues identified during code review that scored 75/100 confidence. All addressed:
 
-1. **`Skill` tool missing from `allowed-tools`** — Step 4 routes to sub-skills via the `Skill` tool, but `allowed-tools` only lists `Read` and `Bash`. Other orchestrating skills (`ralph-hero`, `ralph-team`) explicitly list `Skill`. If Claude Code enforces `allowed-tools` as a strict allowlist, routing will be blocked at runtime. **Fix**: add `- Skill` to `allowed-tools`.
+1. ~~**`Skill` tool missing from `allowed-tools`**~~ — Fixed: added `Skill` to `allowed-tools` in SKILL.md.
 
-2. **MCP tools missing from `allowed-tools`** — Step 1 calls `ralph_hero__pipeline_dashboard` and `ralph_hero__project_hygiene` directly, but neither is listed in `allowed-tools`. Skills that call MCP tools directly (`ralph-merge`, `ralph-pr`) enumerate them explicitly. **Fix**: add both MCP tool names to `allowed-tools`.
+2. ~~**MCP tools missing from `allowed-tools`**~~ — Fixed: added `ralph_hero__pipeline_dashboard` and `ralph_hero__project_hygiene` to `allowed-tools`.
 
-3. **`AskUserQuestion` missing from `allowed-tools`** — Step 3 uses `AskUserQuestion` for routing, but it's not listed. No existing skill lists it either (may be exempt as a built-in), but if enforcement applies, the routing prompt will be blocked. **Fix**: add `- AskUserQuestion` to `allowed-tools`, or verify it is exempt from enforcement.
+3. **`AskUserQuestion` missing from `allowed-tools`** — Not added. `AskUserQuestion` is a Claude Code built-in tool exempt from `allowed-tools` enforcement (no existing skill lists it, including `ralph-review` and `ralph-setup` which both use it). Verified as non-issue.
 
-4. **`specs/skill-permissions.md` not updated** — The permission matrix and `specs/skill-io-contracts.md` I/O contract table do not include a `ralph-hello` column/row. Previous PRs that added skills (PR #462, #504) updated these spec files. **Fix**: add `ralph-hello` to both spec tables.
+4. ~~**`specs/skill-permissions.md` not updated**~~ — Fixed: added `hello` column to permission matrix and `ralph-hello` row to I/O contracts table.
 
 ## References
 - Research: https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-03-03-GH-0480-hello-session-briefing.md


### PR DESCRIPTION
## Summary

Add a new `/ralph-hero:ralph-hello` skill that acts as a session-start briefing. It pulls recent activity (PRs, issues), urgent items (blocked, stale, high-priority), and a brief pipeline snapshot — then synthesizes exactly 3 ranked, actionable insights. After presenting the briefing, it offers to route the user to the appropriate skill to act on each insight.

## Implementation

Creates `plugin/ralph-hero/skills/ralph-hello/SKILL.md` (~137 lines) with:
- Parallel data fetch: pipeline_dashboard + project_hygiene + gh pr list
- LLM synthesis of 3 ranked insights by urgency
- AskUserQuestion routing to appropriate skill (triage, research, plan, review, merge)
- Model: sonnet, context: fork, SessionStart hook for env setup

Closes #480