### PR TITLE
GH-611: ralph-knowledge type inference from path + spec as first-class type + frontmatter bulk-patch

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/generate-indexes.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/generate-indexes.test.ts
@@ -241,6 +241,22 @@ describe("generateIndexes", () => {
     const index = readFileSync(join(dir, "_index.md"), "utf-8");
     expect(index).not.toContain("[[_uncategorized]]");
   });
+
+  it("routes spec docs to _specs.md and not to uncategorized", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gen-test-"));
+    const docs = [
+      makeParsedDoc({ id: "debug-spec", type: "spec", title: "Debug Mode Spec" }),
+      makeParsedDoc({ id: "r1", type: "research" }),
+    ];
+    generateIndexes(dir, docs);
+    expect(existsSync(join(dir, "_specs.md"))).toBe(true);
+    const specs = readFileSync(join(dir, "_specs.md"), "utf-8");
+    expect(specs).toContain("[[debug-spec]]");
+    expect(existsSync(join(dir, "_uncategorized.md"))).toBe(false);
+    const index = readFileSync(join(dir, "_index.md"), "utf-8");
+    expect(index).toContain("[[_specs]]");
+    expect(index).not.toContain("[[_uncategorized]]");
+  });
 });
 
 describe("findMarkdownFiles", () => {

--- a/plugin/ralph-knowledge/src/__tests__/parser.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseDocument } from "../parser.js";
+import { parseDocument, inferTypeFromPath } from "../parser.js";
 
 const FULL_DOC = `---
 date: 2026-03-08
@@ -179,5 +179,69 @@ describe("parseDocument", () => {
       const doc = parseDocument("test-plan", "thoughts/shared/plans/test-plan.md", raw);
       expect(doc.githubIssue).toBe(550);
     });
+  });
+});
+
+describe("inferTypeFromPath", () => {
+  it("infers plan from /plans/ segment", () => {
+    expect(inferTypeFromPath("thoughts/shared/plans/foo.md")).toBe("plan");
+  });
+
+  it("infers research from /research/ segment", () => {
+    expect(inferTypeFromPath("thoughts/shared/research/foo.md")).toBe("research");
+  });
+
+  it("infers report from /reports/ segment", () => {
+    expect(inferTypeFromPath("thoughts/shared/reports/foo.md")).toBe("report");
+  });
+
+  it("infers idea from /ideas/ segment", () => {
+    expect(inferTypeFromPath("thoughts/ideas/foo.md")).toBe("idea");
+  });
+
+  it("returns null for unknown path", () => {
+    expect(inferTypeFromPath("thoughts/misc/foo.md")).toBeNull();
+  });
+});
+
+describe("parseDocument type inference", () => {
+  const NO_TYPE_DOC = `---
+date: 2026-03-01
+status: draft
+---
+
+# My Plan
+`;
+
+  const SPEC_DOC = `---
+date: 2026-02-21
+status: draft
+type: spec
+---
+
+# Debug Mode Spec
+`;
+
+  it("infers type from path when frontmatter type is absent", () => {
+    const doc = parseDocument("my-plan", "thoughts/shared/plans/my-plan.md", NO_TYPE_DOC);
+    expect(doc.type).toBe("plan");
+  });
+
+  it("preserves frontmatter type: spec without aliasing", () => {
+    const doc = parseDocument("debug-spec", "thoughts/shared/plans/debug-spec.md", SPEC_DOC);
+    expect(doc.type).toBe("spec");
+  });
+
+  it("frontmatter type takes priority over path inference", () => {
+    // file is in /plans/ but has type: research in frontmatter
+    const raw = `---\ndate: 2026-03-01\ntype: research\n---\n\n# Research in plans dir\n`;
+    const doc = parseDocument("x", "thoughts/shared/plans/x.md", raw);
+    expect(doc.type).toBe("research");
+  });
+
+  it("returns null when path gives no hint and type is absent", () => {
+    const raw = `---\ndate: 2026-03-01\n---\n\n# Mystery\n`;
+    const doc = parseDocument("x", "thoughts/misc/x.md", raw);
+    expect(doc.type).toBeNull();
   });
 });

