### PR TITLE
fix(hello): switch to inline context so AskUserQuestion works

### DIFF
--- a/plugin/ralph-hero/skills/hello/SKILL.md
+++ b/plugin/ralph-hero/skills/hello/SKILL.md
@@ -1,17 +1,12 @@
 ---
 description: Session briefing that tells you what to work on. Fetches pipeline status, hygiene warnings, and open PRs, then synthesizes ranked actionable insights with skill routes. Use this skill whenever someone asks "what should I work on", "what needs attention", "catch me up", "anything on fire", "what's blocking", or wants to know the current state of the project before deciding what to do. Also trigger when users start a session with greetings like "hello", "good morning", or "hey" combined with questions about project status, priorities, or next steps. This is the go-to skill for session-start orientation, post-vacation catch-ups, pre-meeting status checks, and "where do things stand" questions.
 argument-hint: ""
-context: fork
-model: sonnet
-hooks:
-  SessionStart:
-    - hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=hello"
+context: inline
 allowed-tools:
   - Read
   - Bash
   - Skill
+  - AskUserQuestion
   - ralph_hero__pipeline_dashboard
   - ralph_hero__project_hygiene
 ---

--- a/specs/skill-permissions.md
+++ b/specs/skill-permissions.md
@@ -31,6 +31,7 @@ Each cell: **allow** = tool is in `allowed-tools`, **—** = tool is not listed 
 | TaskCreate/List/Get/Update | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — | — |
 | SendMessage | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — | — |
 | TeamCreate/Delete | — | — | — | — | — | — | — | allow | — | — | — | — | — | — | — | — |
+| AskUserQuestion | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | allow |
 | MCP tools (ralph_hero__*) | indirect | indirect | indirect | indirect | indirect | indirect | indirect | indirect | direct | direct | — | — | — | — | — | direct |
 
 **Note on MCP tools**: Most skills access `ralph_hero__*` tools indirectly through Bash/Task delegation. `ralph-merge` and `ralph-pr` have direct MCP tool access in their `allowed-tools`.


### PR DESCRIPTION
## Summary

- The `/ralph-hero:hello` skill used `context: fork` which spawns an autonomous subagent with no interactive tool access
- Step 3 instructs the model to call `AskUserQuestion` for routing the user to the right skill, but forked contexts cannot use interactive tools (confirmed by eval benchmarks in `hello-workspace/iteration-2/benchmark.md`)
- Additionally, `AskUserQuestion` was never added to `allowed-tools` despite eval feedback explicitly requesting it

## Changes

- `context: fork` → `context: inline` — enables interactive `AskUserQuestion` in the main session
- Removed `model: sonnet` and `SessionStart` hook (not applicable to inline context)
- Added `AskUserQuestion` to `allowed-tools`
- Added `AskUserQuestion` row to `specs/skill-permissions.md` matrix

## Test plan

- [ ] Invoke `/ralph-hero:hello` — should complete without error
- [ ] Verify pipeline dashboard, hygiene, and PR data all fetch successfully
- [ ] Verify `AskUserQuestion` presents the 3 insights with selectable options
- [ ] Verify selecting an option routes to the correct skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)