### PR TITLE
feat(cli): add --version, --help, and first-run welcome banner

### DIFF
--- a/plugin/ralph-hero/scripts/ralph-cli.sh
+++ b/plugin/ralph-hero/scripts/ralph-cli.sh
@@ -4,19 +4,92 @@
 set -euo pipefail
 
 RALPH_JUSTFILE="${RALPH_JUSTFILE:-}"
+RALPH_VERSION=""
 
+# Resolve plugin cache dir and latest version
+CACHE_DIR="$HOME/.claude/plugins/cache/ralph-hero/ralph-hero"
 if [ -z "$RALPH_JUSTFILE" ]; then
-    CACHE_DIR="$HOME/.claude/plugins/cache/ralph-hero/ralph-hero"
     if [ -d "$CACHE_DIR" ]; then
         LATEST=$(ls "$CACHE_DIR" | sort -V | tail -1)
         RALPH_JUSTFILE="$CACHE_DIR/$LATEST/justfile"
     fi
 fi
 
+# Read version from plugin.json if available
+if [ -d "$CACHE_DIR" ]; then
+    LATEST=$(ls "$CACHE_DIR" | sort -V | tail -1)
+    PLUGIN_JSON="$CACHE_DIR/$LATEST/.claude-plugin/plugin.json"
+    if [ -f "$PLUGIN_JSON" ] && command -v jq &>/dev/null; then
+        RALPH_VERSION=$(jq -r '.version // empty' "$PLUGIN_JSON" 2>/dev/null || echo "")
+    fi
+    if [ -z "$RALPH_VERSION" ]; then
+        RALPH_VERSION="${LATEST:-unknown}"
+    fi
+fi
+
+# --version flag
+if [ "${1:-}" = "--version" ] || [ "${1:-}" = "-V" ]; then
+    echo "ralph version ${RALPH_VERSION}"
+    exit 0
+fi
+
+# --help flag
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    cat <<EOF
+Usage: ralph <command> [options]
+
+Ralph Hero — autonomous GitHub Projects V2 workflow automation.
+
+Common commands:
+  loop        Run the full analyst+builder+integrator loop
+  impl        Implement the next In Progress issue
+  plan        Write an implementation plan for the next issue
+  triage      Triage new issues onto the project board
+  research    Run the research phase for an issue
+  review      Review an implementation plan
+  hygiene     Run project hygiene checks
+  doctor      Diagnose your Ralph installation
+
+Options:
+  --version, -V   Print the installed Ralph version and exit
+  --help,    -h   Print this help message and exit
+  -i              Run in interactive mode (opens Claude session)
+  -q              Run in quick mode (direct MCP tool call)
+  --budget=N      Set spend cap in USD (default: 2.00)
+  --timeout=T     Set per-task timeout (default: 15m)
+
+Examples:
+  ralph loop                 # Run the full workflow loop
+  ralph impl 42              # Implement issue #42
+  ralph triage -q            # Quick-triage without AI
+  ralph loop --budget=5.00   # Loop with a higher budget cap
+
+Docs: https://github.com/cdubiel08/ralph-hero
+EOF
+    exit 0
+fi
+
 if [ -z "$RALPH_JUSTFILE" ] || [ ! -f "$RALPH_JUSTFILE" ]; then
     echo "Error: Ralph justfile not found."
     echo "Install: claude plugin install https://github.com/cdubiel08/ralph-hero"
     exit 1
+fi
+
+# Welcome banner on first run
+RALPH_STATE_DIR="${RALPH_STATE_DIR:-$HOME/.ralph}"
+WELCOMED_FILE="$RALPH_STATE_DIR/welcomed"
+if [ ! -f "$WELCOMED_FILE" ]; then
+    mkdir -p "$RALPH_STATE_DIR"
+    cat <<EOF
+
+  Welcome to Ralph v${RALPH_VERSION}!
+  Autonomous GitHub Projects V2 workflow automation.
+
+  Run 'ralph --help' to see available commands.
+  Run 'ralph loop' to start the full workflow.
+
+EOF
+    touch "$WELCOMED_FILE"
 fi
 
 exec just --justfile "$RALPH_JUSTFILE" "$@"

