### PR TITLE
feat: cross-repo dependency tooling

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/advance-issue.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/advance-issue.test.ts
@@ -299,13 +299,13 @@ describe("advance_issue structural", () => {
     expect(src).not.toContain('"ralph_hero__advance_parent"');
   });
 
-  it("does not register list_dependencies", () => {
+  it("registers list_dependencies (GH-539)", () => {
     const fs = require("fs");
     const path = require("path");
     const src = fs.readFileSync(
       path.resolve(__dirname, "../tools/relationship-tools.ts"),
       "utf-8",
     );
-    expect(src).not.toContain('"ralph_hero__list_dependencies"');
+    expect(src).toContain('"ralph_hero__list_dependencies"');
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/cross-repo-dependencies.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/cross-repo-dependencies.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for cross-repo dependency tooling (GH-539):
+ * - add_dependency / remove_dependency cross-repo param resolution
+ * - list_dependencies response shape
+ * - decompose_feature addBlockedBy wiring
+ * - group-detection cross-repo expansion
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const relationshipSrc = fs.readFileSync(
+  path.resolve(__dirname, "../tools/relationship-tools.ts"),
+  "utf-8",
+);
+
+const decomposeSrc = fs.readFileSync(
+  path.resolve(__dirname, "../tools/decompose-tools.ts"),
+  "utf-8",
+);
+
+const groupDetectionSrc = fs.readFileSync(
+  path.resolve(__dirname, "../lib/group-detection.ts"),
+  "utf-8",
+);
+
+// ---------------------------------------------------------------------------
+// add_dependency cross-repo
+// ---------------------------------------------------------------------------
+
+describe("add_dependency cross-repo (GH-539)", () => {
+  it("has blockedOwner parameter", () => {
+    expect(relationshipSrc).toContain("blockedOwner:");
+  });
+
+  it("has blockedRepo parameter", () => {
+    expect(relationshipSrc).toContain("blockedRepo:");
+  });
+
+  it("has blockingOwner parameter", () => {
+    expect(relationshipSrc).toContain("blockingOwner:");
+  });
+
+  it("has blockingRepo parameter", () => {
+    expect(relationshipSrc).toContain("blockingRepo:");
+  });
+
+  it("resolves blocked issue with per-side owner/repo", () => {
+    expect(relationshipSrc).toContain("args.blockedOwner || owner");
+    expect(relationshipSrc).toContain("args.blockedRepo || repo");
+  });
+
+  it("resolves blocking issue with per-side owner/repo", () => {
+    expect(relationshipSrc).toContain("args.blockingOwner || owner");
+    expect(relationshipSrc).toContain("args.blockingRepo || repo");
+  });
+
+  it("returns repository in response", () => {
+    // Verify the addBlockedBy mutation selects repository { nameWithOwner }
+    expect(relationshipSrc).toContain(
+      "issue { id number title repository { nameWithOwner } }",
+    );
+  });
+
+  it("describes cross-repo support in tool description", () => {
+    expect(relationshipSrc).toContain(
+      "Supports cross-repo",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// remove_dependency cross-repo
+// ---------------------------------------------------------------------------
+
+describe("remove_dependency cross-repo (GH-539)", () => {
+  it("has blockedOwner parameter", () => {
+    // Verify remove_dependency section also has per-side params
+    const removeSection = relationshipSrc.slice(
+      relationshipSrc.indexOf("ralph_hero__remove_dependency"),
+    );
+    expect(removeSection).toContain("blockedOwner:");
+    expect(removeSection).toContain("blockedRepo:");
+    expect(removeSection).toContain("blockingOwner:");
+    expect(removeSection).toContain("blockingRepo:");
+  });
+
+  it("resolves per-side owner/repo with fallback", () => {
+    const removeSection = relationshipSrc.slice(
+      relationshipSrc.indexOf("ralph_hero__remove_dependency"),
+    );
+    expect(removeSection).toContain("args.blockedOwner || owner");
+    expect(removeSection).toContain("args.blockingOwner || owner");
+  });
+
+  it("returns repository in remove_dependency response", () => {
+    const removeSection = relationshipSrc.slice(
+      relationshipSrc.indexOf("ralph_hero__remove_dependency"),
+    );
+    expect(removeSection).toContain("repository { nameWithOwner }");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_dependencies
+// ---------------------------------------------------------------------------
+
+describe("list_dependencies (GH-539)", () => {
+  it("is registered as ralph_hero__list_dependencies", () => {
+    expect(relationshipSrc).toContain('"ralph_hero__list_dependencies"');
+  });
+
+  it("queries blocking(first: 50) and blockedBy(first: 50)", () => {
+    expect(relationshipSrc).toContain("blocking(first: 50)");
+    expect(relationshipSrc).toContain("blockedBy(first: 50)");
+  });
+
+  it("selects repository { nameWithOwner } on dependency nodes", () => {
+    // The list_dependencies query should include repo info
+    const listSection = relationshipSrc.slice(
+      relationshipSrc.indexOf("ralph_hero__list_dependencies"),
+    );
+    expect(listSection).toContain("repository { nameWithOwner }");
+  });
+
+  it("returns summary with blockingCount and blockedByCount", () => {
+    const listSection = relationshipSrc.slice(
+      relationshipSrc.indexOf("ralph_hero__list_dependencies"),
+    );
+    expect(listSection).toContain("blockingCount");
+    expect(listSection).toContain("blockedByCount");
+    expect(listSection).toContain("isBlocked");
+    expect(listSection).toContain("isBlocking");
+  });
+
+  it("returns issue info with repository field", () => {
+    const listSection = relationshipSrc.slice(
+      relationshipSrc.indexOf("ralph_hero__list_dependencies"),
+    );
+    expect(listSection).toContain("repository:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decompose_feature: addBlockedBy wiring
+// ---------------------------------------------------------------------------
+
+describe("decompose_feature blockedBy wiring (GH-539)", () => {
+  it("uses addBlockedBy instead of addSubIssue for dependency wiring", () => {
+    expect(decomposeSrc).toContain("addBlockedBy");
+    // Should NOT contain addSubIssue in the wiring section
+    const wiringSection = decomposeSrc.slice(
+      decomposeSrc.indexOf("Step 5"),
+    );
+    expect(wiringSection).not.toContain("addSubIssue");
+  });
+
+  it("wiring results include type: blockedBy", () => {
+    expect(decomposeSrc).toContain('type: "blockedBy"');
+  });
+
+  it("maps edge direction correctly: blockingRepo blocks blockedRepo", () => {
+    // "a -> b" means a blocks b, so b is blocked by a
+    // Variables should be: blockedId = b, blockingId = a
+    const wiringSection = decomposeSrc.slice(
+      decomposeSrc.indexOf("Step 5"),
+    );
+    expect(wiringSection).toContain("blockingRepo, blockedRepo");
+    expect(wiringSection).toContain("blockedId: blockedIssue.id, blockingId: blockingIssue.id");
+  });
+
+  it("JSDoc describes blocking dependency edges", () => {
+    expect(decomposeSrc).toContain(
+      "Blocking dependency edges from the pattern",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// group-detection cross-repo
+// ---------------------------------------------------------------------------
+
+describe("group-detection cross-repo (GH-539)", () => {
+  it("IssueRelationData includes repoOwner and repoName", () => {
+    expect(groupDetectionSrc).toContain("repoOwner: string;");
+    expect(groupDetectionSrc).toContain("repoName: string;");
+  });
+
+  it("GroupIssue includes optional repository field", () => {
+    expect(groupDetectionSrc).toContain('repository?: string;');
+  });
+
+  it("SEED_QUERY includes repository info on blocking/blockedBy nodes", () => {
+    // Check that the seed query fetches repo info for dependency nodes
+    expect(groupDetectionSrc).toContain(
+      "repository { owner { login } name }",
+    );
+  });
+
+  it("tracks cross-repo info in depRepoInfo map", () => {
+    expect(groupDetectionSrc).toContain("depRepoInfo");
+    expect(groupDetectionSrc).toContain(
+      "new Map<number, { owner: string; repo: string }>()",
+    );
+  });
+
+  it("uses cross-repo info for expand queries", () => {
+    expect(groupDetectionSrc).toContain("depRepoInfo.get(num)");
+    expect(groupDetectionSrc).toContain("crossRepoInfo?.owner ?? owner");
+    expect(groupDetectionSrc).toContain("crossRepoInfo?.repo ?? repo");
+  });
+
+  it("addIssueToMap merges repoOwner and repoName", () => {
+    expect(groupDetectionSrc).toContain(
+      "if (!existing.repoOwner && data.repoOwner) existing.repoOwner = data.repoOwner;",
+    );
+    expect(groupDetectionSrc).toContain(
+      "if (!existing.repoName && data.repoName) existing.repoName = data.repoName;",
+    );
+  });
+
+  it("populates repository on GroupIssue only for cross-repo issues", () => {
+    expect(groupDetectionSrc).toContain(
+      "issue.repoOwner !== owner || issue.repoName !== repo",
+    );
+  });
+
+  it("EXPAND_QUERY also includes repository info on dep nodes", () => {
+    // Both queries should have repository info
+    const expandSection = groupDetectionSrc.slice(
+      groupDetectionSrc.indexOf("EXPAND_QUERY"),
+    );
+    expect(expandSection).toContain("repository { owner { login } name }");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/lib/group-detection.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/group-detection.ts
@@ -18,6 +18,7 @@ export interface GroupIssue {
   title: string;
   state: string;
   order: number;
+  repository?: string; // "owner/repo" — present for cross-repo issues
 }
 
 export interface GroupDetectionResult {
@@ -32,6 +33,8 @@ interface IssueRelationData {
   number: number;
   title: string;
   state: string;
+  repoOwner: string;
+  repoName: string;
   parentNumber: number | null;
   subIssueNumbers: number[];
   blockingNumbers: number[];
@@ -60,8 +63,8 @@ const SEED_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
             number
             title
             state
-            blocking(first: 20) { nodes { number } }
-            blockedBy(first: 20) { nodes { number } }
+            blocking(first: 20) { nodes { number repository { owner { login } name } } }
+            blockedBy(first: 20) { nodes { number repository { owner { login } name } } }
           }
         }
       }
@@ -71,15 +74,15 @@ const SEED_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
           number
           title
           state
-          blocking(first: 20) { nodes { number } }
-          blockedBy(first: 20) { nodes { number } }
+          blocking(first: 20) { nodes { number repository { owner { login } name } } }
+          blockedBy(first: 20) { nodes { number repository { owner { login } name } } }
         }
       }
       blocking(first: 20) {
-        nodes { id number title state }
+        nodes { id number title state repository { owner { login } name } }
       }
       blockedBy(first: 20) {
-        nodes { id number title state }
+        nodes { id number title state repository { owner { login } name } }
       }
     }
   }
@@ -104,8 +107,8 @@ const EXPAND_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
             number
             title
             state
-            blocking(first: 20) { nodes { number } }
-            blockedBy(first: 20) { nodes { number } }
+            blocking(first: 20) { nodes { number repository { owner { login } name } } }
+            blockedBy(first: 20) { nodes { number repository { owner { login } name } } }
           }
         }
       }
@@ -115,15 +118,15 @@ const EXPAND_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
           number
           title
           state
-          blocking(first: 20) { nodes { number } }
-          blockedBy(first: 20) { nodes { number } }
+          blocking(first: 20) { nodes { number repository { owner { login } name } } }
+          blockedBy(first: 20) { nodes { number repository { owner { login } name } } }
         }
       }
       blocking(first: 20) {
-        nodes { id number title state }
+        nodes { id number title state repository { owner { login } name } }
       }
       blockedBy(first: 20) {
-        nodes { id number title state }
+        nodes { id number title state repository { owner { login } name } }
       }
     }
   }
@@ -133,13 +136,26 @@ const EXPAND_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
 // Response types for the seed/expand query
 // ---------------------------------------------------------------------------
 
+interface DepRepoInfo {
+  owner: { login: string };
+  name: string;
+}
+
 interface SeedIssueNode {
   id: string;
   number: number;
   title: string;
   state: string;
-  blocking?: { nodes: Array<{ number: number }> };
-  blockedBy?: { nodes: Array<{ number: number }> };
+  blocking?: { nodes: Array<{ number: number; repository?: DepRepoInfo }> };
+  blockedBy?: { nodes: Array<{ number: number; repository?: DepRepoInfo }> };
+}
+
+interface SeedDepNode {
+  id: string;
+  number: number;
+  title: string;
+  state: string;
+  repository?: DepRepoInfo;
 }
 
 interface SeedIssueResponse {
@@ -155,12 +171,8 @@ interface SeedIssueResponse {
     subIssues: { nodes: SeedIssueNode[] };
   } | null;
   subIssues: { nodes: SeedIssueNode[] };
-  blocking: {
-    nodes: Array<{ id: string; number: number; title: string; state: string }>;
-  };
-  blockedBy: {
-    nodes: Array<{ id: string; number: number; title: string; state: string }>;
-  };
+  blocking: { nodes: SeedDepNode[] };
+  blockedBy: { nodes: SeedDepNode[] };
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +199,22 @@ export async function detectGroup(
   const issueMap = new Map<number, IssueRelationData>();
   // Queue of issue numbers to expand
   const expandQueue: number[] = [];
+  // Cross-repo info for dependency targets (number -> { owner, repo })
+  const depRepoInfo = new Map<number, { owner: string; repo: string }>();
+
+  // Helper to store cross-repo info from dependency nodes
+  function trackDepRepoInfo(
+    nodes: Array<{ number: number; repository?: DepRepoInfo }>,
+  ): void {
+    for (const dep of nodes) {
+      if (dep.repository) {
+        depRepoInfo.set(dep.number, {
+          owner: dep.repository.owner.login,
+          repo: dep.repository.name,
+        });
+      }
+    }
+  }
 
   // Step 1: Seed query
   const seedResult = await client.query<{
@@ -198,12 +226,18 @@ export async function detectGroup(
     throw new Error(`Issue #${seedNumber} not found in ${owner}/${repo}`);
   }
 
+  // Track cross-repo info from seed's direct dependencies
+  trackDepRepoInfo(seedIssue.blocking.nodes);
+  trackDepRepoInfo(seedIssue.blockedBy.nodes);
+
   // Process seed issue
   addIssueToMap(issueMap, {
     id: seedIssue.id,
     number: seedIssue.number,
     title: seedIssue.title,
     state: seedIssue.state,
+    repoOwner: owner,
+    repoName: repo,
     parentNumber: seedIssue.parent?.number ?? null,
     subIssueNumbers: seedIssue.subIssues.nodes.map((n) => n.number),
     blockingNumbers: seedIssue.blocking.nodes.map((n) => n.number),
@@ -218,6 +252,8 @@ export async function detectGroup(
       number: parent.number,
       title: parent.title,
       state: parent.state,
+      repoOwner: owner,
+      repoName: repo,
       parentNumber: null,
       subIssueNumbers: parent.subIssues.nodes.map((n) => n.number),
       blockingNumbers: [],
@@ -225,11 +261,17 @@ export async function detectGroup(
     });
 
     for (const sibling of parent.subIssues.nodes) {
+      // Track cross-repo info from sibling dependencies
+      trackDepRepoInfo(sibling.blocking?.nodes ?? []);
+      trackDepRepoInfo(sibling.blockedBy?.nodes ?? []);
+
       addIssueToMap(issueMap, {
         id: sibling.id,
         number: sibling.number,
         title: sibling.title,
         state: sibling.state,
+        repoOwner: owner,
+        repoName: repo,
         parentNumber: parent.number,
         subIssueNumbers: [],
         blockingNumbers: sibling.blocking?.nodes.map((n) => n.number) ?? [],
@@ -240,11 +282,17 @@ export async function detectGroup(
 
   // Process sub-issues of seed
   for (const child of seedIssue.subIssues.nodes) {
+    // Track cross-repo info from child dependencies
+    trackDepRepoInfo(child.blocking?.nodes ?? []);
+    trackDepRepoInfo(child.blockedBy?.nodes ?? []);
+
     addIssueToMap(issueMap, {
       id: child.id,
       number: child.number,
       title: child.title,
       state: child.state,
+      repoOwner: owner,
+      repoName: repo,
       parentNumber: seedIssue.number,
       subIssueNumbers: [],
       blockingNumbers: child.blocking?.nodes.map((n) => n.number) ?? [],
@@ -254,12 +302,16 @@ export async function detectGroup(
 
   // Process direct dependencies
   for (const dep of seedIssue.blocking.nodes) {
+    const depOwner = dep.repository?.owner.login ?? owner;
+    const depRepo = dep.repository?.name ?? repo;
     if (!issueMap.has(dep.number)) {
       addIssueToMap(issueMap, {
         id: dep.id,
         number: dep.number,
         title: dep.title,
         state: dep.state,
+        repoOwner: depOwner,
+        repoName: depRepo,
         parentNumber: null,
         subIssueNumbers: [],
         blockingNumbers: [],
@@ -269,12 +321,16 @@ export async function detectGroup(
     }
   }
   for (const dep of seedIssue.blockedBy.nodes) {
+    const depOwner = dep.repository?.owner.login ?? owner;
+    const depRepo = dep.repository?.name ?? repo;
     if (!issueMap.has(dep.number)) {
       addIssueToMap(issueMap, {
         id: dep.id,
         number: dep.number,
         title: dep.title,
         state: dep.state,
+        repoOwner: depOwner,
+        repoName: depRepo,
         parentNumber: null,
         subIssueNumbers: [],
         blockingNumbers: [],
@@ -307,19 +363,40 @@ export async function detectGroup(
     }
     expanded.add(num);
 
+    // Resolve owner/repo for this issue — check cross-repo info first
+    const crossRepoInfo = depRepoInfo.get(num);
+    const expandOwner = crossRepoInfo?.owner ?? owner;
+    const expandRepo = crossRepoInfo?.repo ?? repo;
+
     try {
       const expandResult = await client.query<{
         repository: { issue: SeedIssueResponse | null } | null;
-      }>(EXPAND_QUERY, { owner, repo, number: num });
+      }>(EXPAND_QUERY, { owner: expandOwner, repo: expandRepo, number: num });
 
       const expandedIssue = expandResult.repository?.issue;
-      if (!expandedIssue) continue; // Cross-repo or deleted issue, skip
+      if (!expandedIssue) continue; // Deleted issue, skip
+
+      // Track cross-repo info from expanded issue's dependency nodes
+      trackDepRepoInfo(expandedIssue.blocking.nodes);
+      trackDepRepoInfo(expandedIssue.blockedBy.nodes);
+      for (const child of expandedIssue.subIssues.nodes) {
+        trackDepRepoInfo(child.blocking?.nodes ?? []);
+        trackDepRepoInfo(child.blockedBy?.nodes ?? []);
+      }
+      if (expandedIssue.parent) {
+        for (const sibling of expandedIssue.parent.subIssues.nodes) {
+          trackDepRepoInfo(sibling.blocking?.nodes ?? []);
+          trackDepRepoInfo(sibling.blockedBy?.nodes ?? []);
+        }
+      }
 
       addIssueToMap(issueMap, {
         id: expandedIssue.id,
         number: expandedIssue.number,
         title: expandedIssue.title,
         state: expandedIssue.state,
+        repoOwner: expandOwner,
+        repoName: expandRepo,
         parentNumber: expandedIssue.parent?.number ?? null,
         subIssueNumbers: expandedIssue.subIssues.nodes.map((n) => n.number),
         blockingNumbers: expandedIssue.blocking.nodes.map((n) => n.number),
@@ -338,7 +415,7 @@ export async function detectGroup(
     } catch {
       // Skip issues that can't be fetched (cross-repo, permissions, etc.)
       console.error(
-        `[group-detection] Could not fetch issue #${num}, skipping (may be cross-repo)`,
+        `[group-detection] Could not fetch issue #${num} from ${expandOwner}/${expandRepo}, skipping`,
       );
     }
   }
@@ -353,13 +430,18 @@ export async function detectGroup(
   // Step 4: Build result
   const groupTickets: GroupIssue[] = sorted.map((num, index) => {
     const issue = issueMap.get(num)!;
-    return {
+    const result: GroupIssue = {
       id: issue.id,
       number: issue.number,
       title: issue.title,
       state: issue.state,
       order: index + 1,
     };
+    // Include repository only for cross-repo issues
+    if (issue.repoOwner !== owner || issue.repoName !== repo) {
+      result.repository = `${issue.repoOwner}/${issue.repoName}`;
+    }
+    return result;
   });
 
   const primary = groupTickets[0] || {
@@ -403,10 +485,12 @@ function addIssueToMap(
     if (data.parentNumber !== null && existing.parentNumber === null) {
       existing.parentNumber = data.parentNumber;
     }
-    // Prefer non-empty id/title/state
+    // Prefer non-empty id/title/state/repo
     if (!existing.id && data.id) existing.id = data.id;
     if (!existing.title && data.title) existing.title = data.title;
     if (!existing.state && data.state) existing.state = data.state;
+    if (!existing.repoOwner && data.repoOwner) existing.repoOwner = data.repoOwner;
+    if (!existing.repoName && data.repoName) existing.repoName = data.repoName;
   } else {
     map.set(data.number, { ...data });
   }

--- a/plugin/ralph-hero/mcp-server/src/tools/decompose-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/decompose-tools.ts
@@ -55,7 +55,7 @@ export interface ProposedIssue {
  */
 export interface DecompositionResult {
   proposed_issues: ProposedIssue[];
-  /** Human-readable dependency edges from the pattern, e.g. ["api -> frontend"] */
+  /** Blocking dependency edges from the pattern, e.g. ["api -> frontend"] meaning api blocks frontend */
   dependency_chain: string[];
   /** The canonical pattern name used (from registry, case-preserved) */
   matched_pattern: string;
@@ -428,11 +428,11 @@ export function registerDecomposeTools(
           });
         }
 
-        // Step 5: Wire dependencies (addSubIssue for dependency edges)
-        // Parse "a -> b" edges from dependency_chain; cross-repo sub-issues
-        // may not be supported — catch and continue.
+        // Step 5: Wire dependencies (addBlockedBy for dependency-flow edges)
+        // Parse "a -> b" edges: a blocks b (b is blocked by a)
         const wiringResults: Array<{
           edge: string;
+          type: "blockedBy";
           status: "ok" | "skipped";
           reason?: string;
         }> = [];
@@ -442,45 +442,48 @@ export function registerDecomposeTools(
           if (!match) {
             wiringResults.push({
               edge,
+              type: "blockedBy",
               status: "skipped",
               reason: "Unrecognized edge format (expected 'a -> b')",
             });
             continue;
           }
 
-          const [, fromRepo, toRepo] = match;
-          const fromIssue = createdIssues.find((i) => i.repoKey === fromRepo);
-          const toIssue = createdIssues.find((i) => i.repoKey === toRepo);
+          const [, blockingRepo, blockedRepo] = match;
+          const blockingIssue = createdIssues.find((i) => i.repoKey === blockingRepo);
+          const blockedIssue = createdIssues.find((i) => i.repoKey === blockedRepo);
 
-          if (!fromIssue || !toIssue) {
+          if (!blockingIssue || !blockedIssue) {
             wiringResults.push({
               edge,
+              type: "blockedBy",
               status: "skipped",
-              reason: `Could not find created issue for repo "${fromRepo}" or "${toRepo}"`,
+              reason: `Could not find created issue for repo "${blockingRepo}" or "${blockedRepo}"`,
             });
             continue;
           }
 
           try {
             await client.mutate(
-              `mutation($parentId: ID!, $childId: ID!) {
-                addSubIssue(input: {
-                  issueId: $parentId,
-                  subIssueId: $childId
+              `mutation($blockedId: ID!, $blockingId: ID!) {
+                addBlockedBy(input: {
+                  issueId: $blockedId,
+                  blockingIssueId: $blockingId
                 }) {
                   issue { id }
-                  subIssue { id }
+                  blockingIssue { id }
                 }
               }`,
-              { parentId: fromIssue.id, childId: toIssue.id },
+              { blockedId: blockedIssue.id, blockingId: blockingIssue.id },
             );
-            wiringResults.push({ edge, status: "ok" });
+            wiringResults.push({ edge, type: "blockedBy", status: "ok" });
           } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             wiringResults.push({
               edge,
+              type: "blockedBy",
               status: "skipped",
-              reason: `addSubIssue failed (cross-repo sub-issues may not be supported): ${reason}`,
+              reason: `addBlockedBy failed: ${reason}`,
             });
           }
         }

--- a/plugin/ralph-hero/mcp-server/src/tools/relationship-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/relationship-tools.ts
@@ -333,46 +333,59 @@ export function registerRelationshipTools(
   // -------------------------------------------------------------------------
   server.tool(
     "ralph_hero__add_dependency",
-    "Create a blocking dependency between two GitHub issues. The 'blockingNumber' issue blocks the 'blockedNumber' issue.",
+    "Create a blocking dependency between two GitHub issues. Supports cross-repo: " +
+      "the blocked and blocking issues can be in different repositories. " +
+      "The 'blockingNumber' issue blocks the 'blockedNumber' issue.",
     {
       owner: z
         .string()
         .optional()
-        .describe("GitHub owner. Defaults to GITHUB_OWNER env var"),
+        .describe("Default GitHub owner for both issues. Defaults to GITHUB_OWNER env var"),
       repo: z
         .string()
         .optional()
-        .describe("Repository name. Defaults to GITHUB_REPO env var"),
+        .describe("Default repository for both issues. Defaults to GITHUB_REPO env var"),
       blockedNumber: z
         .number()
         .describe(
           "Issue number that IS blocked (cannot proceed until blocker is done)",
         ),
+      blockedOwner: z
+        .string()
+        .optional()
+        .describe("GitHub owner for the blocked issue. Defaults to 'owner' param"),
+      blockedRepo: z
+        .string()
+        .optional()
+        .describe("Repository for the blocked issue. Defaults to 'repo' param"),
       blockingNumber: z
         .number()
         .describe("Issue number that IS the blocker (must be completed first)"),
+      blockingOwner: z
+        .string()
+        .optional()
+        .describe("GitHub owner for the blocking issue. Defaults to 'owner' param"),
+      blockingRepo: z
+        .string()
+        .optional()
+        .describe("Repository for the blocking issue. Defaults to 'repo' param"),
     },
     async (args) => {
       try {
         const { owner, repo } = resolveConfig(client, args);
 
-        const blockedId = await resolveIssueNodeId(
-          client,
-          owner,
-          repo,
-          args.blockedNumber,
-        );
-        const blockingId = await resolveIssueNodeId(
-          client,
-          owner,
-          repo,
-          args.blockingNumber,
-        );
+        const bOwner = args.blockedOwner || owner;
+        const bRepo = args.blockedRepo || repo;
+        const kOwner = args.blockingOwner || owner;
+        const kRepo = args.blockingRepo || repo;
+
+        const blockedId = await resolveIssueNodeId(client, bOwner, bRepo, args.blockedNumber);
+        const blockingId = await resolveIssueNodeId(client, kOwner, kRepo, args.blockingNumber);
 
         const result = await client.mutate<{
           addBlockedBy: {
-            issue: { id: string; number: number; title: string };
-            blockingIssue: { id: string; number: number; title: string };
+            issue: { id: string; number: number; title: string; repository: { nameWithOwner: string } };
+            blockingIssue: { id: string; number: number; title: string; repository: { nameWithOwner: string } };
           };
         }>(
           `mutation($blockedId: ID!, $blockingId: ID!) {
@@ -380,8 +393,8 @@ export function registerRelationshipTools(
               issueId: $blockedId,
               blockingIssueId: $blockingId
             }) {
-              issue { id number title }
-              blockingIssue { id number title }
+              issue { id number title repository { nameWithOwner } }
+              blockingIssue { id number title repository { nameWithOwner } }
             }
           }`,
           { blockedId, blockingId },
@@ -392,11 +405,13 @@ export function registerRelationshipTools(
             id: result.addBlockedBy.issue.id,
             number: result.addBlockedBy.issue.number,
             title: result.addBlockedBy.issue.title,
+            repository: result.addBlockedBy.issue.repository.nameWithOwner,
           },
           blocking: {
             id: result.addBlockedBy.blockingIssue.id,
             number: result.addBlockedBy.blockingIssue.number,
             title: result.addBlockedBy.blockingIssue.title,
+            repository: result.addBlockedBy.blockingIssue.repository.nameWithOwner,
           },
         });
       } catch (error: unknown) {
@@ -411,40 +426,52 @@ export function registerRelationshipTools(
   // -------------------------------------------------------------------------
   server.tool(
     "ralph_hero__remove_dependency",
-    "Remove a blocking dependency between two GitHub issues",
+    "Remove a blocking dependency between two GitHub issues. Supports cross-repo: " +
+      "the blocked and blocking issues can be in different repositories.",
     {
       owner: z
         .string()
         .optional()
-        .describe("GitHub owner. Defaults to GITHUB_OWNER env var"),
+        .describe("Default GitHub owner for both issues. Defaults to GITHUB_OWNER env var"),
       repo: z
         .string()
         .optional()
-        .describe("Repository name. Defaults to GITHUB_REPO env var"),
+        .describe("Default repository for both issues. Defaults to GITHUB_REPO env var"),
       blockedNumber: z.coerce.number().describe("Issue number that was blocked"),
+      blockedOwner: z
+        .string()
+        .optional()
+        .describe("GitHub owner for the blocked issue. Defaults to 'owner' param"),
+      blockedRepo: z
+        .string()
+        .optional()
+        .describe("Repository for the blocked issue. Defaults to 'repo' param"),
       blockingNumber: z.coerce.number().describe("Issue number that was the blocker"),
+      blockingOwner: z
+        .string()
+        .optional()
+        .describe("GitHub owner for the blocking issue. Defaults to 'owner' param"),
+      blockingRepo: z
+        .string()
+        .optional()
+        .describe("Repository for the blocking issue. Defaults to 'repo' param"),
     },
     async (args) => {
       try {
         const { owner, repo } = resolveConfig(client, args);
 
-        const blockedId = await resolveIssueNodeId(
-          client,
-          owner,
-          repo,
-          args.blockedNumber,
-        );
-        const blockingId = await resolveIssueNodeId(
-          client,
-          owner,
-          repo,
-          args.blockingNumber,
-        );
+        const bOwner = args.blockedOwner || owner;
+        const bRepo = args.blockedRepo || repo;
+        const kOwner = args.blockingOwner || owner;
+        const kRepo = args.blockingRepo || repo;
+
+        const blockedId = await resolveIssueNodeId(client, bOwner, bRepo, args.blockedNumber);
+        const blockingId = await resolveIssueNodeId(client, kOwner, kRepo, args.blockingNumber);
 
         const result = await client.mutate<{
           removeBlockedBy: {
-            issue: { id: string; number: number; title: string };
-            blockingIssue: { id: string; number: number; title: string };
+            issue: { id: string; number: number; title: string; repository: { nameWithOwner: string } };
+            blockingIssue: { id: string; number: number; title: string; repository: { nameWithOwner: string } };
           };
         }>(
           `mutation($blockedId: ID!, $blockingId: ID!) {
@@ -452,8 +479,8 @@ export function registerRelationshipTools(
               issueId: $blockedId,
               blockingIssueId: $blockingId
             }) {
-              issue { id number title }
-              blockingIssue { id number title }
+              issue { id number title repository { nameWithOwner } }
+              blockingIssue { id number title repository { nameWithOwner } }
             }
           }`,
           { blockedId, blockingId },
@@ -464,16 +491,135 @@ export function registerRelationshipTools(
             id: result.removeBlockedBy.issue.id,
             number: result.removeBlockedBy.issue.number,
             title: result.removeBlockedBy.issue.title,
+            repository: result.removeBlockedBy.issue.repository.nameWithOwner,
           },
           blocking: {
             id: result.removeBlockedBy.blockingIssue.id,
             number: result.removeBlockedBy.blockingIssue.number,
             title: result.removeBlockedBy.blockingIssue.title,
+            repository: result.removeBlockedBy.blockingIssue.repository.nameWithOwner,
           },
         });
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         return toolError(`Failed to remove dependency: ${message}`);
+      }
+    },
+  );
+
+// -------------------------------------------------------------------------
+  // ralph_hero__list_dependencies
+  // -------------------------------------------------------------------------
+  server.tool(
+    "ralph_hero__list_dependencies",
+    "List all blocking dependencies for a GitHub issue. Returns both 'blocking' " +
+      "(issues this issue blocks) and 'blockedBy' (issues blocking this issue) " +
+      "with full cross-repo context including repository name.",
+    {
+      owner: z
+        .string()
+        .optional()
+        .describe("GitHub owner. Defaults to GITHUB_OWNER env var"),
+      repo: z
+        .string()
+        .optional()
+        .describe("Repository name. Defaults to GITHUB_REPO env var"),
+      number: z.coerce.number().describe("Issue number to query dependencies for"),
+    },
+    async (args) => {
+      try {
+        const { owner, repo } = resolveConfig(client, args);
+
+        const result = await client.query<{
+          repository: {
+            issue: {
+              id: string;
+              number: number;
+              title: string;
+              state: string;
+              blocking: {
+                nodes: Array<{
+                  id: string;
+                  number: number;
+                  title: string;
+                  state: string;
+                  repository: { nameWithOwner: string };
+                }>;
+              };
+              blockedBy: {
+                nodes: Array<{
+                  id: string;
+                  number: number;
+                  title: string;
+                  state: string;
+                  repository: { nameWithOwner: string };
+                }>;
+              };
+            } | null;
+          } | null;
+        }>(
+          `query($owner: String!, $repo: String!, $number: Int!) {
+            repository(owner: $owner, name: $repo) {
+              issue(number: $number) {
+                id
+                number
+                title
+                state
+                blocking(first: 50) {
+                  nodes {
+                    id number title state
+                    repository { nameWithOwner }
+                  }
+                }
+                blockedBy(first: 50) {
+                  nodes {
+                    id number title state
+                    repository { nameWithOwner }
+                  }
+                }
+              }
+            }
+          }`,
+          { owner, repo, number: args.number },
+        );
+
+        const issue = result.repository?.issue;
+        if (!issue) {
+          return toolError(`Issue #${args.number} not found in ${owner}/${repo}`);
+        }
+
+        return toolSuccess({
+          issue: {
+            id: issue.id,
+            number: issue.number,
+            title: issue.title,
+            state: issue.state,
+            repository: `${owner}/${repo}`,
+          },
+          blocking: issue.blocking.nodes.map((n) => ({
+            id: n.id,
+            number: n.number,
+            title: n.title,
+            state: n.state,
+            repository: n.repository.nameWithOwner,
+          })),
+          blockedBy: issue.blockedBy.nodes.map((n) => ({
+            id: n.id,
+            number: n.number,
+            title: n.title,
+            state: n.state,
+            repository: n.repository.nameWithOwner,
+          })),
+          summary: {
+            blockingCount: issue.blocking.nodes.length,
+            blockedByCount: issue.blockedBy.nodes.length,
+            isBlocked: issue.blockedBy.nodes.length > 0,
+            isBlocking: issue.blocking.nodes.length > 0,
+          },
+        });
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return toolError(`Failed to list dependencies: ${message}`);
       }
     },
   );


### PR DESCRIPTION
## Summary

Implements #539: Cross-repo dependency tooling across Ralph's MCP tools.

- Closes #539

## Changes

- **`add_dependency` / `remove_dependency`**: Accept `blockedOwner`/`blockedRepo`/`blockingOwner`/`blockingRepo` optional params for cross-repo blocking relationships. Response now includes `repository` field.
- **New `list_dependencies` tool**: Queries `blocking(first: 50)` and `blockedBy(first: 50)` with full cross-repo context including repository name.
- **`decompose_feature`**: Wires `addBlockedBy` instead of `addSubIssue` for dependency-flow edges. Wiring results include `type: "blockedBy"`.
- **Group detection**: Includes `repository { owner { login } name }` on dependency nodes, tracks cross-repo info via `depRepoInfo` map, uses per-issue owner/repo for expansion, populates `GroupIssue.repository` for cross-repo issues.
- **28 new tests** covering all cross-repo dependency scenarios.

## Test plan

- [x] `npm run build` passes
- [x] All 838 tests pass (38 test files)
- [ ] Manual: `add_dependency` with issues in two different repos
- [ ] Manual: `remove_dependency` cross-repo
- [ ] Manual: `list_dependencies` on issue with known blocking relationships
- [ ] Manual: `decompose_feature` with `dryRun=false` verifying blockedBy wiring
- [ ] Manual: Group detection on cross-repo dependency graph

---
Generated with [Claude Code](https://claude.com/claude-code)