### PR TITLE
feat: add ralph-demo plugin for sprint demo videos

### DIFF
--- a/plugin/ralph-hero/skills/plan/SKILL.md
+++ b/plugin/ralph-hero/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Create detailed implementation plans through interactive research and iteration. Collaboratively explores codebase, proposes phased structure, and writes a plan document. Optionally links to a GitHub issue and transitions to Plan in Review or directly to In Progress.
+description: Interactive implementation planning with human collaboration. Researches codebase, asks clarifying questions, proposes approaches, iterates on structure with the user, then writes a phased plan document. Use this skill when you want to plan interactively, create a spec collaboratively, or need human input during planning. This is the human-in-the-loop planner — unlike ralph-plan (autonomous, no questions), this skill works WITH the user through research, design options, and incremental approval.
 argument-hint: "[optional: #NNN issue number, file path, or description]"
 model: opus
 allowed-tools:


### PR DESCRIPTION
## Summary
- New `ralph-demo` Claude Code plugin for generating sprint demo videos using Remotion 4.x
- 7 reusable scene templates: title, feature, screenshot, before-after, bullets, flow, outro
- Pluggable theme system (energetic theme included), 4 export presets (16:9, 1:1, 9:16)
- Zod schema validation for video input JSON, 51 tests passing
- Interactive `/demo-video` skill walks through content collection, preview, and rendering

## Test plan
- [ ] `cd plugin/ralph-demo/remotion && pnpm install && pnpm test` — 51 tests pass
- [ ] `npx remotion studio` with `inputs/sample-sprint.json` renders preview
- [ ] Install plugin and verify `/demo-video` skill triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)