### PR TITLE
GH-756: Plan skill auto mode — fully automate GitHub Integration step

### DIFF
--- a/plugin/ralph-hero/skills/finish/SKILL.md
+++ b/plugin/ralph-hero/skills/finish/SKILL.md
@@ -119,6 +119,26 @@ Check the skill output:
 
 - If output contains `MERGE BLOCKED` or `MERGE NOT READY`: report the status and stop.
 - If output contains `MERGED`: continue to Step 5.
+- If output contains `CODE_REVIEW_FEEDBACK`: automated code review flagged issues. Proceed to Step 4a.
+
+## Step 4a: Code Review Fix Cycle
+
+Dispatch impl-agent in Address Mode to fix the flagged issues. The issue is already "In Review" with an open PR that has review comments — impl-agent will auto-detect Address Mode.
+
+```
+Agent(subagent_type="ralph-hero:impl-agent", prompt="Address PR review feedback for GH-NNN. The automated code review flagged issues on PR #PR_NUMBER. Fix the MUST_FIX and SHOULD_FIX items, push, and reply to comments.")
+```
+
+After impl-agent completes, re-run ralph-merge:
+
+```
+Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")
+```
+
+Check the output again:
+
+- If `MERGED`: continue to Step 5.
+- If `MERGE BLOCKED`, `MERGE NOT READY`, or `CODE_REVIEW_FEEDBACK` again: stop. Max 1 fix cycle — report the status and let the human intervene.
 
 ## Step 5: CI Watch
 

--- a/plugin/ralph-hero/skills/finish/SKILL.md
+++ b/plugin/ralph-hero/skills/finish/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Validate, merge, and watch CI for a completed implementation. Chains ralph-val → ralph-merge → CI watch into one command. Code review is handled by ralph-merge's built-in gate.
+description: Validate, merge, and watch CI for a completed implementation. Chains ralph-val → ralph-merge → CI watch into one command. Code review is handled by ralph-merge's built-in gate; when RALPH_REVIEW_MODE=auto and code review flags issues, dispatches impl-agent to fix them.
 user-invocable: true
 argument-hint: <issue-number> [--pr-url url] [--plan-doc path]
 context: fork
@@ -40,7 +40,7 @@ Use these resolved values when constructing GitHub URLs or referencing the repos
 
 # Ralph Finish
 
-Validate, merge, and watch CI for a completed implementation. Code review is handled by ralph-merge's built-in gate — finish does not invoke code-review directly.
+Validate, merge, and watch CI for a completed implementation. Code review is handled by ralph-merge's built-in gate — when `RALPH_REVIEW_MODE=auto`, finish also orchestrates a code-review → impl-fix → re-merge cycle if the automated review flags issues (max 1 fix cycle).
 
 ## Step 1: Parse Arguments
 

