### PR TITLE
fix: ralph-knowledge CJS/ESM crash, schema migration, stub creation

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/db.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/db.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { KnowledgeDB } from "../db.js";
 
 let db: KnowledgeDB;
@@ -352,5 +356,69 @@ describe("deleteDocument", () => {
     expect(db.getDocument("doc-a")).toBeUndefined();
     expect(db.getTags("doc-a")).toEqual([]);
     expect(db.getRelationshipsFrom("doc-a")).toEqual([]);
+  });
+});
+
+describe("Schema migration: is_stub column", () => {
+  it("adds is_stub column to a database created without it", () => {
+    const dir = mkdtempSync(join(tmpdir(), "knowledge-migration-"));
+    const dbPath = join(dir, "legacy.db");
+
+    // Create a DB with the old schema (no is_stub column)
+    const rawDb = new Database(dbPath);
+    rawDb.exec(`
+      CREATE TABLE documents (
+        id TEXT PRIMARY KEY,
+        path TEXT,
+        title TEXT,
+        date TEXT,
+        type TEXT,
+        status TEXT,
+        github_issue INTEGER,
+        content TEXT
+      );
+    `);
+    rawDb.close();
+
+    // Opening via KnowledgeDB should migrate the schema
+    const migrated = new KnowledgeDB(dbPath);
+    expect(() => migrated.upsertStubDocument("stub-1")).not.toThrow();
+    const doc = migrated.getDocument("stub-1");
+    expect(doc).toBeTruthy();
+    expect(doc!.isStub).toBe(1);
+    migrated.close();
+  });
+
+  it("is idempotent on a database that already has is_stub", () => {
+    const dir = mkdtempSync(join(tmpdir(), "knowledge-migration-"));
+    const dbPath = join(dir, "current.db");
+
+    // First open creates the full schema including is_stub
+    const db1 = new KnowledgeDB(dbPath);
+    db1.upsertStubDocument("stub-1");
+    db1.close();
+
+    // Second open should not error (migration is a no-op)
+    const db2 = new KnowledgeDB(dbPath);
+    const doc = db2.getDocument("stub-1");
+    expect(doc).toBeTruthy();
+    expect(doc!.isStub).toBe(1);
+    db2.close();
+  });
+});
+
+describe("documentExists", () => {
+  it("returns true for an existing document", () => {
+    db.upsertDocument({ id: "doc-1", path: "p", title: "t", date: null, type: null, status: null, githubIssue: null, content: "" });
+    expect(db.documentExists("doc-1")).toBe(true);
+  });
+
+  it("returns false for a non-existent document", () => {
+    expect(db.documentExists("nonexistent")).toBe(false);
+  });
+
+  it("returns true for stub documents", () => {
+    db.upsertStubDocument("stub-1");
+    expect(db.documentExists("stub-1")).toBe(true);
   });
 });

--- a/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
@@ -158,4 +158,46 @@ describe("incremental reindex", () => {
     // All files should be re-embedded since sync table was cleared
     expect(mockedEmbed).toHaveBeenCalledTimes(2);
   });
+
+  it("scenario 6: stub created for unresolved wikilink target, not for real documents", async () => {
+    // File A references file B via wikilink; both exist on disk
+    writeFileSync(join(dir, "doc-a.md"), `---\ndate: 2026-03-24\ntype: research\nstatus: draft\n---\n\n# Doc A\n\nSee also builds_on:: [[doc-b]]\n`);
+    writeFileSync(join(dir, "doc-b.md"), makeDoc("Doc B"));
+
+    await reindex([dir], dbPath);
+
+    const db = new KnowledgeDB(dbPath);
+    // doc-b is a real document — should NOT be a stub
+    const docB = db.getDocument("doc-b");
+    expect(docB).toBeTruthy();
+    expect(docB!.isStub).toBe(0);
+    db.close();
+  });
+
+  it("scenario 7: stub survives incremental reindex when referencing file is skipped", async () => {
+    // File A references non-existent target "phantom"
+    writeFileSync(join(dir, "doc-a.md"), `---\ndate: 2026-03-24\ntype: research\nstatus: draft\n---\n\n# Doc A\n\nSee builds_on:: [[phantom]]\n`);
+
+    await reindex([dir], dbPath);
+
+    // Verify stub was created
+    const db1 = new KnowledgeDB(dbPath);
+    expect(db1.documentExists("phantom")).toBe(true);
+    const phantomDoc = db1.getDocument("phantom");
+    expect(phantomDoc!.isStub).toBe(1);
+    db1.close();
+
+    mockedEmbed.mockClear();
+
+    // Add a new file (doc-a is unchanged and will be skipped)
+    writeFileSync(join(dir, "doc-c.md"), makeDoc("Doc C"));
+    await reindex([dir], dbPath);
+
+    // phantom stub should still exist even though doc-a was skipped
+    const db2 = new KnowledgeDB(dbPath);
+    expect(db2.documentExists("phantom")).toBe(true);
+    const phantomDoc2 = db2.getDocument("phantom");
+    expect(phantomDoc2!.isStub).toBe(1);
+    db2.close();
+  });
 });

