### PR TITLE
fix(agents): add missing tools to worker agent definitions

### DIFF
--- a/plugin/ralph-hero/agents/ralph-analyst.md
+++ b/plugin/ralph-hero/agents/ralph-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: ralph-analyst
 description: Analyst worker - composes triage, split, research, and plan skills for issue assessment, investigation, and planning
-tools: Read, Write, Glob, Grep, Skill, Bash, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue, ralph_hero__create_issue, ralph_hero__create_comment, ralph_hero__add_sub_issue, ralph_hero__add_dependency, ralph_hero__remove_dependency, ralph_hero__list_sub_issues
+tools: Read, Write, Edit, Glob, Grep, Skill, Bash, Agent, WebSearch, WebFetch, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue, ralph_hero__create_issue, ralph_hero__create_comment, ralph_hero__add_sub_issue, ralph_hero__add_dependency, ralph_hero__remove_dependency, ralph_hero__list_sub_issues, ralph_hero__decompose_feature, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
 model: sonnet
 color: green
 hooks:

--- a/plugin/ralph-hero/agents/ralph-builder.md
+++ b/plugin/ralph-hero/agents/ralph-builder.md
@@ -1,7 +1,7 @@
 ---
 name: ralph-builder
 description: Builder worker - reviews plans and implements code for the full build lifecycle
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, TaskList, TaskGet, TaskUpdate, SendMessage
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill, Agent, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue, ralph_hero__create_comment, ralph_hero__list_sub_issues
 model: sonnet
 color: yellow
 hooks:

--- a/plugin/ralph-hero/agents/ralph-integrator.md
+++ b/plugin/ralph-hero/agents/ralph-integrator.md
@@ -1,7 +1,7 @@
 ---
 name: ralph-integrator
 description: Integration specialist - validates implementation against plan requirements, handles PR creation, merge, worktree cleanup, and git operations
-tools: Read, Glob, Bash, Skill, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue, ralph_hero__create_comment, ralph_hero__advance_issue, ralph_hero__list_sub_issues
+tools: Read, Glob, Grep, Bash, Skill, TaskList, TaskGet, TaskUpdate, SendMessage, ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue, ralph_hero__create_comment, ralph_hero__advance_issue, ralph_hero__list_sub_issues, ralph_hero__list_dependencies
 model: haiku
 color: green
 hooks:

--- a/plugin/ralph-hero/skills/hero/SKILL.md
+++ b/plugin/ralph-hero/skills/hero/SKILL.md
@@ -25,8 +25,8 @@ allowed-tools:
   - ralph_hero__detect_stream_positions
   - ralph_hero__pick_actionable_issue
   - ralph_hero__pipeline_dashboard
-  - knowledge_search
-  - knowledge_traverse
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
   - AskUserQuestion
 ---
 

--- a/plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md
@@ -43,7 +43,7 @@ allowed-tools:
   - ralph_hero__add_sub_issue
   - ralph_hero__list_sub_issues
   - ralph_hero__decompose_feature
-  - knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
 ---
 
 # ralph-plan-epic — Strategic Planning for Multi-Tier Work


### PR DESCRIPTION
## Summary

- **ralph-analyst**: Added `Agent`, `Edit`, `WebSearch`, `WebFetch`, `ralph_hero__decompose_feature`, and `knowledge_search` (full MCP path) — required by ralph-research, ralph-triage, ralph-split, ralph-plan, and ralph-plan-epic skills to spawn sub-agents and call MCP tools
- **ralph-builder**: Added `Agent` and 5 `ralph_hero__` MCP tools — required by ralph-review and ralph-impl skills to interact with GitHub issues
- **ralph-integrator**: Added `Grep` and `ralph_hero__list_dependencies` — required by ralph-val and ralph-merge skills
- **hero/SKILL.md** and **ralph-plan-epic/SKILL.md**: Fixed `knowledge_search`/`knowledge_traverse` short names to full MCP paths (`mcp__plugin_ralph-knowledge_ralph-knowledge__*`)

## Test plan

- [ ] Run `/ralph-hero:hero` on an issue in "Research Needed" — verify analyst sub-agent can spawn codebase-locator/analyzer sub-agents during research
- [ ] Verify builder sub-agent can call `ralph_hero__get_issue` during ralph-impl
- [ ] Verify integrator sub-agent can use `Grep` during ralph-val validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)