--- a/thoughts/shared/plans/2026-03-18-group-GH-0604-demo-cli-greeting.md
+++ b/thoughts/shared/plans/2026-03-18-group-GH-0604-demo-cli-greeting.md
@@ -1,0 +1,81 @@
+---
+title: "Demo: Add greeting message to CLI"
+date: 2026-03-18
+github_issues: [605, 606, 607]
+primary_issue: 604
+estimate: XS
+status: approved
+---
+
+# Group Implementation Plan: GH-604 — Demo CLI Greeting Messages
+
+## Overview
+
+Three XS sub-issues that add user-facing polish to `ralph-cli.sh`:
+
+- **#605**: Add "Welcome to Ralph" banner on first run
+- **#606**: Add `--version` flag
+- **#607**: Add `--help` flag with usage summary
+
+All changes are confined to a single file: `plugin/ralph-hero/scripts/ralph-cli.sh`.
+
+## Shared Constraints
+
+- Shell: `bash` with `set -euo pipefail`
+- No external dependencies — pure shell
+- First-run detection uses a sentinel file `~/.ralph/welcomed` (created on first run)
+- Version is read from the plugin's `plugin.json` at runtime so it stays in sync with releases
+- Help output goes to stdout; exit code 0
+- Changes must not break existing passthrough behavior (`exec just ...`)
+
+## Phase 1: All Three Features
+
+### Tasks
+
+#### Task 1.1: Add --version flag
+
+- **files**: `plugin/ralph-hero/scripts/ralph-cli.sh`
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: null
+- **acceptance**:
+  - `ralph --version` prints a version string and exits 0
+  - Version is sourced from the installed plugin's `plugin.json`
+  - Existing `exec just ...` passthrough is unaffected
+
+#### Task 1.2: Add --help flag
+
+- **files**: `plugin/ralph-hero/scripts/ralph-cli.sh`
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: null
+- **acceptance**:
+  - `ralph --help` prints a usage summary and exits 0
+  - Summary lists common commands (loop, impl, plan, triage, doctor)
+  - Existing `exec just ...` passthrough is unaffected
+
+#### Task 1.3: Add welcome banner on first run
+
+- **files**: `plugin/ralph-hero/scripts/ralph-cli.sh`
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: [1.1, 1.2]
+- **acceptance**:
+  - On first invocation, prints a "Welcome to Ralph" banner
+  - Subsequent invocations do not print the banner
+  - Sentinel file stored at `~/.ralph/welcomed`
+  - Banner includes version and a hint about `ralph --help`
+
+### Automated Verification
+
+- [x] `ralph --version` exits 0 and prints a non-empty version string
+- [x] `ralph --help` exits 0 and output contains "Usage:"
+- [x] Sentinel file `~/.ralph/welcomed` is created after first run
+- [x] Removing sentinel file causes banner to reappear
+
+## File Ownership Summary
+
+| File | Phase |
+|------|-------|
+| `plugin/ralph-hero/scripts/ralph-cli.sh` | 1 |
+| `thoughts/shared/plans/2026-03-18-group-GH-0604-demo-cli-greeting.md` | 1 |


### PR DESCRIPTION
Closes #605, #606, #607

## Changes
- Add `--version` flag to display CLI version from plugin.json
- Add `--help` flag with usage summary  
- Add welcome banner on first run (sentinel: ~/.ralph/welcomed)

All changes are in `plugin/ralph-hero/scripts/ralph-cli.sh`.

## Validation
All checks passed in prior session:
- [x] Shell syntax valid
- [x] --version flag implemented
- [x] --help flag implemented  
- [x] Welcome banner logic implemented
- [x] Version sourced from plugin.json
- [x] Help text contains 'Usage:'

Ready for merge.