### PR TITLE
fix(skill): setup-cli — detect compinit, add autoload to zsh next steps

### DIFF
--- a/docs/superpowers/plans/2026-03-19-setup-cli-skill.md
+++ b/docs/superpowers/plans/2026-03-19-setup-cli-skill.md
@@ -119,6 +119,18 @@ Check if `$PLUGIN_DIR/scripts/ralph-completions.bash` exists.
 
 Print: `Note: only bash/zsh completions are available — skipping completions.`
 
+## Step 3a: Check compinit (zsh only)
+
+Only run this step if the shell is zsh AND completions were installed in Step 3.
+
+Run:
+
+```bash
+grep -q "compinit" "$HOME/.zshrc" 2>/dev/null && echo "compinit_ok" || echo "compinit_missing"
+```
+
+Record the result as `COMPINIT_OK` (true/false) for use in Step 6. If the shell is not zsh or completions were skipped, treat `COMPINIT_OK` as true (no action needed).
+
 ## Step 4: Check PATH
 
 Run:
@@ -143,7 +155,7 @@ Record the result as `JUST_OK` (true/false) for use in Step 6.
 
 Print what was done and the next steps, tailored to the detected shell and what warnings were triggered.
 
-**For zsh**, print (omit the PATH line if `PATH_OK` is true, omit just warning if `JUST_OK` is true):
+**For zsh**, print (omit the PATH line if `PATH_OK` is true, omit the `autoload` and `source` lines if completions were not installed in Step 3, omit the `autoload` line if `COMPINIT_OK` is true, omit just warning if `JUST_OK` is true):
 
 ```
 Done! Ralph CLI installed.
@@ -151,6 +163,7 @@ Done! Ralph CLI installed.
 Next steps:
 1. Add to ~/.zshrc, then restart your shell (or run: source ~/.zshrc):
    export PATH="$HOME/.local/bin:$PATH"           # omit if PATH_OK
+   autoload -Uz compinit && compinit               # omit if COMPINIT_OK or completions skipped
    source ~/.local/share/ralph/ralph-completions.zsh
 
 2. Verify: ralph doctor
@@ -361,3 +374,34 @@ git commit -m "fix(skill): setup-cli smoke test fixups"
 ```
 
 Only needed if issues were found.
+
+---
+
+### Task 4: Evaluate skill efficacy with skill-creator
+
+Run the skill-creator evaluator on the completed skill to measure quality and identify gaps.
+
+- [ ] **Step 1: Run skill-creator eval**
+
+In Claude Code, invoke:
+
+```
+/skill-creator eval setup-cli
+```
+
+Expected: skill-creator runs the skill against representative scenarios, scores output quality, and reports any cases where the skill mishandles edge cases (e.g., other shells, missing completions, existing compinit in .zshrc, PATH already set).
+
+- [ ] **Step 2: Address any failures**
+
+For each failure or low-score scenario reported:
+- Edit `plugin/ralph-hero/skills/setup-cli/SKILL.md` to fix the issue
+- Re-run the eval to confirm the fix
+
+- [ ] **Step 3: Commit eval fixes (if any)**
+
+```bash
+git add plugin/ralph-hero/skills/setup-cli/SKILL.md
+git commit -m "fix(skill): setup-cli eval-driven improvements"
+```
+
+Only needed if step 2 produced changes.

--- a/plugin/ralph-hero/skills/setup-cli/SKILL.md
+++ b/plugin/ralph-hero/skills/setup-cli/SKILL.md
@@ -84,6 +84,18 @@ fi
 
 **For any other shell:** no bash block to run. Print: `Note: only bash/zsh completions are available — skipping completions.`
 
+## Step 3a: Check compinit (zsh only)
+
+Only run this step if the shell is zsh AND completions were installed in Step 3.
+
+Run:
+
+```bash
+grep -q "compinit" "$HOME/.zshrc" 2>/dev/null && echo "compinit_ok" || echo "compinit_missing"
+```
+
+Record the result as `COMPINIT_OK` (true/false) for use in Step 6. If the shell is not zsh or completions were skipped, treat `COMPINIT_OK` as true (no action needed).
+
 ## Step 4: Check PATH
 
 Run:
@@ -108,7 +120,7 @@ Record the result as `JUST_OK` (true/false) for use in Step 6.
 
 Print what was done and the next steps, tailored to the detected shell and what warnings were triggered.
 
-**For zsh**, print (omit the PATH line if `PATH_OK` is true, omit the `source` completions line if completions were not installed in Step 3):
+**For zsh**, print (omit the PATH line if `PATH_OK` is true, omit the `autoload` and `source` lines if completions were not installed in Step 3, omit the `autoload` line if `COMPINIT_OK` is true):
 
 ```
 Done! Ralph CLI installed.
@@ -116,6 +128,7 @@ Done! Ralph CLI installed.
 Next steps:
 1. Add to ~/.zshrc, then restart your shell (or run: source ~/.zshrc):
    export PATH="$HOME/.local/bin:$PATH"           # omit if PATH_OK
+   autoload -Uz compinit && compinit               # omit if COMPINIT_OK or completions skipped
    source ~/.local/share/ralph/ralph-completions.zsh  # omit if completions skipped in Step 3
 
 2. Verify: ralph doctor


### PR DESCRIPTION
## Summary

- Adds Step 3a to detect whether `compinit` is already configured in `~/.zshrc`
- Updates Step 6 zsh next-steps block to include `autoload -Uz compinit && compinit` before the `source` line (conditionally omitted if already configured)
- Updates the setup-cli plan with the same changes + Task 4 for skill-creator eval

## Problem

`ralph-completions.zsh` calls `compdef`, which requires the zsh completion system to be initialized. Users without Oh My Zsh or an explicit `compinit` setup got:

```
zsh: command not found: compdef
```

The fix is not to call `compinit` from inside the completions file — that's wrong. Instead the skill should detect whether the user needs it and include `autoload -Uz compinit && compinit` in the `~/.zshrc` instructions.

## Test plan

- [ ] Run `/ralph-hero:setup-cli` on a zsh shell without `compinit` in `~/.zshrc` — confirm `autoload` line appears in next steps
- [ ] Run on a zsh shell that already has `compinit` — confirm `autoload` line is omitted
- [ ] Run `/skill-creator eval setup-cli` per Task 4 in the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)