### PR TITLE
GH-520: Dashboard: suppress oversized_in_pipeline for issues with sub-issues

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/dashboard.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/dashboard.test.ts
@@ -43,6 +43,7 @@ function makeItem(overrides: Partial<DashboardItem> = {}): DashboardItem {
     priority: null,
     estimate: null,
     assignees: [],
+    subIssueCount: 0,
     blockedBy: [],
     ...overrides,
   };
@@ -234,6 +235,7 @@ describe("detectHealthIssues", () => {
           ageHours: 1,
           isLocked: true,
           blockedBy: [],
+          subIssueCount: 0,
         })),
       },
     ];
@@ -263,6 +265,7 @@ describe("detectHealthIssues", () => {
           ageHours: 1,
           isLocked: true,
           blockedBy: [],
+          subIssueCount: 0,
         })),
       },
     ];
@@ -291,6 +294,7 @@ describe("detectHealthIssues", () => {
             ageHours: 60,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -318,6 +322,7 @@ describe("detectHealthIssues", () => {
             ageHours: 100,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -344,6 +349,7 @@ describe("detectHealthIssues", () => {
             ageHours: 200,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -368,6 +374,7 @@ describe("detectHealthIssues", () => {
             ageHours: 200,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -392,6 +399,7 @@ describe("detectHealthIssues", () => {
             ageHours: 200,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -417,6 +425,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: false,
             blockedBy: [{ number: 5, workflowState: "In Progress" }],
+            subIssueCount: 0,
           },
         ],
       },
@@ -443,6 +452,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: false,
             blockedBy: [{ number: 5, workflowState: "Done" }],
+            subIssueCount: 0,
           },
         ],
       },
@@ -467,6 +477,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: false,
             blockedBy: [{ number: 5, workflowState: "Canceled" }],
+            subIssueCount: 0,
           },
         ],
       },
@@ -522,6 +533,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: true,
             blockedBy: [],
+            subIssueCount: 0,
           },
           {
             number: 2,
@@ -532,6 +544,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: true,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -558,6 +571,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: true,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -583,6 +597,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -611,6 +626,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -637,6 +653,34 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: true,
             blockedBy: [],
+            subIssueCount: 0,
+          },
+        ],
+      },
+    ];
+
+    const warnings = detectHealthIssues(phases);
+    expect(
+      warnings.filter((w) => w.type === "oversized_in_pipeline").length,
+    ).toBe(0);
+  });
+
+  it("oversized_in_pipeline: M/L/XL with sub-issues not flagged", () => {
+    const phases: PhaseSnapshot[] = [
+      {
+        state: "Ready for Plan",
+        count: 1,
+        issues: [
+          {
+            number: 10,
+            title: "Split parent",
+            priority: null,
+            estimate: "L",
+            assignees: [],
+            ageHours: 1,
+            isLocked: false,
+            blockedBy: [],
+            subIssueCount: 3,
           },
         ],
       },
@@ -664,6 +708,7 @@ describe("detectHealthIssues", () => {
             ageHours: 100,
             isLocked: true,
             blockedBy: [{ number: 5, workflowState: "Backlog" }],
+            subIssueCount: 0,
           },
           {
             number: 2,
@@ -674,6 +719,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: true,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -702,6 +748,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: false,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       },
@@ -727,6 +774,7 @@ describe("detectHealthIssues", () => {
             ageHours: 60,
             isLocked: true,
             blockedBy: [],
+            subIssueCount: 0,
           },
           {
             number: 2,
@@ -737,6 +785,7 @@ describe("detectHealthIssues", () => {
             ageHours: 1,
             isLocked: true,
             blockedBy: [],
+            subIssueCount: 0,
           },
         ],
       }, // lock_collision (critical) + stuck (warning)

--- a/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
@@ -36,6 +36,7 @@ export interface DashboardItem {
   priority: string | null; // P0, P1, P2, P3
   estimate: string | null; // XS, S, M, L, XL
   assignees: string[];
+  subIssueCount: number;
   blockedBy: Array<{ number: number; workflowState: string | null }>;
   projectNumber?: number; // Source project number (multi-project)
   projectTitle?: string; // Human-readable project title (multi-project)
@@ -56,6 +57,7 @@ export interface PhaseSnapshot {
     ageHours: number;
     isLocked: boolean;
     blockedBy: Array<{ number: number; workflowState: string | null }>;
+    subIssueCount: number;
   }>;
 }
 
@@ -290,6 +292,7 @@ function buildSnapshot(
       ),
       isLocked: LOCK_STATES.includes(state),
       blockedBy: item.blockedBy,
+      subIssueCount: item.subIssueCount,
     })),
   };
 }
@@ -385,10 +388,11 @@ export function detectHealthIssues(
         });
       }
 
-      // Oversized in pipeline: M/L/XL estimate past Backlog
+      // Oversized in pipeline: M/L/XL estimate past Backlog (skip already-split parents)
       if (
         issue.estimate &&
         OVERSIZED_ESTIMATES.has(issue.estimate) &&
+        issue.subIssueCount === 0 &&
         phase.state !== "Backlog" &&
         !TERMINAL_STATES.includes(phase.state) &&
         phase.state !== "Human Needed"

--- a/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
@@ -131,6 +131,7 @@ export interface RawDashboardItem {
     assignees?: { nodes: Array<{ login: string }> };
     trackedInIssues?: { nodes: Array<{ number: number; state: string }> };
     repository?: { nameWithOwner: string; name: string } | null;
+    subIssues?: { totalCount: number };
   } | null;
   fieldValues: {
     nodes: Array<{
@@ -180,6 +181,7 @@ export function toDashboardItems(
       estimate: getFieldValue(r, "Estimate"),
       assignees:
         r.content.assignees?.nodes?.map((a) => a.login) ?? [],
+      subIssueCount: r.content.subIssues?.totalCount ?? 0,
       blockedBy: [], // blockedBy requires separate queries; omit for now
       ...(projectNumber !== undefined ? { projectNumber } : {}),
       ...(projectTitle !== undefined ? { projectTitle } : {}),
@@ -213,6 +215,7 @@ export const DASHBOARD_ITEMS_QUERY = `query($projectId: ID!, $cursor: String, $f
               closedAt
               assignees(first: 5) { nodes { login } }
               repository { nameWithOwner name }
+              subIssues { totalCount }
             }
             ... on PullRequest {
               __typename


### PR DESCRIPTION
## Summary

Add `subIssueCount` to `DashboardItem` and guard the `oversized_in_pipeline` health warning so it doesn't fire on already-split parent/umbrella issues.

## Changes

- Add `subIssues { totalCount }` to `DASHBOARD_ITEMS_QUERY`
- Add `subIssueCount` field to `DashboardItem` and `PhaseSnapshot`
- Guard `oversized_in_pipeline` check with `issue.subIssueCount === 0`
- Update dashboard tests with new test case for sub-issue guard

## Related

Part of #519 group (parent state advancement & dashboard false positive fix)

Closes #520