### PR TITLE
fix: remove .mcp.json env block — inherit parent environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Two separate caches serve different purposes:
 
 - **`@octokit/graphql` v9 reserves `query`, `method`, and `url`** as option keys. Never use these as GraphQL variable names.
 - **ESM module system**: All internal imports require `.js` extensions (e.g., `import { foo } from "./bar.js"`). The project uses `"type": "module"` with `"module": "NodeNext"`.
-- **`resolveEnv()` pattern**: Claude Code passes unexpanded `${VAR}` literals for unset env vars in `.mcp.json`. The `resolveEnv()` function in `index.ts` filters these out. Only non-sensitive defaults with fallbacks belong in `.mcp.json`.
+- **`resolveEnv()` pattern**: The MCP server inherits env vars from Claude Code's process (set via `settings.local.json`). `resolveEnv()` in `index.ts` filters out unexpanded `${VAR}` literals that may appear when vars are unset. The `.mcp.json` has no `env` block — all configuration flows through `settings.local.json`.
 - **Split-owner support**: Repo and project can have different owners. `resolveProjectOwner()` handles this. `fetchProjectForCache()` tries both `user` and `organization` GraphQL types.
 - **Aliased GraphQL mutations**: Bulk operations (like `batch_update`) use GraphQL aliases (`m0:`, `m1:`, ...) to batch multiple mutations in a single request.
 - **mcptools args normalization**: `index.ts` patches `validateToolInput` to normalize `undefined` args to `{}` because mcptools 0.7.1 strips empty `{}` params.
@@ -146,7 +146,7 @@ Set in `.claude/settings.local.json` (gitignored) under `"env"`:
 | `RALPH_GH_PROJECT_OWNER` | No | Project owner if different from repo owner |
 | `RALPH_DEBUG` | No | Set to `"true"` to enable JSONL debug logging and register debug tools |
 
-**Do NOT put tokens in `.mcp.json`** — the `env` block can overwrite inherited values with unexpanded `${VAR}` literals.
+**Do NOT put tokens in `.mcp.json`** — all env vars should be set in `.claude/settings.local.json` (gitignored). The `.mcp.json` has no `env` block; the MCP server inherits the parent environment.
 
 ## GitHub Actions Workflows
 

--- a/plugin/ralph-hero/.mcp.json
+++ b/plugin/ralph-hero/.mcp.json
@@ -3,12 +3,7 @@
     "ralph-github": {
       "command": "npx",
       "args": ["-y", "ralph-hero-mcp-server@2.5.13"],
-      "cwd": "${CLAUDE_PLUGIN_ROOT}",
-      "env": {
-        "RALPH_GH_OWNER": "${RALPH_GH_OWNER:-cdubiel08}",
-        "RALPH_GH_REPO": "${RALPH_GH_REPO:-ralph-hero}",
-        "RALPH_GH_PROJECT_NUMBER": "${RALPH_GH_PROJECT_NUMBER:-3}"
-      }
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
     }
   }
 }

--- a/plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts
@@ -136,9 +136,11 @@ describe("Token resolution logic", () => {
 });
 
 describe(".mcp.json contract", () => {
-  it("should NOT pass GITHUB_TOKEN or GH_TOKEN to MCP server", () => {
-    // This test documents the .mcp.json contract: only RALPH_-prefixed vars
-    const allowedVars = [
+  it("should only accept RALPH_-prefixed env vars", () => {
+    // Contract: .mcp.json has no env block — the MCP server inherits
+    // the parent environment. Only RALPH_-prefixed vars are read by
+    // resolveEnv(). This test documents which vars the server accepts.
+    const acceptedVars = [
       "RALPH_GH_REPO_TOKEN",
       "RALPH_GH_PROJECT_TOKEN",
       "RALPH_HERO_GITHUB_TOKEN",
@@ -146,6 +148,10 @@ describe(".mcp.json contract", () => {
       "RALPH_GH_REPO",
       "RALPH_GH_PROJECT_OWNER",
       "RALPH_GH_PROJECT_NUMBER",
+      "RALPH_GH_PROJECT_NUMBERS",
+      "RALPH_GH_TEMPLATE_PROJECT",
+      "RALPH_HERO_AUTO",
+      "RALPH_DEBUG",
     ];
 
     const forbiddenVars = [
@@ -156,14 +162,12 @@ describe(".mcp.json contract", () => {
       "GITHUB_REPO",
     ];
 
-    // Verify none of the forbidden vars are in the allowed list
     for (const forbidden of forbiddenVars) {
-      expect(allowedVars).not.toContain(forbidden);
+      expect(acceptedVars).not.toContain(forbidden);
     }
 
-    // Verify all allowed vars start with RALPH_
-    for (const allowed of allowedVars) {
-      expect(allowed).toMatch(/^RALPH_/);
+    for (const accepted of acceptedVars) {
+      expect(accepted).toMatch(/^RALPH_/);
     }
   });
 });

--- a/plugin/ralph-hero/skills/setup/SKILL.md
+++ b/plugin/ralph-hero/skills/setup/SKILL.md
@@ -51,7 +51,7 @@ The MCP server reads environment variables at startup. After changing settings, 
 
 ### Where NOT to put tokens
 
-- **Don't put tokens in `.mcp.json`** — the `env` block can overwrite inherited values with unexpanded literals
+- **Don't put tokens in `.mcp.json`** — all env vars belong in `settings.local.json`, not in the plugin config
 - **Don't put tokens in `.bashrc` after the interactive guard** — non-interactive processes (like MCP servers) won't see them
 - **Don't commit tokens to git** — use `settings.local.json` (gitignored) or shell profile
 
@@ -272,7 +272,7 @@ export RALPH_GH_REPO="[repo]"
 export RALPH_GH_PROJECT_NUMBER="[number]"
 ```
 
-**Important**: Do NOT put tokens in `.mcp.json` — the env block can mask inherited values.
+**Important**: Do NOT put tokens in `.mcp.json` — all env vars belong in `settings.local.json`.
 ```
 
 **If repo owner != project owner (split-owner setup):**
@@ -324,7 +324,7 @@ For dual-token setups (separate org repo + personal project tokens):
 }
 ```
 
-**Important**: Do NOT put tokens in `.mcp.json` — the env block can mask inherited values.
+**Important**: Do NOT put tokens in `.mcp.json` — all env vars belong in `settings.local.json`.
 ```
 
 Also include the Workflow States table in both cases:


### PR DESCRIPTION
## Summary

- Remove explicit `env` block from `plugin/ralph-hero/.mcp.json` so the MCP server inherits the full parent environment
- Update CLAUDE.md and setup skill documentation to reflect the change
- Expand contract test to document all 11 env vars the server reads

Closes #588
Supersedes #589

## Why

The `env` block acted as an allowlist — only listed vars reached the child process. It listed 3 of 11 vars, silently dropping tokens and optional config. PR #589 added one more, but the root cause is the block itself. Removing it matches the pattern ralph-knowledge already uses and eliminates the maintenance burden of enumerating every var in two places.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (838/838)
- [ ] Restart Claude Code with env vars only in `settings.local.json`, verify MCP server connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)