--- a/plugin/ralph-knowledge/src/generate-indexes.ts
+++ b/plugin/ralph-knowledge/src/generate-indexes.ts
@@ -55,6 +55,7 @@ export function writeTypeIndex(
 const TYPE_HEADINGS: Record<string, string> = {
   research: "Research",
   plan: "Plans",
+  spec: "Specs",
   idea: "Ideas",
   review: "Reviews",
   report: "Reports",
@@ -138,6 +139,7 @@ export function writeMasterIndex(outDir: string, allDocs: ParsedDocument[], hasU
     "## Browse by Type\n",
     "- [[_research]] — Research documents",
     "- [[_plans]] — Implementation plans",
+    "- [[_specs]] — Specifications",
     "- [[_ideas]] — Ideas and drafts",
     "- [[_reviews]] — Code and plan reviews",
     "- [[_reports]] — Status reports",
@@ -254,6 +256,7 @@ WHERE !contains(rows.type, "plan")
 const TYPE_INDEX_CONFIG: Array<{ type: string; filename: string; heading: string }> = [
   { type: "research", filename: "research", heading: "Research Documents" },
   { type: "plan", filename: "plans", heading: "Implementation Plans" },
+  { type: "spec", filename: "specs", heading: "Specifications" },
   { type: "idea", filename: "ideas", heading: "Ideas & Drafts" },
   { type: "review", filename: "reviews", heading: "Reviews" },
   { type: "report", filename: "reports", heading: "Reports" },

--- a/plugin/ralph-knowledge/src/parser.ts
+++ b/plugin/ralph-knowledge/src/parser.ts
@@ -24,6 +24,21 @@ const TITLE_RE = /^# (.+)$/m;
 const WIKILINK_REL_RE = /^- (builds_on|tensions):: \[\[(.+?)\]\]/gm;
 const SUPERSEDED_BY_RE = /\[\[(.+?)\]\]/;
 
+const PATH_TYPE_MAP: Array<{ segment: string; type: string }> = [
+  { segment: "/research/", type: "research" },
+  { segment: "/plans/",    type: "plan" },
+  { segment: "/ideas/",    type: "idea" },
+  { segment: "/reviews/",  type: "review" },
+  { segment: "/reports/",  type: "report" },
+];
+
+export function inferTypeFromPath(path: string): string | null {
+  for (const { segment, type } of PATH_TYPE_MAP) {
+    if (path.includes(segment)) return type;
+  }
+  return null;
+}
+
 export function parseDocument(id: string, path: string, raw: string): ParsedDocument {
   const fmMatch = raw.match(FRONTMATTER_RE);
   const frontmatter = fmMatch ? parseYaml(fmMatch[1]) ?? {} : {};
@@ -55,7 +70,9 @@ export function parseDocument(id: string, path: string, raw: string): ParsedDocu
   return {
     id, path, title,
     date: frontmatter.date ? String(frontmatter.date) : null,
-    type: frontmatter.type ?? null,
+    type: (typeof frontmatter.type === "string" && frontmatter.type.length > 0)
+      ? frontmatter.type
+      : inferTypeFromPath(path),
     status: frontmatter.status ?? null,
     githubIssue: typeof frontmatter.github_issue === "number"
       ? frontmatter.github_issue

--- a/thoughts/ideas/2026-02-18-github-projects-v2-docs-deep-dive.md
+++ b/thoughts/ideas/2026-02-18-github-projects-v2-docs-deep-dive.md
@@ -1,4 +1,5 @@
 ---
+type: idea
 date: 2026-02-18
 status: closed
 reason: "Ideas triaged: #367 (iteration), #368 (capacity). Ideas 2,3,4,7 already implemented. Ideas 5,8,9 covered by existing issues."

--- a/thoughts/ideas/2026-02-21-showcase-demo-onboarding.md
+++ b/thoughts/ideas/2026-02-21-showcase-demo-onboarding.md
@@ -1,4 +1,5 @@
 ---
+type: idea
 date: 2026-02-21
 status: closed
 reason: Covered by GH-310 and GH-364

--- a/thoughts/ideas/2026-02-22-orchestrator-no-message-on-task-assign.md
+++ b/thoughts/ideas/2026-02-22-orchestrator-no-message-on-task-assign.md
@@ -1,4 +1,5 @@
 ---
+type: idea
 date: 2026-02-22
 status: closed
 reason: Handled by existing epic (team worker redesign)

--- a/thoughts/shared/ideas/2026-02-25-idea-hunt-synthesis.md
+++ b/thoughts/shared/ideas/2026-02-25-idea-hunt-synthesis.md
@@ -1,3 +1,8 @@
+---
+type: idea
+date: 2026-02-25
+---
+
 # Idea Hunt Synthesis: What's Actually Interesting Out There
 
 **Date:** 2026-02-25

--- a/thoughts/shared/ideas/2026-03-01-hello-session-briefing.md
+++ b/thoughts/shared/ideas/2026-03-01-hello-session-briefing.md
@@ -1,4 +1,5 @@
 ---
+type: idea
 date: 2026-03-01
 status: formed
 author: user

--- a/thoughts/shared/plans/2026-02-20-ralph-team-worker-redesign.md
+++ b/thoughts/shared/plans/2026-02-20-ralph-team-worker-redesign.md
@@ -1,3 +1,8 @@
+---
+type: plan
+date: 2026-02-20
+---
+
 # Ralph Team Worker Redesign
 
 **Date**: 2026-02-20

--- a/thoughts/shared/plans/2026-02-26-GH-0418-interactive-ralph-parity.md
+++ b/thoughts/shared/plans/2026-02-26-GH-0418-interactive-ralph-parity.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-02-26
 status: draft
 github_issues: [418]

--- a/thoughts/shared/plans/2026-02-27-GH-0433-auto-mode-pipeline-detection.md
+++ b/thoughts/shared/plans/2026-02-27-GH-0433-auto-mode-pipeline-detection.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-02-27
 status: draft
 github_issues: [433]

--- a/thoughts/shared/plans/2026-02-27-mcp-toolspace-consolidation.md
+++ b/thoughts/shared/plans/2026-02-27-mcp-toolspace-consolidation.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-02-27
 status: draft
 github_issues: [451]

--- a/thoughts/shared/plans/2026-02-27-ralph-cli-qol-improvements.md
+++ b/thoughts/shared/plans/2026-02-27-ralph-cli-qol-improvements.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-02-27
 status: draft
 github_issues: []

--- a/thoughts/shared/plans/2026-02-28-ralph-protocol-specs.md
+++ b/thoughts/shared/plans/2026-02-28-ralph-protocol-specs.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-02-28
 status: draft
 ---

--- a/thoughts/shared/plans/2026-03-02-builder-main-branch-guard.md
+++ b/thoughts/shared/plans/2026-03-02-builder-main-branch-guard.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-03-02
 status: draft
 github_issues: []

--- a/thoughts/shared/plans/2026-03-03-group-GH-0519-parent-advancement-dashboard-fix.md
+++ b/thoughts/shared/plans/2026-03-03-group-GH-0519-parent-advancement-dashboard-fix.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-03-03
 status: draft
 github_issues: [519, 520, 521, 522]

--- a/thoughts/shared/plans/2026-03-05-GH-0539-cross-repo-dependency-tooling.md
+++ b/thoughts/shared/plans/2026-03-05-GH-0539-cross-repo-dependency-tooling.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 date: 2026-03-05
 status: draft
 github_issues: [539]

--- a/thoughts/shared/plans/2026-03-18-group-GH-0604-demo-cli-greeting.md
+++ b/thoughts/shared/plans/2026-03-18-group-GH-0604-demo-cli-greeting.md
@@ -1,4 +1,5 @@
 ---
+type: plan
 title: "Demo: Add greeting message to CLI"
 date: 2026-03-18
 github_issues: [605, 606, 607]

--- a/thoughts/shared/reports/2026-02-21-weekly-ship-report.md
+++ b/thoughts/shared/reports/2026-02-21-weekly-ship-report.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-02-21
+---
+
 # Ralph Hero — Weekly Ship Report
 
 **Period**: Feb 14–21, 2026

--- a/thoughts/shared/reports/2026-02-25-idea-hunt-team-diagnostic.md
+++ b/thoughts/shared/reports/2026-02-25-idea-hunt-team-diagnostic.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-02-25
+---
+
 # Idea Hunt Team Diagnostic Report
 
 **Date:** 2026-02-25

--- a/thoughts/shared/reports/2026-02-27-ralph-team-GH-451.md
+++ b/thoughts/shared/reports/2026-02-27-ralph-team-GH-451.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-02-27
+---
+
 # Ralph Team Session Report: GH-451
 
 **Date**: 2026-02-27

--- a/thoughts/shared/reports/2026-03-01-ralph-team-431-464-466.md
+++ b/thoughts/shared/reports/2026-03-01-ralph-team-431-464-466.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-01
+---
+
 # Ralph Team Session Report: 431-464-466
 
 **Date**: 2026-03-01

--- a/thoughts/shared/reports/2026-03-01-ralph-team-GH-433.md
+++ b/thoughts/shared/reports/2026-03-01-ralph-team-GH-433.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-01
+---
+
 # Ralph Team Session Report: GH-433
 
 **Date**: 2026-03-01

--- a/thoughts/shared/reports/2026-03-01-ralph-team-GH-467.md
+++ b/thoughts/shared/reports/2026-03-01-ralph-team-GH-467.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-01
+---
+
 # Ralph Team Session Report: GH-467
 
 **Date**: 2026-03-01

--- a/thoughts/shared/reports/2026-03-01-ralph-team-GH-477.md
+++ b/thoughts/shared/reports/2026-03-01-ralph-team-GH-477.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-01
+---
+
 # Ralph Team Session Report: GH-477
 
 **Date**: 2026-03-01

--- a/thoughts/shared/reports/2026-03-01-ralph-team-bugs-and-triage.md
+++ b/thoughts/shared/reports/2026-03-01-ralph-team-bugs-and-triage.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-01
+---
+
 # Ralph Team Session Report: bugs-and-triage
 
 **Date**: 2026-03-01

--- a/thoughts/shared/reports/2026-03-01-ralph-team-plugin-cleanup.md
+++ b/thoughts/shared/reports/2026-03-01-ralph-team-plugin-cleanup.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-01
+---
+
 # Ralph Team Session Report: plugin-cleanup
 
 **Date**: 2026-03-01

--- a/thoughts/shared/reports/2026-03-01-ralph-team-triage-oldest-5.md
+++ b/thoughts/shared/reports/2026-03-01-ralph-team-triage-oldest-5.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-01
+---
+
 # Ralph Team Session Report: triage-oldest-5
 
 **Date**: 2026-03-01

--- a/thoughts/shared/reports/2026-03-02-ralph-team-464-466.md
+++ b/thoughts/shared/reports/2026-03-02-ralph-team-464-466.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-02
+---
+
 # Ralph Team Session Report: 464-466
 
 **Date**: 2026-03-02

--- a/thoughts/shared/reports/2026-03-02-ralph-team-GH-493.md
+++ b/thoughts/shared/reports/2026-03-02-ralph-team-GH-493.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-02
+---
+
 # Ralph Team Session Report: GH-493
 
 **Date**: 2026-03-02

--- a/thoughts/shared/reports/2026-03-03-ralph-team-gh-0480.md
+++ b/thoughts/shared/reports/2026-03-03-ralph-team-gh-0480.md
@@ -1,4 +1,5 @@
 ---
+type: report
 date: 2026-03-03
 ---
 

--- a/thoughts/shared/reports/2026-03-04-ralph-team-gh-0519.md
+++ b/thoughts/shared/reports/2026-03-04-ralph-team-gh-0519.md
@@ -1,4 +1,5 @@
 ---
+type: report
 date: 2026-03-04
 ---
 

--- a/thoughts/shared/reports/2026-03-04-ralph-team-gh-514-515-516.md
+++ b/thoughts/shared/reports/2026-03-04-ralph-team-gh-514-515-516.md
@@ -1,4 +1,5 @@
 ---
+type: report
 date: 2026-03-04
 ---
 

--- a/thoughts/shared/reports/2026-03-04-ralph-team-pir-batch.md
+++ b/thoughts/shared/reports/2026-03-04-ralph-team-pir-batch.md
@@ -1,4 +1,5 @@
 ---
+type: report
 date: 2026-03-04
 ---
 

--- a/thoughts/shared/reports/2026-03-05-ralph-team-gh-541-worktree-lifecycle.md
+++ b/thoughts/shared/reports/2026-03-05-ralph-team-gh-541-worktree-lifecycle.md
@@ -1,4 +1,5 @@
 ---
+type: report
 date: 2026-03-05
 ---
 

--- a/thoughts/shared/reports/2026-03-18-ralph-team-GH-604-demo-cli.md
+++ b/thoughts/shared/reports/2026-03-18-ralph-team-GH-604-demo-cli.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-18
+---
+
 # Ralph Team Session Report: GH-604-demo-cli
 
 **Date**: 2026-03-18

--- a/thoughts/shared/reports/2026-03-19-ralph-team-GH-604-demo-cli-merge.md
+++ b/thoughts/shared/reports/2026-03-19-ralph-team-GH-604-demo-cli-merge.md
@@ -1,3 +1,8 @@
+---
+type: report
+date: 2026-03-19
+---
+
 # Ralph Team Session Report: GH-604-demo-cli (merge session)
 
 **Date**: 2026-03-19

--- a/thoughts/shared/research/2026-02-18-GH-0066-github-projects-v2-docs-guidance.md
+++ b/thoughts/shared/research/2026-02-18-GH-0066-github-projects-v2-docs-guidance.md
@@ -1,4 +1,5 @@
 ---
+type: research
 date: 2026-02-18
 github_issue: 66
 github_url: https://github.com/cdubiel08/ralph-hero/issues/66

--- a/thoughts/shared/research/2026-02-20-GH-0199-cross-project-sync-audit-trail.md
+++ b/thoughts/shared/research/2026-02-20-GH-0199-cross-project-sync-audit-trail.md
@@ -1,3 +1,8 @@
+---
+type: research
+date: 2026-02-20
+---
+
 # GH-199: Add Audit Trail Comments for Cross-Project State Sync
 
 **Issue**: https://github.com/cdubiel08/ralph-hero/issues/199


### PR DESCRIPTION
## Summary

36 documents were appearing in `_uncategorized.md` despite having obvious types derivable from their directory path or containing `type: spec` which the indexer didn't recognize.

### Changes

**Phase 1: Plugin Code**
- Added `inferTypeFromPath()` to `plugin/ralph-knowledge/src/parser.ts` for path-based type inference
- Added `spec` as a first-class type in `plugin/ralph-knowledge/src/generate-indexes.ts`
- Added comprehensive test coverage for inference logic (77 tests pass)

**Phase 2: Frontmatter Bulk-Patch**
- Added `type:` frontmatter to all 36 affected documents:
  - 10 plan docs
  - 16 report docs
  - 5 idea docs
  - 2 research docs
  - 1 spec doc (now recognized)

### Verification
- ✅ `npm test` passes (77/77 tests in ralph-knowledge)
- ✅ `npm run build` passes (TypeScript clean)
- ✅ All 36 docs have `type:` frontmatter
- ✅ New docs without `type:` are automatically categorized by directory

Closes #611