--- a/plugin/ralph-hero/skills/hero/SKILL.md
+++ b/plugin/ralph-hero/skills/hero/SKILL.md
@@ -510,7 +510,7 @@ Ralph Hero is **resumable** across context windows:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RALPH_REVIEW_PLAN` | `auto` | Plan review: `auto` (review-agent), `interactive` (human approval) |
-| `RALPH_REVIEW_MODE` | `interactive` | Merge review: `interactive` (stop at PR), `auto` (trust control plane) |
+| `RALPH_REVIEW_MODE` | `interactive` | Merge review: `interactive` (stop at PR, prompt for code review), `auto` (auto-run code review, fix flagged issues via impl-agent, merge) |
 | `RALPH_COMMAND` | `hero` | Command identifier for hooks |
 | `RALPH_GH_OWNER` | required | GitHub repository owner |
 | `RALPH_GH_REPO` | required | GitHub repository name |

--- a/plugin/ralph-hero/skills/plan/SKILL.md
+++ b/plugin/ralph-hero/skills/plan/SKILL.md
@@ -375,7 +375,40 @@ primary_issue: NNN              # optional until linked to an issue
 
 ### Step 5: Review
 
-If plan review is "auto", skip human review — proceed directly to Step 6 (GitHub Integration) with the plan as-is. Report the plan location but do not ask for feedback.
+If plan review is "auto", skip human review and proceed to autonomous GitHub integration:
+
+1. **Search for matching open issues**: Use `list_issues` to search by keywords from the plan title. Look for issues in Backlog, Research Needed, or Ready for Plan states that match the plan's scope.
+
+2. **If a matching issue exists**: Link the plan to it:
+   - Rename the plan file to include `GH-NNNN` if not already present
+   - Update plan frontmatter with `github_issue`, `github_issues`, `github_urls`, `primary_issue`
+   - Post an Artifact Comment on the issue (per the Artifact Comment Protocol):
+     ```markdown
+     ## Implementation Plan
+
+     https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/thoughts/shared/plans/[filename].md
+
+     Summary: [1-3 line summary of the plan]
+     ```
+
+3. **If no matching issue exists**: Create a new issue:
+   - Create a GitHub issue with the plan summary as the body
+   - Set estimate based on plan complexity (XS/S/M)
+   - Rename the plan file to include the new issue number
+   - Post the Artifact Comment (same as above)
+   - Update plan frontmatter with the new issue reference
+
+4. **Auto-advance**: Update the issue workflow state to "Plan in Review" so the review-agent can pick it up.
+
+5. **Report result**:
+   ```
+   Plan linked to GitHub issue: #NNN
+   URL: https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/issues/NNN
+   State: Plan in Review
+   Ready for review. Use /ralph-hero:ralph-review #NNN or /ralph-hero:impl #NNN after approval.
+   ```
+
+   Then STOP — do not proceed to Step 6 (which is interactive-only).
 
 Otherwise (plan review is "interactive", the default), present the draft for human review:
 
@@ -399,7 +432,9 @@ Otherwise (plan review is "interactive", the default), present the draft for hum
 
 3. **Continue refining** until the user is satisfied
 
-### Step 6: GitHub Integration (Optional)
+### Step 6: GitHub Integration (Interactive Mode Only)
+
+> This step only applies when plan review is "interactive". When "auto", GitHub integration is handled autonomously in Step 5.
 
 After the plan is finalized and the user is satisfied:
 

--- a/plugin/ralph-hero/skills/ralph-merge/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-merge/SKILL.md
@@ -33,6 +33,7 @@ allowed-tools:
 - Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
 - Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
 - Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+- Review mode: !`echo ${RALPH_REVIEW_MODE:-interactive}`
 
 Use these resolved values when constructing GitHub URLs or referencing the repository.
 
@@ -103,7 +104,31 @@ And stop.
 
 1. Check if the `code-review:code-review` skill is available by looking for it in the available skills list (it is an official Anthropic plugin).
 
-2. **If the skill is available**, present a choice:
+2. **If the skill is available AND review mode is "auto":**
+
+   Run code review automatically — do NOT prompt the user:
+
+   ```
+   Skill("code-review:code-review", "PR_NUMBER")
+   ```
+
+   After the review completes, re-check `reviewDecision` via `gh pr view`.
+
+   - If the PR was approved: continue to Step 5.
+   - If changes were requested: output the review findings with a distinct status so the caller (finish) can dispatch a fix cycle:
+
+   ```
+   CODE_REVIEW_FEEDBACK
+   Issue: #NNN
+   PR: #PR_NUMBER
+   Reason: Automated code review flagged issues — impl-agent fix cycle available.
+   ```
+
+   And stop. Do NOT output `MERGE BLOCKED` for automated review feedback — the `CODE_REVIEW_FEEDBACK` status signals that finish should attempt a fix cycle.
+
+3. **If the skill is available AND review mode is "interactive" (default):**
+
+   Present a choice:
 
    !cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
 
@@ -125,7 +150,7 @@ And stop.
    - If user selects **"Merge without review"**: proceed to Step 5.
    - If user selects **"Other"**: stop.
 
-3. **If the skill is NOT available**, inform the user:
+4. **If the skill is NOT available**, inform the user:
 
    ```
    This PR has no code review. Consider installing the code-review plugin:


### PR DESCRIPTION
## Summary

- **Phase 1**: ralph-merge auto code review gate — reads `RALPH_REVIEW_MODE`, auto-runs `code-review:code-review` when `auto`, introduces `CODE_REVIEW_FEEDBACK` output status
- **Phase 2**: finish code review fix cycle — Step 4a dispatches impl-agent in Address Mode when `CODE_REVIEW_FEEDBACK` received, re-runs ralph-merge (max 1 fix cycle)
- **Phase 3**: plan skill auto mode GitHub integration — Step 5 auto path autonomously searches for matching issues, links or creates, auto-advances to Plan in Review without prompting
- **Phase 4**: documentation updates — hero env var table and finish skill description/preamble updated

Closes #756