### PR TITLE
feat(setup): add create_views tool for REST view creation

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/view-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/view-tools.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for view-tools: source inspection and pure-function tests
+ * for the create_views tool and toRestLayout converter.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { toRestLayout } from "../tools/view-tools.js";
+
+const viewToolsSrc = fs.readFileSync(
+  path.resolve(__dirname, "../tools/view-tools.ts"),
+  "utf-8",
+);
+
+describe("view-tools source structure", () => {
+  it("registers ralph_hero__create_views tool", () => {
+    expect(viewToolsSrc).toContain("ralph_hero__create_views");
+  });
+
+  it("has sourceProjectNumber param", () => {
+    expect(viewToolsSrc).toContain("sourceProjectNumber");
+  });
+
+  it("has targetProjectNumber param", () => {
+    expect(viewToolsSrc).toContain("targetProjectNumber");
+  });
+
+  it("imports fetchProjectViews from project-tools", () => {
+    expect(viewToolsSrc).toContain("fetchProjectViews");
+  });
+
+  it("calls restPost on client", () => {
+    expect(viewToolsSrc).toContain("client.restPost");
+  });
+});
+
+describe("toRestLayout", () => {
+  it("converts TABLE_LAYOUT to table", () => {
+    expect(toRestLayout("TABLE_LAYOUT")).toBe("table");
+  });
+
+  it("converts BOARD_LAYOUT to board", () => {
+    expect(toRestLayout("BOARD_LAYOUT")).toBe("board");
+  });
+
+  it("converts ROADMAP_LAYOUT to roadmap", () => {
+    expect(toRestLayout("ROADMAP_LAYOUT")).toBe("roadmap");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/github-client.ts
+++ b/plugin/ralph-hero/mcp-server/src/github-client.ts
@@ -67,6 +67,13 @@ export interface GitHubClient {
   /** Get the authenticated user's login. */
   getAuthenticatedUser: () => Promise<string>;
 
+  /** Execute a REST API POST request. Uses project token by default. */
+  restPost: <T = unknown>(
+    path: string,
+    body: unknown,
+    useProjectToken?: boolean,
+  ) => Promise<T>;
+
   /** Configuration. */
   config: GitHubClientConfig;
 }
@@ -281,6 +288,37 @@ export function createGitHubClient(
       const login = result.viewer.login;
       cache.set(cacheKey, login, 60 * 60 * 1000); // Cache for 1 hour
       return login;
+    },
+
+    async restPost<T>(
+      path: string,
+      body: unknown,
+      useProjectToken = true,
+    ): Promise<T> {
+      const token = useProjectToken
+        ? (clientConfig.projectToken ?? clientConfig.token)
+        : clientConfig.token;
+
+      const url = `https://api.github.com${path}`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(
+          `GitHub REST API error ${response.status} for ${path}: ${text}`,
+        );
+      }
+
+      return response.json() as Promise<T>;
     },
   };
 }

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -24,6 +24,7 @@ import { registerProjectManagementTools } from "./tools/project-management-tools
 import { registerHygieneTools } from "./tools/hygiene-tools.js";
 import { registerDebugTools } from "./tools/debug-tools.js";
 import { registerDecomposeTools } from "./tools/decompose-tools.js";
+import { registerViewTools } from "./tools/view-tools.js";
 
 /**
  * Initialize the GitHub client from environment variables.
@@ -372,6 +373,9 @@ async function main(): Promise<void> {
 
   // Decompose feature tool (cross-repo decomposition via .ralph-repos.yml)
   registerDecomposeTools(server, client, fieldCache);
+
+  // View management tools (REST API view creation)
+  registerViewTools(server, client, fieldCache);
 
   // Debug tools (only when RALPH_DEBUG=true)
   if (process.env.RALPH_DEBUG === 'true') {

--- a/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/project-tools.ts
@@ -17,6 +17,7 @@ import type {
   ProjectV2ItemFieldSingleSelectValue,
   ProjectV2FieldUnion,
   ProjectV2SingleSelectField,
+  ProjectV2View,
 } from "../types.js";
 import { resolveProjectOwner } from "../types.js";
 import { queryProjectRepositories } from "../lib/helpers.js";
@@ -602,6 +603,82 @@ async function fetchProject(
   }
 
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// View Queries (for create_views tool)
+// ---------------------------------------------------------------------------
+
+interface ViewsQueryResult {
+  user?: { projectV2: { views: { nodes: ProjectV2View[] } } | null } | null;
+  organization?: {
+    projectV2: { views: { nodes: ProjectV2View[] } } | null;
+  } | null;
+}
+
+const VIEWS_QUERY_USER = `
+  query($login: String!, $number: Int!) {
+    user(login: $login) {
+      projectV2(number: $number) {
+        views(first: 50) {
+          nodes { id name number layout filter }
+        }
+      }
+    }
+  }
+`;
+
+const VIEWS_QUERY_ORG = `
+  query($login: String!, $number: Int!) {
+    organization(login: $login) {
+      projectV2(number: $number) {
+        views(first: 50) {
+          nodes { id name number layout filter }
+        }
+      }
+    }
+  }
+`;
+
+export interface FetchProjectViewsResult {
+  views: ProjectV2View[];
+  ownerType: "users" | "orgs";
+}
+
+/**
+ * Fetch project views via GraphQL with user→org fallback.
+ * Returns views AND the resolved ownerType so callers can construct
+ * the correct REST API path without a separate round-trip.
+ */
+export async function fetchProjectViews(
+  client: GitHubClient,
+  owner: string,
+  projectNumber: number,
+): Promise<FetchProjectViewsResult> {
+  // Try user first
+  try {
+    const result = await client.projectQuery<ViewsQueryResult>(
+      VIEWS_QUERY_USER,
+      { login: owner, number: projectNumber },
+    );
+    const nodes = result.user?.projectV2?.views?.nodes;
+    if (nodes) return { views: nodes, ownerType: "users" };
+  } catch {
+    // fall through to org
+  }
+
+  // Try org
+  const result = await client.projectQuery<ViewsQueryResult>(
+    VIEWS_QUERY_ORG,
+    { login: owner, number: projectNumber },
+  );
+  const nodes = result.organization?.projectV2?.views?.nodes;
+  if (!nodes) {
+    throw new Error(
+      `Project #${projectNumber} not found for owner "${owner}"`,
+    );
+  }
+  return { views: nodes, ownerType: "orgs" };
 }
 
 async function createSingleSelectField(

--- a/plugin/ralph-hero/mcp-server/src/tools/view-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/view-tools.ts
@@ -1,0 +1,140 @@
+/**
+ * MCP tools for GitHub Projects V2 view management.
+ *
+ * Copies views from a source project (read via GraphQL) to a target
+ * project using the REST API POST endpoint.
+ */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toolError, toolSuccess } from "../types.js";
+import type { GitHubClient } from "../github-client.js";
+import type { FieldOptionCache } from "../lib/cache.js";
+import type { ProjectV2ViewLayout } from "../types.js";
+import { fetchProjectViews } from "./project-tools.js";
+
+/**
+ * Convert GraphQL layout enum to REST API layout value.
+ * All three variants are handled exhaustively — TypeScript will error
+ * at build time if a new layout variant is added and not handled here.
+ */
+export function toRestLayout(
+  layout: ProjectV2ViewLayout,
+): "table" | "board" | "roadmap" {
+  switch (layout) {
+    case "TABLE_LAYOUT":
+      return "table";
+    case "BOARD_LAYOUT":
+      return "board";
+    case "ROADMAP_LAYOUT":
+      return "roadmap";
+  }
+}
+
+export function registerViewTools(
+  server: McpServer,
+  client: GitHubClient,
+  _fieldCache: FieldOptionCache,
+): void {
+  server.tool(
+    "ralph_hero__create_views",
+    "Copy views from a source GitHub Project V2 to a target project using the REST API. Reads view names, layouts, and filter strings from the source project via GraphQL, then creates matching views in the target. Note: sort/group configuration is not available via API and must be set manually after creation.",
+    {
+      owner: z
+        .string()
+        .optional()
+        .describe(
+          "GitHub owner (user or org). Defaults to RALPH_GH_OWNER env var",
+        ),
+      sourceProjectNumber: z.coerce
+        .number()
+        .describe("Project number to copy views FROM"),
+      targetProjectNumber: z.coerce
+        .number()
+        .describe("Project number to copy views INTO"),
+    },
+    async (args) => {
+      const owner =
+        args.owner ?? client.config.projectOwner ?? client.config.owner;
+      if (!owner) {
+        return toolError(
+          "owner is required — set RALPH_GH_OWNER or pass owner param",
+        );
+      }
+
+      // Read views from source project; ownerType drives REST path selection
+      let sourceViews;
+      let ownerType: "users" | "orgs";
+      try {
+        const result = await fetchProjectViews(
+          client,
+          owner,
+          args.sourceProjectNumber,
+        );
+        sourceViews = result.views;
+        ownerType = result.ownerType;
+      } catch (err) {
+        return toolError(
+          `Failed to read views from project #${args.sourceProjectNumber}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      if (sourceViews.length === 0) {
+        return toolSuccess({
+          created: [],
+          failed: [],
+          count: 0,
+          sourceProject: args.sourceProjectNumber,
+          targetProject: args.targetProjectNumber,
+          message: "Source project has no views",
+        });
+      }
+
+      // REST path uses owner login (not numeric ID).
+      // filter is a plain top-level string matching the GraphQL field value.
+      const basePath =
+        ownerType === "users"
+          ? `/users/${owner}/projectsV2/${args.targetProjectNumber}/views`
+          : `/orgs/${owner}/projectsV2/${args.targetProjectNumber}/views`;
+
+      const created: Array<{ name: string; layout: string; id: string }> = [];
+      const failed: Array<{ name: string; error: string }> = [];
+
+      for (const view of sourceViews) {
+        const body: Record<string, unknown> = {
+          name: view.name,
+          layout: toRestLayout(view.layout),
+        };
+        if (view.filter) {
+          body.filter = view.filter;
+        }
+
+        try {
+          const createdView = await client.restPost<{
+            id: string;
+            name: string;
+            layout: string;
+          }>(basePath, body);
+          created.push({
+            name: createdView.name,
+            layout: createdView.layout,
+            id: createdView.id,
+          });
+        } catch (err) {
+          failed.push({
+            name: view.name,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      return toolSuccess({
+        created,
+        failed,
+        count: created.length,
+        sourceProject: args.sourceProjectNumber,
+        targetProject: args.targetProjectNumber,
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Implements #615: Adds `ralph_hero__create_views` MCP tool that copies views from a source GitHub Project V2 to a target project using the REST API.

- Closes #615

## Changes
- **`github-client.ts`**: Add `restPost<T>()` method to `GitHubClient` interface and implementation using native `fetch` with dual-token support
- **`project-tools.ts`**: Add `fetchProjectViews()` helper — reads views via GraphQL with user→org fallback, returns `{ views, ownerType }` to avoid extra API round-trip
- **`view-tools.ts`** (new): `ralph_hero__create_views` tool — reads source views, POSTs each to target via REST with name, layout, and filter
- **`index.ts`**: Wire `registerViewTools` into server initialization
- **`view-tools.test.ts`** (new): Source inspection tests + pure-function `toRestLayout` tests (8 tests)

## Test Plan
- [x] `npm run build` — TypeScript compiles without errors
- [x] `npm test` — all 965 tests pass (40 test files), zero regressions
- [x] New `view-tools.test.ts` — 8 tests pass (source structure + layout conversion)
- [ ] Manual: `ralph_hero__create_views({ sourceProjectNumber: 3, targetProjectNumber: 7 })` creates views in project #7

---
Generated with Claude Code (Ralph GitHub Plugin)