--- a/plugin/ralph-knowledge/src/db.ts
+++ b/plugin/ralph-knowledge/src/db.ts
@@ -156,6 +156,15 @@ export class KnowledgeDB {
         indexed_at INTEGER NOT NULL
       );
     `);
+
+    // Migration: add is_stub column for databases created before it existed.
+    // SQLite has no IF NOT EXISTS for ALTER TABLE ADD COLUMN, so we catch the
+    // "duplicate column" error and ignore it.
+    try {
+      this.db.exec("ALTER TABLE documents ADD COLUMN is_stub INTEGER DEFAULT 0");
+    } catch {
+      // Column already exists — expected for new databases
+    }
   }
 
   upsertDocument(doc: Omit<DocumentRow, "isStub"> & { isStub?: number }): void {
@@ -386,6 +395,11 @@ export class KnowledgeDB {
 
   getAllSyncPaths(): string[] {
     return (this.db.prepare("SELECT path FROM sync").all() as Array<{ path: string }>).map(r => r.path);
+  }
+
+  documentExists(id: string): boolean {
+    const row = this.db.prepare("SELECT 1 FROM documents WHERE id = ?").get(id);
+    return row !== undefined;
   }
 
   deleteDocument(id: string): void {

--- a/plugin/ralph-knowledge/src/graph-builder.ts
+++ b/plugin/ralph-knowledge/src/graph-builder.ts
@@ -1,5 +1,8 @@
-import { MultiDirectedGraph } from "graphology";
+import graphology from "graphology";
+import type { MultiDirectedGraph as MultiDirectedGraphType } from "graphology";
 import type { KnowledgeDB } from "./db.js";
+
+const { MultiDirectedGraph } = graphology;
 
 export interface NodeAttributes {
   title: string;
@@ -12,7 +15,7 @@ export interface EdgeAttributes {
   type: string;
 }
 
-export type KnowledgeGraph = MultiDirectedGraph<NodeAttributes, EdgeAttributes>;
+export type KnowledgeGraph = MultiDirectedGraphType<NodeAttributes, EdgeAttributes>;
 
 export class GraphBuilder {
   private readonly db: KnowledgeDB;

--- a/plugin/ralph-knowledge/src/reindex.ts
+++ b/plugin/ralph-knowledge/src/reindex.ts
@@ -95,11 +95,17 @@ export async function reindex(dirs: string[], dbPath: string, generate: boolean 
     // Delete old relationships before re-inserting so context updates propagate
     db.db.prepare("DELETE FROM relationships WHERE source_id = ?").run(parsed.id);
 
+    // Ensure relationship targets exist before insertion (better-sqlite3 enables
+    // PRAGMA foreign_keys by default, so inserting a relationship to a non-existent
+    // document throws). upsertStubDocument uses INSERT OR IGNORE, so it's a no-op
+    // when the target is already a real document.
     for (const rel of parsed.relationships) {
+      db.upsertStubDocument(rel.targetId);
       db.addRelationship(rel.sourceId, rel.targetId, rel.type);
     }
 
     for (const edge of parsed.untypedEdges) {
+      db.upsertStubDocument(edge.targetId);
       db.addRelationship(edge.sourceId, edge.targetId, "untyped", edge.context);
     }
 
@@ -122,24 +128,16 @@ export async function reindex(dirs: string[], dbPath: string, generate: boolean 
   // Phase 3: Rebuild FTS index from scratch (required — FTS5 content tables don't support partial sync)
   fts.rebuildIndex();
 
-  // Collect all known document IDs from the indexing pass
-  const knownIds = new Set(parsedDocs.map(p => p.id));
+  // Collect all relationship targets from the database (covers both current batch and prior runs)
+  const allTargetIds = new Set<string>(
+    (db.db.prepare("SELECT DISTINCT target_id FROM relationships").all() as Array<{ target_id: string }>)
+      .map(r => r.target_id)
+  );
 
-  // Collect all target IDs referenced by both typed and untyped edges
-  const allTargetIds = new Set<string>();
-  for (const parsed of parsedDocs) {
-    for (const rel of parsed.relationships) {
-      allTargetIds.add(rel.targetId);
-    }
-    for (const edge of parsed.untypedEdges) {
-      allTargetIds.add(edge.targetId);
-    }
-  }
-
-  // Create stub documents for unresolved wikilink targets
+  // Create stub documents for targets that don't exist as real documents
   let stubCount = 0;
   for (const targetId of allTargetIds) {
-    if (!knownIds.has(targetId)) {
+    if (!db.documentExists(targetId)) {
       db.upsertStubDocument(targetId);
       stubCount++;
     }

--- a/thoughts/shared/plans/2026-03-25-GH-0682-ralph-knowledge-three-bug-fix.md
+++ b/thoughts/shared/plans/2026-03-25-GH-0682-ralph-knowledge-three-bug-fix.md
@@ -1,0 +1,236 @@
+---
+date: 2026-03-25
+status: complete
+type: plan
+tags: [ralph-knowledge, bug-fix, esm-cjs, schema-migration, reindex]
+github_issue: 682
+github_issues: [682]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/682
+primary_issue: 682
+---
+
+# ralph-knowledge Three Bug Fix Plan
+
+## Prior Work
+
+- builds_on:: [[2026-03-24-knowledge-graph-plugin-comparison]]
+
+## Overview
+
+Fix three ralph-knowledge bugs discovered during research:
+1. **P0 — CJS/ESM interop crash** blocking all remote MCP server startup
+2. **P1 — Missing schema migration** for `is_stub` column on existing databases
+3. **P2 — Incomplete stub creation** during incremental reindex
+
+## Current State Analysis
+
+### Bug 1: CJS/ESM crash (P0)
+`graph-builder.ts:1` uses `import { MultiDirectedGraph } from "graphology"`. The `graphology` package is CJS-only and exposes only `default` to Node's ESM loader. Since `index.ts` → `graph-tools.ts` → `graph-builder.ts` forms the import chain, the entire MCP server crashes at module load time. This was introduced in `f1bbe25` (v0.1.15).
+
+Vitest masks this because it has its own CJS/ESM interop layer. The bug only manifests when running compiled `dist/` output under Node's native ESM loader (i.e., every remote user via `npx`).
+
+### Bug 2: Schema migration gap (P1)
+`db.ts:102-114` uses `CREATE TABLE IF NOT EXISTS documents(... is_stub INTEGER DEFAULT 0)`. For users with a DB created before `is_stub` was added, this is a no-op — the table exists, so the column is never added. Any code referencing `is_stub` then fails:
+- `upsertStubDocument()` at `db.ts:175-179`
+- `upsertDocument()` at `db.ts:162-168`
+- `getDocument()` at `db.ts:182-185`
+- `graph-builder.ts:29` (`WHERE is_stub = 0 OR is_stub IS NULL`)
+
+### Bug 3: Stub creation timing (P2)
+`reindex.ts:126` builds `knownIds` from only the current batch (`parsedDocs`), which excludes files skipped at line 57-59 (unchanged since last index). The stub-creation loop at lines 139-146 therefore:
+- Misses targets referenced by skipped files' edges (those stubs were presumably created in a prior run, but if the DB was rebuilt without them, they'd be lost)
+- More importantly, `knownIds` doesn't include documents already in the DB from prior runs, so the stub check at line 142 (`!knownIds.has(targetId)`) over-creates stubs for targets that are real documents from previous indexing
+
+The `INSERT OR IGNORE` at `db.ts:177` prevents overwriting real documents, so this is a correctness/efficiency issue rather than data corruption.
+
+## Desired End State
+
+1. MCP server starts successfully for remote users via `npx ralph-hero-knowledge-index@*`
+2. Existing databases transparently gain the `is_stub` column on next server start
+3. Stub creation during incremental reindex correctly identifies which targets need stubs by checking the database, not just the current batch
+
+### Verification:
+- `node dist/index.js` loads without error (no CJS/ESM crash)
+- Opening a pre-`is_stub` database works without "no column named is_stub" errors
+- Incremental reindex with skipped files creates stubs only for truly missing targets
+
+## What We're NOT Doing
+
+- Enabling `PRAGMA foreign_keys = ON` — the FK declarations are documentation-only today and enabling them would require reordering the entire indexing pipeline
+- Changing the reindex architecture (e.g., two-pass relationship insertion)
+- Adding a formal migration framework — a single `ALTER TABLE` suffices for now
+
+## Implementation Approach
+
+All three fixes are small, independent, and testable. They can ship in a single release.
+
+## Phase 1: Fix CJS/ESM Interop Crash
+
+### Overview
+Change `graph-builder.ts` to use a default import for `graphology`, matching the pattern already used in `graph-tools.ts` for other CJS graphology packages.
+
+### Changes Required:
+
+#### 1. `plugin/ralph-knowledge/src/graph-builder.ts`
+**Lines**: 1, 15, 25
+**Changes**: Switch from named import to default import with destructuring.
+
+Replace line 1:
+```typescript
+import { MultiDirectedGraph } from "graphology";
+```
+
+With:
+```typescript
+import graphology from "graphology";
+const { MultiDirectedGraph } = graphology;
+```
+
+Line 15 (`export type KnowledgeGraph = ...`) and line 25 (`new MultiDirectedGraph<...>()`) remain unchanged — they reference the destructured class.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x]`npm run build` succeeds (TypeScript compiles)
+- [x]`npm test` passes
+- [x]`node -e "import('./dist/graph-builder.js').then(() => console.log('OK')).catch(e => console.error('FAIL:', e.message))"` prints `OK`
+- [x]`node -e "import('./dist/index.js').then(() => console.log('OK')).catch(e => console.error('FAIL:', e.message))"` prints `OK` (full server module loads)
+
+---
+
+## Phase 2: Add Schema Migration for `is_stub` Column
+
+### Overview
+Add an `ALTER TABLE` migration after `CREATE TABLE IF NOT EXISTS` so existing databases transparently gain the `is_stub` column.
+
+### Changes Required:
+
+#### 1. `plugin/ralph-knowledge/src/db.ts`
+**Method**: `createSchema()` (line 102)
+**Changes**: After the existing `CREATE TABLE IF NOT EXISTS` block (after the closing `);` at line 158), add a migration that attempts to add the column and silently ignores the error if it already exists.
+
+Add after line 158 (after the closing of `this.db.exec(...)`):
+```typescript
+    // Migration: add is_stub column for databases created before it existed.
+    // SQLite has no IF NOT EXISTS for ALTER TABLE ADD COLUMN, so we catch the
+    // "duplicate column" error and ignore it.
+    try {
+      this.db.exec("ALTER TABLE documents ADD COLUMN is_stub INTEGER DEFAULT 0");
+    } catch {
+      // Column already exists — expected for new databases
+    }
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x]`npm run build` succeeds
+- [x]`npm test` passes
+- [x]New test: create a DB with the old schema (no `is_stub`), construct `KnowledgeDB`, verify `is_stub` column exists and `upsertStubDocument()` works
+- [x]New test: create a DB with the current schema (has `is_stub`), construct `KnowledgeDB`, verify no error (idempotent)
+
+---
+
+## Phase 3: Fix Stub Creation for Incremental Reindex
+
+### Overview
+Replace the in-memory `knownIds` check with a database query so stub creation correctly accounts for all documents, not just the current batch.
+
+### Changes Required:
+
+#### 1. `plugin/ralph-knowledge/src/db.ts`
+**Changes**: Add a method to check document existence.
+
+```typescript
+  documentExists(id: string): boolean {
+    const row = this.db.prepare("SELECT 1 FROM documents WHERE id = ?").get(id);
+    return row !== undefined;
+  }
+```
+
+#### 2. `plugin/ralph-knowledge/src/reindex.ts`
+**Lines**: 125-147
+**Changes**: Replace the `knownIds` set with `db.documentExists()` checks. Also collect targets from ALL documents in the DB (not just `parsedDocs`) to cover skipped files.
+
+Replace lines 125-147:
+```typescript
+  // Collect all known document IDs from the indexing pass
+  const knownIds = new Set(parsedDocs.map(p => p.id));
+
+  // Collect all target IDs referenced by both typed and untyped edges
+  const allTargetIds = new Set<string>();
+  for (const parsed of parsedDocs) {
+    for (const rel of parsed.relationships) {
+      allTargetIds.add(rel.targetId);
+    }
+    for (const edge of parsed.untypedEdges) {
+      allTargetIds.add(edge.targetId);
+    }
+  }
+
+  // Create stub documents for unresolved wikilink targets
+  let stubCount = 0;
+  for (const targetId of allTargetIds) {
+    if (!knownIds.has(targetId)) {
+      db.upsertStubDocument(targetId);
+      stubCount++;
+    }
+  }
+  console.log(`  Created ${stubCount} stub documents for unresolved links`);
+```
+
+With:
+```typescript
+  // Collect all relationship targets from the database (covers both current batch and prior runs)
+  const allTargetIds = new Set<string>(
+    (db.db.prepare("SELECT DISTINCT target_id FROM relationships").all() as Array<{ target_id: string }>)
+      .map(r => r.target_id)
+  );
+
+  // Create stub documents for targets that don't exist as real documents
+  let stubCount = 0;
+  for (const targetId of allTargetIds) {
+    if (!db.documentExists(targetId)) {
+      db.upsertStubDocument(targetId);
+      stubCount++;
+    }
+  }
+  console.log(`  Created ${stubCount} stub documents for unresolved links`);
+```
+
+This is correct because:
+- It queries the `relationships` table for ALL targets, not just the current batch
+- `documentExists()` checks the actual database, which includes documents from prior runs
+- `upsertStubDocument` uses `INSERT OR IGNORE`, so it won't overwrite real documents even in race conditions
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x]`npm run build` succeeds
+- [x]`npm test` passes
+- [x]New test: index file A (references B), then incrementally index file C (A skipped) — verify B still has a stub
+- [x]New test: index files A and B (A references B) — verify no stub created for B since it's a real document
+
+---
+
+## Testing Strategy
+
+### Unit Tests (`db.test.ts`):
+- Schema migration: old DB gains `is_stub` column
+- Schema migration: idempotent on new DB
+- `documentExists()` returns true/false correctly
+
+### Integration Tests (`reindex.test.ts`):
+- Incremental reindex creates stubs only for truly missing targets
+- Full reindex with mixed real/stub documents
+
+### Manual Verification:
+- `node dist/index.js` starts without error in a clean npm install
+- Existing `~/.ralph-hero/knowledge.db` works after upgrade without manual rebuild
+
+## References
+
+- CJS/ESM interop pattern: `graph-tools.ts:4` (louvain default import)
+- `graphology` ESM exports: only `default` (verified via `node -e "import('graphology').then(m => console.log(Object.keys(m)))"`)
+- Introduced in: `f1bbe25` feat: ralph-knowledge graph intelligence enhancements (#675)


### PR DESCRIPTION
## Summary

Fixes three ralph-knowledge bugs discovered via downstream user report:

- **P0 — CJS/ESM interop crash**: `graph-builder.ts` used named import from CJS `graphology` package, crashing MCP server at startup for all remote users (introduced in v0.1.15)
- **P1 — Schema migration gap**: `CREATE TABLE IF NOT EXISTS` didn't add `is_stub` column to existing databases, breaking stub queries on upgrade
- **P2 — FK constraint + stub creation**: `better-sqlite3` enables `PRAGMA foreign_keys` by default — inserting relationships before target documents exist threw FK errors. Also fixed incremental reindex stub creation to query the DB instead of in-memory batch

Closes #682

## Changes
- `graph-builder.ts`: Default import + type-only import for graphology CJS/ESM interop
- `db.ts`: `ALTER TABLE` migration for `is_stub` column, new `documentExists()` method
- `reindex.ts`: Create stub documents before relationship insertion; query DB for comprehensive post-loop stub pass
- 7 new tests covering all three fixes

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 216 tests pass (12 test files)
- [x] `node dist/index.js` loads without CJS/ESM error
- [x] Legacy DB without `is_stub` migrated transparently
- [x] Reindex with wikilinks works without FK errors
- [x] Stub documents created for missing targets, not for real docs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)