### PR TITLE
feat(review): add "Open in editor" option to plan review picker

### DIFF
--- a/plugin/ralph-hero/skills/ralph-review/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-review/SKILL.md
@@ -147,7 +147,8 @@ AskUserQuestion(
       {"label": "Approve", "description": "Plan is complete and ready for implementation"},
       {"label": "Minor Changes", "description": "Small adjustments needed, can fix and proceed"},
       {"label": "Major Changes", "description": "Significant rework needed, return to planning"},
-      {"label": "Reject", "description": "Plan is fundamentally flawed, needs complete redo"}
+      {"label": "Reject", "description": "Plan is fundamentally flawed, needs complete redo"},
+      {"label": "Open in editor", "description": "Opens plan file in system default editor — picker re-appears after"}
     ],
     "multiSelect": false
   }]
@@ -155,6 +156,18 @@ AskUserQuestion(
 ```
 
 **Route based on response**:
+
+**If "Open in editor"**:
+```bash
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  open "<plan-local-path>"
+else
+  xdg-open "<plan-local-path>"
+fi
+```
+where `<plan-local-path>` is the local file path discovered in Step 3.
+
+Then re-present this same picker (loop until a verdict is selected).
 
 **If "Approve"**:
 -> Proceed to Step 5 (approve flow)


### PR DESCRIPTION
## Summary

Implements #642: Add "Open in editor" option to plan review picker

- Closes #642

## Changes

- Adds a 5th option "Open in editor" to the `AskUserQuestion` picker in `ralph-review/SKILL.md` Step 4A
- Adds a routing branch that detects OS (`uname -s`) and calls `open` (macOS) or `xdg-open` (Linux) on the plan file path discovered in Step 3
- After opening, the skill re-presents the identical 5-option picker, looping until the user selects a verdict
- All four existing verdict options (Approve, Minor Changes, Major Changes, Reject) and their routing are unchanged

## Test Plan

- [ ] Run `/ralph-hero:ralph-review [any issue in Plan in Review] --interactive` and confirm 5 options appear in the picker
- [ ] Select "Open in editor" and confirm the plan file opens without advancing the review state
- [ ] Confirm the picker re-appears after the file opens
- [ ] Select "Approve" from the re-presented picker and confirm issue moves to "In Progress"

---
Generated with Claude Code (Ralph GitHub Plugin)