### PR TITLE
GH-758: finish skill hangs at Initializing due to context: fork

### DIFF
--- a/.playwright/cli.config.json
+++ b/.playwright/cli.config.json
@@ -1,0 +1,8 @@
+{
+  "browser": {
+    "browserName": "chromium",
+    "launchOptions": {
+      "channel": "chromium"
+    }
+  }
+}

--- a/.ralphrc
+++ b/.ralphrc
@@ -1,0 +1,10 @@
+{
+  "github": {
+    "owner": "cdubiel08",
+    "repo": "ralph-hero",
+    "token": "$GITHUB_TOKEN"
+  },
+  "anthropic": {
+    "apiKey": "$ANTHROPIC_API_KEY"
+  }
+}

--- a/plugin/ralph-hero/hooks/scripts/prune-merged-worktrees.sh
+++ b/plugin/ralph-hero/hooks/scripts/prune-merged-worktrees.sh
@@ -20,7 +20,7 @@ if [[ ! -d "$WORKTREE_DIR" ]]; then
 fi
 
 # Fetch latest main to ensure merge checks are accurate
-git fetch origin main --quiet 2>/dev/null || exit 0
+timeout 10 git fetch origin main --quiet 2>/dev/null || exit 0
 
 pruned=0
 for wt_path in "$WORKTREE_DIR"/*/; do

--- a/plugin/ralph-hero/scripts/obs-ctl.mjs
+++ b/plugin/ralph-hero/scripts/obs-ctl.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// obs-ctl.mjs — OBS WebSocket v5 controller for record-demo skill
+// Usage: node obs-ctl.mjs <status|start|stop> [--port 4455]
+
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+
+const require = createRequire(import.meta.url);
+const globalModules = '/Users/dubiel/.local/share/mise/installs/node/22.22.1/lib/node_modules';
+
+const { default: OBSWebSocket } = await import(
+  pathToFileURL(`${globalModules}/obs-websocket-js/dist/json.js`).href
+);
+
+const command = process.argv[2];
+const portIdx = process.argv.indexOf('--port');
+const port = portIdx !== -1 ? process.argv[portIdx + 1] : '4455';
+
+if (!['status', 'start', 'stop'].includes(command)) {
+  console.error('Usage: obs-ctl.mjs <status|start|stop> [--port PORT]');
+  process.exit(1);
+}
+
+const obs = new OBSWebSocket();
+
+try {
+  await obs.connect(`ws://localhost:${port}`);
+
+  if (command === 'status') {
+    const status = await obs.call('GetRecordStatus');
+    console.log(JSON.stringify(status, null, 2));
+  } else if (command === 'start') {
+    await obs.call('StartRecord');
+    console.log('Recording started.');
+  } else if (command === 'stop') {
+    const result = await obs.call('StopRecord');
+    console.log('Recording stopped.');
+    if (result?.outputPath) console.log('Saved to:', result.outputPath);
+  }
+
+  await obs.disconnect();
+} catch (err) {
+  console.error('Error:', err.message);
+  process.exit(1);
+}

--- a/plugin/ralph-hero/skills/finish/SKILL.md
+++ b/plugin/ralph-hero/skills/finish/SKILL.md
@@ -2,8 +2,7 @@
 description: Validate, merge, and watch CI for a completed implementation. Chains ralph-val → ralph-merge → CI watch into one command. Code review is handled by ralph-merge's built-in gate; when RALPH_REVIEW_MODE=auto and code review flags issues, dispatches impl-agent to fix them.
 user-invocable: true
 argument-hint: <issue-number> [--pr-url url] [--plan-doc path]
-context: fork
-model: sonnet
+context: inline
 hooks:
   SessionStart:
     - hooks:

--- a/plugin/ralph-hero/skills/shared/fragments/skill-vs-agent-dispatch.md
+++ b/plugin/ralph-hero/skills/shared/fragments/skill-vs-agent-dispatch.md
@@ -23,6 +23,7 @@ Each autonomous skill has a dedicated agent for team mode dispatch:
 | `ralph-hero:pr-agent` | ralph-pr | haiku |
 | `ralph-hero:merge-agent` | ralph-merge | haiku |
 | `ralph-hero:val-agent` | ralph-val | haiku |
+| `ralph-hero:finish-agent` | finish | sonnet |
 
 ### Single-Session: Skill() Dispatch
 

--- a/plugin/ralph-knowledge/test_script.js
+++ b/plugin/ralph-knowledge/test_script.js
@@ -1,0 +1,50 @@
+const Database = require("better-sqlite3");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+// Create a fresh test DB
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "fts-bug-"));
+const dbPath = path.join(testDir, "test.db");
+
+// Create a fresh database
+const db = new Database(dbPath);
+db.pragma("journal_mode = WAL");
+
+// Create basic schema like KnowledgeDB does
+db.exec(`
+  CREATE TABLE IF NOT EXISTS documents (
+    id TEXT PRIMARY KEY,
+    path TEXT,
+    title TEXT,
+    date TEXT,
+    type TEXT,
+    status TEXT,
+    github_issue INTEGER,
+    content TEXT,
+    is_stub INTEGER DEFAULT 0
+  );
+`);
+
+// Insert a test document
+db.prepare(`
+  INSERT INTO documents (id, path, title, date, type, status, content)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+`).run("test-doc", "test.md", "Test Doc", "2026-04-03", "idea", "active", "searchable content");
+
+// Now try to query the FTS table that doesn't exist
+try {
+  const results = db.prepare(`
+    SELECT d.id FROM documents_fts
+    JOIN documents d ON d.rowid = documents_fts.rowid
+    WHERE documents_fts MATCH ?
+  `).all("test");
+  console.log("SUCCESS: Got results:", results);
+} catch (err) {
+  console.log("ERROR (bug confirmed):");
+  console.log("  Message:", err.message);
+  console.log("  Code:", err.code);
+}
+
+db.close();
+fs.rmSync(testDir, { recursive: true });

--- a/thoughts/ideas/strip-minions-transcript.txt
+++ b/thoughts/ideas/strip-minions-transcript.txt
@@ -1,0 +1,795 @@
+strip-minions-transcript.txt
+0:00
+Are you vibe coding or are you a gentic engineering? The difference is massive.
+0:05
+Keep that question in mind as you look at one of the best engineering teams on the planet to determine if they're vibe
+0:12
+coding or agentic engineering. Stripe engineers are shipping 1,300 pull
+0:18
+requests every single week. Get this. There is zero human written code and
+0:24
+they're doing it right. Imagine what will happen to their insane numbers of 1.9 trillion in total volume up 34%
+0:33
+which is the equivalent to 1.6 of global GDP. Stripe's doing 1 billion this year
+0:39
+and they power all of the best companies that you and I use and you yourself might be running on Stripe as well. What
+0:46
+happens when Stripe multiplies all this with agents? And not just agents, what happens when they multiply it with their
+0:52
+custom end-to-end solution they're calling minions, fully unattended coding
+0:58
+agents that start from a Slack message and end in a production ready PR. This
+1:03
+is Stripe's oneshot endto-end coding agent. To me, the minions aren't even
+1:08
+the interesting part here. The interesting stat here to me is that their agents operate a code base with
+1:15
+millions of lines of code operating a uncommon stack with a number of
+1:20
+homegrown libraries that are unique to Stripe and therefore unknown to LLMs. On
+1:27
+top of that, the stakes that Stripe operates in are extremely high. The code
+1:32
+they write moves over 1 trillion per year of payment volume. They have a
+1:37
+number of real world dependencies, regulatory and compliance obligations that their code must honor. Now, here's
+1:43
+a simple important question for you. Do you think Stripe can afford to vibe code? I personally have written millions
+1:51
+of lines of code with agents and without agents. I've been building with agents
+1:56
+since it was first possible way, way back in the day when we were using GPT 3.5 Turbo. Many engineers don't even
+2:03
+know that model exists or once existed. So allow me to clarify these terms a little bit. Aentic engineering is
+2:10
+knowing what will happen in your system so well you don't need to look. Vibe
+2:16
+coding is not knowing and not looking. It's very clear stripe engineers are
+2:21
+agentic engineering. And in this video we'll break down stripes aentic layer so
+2:26
+you can take the best pieces and add it to your agentic systems. Vibe coding is
+2:32
+the lowest hanging fruit. When you agentic engineer systems just like Stripe has, from the prompt to your
+2:38
+skills to your custom agents to your agent harness all the way up through your tech stack, you capitalize on the
+2:44
+greatest opportunity for engineers to ever exist. Agents,
+2:53
+let's look at their agendic system at a high level so that we can analyze the key pieces of their system. If these
+2:59
+components interest you, definitely stick around. We're going to be breaking down Stripe's key components. And as we
+3:04
+do this, you'll see what you have and what you're missing. All right. So, the first thing is the API layer. They have a way to communicate to their agents. As
+3:11
+you'll see, they have many ways to do this. Then they have a warm devbox pool. What is this? This is an agent sandbox,
+3:18
+a space to place their agent. Fantastic. They then have the agent harness. Stripe built their agent harness. They forked
+3:24
+it from a tool we'll cover in a second here. And then they have this blueprint engine, the marriage of the old world
+3:30
+and the new world, code and agents. This is super super important. This single piece has given Stripe a massive edge.
+3:37
+You'll see why in a second. All right. Then we have the rules file. How did they manage the context problem? Agents
+3:43
+cannot read their 100 million line of code codebase. So how do they solve that problem? We'll then talk about the meta
+3:49
+layer of their tool shed. You can imagine they have hundreds of tools and tens of services that they want their agents to operate with. How do they
+3:56
+solve that problem? They built a tool shed. All right. Then of course they have a way to validate all their agents work. This is a critical validation
+4:02
+layer that they can use to give their agents feedback and to validate that they're not breaking existing working
+4:09
+features that's helping them generate and maintain that movement of that $1 trillion. All right, so we're talking
+4:15
+about real stakes that the Stripe engineers are facing. All right, this is not a green field rapid prototype application. All right, these are
+4:21
+serious stakes with real world consequences. And then of course you need a place to review your agents work. They're using GitHub PRs. Everyone's
+4:27
+using GitHub PRS. This is the standard. Nothing new here. All right. But these are the critical pieces. We're going to walk through these piece by piece and
+4:34
+understand how they put these together to build their Agentic layer. Let's go ahead and start with their minions. So
+4:39
+what is Stripe's take on agentic coding? Let's find out. Aentic coding has gone from new and exciting to table stakes.
+4:46
+Unattended coding agents have gone from possibility to reality. You know, Stripe engineers know what they're talking
+4:52
+about because this is true. If you are not agentic coding, the gap between you and the agent coding team within a week,
+5:00
+within a month is going to be astronomical. Okay? It's going to be exponential. This is the last moment to
+5:05
+hop on the train. Stripe minions are Stripe's homegrown coding agents. They're fully unattended, built to
+5:11
+oneshot tasks. Thousands of pull requests merge each week. So one week goes by, Stripe engineers merge a
+5:18
+thousand pull requests. Let's just really understand that scale. All right. And as I mentioned, they contain no
+5:24
+human written code. They realize you have to stop coding to get the real scale, to get the real power out of
+5:30
+these agents. You work on the agents, not the application. Right? This is a weird mindset shift that you need to
+5:36
+make if you're going to be building with agents. Now, interesting to note here, our developers can still plan and
+5:41
+collaborate with traditional agent decoding tools, Claude and Cursor. But in a world where one of our most
+5:48
+constrained resources is developer attention, the agents allow for parallelization of tasks. This is super
+5:54
+super super critical. All right, they realize that the most important resource and really any software company's most
+6:00
+important resource is your developers time. It's your developer attention. And when you maximize the leverage your
+6:06
+developers get, you can do crazy things like this. They see their engineers spinning up multiple minions in parallel and able to solve multiple problems at
+6:13
+the same time in different conditions. All right, so this is fantastic. So the first thing we need to figure out is why
+6:18
+they built the minions in the first place. Why did they build it themselves? What's the point of this? Isn't cloud
+6:24
+code good enough? Vibe coding a prototype from scratch is fundamentally different from contributing to Stripe's
+6:30
+codebase. Okay, interesting. Say more. Stress codebase encompasses hundreds of millions of code across a few large
+6:35
+repositories. Okay. Written in Ruby, uncommon stack, homegrown libraries, LLMs don't have it baked in, right? It's
+6:42
+not in the models training data. Stakes are high. Stripe moves over 1 trillion
+6:48
+per year in payment volume. As mentioned, they have real world dependencies and compliance obligations.
+6:53
+LLM agents are really great at building from scratch when there are no constraints on the system. However,
+6:59
+iterating on any codebase of scale, complexity, and maturity is inherently much harder. Very, very true. Engineers
+7:06
+build sophisticated models to make changes inside their large repo. This is huge. And we talk about this on the
+7:13
+channel all the time. Specialization is how you win. When you're building a great product, it is literally a
+7:20
+specialized solution to a specialized problem. So, why would you stop at your
+7:25
+tooling? Your tooling and your code must also be specialized. So, this is why
+7:30
+they built their own custom agent. It's because they're solving specific problems in specific ways better than
+7:36
+anyone. And again, this is a theme we talk about on the channel all the time. Specialization is your advantage. And in
+7:43
+last week's video, we talked about the PI coding agent because there are many coding agents, but this one is mine. We
+7:50
+emphasized this very idea. You can customize your prompt. You can customize your skills. You can customize your
+7:56
+custom agents and you can specialize your agent harness. The more you're specializing, the more you're building
+8:02
+specific solutions to specific problems, the bigger your edge is. And the more you distance yourself from the out-
+8:08
+of-the-box experiences that a lot of agentic coding tools are driving everyone toward, the better off you're
+8:13
+going to be. So, Stripe built minions to solve their specific problem and to operate their large code base better
+8:20
+than anyone. Makes sense, right? Big shout out to everyone who shared that video. That one went absolutely viral and for a good reason. Engineers are
+8:27
+realizing that we don't want to be super locked in to a single tool like cloud code or cursor or codeex or whatever.
+8:33
+Every tool is going to have a problem, but the tool that won't have a problem is the one you customize to solve your specific problems better than anyone.
+8:40
+There are many coding agents, but this one is mine. I love this slogan. Let's see how Stripe customized their minions.
+8:47
+So, what is it like to use a minion? Right away, we jump into another critical idea. There are several entry
+8:53
+points for minions. They're designed to integrate as ergonomically as possible where Stripe engineers are. All right,
+9:00
+so they use a CLI, a web interface, and they have Slack. Already they have three
+9:05
+points of contact for kicking off their API, I assume, right? They they have a separate application which kicks off
+9:12
+their agents, right? Their pool of agents, but they have multiple ways to interface with that primary service.
+9:18
+Very important. And so we can see here, you know, here's a clear example of an engineer in Stripe using that at symbol at devbox and then they write their
+9:25
+prompt to the agent, right? Makes sense. Nothing new there. Okay. And so we can see here they have a custom UI that they
+9:30
+built, right? They have an interface to allow them to interface with their custom agent. So you know on the left
+9:36
+you can see kind of a typical view. We have that log of tools and the thought process that their agents go through.
+9:42
+And then on the right we can see that they have all the modified files. So they can see very very quickly what's going on with that agent. And then of
+9:48
+course in the top right here they have their actions. All right, so create pull request. And I'm sure they have some prompt interface here as well. So nice
+9:55
+and simple, very concise. You can see that they're just surfacing the most important information. And this hints at another key aspect of your agents and
+10:02
+your agentic system. You need to be able to observe what's going on. Once a task has been completed, a minion will create
+10:08
+a branch, pushes it to CI, and prepares a pull request following Stripe's PR template. And then they're going to
+10:14
+request another review from a Stripe engineer. And they can also iterate. So this is a classic end of process setup.
+10:21
+When you're a genta coding, you show up at the beginning and the end during planning and during review and ideally
+10:27
+not once in the middle. All right? And that is what creates an outloop agent coding system. You just write the prompt
+10:33
+and you just do the review. There's inloop agent coding and then there's outloop agent coding. All right? We'll
+10:38
+circle back to that idea in a second. So how do their minions actually work? A minion starts in an isolated developer
+10:45
+environment or a dev box. Fascinating. So, this is a concept we've talked about on the channel. They're giving their
+10:50
+agents their own environment to operate in, right? Which is the same type of machine that Stripes engineers write on.
+10:57
+This is a simple yet powerful idea. If you want your agent to do what you can, you must give it the tools and the
+11:03
+environment that you have. So, Stripe realizes this. They reuse their developer setup for their agents. They
+11:09
+give them everything that the engineer has. Super super powerful idea here. Dead boxes are pre-warmed, so one can be
+11:15
+spun up in 10 seconds. Love that. Uh, not very fast, but for the machine that they're booting up, which I think
+11:21
+they'll mention in a moment, that is very fast. They're booting up full-on AWS EC2 instances. All right, with
+11:26
+Stripe's code and services preloaded, they're isolated. This is a safe space to place their agent. And they do this
+11:33
+so that they can run minions on dev boxes without human permission checks. Of course, this also gives you
+11:38
+parallelization without the overhead of something like Git Work trees, which just falls apart at certain scales. All
+11:44
+right, after some time, the Git Work trees just fall apart. You're going to need your own dedicated device. I have a
+11:50
+Mac Mini here as a local personal kind of private device. But recently, I also
+11:55
+just said, "Screw it. I'm going to need more scale." And I started spinning up entire dev boxes for my agents on, you
+12:01
+know, use your favorite cloud hosting tool, GCP, AWS, and some of the other ephemeral agent sandbox tools like E2B,
+12:08
+modal, so on so forth. But this is a really big idea, right? Um, the more autonomy you give your agents and the more you set up their environment to be
+12:14
+yours, the more they can act and perform as you would. The core agent loop runs on a fork of blocks coding agent, goose.
+12:22
+One of the first widely used coding agents, which they forked early on. So shout out Goose. They took this and they
+12:28
+customized the orchestration flow in an opinionated way to interle agent loops
+12:33
+and deterministic code. Huge huge huge idea here and they're going to expand on this even more in a moment here with one
+12:40
+of the big ideas they talk about later which is their blueprint engine. Okay, so this is a huge huge huge idea. Let me
+12:47
+just emphasize this. You want to be interle agent loop with deterministic code and what type of operations right
+12:52
+we're talking get liners and most importantly testing. Okay, this lets your agents, your system operate with
+12:58
+feedback. And this gives you the best of both worlds. You get the deterministic world and the non-deterministic
+13:05
+reasoning creativity world. And they explicitly say that here they run a mix of creativity of the agent with
+13:10
+asurances that they'll always complete stripe specific steps like llinters. So
+13:16
+here we have stripe agentic engineering determinism with agents. All right. So a couple additional things to note here.
+13:22
+connected to MCP. They use cursor and clawed code and some conditions. They operate agent rule files. We'll talk
+13:28
+about that more in a second. This solves the large context problem for Stripe. All agent rules are conditionally
+13:34
+applied based on subdirectories. Super important. They have MCP as I mentioned. They have this tool shed idea which is
+13:41
+basically a meta tool to help them select one or more of their 400 MCP tools. Okay. A really big piece of why
+13:49
+this blog post is so incredible, you know, shout out to the Stripe engineers, shout out to Alistar Gray, is the fact
+13:54
+that they're operating at such a massive scale, at such success, and they're still gaining massive value from their
+14:00
+agents and from their agentic layer that they're building. All right, managers are built with a goal of oneshotting, but if they don't, the key is to give
+14:06
+them feedback. Key key idea. Two more ideas here. We seek to shift feedback left when thinking about developer
+14:12
+productivity. The best thing for humans and agents is basically you want the issues to happen earlier rather than
+14:18
+later, right? On the engineers's device, on the agents device as early in the process as possible. All right? And then
+14:24
+if local testing doesn't catch anything, they have a whole suite of tests over 3 million tests that run upon push. Key
+14:31
+idea here, they figured out a way to selectively run tests on push. All right? And they're choosing from many of
+14:38
+3 million tests. Okay? And this is going to, as you can imagine, offer feedback to their agentic system. Now, here's
+14:44
+something that I would critique Stripe on a little bit here. Due to the cost constraints, they only let their minion
+14:50
+run at most two rounds of CI. All right, so you can imagine at this scale that they have to just limit this for it to
+14:56
+be costefficient. This is where I would push back a little bit. We'll talk about that later, but this is a interesting thing here, right? So, they basically
+15:02
+limited the rounds of feedback for their minion to just two. This is part one of their blog. Let's look at part two and
+15:08
+dig into some of the details of some of these key nodes, right? Specifically, their agent sandbox and their powerful
+15:14
+blueprint engine because their blueprint engine sits at the center of how they operate their strike minions at scale.
+15:25
+So, here's part two, dev boxes hot and ready. So for maximum effectiveness, their minion agents requires a cloud
+15:32
+developer environment that's paralyzable, predictable, and isolated. So this is very clearly an agent
+15:38
+sandbox. Okay, it gives them a place to operate at scale with full autonomy. And if something goes wrong, if they destroy
+15:45
+something, the agent can't cause as much damage as they could if they were operating your device or god forbid a
+15:51
+device connected to the production system. And I completely agree. Containerization, get work trees,
+15:56
+they're great, but they have hard limits and it's hard to really really scale without giving each agent their own
+16:03
+device, right? Again, if you want your agent to perform like you, give them the tools that you have. All right. What
+16:08
+else can we learn about Stripes Devbox here? So, very cool. Stripes Devbox is a
+16:14
+full-on computer, right? It's an EC2 instance and it contains their source
+16:19
+code and services under development. Very, very cool. Many engineers use one dev box per tasks and this means that
+16:26
+every engineer might have half a dozen running at a time. Check out how awesome this is, right? They're allowing their
+16:31
+engineers to scale their impact by allowing parallelization of their agents and every agent has their own sandbox.
+16:38
+Okay, so a question I would ask them is, do their minions have access to additional minion sub agents or not even
+16:45
+sub agents, other primary agents that are specialized across their code base? Very cool stuff here. This is again part
+16:51
+of their agentic system, right? It's giving and servicing scale very very quickly so that engineers can knock out
+16:58
+more problems than ever before. All right, we want it to feel effortless to spin up new dev boxes. Right, ready in
+17:04
+10 seconds. Hot and ready. So fantastic. The raw pieces of engineering should feel effortless. You want to be building
+17:10
+systems that allow you to move at the agentic speed, the speed of agents. Something kind of funny happened to me
+17:17
+the other day while I was reading this blog. Actually, I'll throw the image on the screen. I had to save it. The agentic speed is just insane. Your
+17:23
+agents can process information much, much faster than you can. I was reading through this blog, you know, took me
+17:28
+maybe, you know, 20 minutes to read through part one and part two, take notes on this. I also spun up a cloud
+17:34
+code agent to read the blog alongside me. It read the whole thing, of course, in what was it, 5 seconds. And so I just
+17:41
+had like a really funny interaction where uh you know I was shocked and then you know I said something and the agent
+17:48
+literally said nothing. It was the first time I've ever had my agent respond with nothing. It was just a really
+17:53
+interesting interaction point. And and this is the agentic speed, right? It's this multiplied by every single agent
+17:59
+you can spin up. Your agents can read, they can code, they can engineer at agentic speed. So you need to build the
+18:04
+system that allows you to tap into that. And you can see here Stripe is doing that with their powerful dev boxes that
+18:10
+spin up in just 10 seconds and it somehow sets up their entire gigantic repository. Millions of lines of code,
+18:17
+tens and thousands, probably hundreds of thousands of files. All right. And you know, props to Stripe. We built out dev
+18:22
+boxes for the needs of human engineers long before LLM coding agents. As it turns out, parallelism, predictability,
+18:29
+isolation were very, very good properties for engineers as well as agents. Fantastic. We're almost at the
+18:35
+blueprint, which is a really, really big idea. But let's talk about their agent a little bit more, right? So, they built this on their own. They forked Goose.
+18:42
+Let me be clear about that. They forked Goose and then they customized it to work within Stripe's LLM infrastructure.
+18:49
+Okay? So, you can imagine they have custom prompts, custom skills, custom agents, and then they customize the
+18:55
+agent harness. All right? And again, this was the big idea we talked about in last week's video. I'll leave that
+19:00
+linked in the description for you if you're interested. Customizing your Aentic harness gives you a massive edge.
+19:06
+You can do it your way. You can build it to fit the needs of your specific problem. Okay, once again, I want to
+19:12
+beat this idea over the head. Specialization is the advantage of every engineer. Now, you can build specialized
+19:19
+solutions, specialized developer tools to help you solve your problems at the agentic speed. Okay, the speed of
+19:26
+agents, not the speed of humans. And so they focus their use on the needs of minions rather than human supervised
+19:33
+tools. And this is another big idea we need to double click into. That's the use case well filled by third-party
+19:39
+tools such as cursor and claw code. Okay, which are made readily available for our engineers. So a couple things
+19:44
+here. They're not limiting, they're not forcing their engineers to use any specific tooling. That's a terrible idea in general. But what they are doing is
+19:51
+building two types of agent coding tools. Inloop and outloop. I've talked about this on the channel before. This
+19:58
+is a critical idea to get right if you want to do more with your agentic engineering. When you are in loop
+20:03
+agentic coding, your butts in the seat at your desk and you're prompting back and forth and back and forth and back
+20:09
+and forth. This is great for highly specialized work. This is great for when you're building the system that builds
+20:14
+the system, but this is bad for everything else. Okay? Uh as a general rule, I recommend to engineers now that
+20:20
+you spend more than 50% of your time building the system of agents that build
+20:25
+your application for you. That's inloop, right? And that's really the value prop of inloop. You get full control. You can
+20:30
+see everything. It's very manual, but it is very slow and expensive. You're using human engineered time. Then there's
+20:36
+outloop agent coding. And this is what Stripe's minions offer Stripe. Okay, they are building an Outloop system that
+20:42
+operates at scale in parallel in the dev box, right? In dedicated agent
+20:47
+sandboxes. This is a big big idea. Why is that? It's because now instead of having one engineer with one terminal or
+20:54
+one engineer with three terminals, you can have one engineer with six agent sandboxes operating and solving problems
+21:01
+at scale in parallel, right? And six is just the beginning of this. The whole idea here is that you should be handing
+21:06
+off more work over time to your Outloop system. If you're building a great agentic layer, if you're building a
+21:12
+great system that has agents operating your services for you, you should slowly
+21:17
+be handing off more work to them. Okay? And that saves you from the expensive time that you'll spend. And you know,
+21:24
+never forget your time is your most important resource. It is constantly running out. Okay? Let me just be super
+21:30
+clear about that. But your your agentic systems, you can clone, you can dupe, you can parallelize these as far as your
+21:37
+system allows you to. All right? And that's the lever that agentic engineering unlocks. If you build the
+21:43
+system that builds the system, you get massive, massive reasoning at scale. you
+21:48
+get access to intelligence that engineers your way and at some point better than your way. But uh that's key.
+21:54
+So I just wanted to to really dial into that. Minions give Stripe engineers access to outloop agentic coding. Very
+22:01
+very powerful. And so they talk about specialization a little bit more. And you know they're really hitting on this
+22:06
+this idea I just mentioned there. Offtheshelf local coding agents are usually optimized for workflows where
+22:12
+the engineer is sitting looking over his shoulder, right? And I just call this babysitting the agent. Minions are fully
+22:18
+unattended and so their agent harness can't use humanfacing features. Okay, they built the minion to be fully
+22:25
+autonomous, right? They're built so that humans cannot interject. That's not the point, right? The point is that they
+22:31
+operate on their own. Again, inloop agent coding, outloop agentic coding. Cloud code minions. Okay? And just to
+22:37
+emphasize it once again, you know, cloud code has the ability cursor has the cursor CLI. And of course, there are
+22:42
+great tools we've covered on the channel like pi.dev dev or you can programmatically inject these into your
+22:48
+Outloop systems, right? You can deploy an agent outside the loop and have them run on a cron job, have them run via an
+22:54
+API request, so on and so forth. All right, that is where all agent engineers must move to get massive leverage. You
+23:01
+can see stripes engineers using minions to do just that. All right, so uh they
+23:06
+talk about permissions. Uh let's focus on the big idea here right next to dev boxes. The next most important thing
+23:12
+here for sure is their blueprint engine. So let's talk about this thing. So what is this? So they talk about workflows
+23:17
+versus agents. They talk about loops. They talk about, you know, series of steps, which is like the workflow. This
+23:23
+is what a lot of prompts and skills actually are. They're just steps that you want to work through. Sometimes you
+23:28
+have an agent that's actually doing some intelligent reasoning, right? Loop with tools. But you can do much better than
+23:34
+that. You can push a lot further. And that's exactly what Stripe has done. Minions are orchestrated with a primitive we call blueprints. Blueprints
+23:41
+are workflows designed in code that direct a minion run. Okay. And then they go on to say blueprints combine the
+23:48
+determinism of workflows with agents flexibility in dealing with the unknown.
+23:54
+What is this? Every tactical agent coding member knows this as an ADW, an
+23:59
+AI developer workflow. This is the past and the future. This is code plus your agent. Okay, this is the highest
+24:06
+leverage point of agent coding is when you put these two together. You have step-by-step workflows that have
+24:11
+determinism and non-determinism put together. In essence, a blueprint is like a collection of Asian skills
+24:17
+interwoven with deterministic code so that particular subtasks can be handled most appropriately. Okay, there are some
+24:25
+things like a llinter for instance or like a git commit or a whole number of things, right? Running tests, creating
+24:31
+certain structures, creating certain templates, certain reusable pieces, certain hard deterministic code
+24:37
+pathways. There are certain pieces that an agent would perform worse in. Adding an agent to specific steps actually
+24:43
+makes the whole system worse, more brittle, and more expensive, frankly. So, for these steps, why would you throw
+24:49
+an agent at that problem? Right? The real advantage that Stripe has completely identified here with blueprints is the fact that agents plus
+24:56
+code beats agents alone and agents plus code beats code alone. That's the big idea here. So, Alistar goes on to break
+25:03
+this concept down here. You have the agent call here implement the task fix the CI failures whatever but you also
+25:10
+have the actual nodes run configuration lenders push changes which are fully deterministic okay they don't invoke an
+25:16
+LM at all they just run code so imagine you know some toptobottom process where you have agent running and then you have
+25:22
+code running and then you have agent running and then you have code running right so on and so forth this is what you want to build right it's this it's
+25:28
+the combination of both the agent and your code okay because not everything needs an agent and not Everything needs
+25:35
+code. Okay, very very powerful idea here. Another advantage of creating these blueprints of combining code plus
+25:41
+agents is that their blueprint machinery makes contact engineering with sub agents easy. Why is that? It's because
+25:46
+they're operating at a specific step. And so at that step, you might constrain the tools, you might constrain the system prompt, right? Or you might
+25:52
+modify the conversation required by the subtask at hand. Okay? And again, we're hitting on this idea of specialization.
+25:59
+There are specific steps in your engineering, in your product, in your tool that you've uniquely implemented.
+26:05
+Okay? And so when you can break that down into determinism or in a gentic process step by step, this allows you to
+26:12
+specialize, right? And so, you know, once again, what are we doing? We're back at foundational engineering. If
+26:17
+you're trying to tackle a big problem, chunk it up into small pieces. every big problem is just a you know a few small
+26:23
+problems put together and then chunk those problems into types and then give it to code or give it to agents. Okay,
+26:30
+that's what their blueprint system is effectively doing. To me, this is the highest leverage point. This is what
+26:35
+makes their agentic layer, their agentic system so powerful. It's the combination
+26:40
+of code and agents inside of a repeatable format for success. Okay?
+26:46
+Because guess what they can do? They can now deploy meta aentics. they can effectively create an agent that builds
+26:52
+their blueprint just in the right way and then they can validate it, right? They I wouldn't be surprised if they had
+26:58
+a blueprint for creating blueprints. All right. Anyway, let's move into context. So, they use the rule files setup that
+27:05
+you know is much like claude.md or agents.md due to the size of the
+27:10
+repository they can't have unconditional job rules. So, they need a specific solution to do this. They're using a standardized rule format much like
+27:17
+cursors. All right. So this is a rule format that looks like this. So you have your primary directory whatever tool
+27:22
+you're using you know tries to claim that name and then you have / rules and
+27:27
+then you have some markdown files right but the interesting part is that you have a markdown file with some front matter. All right, front matter is going
+27:34
+to be you know MDC files are like the most popular file format and for good reason right so they have these rules
+27:40
+here where you can specify the glob pattern in which to activate this context or you know a specific subset of
+27:47
+this context and then they have rule anatomy you can imply intelligently or you can apply only when specific files
+27:54
+are being accessed. All right. And so this gives you more control over the context that's loaded as you're
+28:00
+accessing different directories throughout your codebase. Okay. And so this is the structure that Stripe
+28:05
+Minions use, right? And the big line is right here. We almost exclusively give minions context from files that are
+28:12
+scoped to specific subdirectories or patterns automatically attached as the agent traverses the file system. And
+28:19
+they're using the, you know, kind of cursor rules to do that. And so they've combined it with a format from cloud
+28:24
+code. Once again here you can see that they're building customized agentic solutions that best solves the problems
+28:31
+they're facing. Okay and they're combining the best for the industry. I'm not saying that you know cursor agents or claw code agents or how they do
+28:37
+things is wrong. That's not the point. There are many ways to do things. The question is what's the best way for you
+28:42
+and how do you get the most leverage out of what's available? We can see stripe engineers doing exactly that. Last important idea to mention here is
+28:49
+Stripes gathering MCPs. Right. So what are and and how does Stripe put together
+28:55
+the tools? So as we all know tools are an essential element of the core for
+29:00
+context model prompt tools. Tools is what created agentic coding, right? It's the only reason that any of this is
+29:06
+possible because our agents can now use tools to take actions as we can. So how does Stripe handle their 500 MCP tools?
+29:14
+Won't this immediately cause a token explosion? Absolutely right. It totally would. What they've done here is they've
+29:20
+built a tool shed. They built a centralized internal MCP server called a tool shed which makes it easy for Stripe
+29:26
+engineers to make new tools and they're automatically discoverable in their agentic systems. Very very powerful
+29:32
+stuff here. Okay. All very agentic systems are able to use the tool shed. I want to be super clear about this. We're
+29:37
+talking about meta agentics. This is something that keeps coming up over and over. You build prompts that create
+29:42
+prompts. You make agents that build agents. You have skills that build skills. You have tools that allow you to select tools. Okay. The tool shed is a
+29:50
+tool that unlocks tools for their agents. Okay, so these are called
+29:55
+metaagentics and they're a powerful way to solve the class of problems, right?
+30:00
+To to solve repeat problems in the space of agents. And you know, to be clear, this is not new at all, right? OG
+30:06
+engineers watching, you've heard of like things like meta programming, right? Passing functions into functions. This
+30:12
+is not a new phenomenon, but what is new and what's really important for you and I to focus on when we're building out these powerful agentic layers is to
+30:18
+think about when we need to build the thing that builds the thing, right? So, Stripe uses a tool shed to create and
+30:26
+connect to over 500 or nearly 500 MCP tools. Okay? Very, very powerful. And
+30:32
+you can imagine they have all types of internal and external services that they want to connect to. And the tool shed lets them do that. This was completely
+30:39
+net new to me. I had not seen a concept like this before. I think this is really cool. A tool shed centralized location
+30:44
+to load specific tools. So, you know, big shout out to the team for uh for building something like this. And then
+30:51
+lastly, you know, one of the big ideas they talk about and that's just super critical for engineering. Like this is just great engineering. You just
+30:56
+iterate, right? All this stuff is so new. All this stuff is moving so quickly. You and I strip engineers. Doesn't really matter who you are. It's
+31:02
+not about what you can do anymore. It's about what you can teach your agents to do for you. Okay? This is a big idea.
+31:08
+It's one of the central thesis we talk about in tactical agentic coding in addition to building agentic layers like
+31:15
+handing off work and thinking about your agents as tools that you're templating into and templating your engineering
+31:21
+into. That's the name of the game, right? Teach your agents how to build like you would so you can scale them to
+31:27
+the moon. All right, so what else do we have here? A lot of really great ideas. I'm curious what you think if you've operated in code bases with more than
+31:34
+10,000 files. Comment down below what would you rank Stripe's agentic layer based on everything we've gone through
+31:40
+here and you know our highle understanding of their system right they have multiple CI entry points they have
+31:46
+EC2 agent sandboxes that mirror developer environments they have their own custom agent harness they have a
+31:52
+customizable blueprint engine that lets them combine code and agents together to outperform either they have rules file
+31:59
+for context engineering they have tool shed for selecting one of 500 tools or
+32:04
+many of 500 tools tools. They of course have CI for self validation and they have GitHub PRs to review the work their
+32:10
+agents have done on their dedicated agent sandboxes. All right, so rank this. I'm super curious what you think.
+32:16
+Rank Stripes agentic layer out of 10. I'm going to go ahead and give them and and you know again if you've worked on
+32:23
+code bases that are larger than 10,000 files, no offense, guys, but I don't want to hear a vibe coders opinion on Stripe's endto-end system. But for mid
+32:29
+to senior level plus engineers, I'd love to hear what you think. I'm going to give Stripe an eight out of 10. Okay, so
+32:35
+very very very powerful agent layer. And let me be super clear here. I have no ego in this. Let me say it this way. I
+32:41
+cannot solve Stripe's programmable financial infrastructure problems better than any one of their engineers on their
+32:46
+team could. They own that problem in this problem space. So that's not what I'm saying at all. They are the experts there for sure. My expertise is in
+32:53
+agentic engineering. It's in building agentic layers. And so I only have two notes of of feedback for them here that
+32:59
+I would pitch to them as potential improvements. The first thing is this. you know, they they identify this right away. Why only two rounds of feedback in
+33:06
+their CI for their agents? Okay. And so they say, you know, speed, completeness, cost, time, compute, blah blah blah.
+33:11
+These are fair constraints and reasons to only run two rounds. But I think this is a mistake, frankly. Think about
+33:17
+yourself as an engineer. Has anyone ever said to you, "Solve this problem. You have two attempts."
+33:22
+All right? You just have two shots at this. Uh, no. No one said that. Right? It often takes us tens and hundreds of
+33:28
+times to get something right. So, I think limiting their minions to just two shots is potentially going to cost them
+33:35
+more developer time and also increase the gap between the next learning of how
+33:41
+to improve their agentic system by letting their agents run more, right? Like, I think the learnings you get from
+33:46
+running five rounds of your agent is going to be a lot more informative than running just two. All right, but I could be totally wrong. Again, they know their
+33:52
+system better than we do. All right, but that's my first note. And my last note here is in the language of their
+33:59
+minions. So, you know, they call these end to-end agents, but you might have noticed they have a prompt step and they
+34:07
+have a review step. Okay, that's two steps. End to end is this, right? And
+34:13
+you take out the review, right? It's prompt to production, P2P. Okay? And this is something we've talked about
+34:19
+inside of Tactical Agentic Coding. This is the northstar for all agentic engineers. This is an idea, a concept
+34:26
+called ZTE, zero touch engineering, prompt to production. No review, no
+34:31
+human in the loop. I want to be a little critical about their language here. I know that this is industry standard and
+34:36
+of course, again, of course, they're operating on a scale most of us engineers will never get to, but that's
+34:43
+what I would push Stripe to think about next. What are the lowlevel simple tasks? maybe some lower risk tasks,
+34:49
+developer tools stuff, you know, some non-userfacing stuff and even some userfacing stuff that they could ship
+34:54
+actually end to end. And the value isn't in doing it. It's in answering the question, what would it take for you to
+35:01
+run a prompt and trust that your agentic system can deliver this to production
+35:06
+without human oversight, right? The value is in the journey of the question. So, that's that's another area where I
+35:12
+would just like really try to push the Stripe engineers to that next next level. Um, I made a prediction on this
+35:17
+at the end of last year in our 2026 top 2% engineering video. I think in 2026
+35:23
+we're going to see a blog post very similar to this where an engineer operating at serious scale, we're
+35:28
+talking tens of millions in revenue. I predict we're going to see a blog post where they break down their agentic layer and talk about how they ship from
+35:35
+prompt to production with ZTE zero touch engineering. So those are the only two notes I have. Again, you know, I'm not
+35:42
+trying to Stripe has some of the most cracked engineers on the planet. This is just a note on the agentic system and not a
+35:49
+note on any of their true core domain problem because again, if you operate a
+35:55
+specific domain for years and years, no one knows how to solve it better than you do. All right, so those are my two notes. Big shout out to the Strap
+36:01
+Engineering team and you know, Alistar Gray for writing this up. This is a great post. This really caught my eye
+36:07
+and I thought it would be valuable to share with you here because it really emphasizes that point that building a
+36:12
+powerful agentic layer really comes down to owning all the pieces bottom to top.
+36:18
+Now there is a point in which you want to start owning your agentic technology,
+36:23
+right? And again, if you're like creating a brand new net new product, you probably don't need to do that for a
+36:29
+while. You just don't have the scale for it out of the box. It's going to work for you for a while. But then there's
+36:34
+going to be a point where you're going to need a specific solution, right? A customized solution to solve a specific
+36:40
+problem. And you want to boil that all the way down just like your application is a is a, you know, a detailed edge
+36:47
+case covering solution. Your agent should reflect that too. That's why we covered the PI coding agent. There are
+36:54
+many, but this one is mine. And the whole idea here that I want to, you know, connect with you on is that
+36:59
+specialization goes all the way up the chain, all the way into the agent harness, all the way to your stack of
+37:05
+technology that you operate. So anyway, big shout out to Stripe Engineers. This was really fun. I like blogs like this.
+37:11
+You know, frankly, I'm getting a bit tired of everyone hyperfixating on models and prompts and skills. Like
+37:18
+let's let's uplevel this and talk about the systems that have agents inside of them that contain agents and that
+37:25
+contain code and that contain, you know, modern engineering technology that puts it all together to generate real value
+37:32
+for you, your team, your company, and ultimately your users and customers, right? Because that's where the value
+37:37
+really is. That's what makes all this stuff actually matter at all. All right? If you're still watching, first off, you
+37:42
+know, big thanks to you. I hope these ideas make sense. You really want to be thinking about the agentic layer as a
+37:48
+whole, not just your coding tool, not just the models. Let's let's ease up on the obsession on these, you know, models
+37:54
+and who's winning and what genera company is more just let's focus on solving problems by building agentic
+38:01
+layers with the key pieces. All right? And Stripe has outlined a lot of them, right? Like every agentic layer, every
+38:08
+product is going to run into the problems that each one of these nodes is a solution to. So let's pay attention to
+38:14
+them, right? Let's think about how these are pieces to the puzzle of building at scale with agents. All right? And this
+38:20
+is just one interpretation. Uh no one has all the answers right now. But it's about collecting the right context to
+38:26
+solving the problem of agentic engineering. Right? And and pushing what you can do further beyond before the
+38:33
+industry before the mainstream catches up. All right. Everything we do in engineering represents an asymmetry of
+38:39
+information and then technology and then results with your product, with your tool, with your team, so on and so
+38:45
+forth. All right? So, you want to be pushing forward on this stuff. Don't let up the gas. Stay focused on valuable
+38:51
+information like this blog and, you know, me being biased, but like this channel. I really try to focus in on
+38:57
+concrete signal in the industry, not hype, not slop. There's going to be a lot of both of those as we move week
+39:03
+after week. But I want this to be a place where you, the engineer, can come to focus and get some serious insight on
+39:09
+how you can continue to win in the age of agents. If you made it to the end and you like this content, definitely feel
+39:15
+free to check out tactical agentic coding. This is my take on how to scale far beyond AI coding and vibe coding
+39:21
+with advanced agentic engineering so powerful your codebase runs itself. As
+39:26
+you can imagine, a lot of the ideas detailed in this blog, detailed in the architecture of how Stripes built their
+39:33
+agentic coding tool has been detailed in here. All right, I'll I'll be honest, I'm not like gloating or anything. I've
+39:40
+been early to this. This is what happens when you're a first mover, when you bet big on an emerging technology.
+39:45
+Everything you're going to see over the next year, I have in tactical Agenta coding and Agenta Horizon, the second
+39:50
+part of this course detailed here. So, if you're interested, I'm going to leave a link to this. You can see all the
+39:56
+ideas are really in stone here and thousands of engineers, some of your favorite engineers mind you, are inside
+40:02
+of this course, have taken this course and have gotten massive value and are moving ahead of the curve. So, I'm going
+40:07
+to leave this in here, link in the description for you. Of course, I'm also going to link the minions post.
+40:13
+Definitely give this a look and I'll bet that if we search hiring. Yeah, so Stripe is hiring. If you're an agent
+40:18
+that's interested in this, you can tell them that Andy Deb Dan sent you if you want. And again, just big shout out to the Stripe team. This is really great
+40:24
+stuff. really great engineering in the age of agents. No matter what, stay focused and keep building.

--- a/thoughts/shared/ideas/2026-03-24-claude-code-hooks-mastery-analysis.md
+++ b/thoughts/shared/ideas/2026-03-24-claude-code-hooks-mastery-analysis.md
@@ -1,0 +1,200 @@
+# Idea Hunt: Claude Code Hooks Patterns
+Date: 2026-03-24
+Source: https://github.com/disler/claude-code-hooks-mastery
+
+## Executive Summary
+
+This repo is the most complete working example of Claude Code hooks in the wild. It demonstrates all 13 hook lifecycle events, a clear UV single-file script packaging pattern, and crucially — it contains the `CLAUDE_ENV_FILE` persistence mechanism via a `persist_env_variable()` helper in `setup.py`. There is no `env:` field in agent or skill frontmatter anywhere; env is handled entirely at the hook and shell level.
+
+## Top Finds
+
+### 1. `CLAUDE_ENV_FILE` — The Setup Hook Writes Persistent Env Vars
+
+**File**: `.claude/hooks/setup.py`
+
+```python
+def persist_env_variable(name, value):
+    """Persist an environment variable via CLAUDE_ENV_FILE."""
+    env_file = os.environ.get('CLAUDE_ENV_FILE')
+    if env_file:
+        with open(env_file, 'a') as f:
+            f.write(f'export {name}="{value}"\n')
+        return True
+    return False
+```
+
+Called during `trigger == 'init'` with:
+```python
+persist_env_variable('PROJECT_ROOT', cwd)
+```
+
+This is the canonical pattern for a Setup hook setting environment state that survives into later hook and agent invocations. `CLAUDE_ENV_FILE` is an official Claude Code mechanism — the hook appends `export KEY="VALUE"` lines to whatever file Claude Code tells it to use.
+
+**Why it matters**: This is exactly the mechanism we would use if we wanted a SessionStart or Setup hook to inject env vars (e.g. `RALPH_HERO_GITHUB_TOKEN`, `RALPH_GH_OWNER`) that downstream hooks and agents could read. No agent frontmatter field required — the OS environment is the channel.
+
+**Could we use this?**: Yes. A `setup.py`-style hook for ralph-hero could detect missing required env vars and emit a clear error via `additionalContext`, or write computed derived vars (e.g. a resolved `RALPH_GH_REPO` from project metadata) into `CLAUDE_ENV_FILE`.
+
+### 2. `hookSpecificOutput.additionalContext` — The SessionStart/Setup Return Contract
+
+Both `session_start.py` and `setup.py` return structured JSON to Claude Code:
+
+```python
+output = {
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",  # or "Setup"
+        "additionalContext": context      # string injected into system prompt
+    }
+}
+print(json.dumps(output))
+sys.exit(0)
+```
+
+The `additionalContext` value is a multi-line string that Claude Code injects as context. `session_start.py` loads `.claude/CONTEXT.md`, git branch, uncommitted changes count, and recent GitHub issues — all injected at session open without requiring any CLAUDE.md changes.
+
+**Why it matters**: This is a clean way to provide dynamic runtime context (today's date, active sprint, token availability) without baking it into static files. Ralph-hero's SessionStart hook could inject the current project board state summary.
+
+### 3. UV Single-File Script Architecture — The Distribution Pattern
+
+Every hook uses the same shebang + inline dependencies pattern:
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+```
+
+This means zero installation step. Hooks are dropped into `.claude/hooks/` and `uv` resolves dependencies on first run, caching them. `settings.json` references hooks via `$CLAUDE_PROJECT_DIR`:
+
+```json
+"command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/pre_tool_use.py"
+```
+
+**Why it matters**: This is the right model for hook distribution in a plugin. A ralph-hero plugin could ship hooks as UV scripts in `.claude/hooks/`, referenced from a settings snippet the user merges. No global install, no version conflicts, works offline after first cache.
+
+### 4. `python-dotenv` Load in Every Hook — The Env Bootstrapping Pattern
+
+Every hook that reads API keys starts with:
+
+```python
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+```
+
+The `.env.sample` defines all needed keys:
+```
+ANTHROPIC_API_KEY=
+ELEVENLABS_API_KEY=
+OPENAI_API_KEY=
+ENGINEER_NAME=Dan
+```
+
+Hooks read these via `os.getenv()` at runtime. TTS provider selection in `stop.py` and `subagent_start.py` implements graceful fallback:
+
+```python
+if os.getenv('ELEVENLABS_API_KEY'):     # try ElevenLabs
+elif os.getenv('OPENAI_API_KEY'):       # try OpenAI
+else:                                    # fall back to pyttsx3 (no key)
+```
+
+**Why it matters**: The dotenv pattern means hooks work identically whether invoked from Claude Code (which inherits `settings.local.json` env) or run directly from a shell (which loads `.env`). This dual-path compatibility is worth mimicking.
+
+### 5. Agent Frontmatter Fields — The Actual Schema
+
+Examining all agent files confirms the supported frontmatter fields. From `crypto-coin-analyzer-haiku.md`:
+
+```yaml
+---
+name: crypto-coin-analyzer-haiku
+description: Cryptocurrency analysis specialist...
+tools: WebSearch, Bash, Write
+model: haiku
+color: green
+---
+```
+
+From `hello-world-agent.md`:
+```yaml
+name: hello-world-agent
+description: Simple greeting agent...
+tools: WebSearch
+color: green
+```
+
+From `team/builder.md` (reconstructed from fetch): `model: opus`, `color: cyan`.
+
+**Critical finding: there is no `env:` field in any agent frontmatter in this repo.** The schema is: `name`, `description`, `tools`, `model` (optional), `color` (optional). Environment is not a frontmatter concern — it is a shell/hook concern. This aligns with how Claude Code actually works: agents inherit the parent process environment.
+
+### 6. Sub-Agent Tracking Pattern — SubagentStart/SubagentStop Hooks
+
+`subagent_start.py` reads `agent_id` and `agent_type` from the JSON payload piped to stdin, logs to `logs/subagent_start.json`, and optionally announces via TTS. The hook has no mechanism to inject env vars into the sub-agent — it is purely observational.
+
+`settings.json` passes `--notify` to `subagent_stop.py` but nothing else. There is no hook-based mechanism here to pass custom env to spawned agents.
+
+**The implication**: Sub-agents receive the same environment as the parent session, set at startup. If you want sub-agents to have specific vars, they must be in the parent's env before the session starts. The `CLAUDE_ENV_FILE` pattern from `setup.py` is the only hook-time mechanism to add to that env.
+
+### 7. `pre_tool_use.py` Blocks `.env` File Access — A Security Pattern Worth Noting
+
+```python
+def is_env_file_access(tool_name, tool_input):
+    if tool_name in ['Read', 'Edit', 'MultiEdit', 'Write', 'Bash']:
+        if tool_name in ['Read', 'Edit', 'MultiEdit', 'Write']:
+            file_path = tool_input.get('file_path', '')
+            if '.env' in file_path and not file_path.endswith('.env.sample'):
+                return True
+```
+
+Exits with code 2 (blocks the tool call) if any tool tries to read/write `.env`. This prevents an agent from accidentally leaking secrets.
+
+**Could we use this?**: Ralph-hero could add a similar guard in a PreToolUse hook: block any Bash command that echoes `$RALPH_HERO_GITHUB_TOKEN` or reads `settings.local.json`.
+
+## Emerging Patterns
+
+- **Hook-as-sidecar**: Every lifecycle event gets its own dedicated Python file. No monolithic hook. One file = one responsibility. The 13-file layout maps 1:1 to Claude Code's 13 events.
+
+- **`$CLAUDE_PROJECT_DIR` as the stable anchor**: All hook paths in `settings.json` use this env var rather than relative paths or hardcoded absolutes. This makes the hook config portable across machines.
+
+- **Flags over config files**: Hooks take CLI flags (`--notify`, `--log-only`, `--store-last-prompt`, `--name-agent`, `--chat`) rather than reading a separate config file. The `settings.json` command string is the configuration: `uv run hook.py --flag-a --flag-b`.
+
+- **Fail silent, never block**: Every hook wraps its entire body in `try/except Exception: sys.exit(0)`. The philosophy is that hooks must never break the main workflow — they are observational and additive.
+
+- **`additionalContext` over stdout injection**: Hooks that want to inject text into Claude's system context return the JSON structure with `hookSpecificOutput.additionalContext`. They do not write to a file that CLAUDE.md then references.
+
+- **Agent body delegates to a shared prompt file**: `crypto-coin-analyzer-haiku.md` body is just `Read and Execute: .claude/commands/agent_prompts/crypto_coin_analyzer_agent_prompt.md`. This means the prompt is shared across the haiku/sonnet/opus variants — only the frontmatter differs. Clean separation of model selection from prompt content.
+
+## Ideas Worth Exploring
+
+1. **Setup hook for ralph-hero environment validation** — a `setup.py`-style hook that checks for `RALPH_HERO_GITHUB_TOKEN`, `RALPH_GH_OWNER`, `RALPH_GH_PROJECT_NUMBER` and returns a clear `additionalContext` error if any are missing, instead of letting the MCP server fail obscurely at first tool call.
+
+2. **SessionStart hook that injects live project state** — use `hookSpecificOutput.additionalContext` to inject the current sprint's top-3 open issues at session start, eliminating the manual "prime" step. The hook can call the MCP server or hit GitHub directly.
+
+3. **PreToolUse hook blocking `settings.local.json` access** — mirroring the `.env` guard from `pre_tool_use.py` to prevent accidental leakage of `RALPH_HERO_GITHUB_TOKEN` via Read or Bash cat.
+
+4. **UV single-file scripts for ralph-hero hooks** — if we ever ship hook files as part of the plugin, the UV shebang pattern means users don't need to install anything beyond `uv`. Hooks become self-contained. Currently our hooks are shell scripts in `plugin/ralph-hero/hooks/` — migrating the complex ones to UV Python scripts would give us proper error handling and testability.
+
+5. **`persist_env_variable` for computed config** — in a multi-repo setup, a Setup hook could call the GitHub API to resolve the project's linked repo name and write `RALPH_GH_REPO=<resolved>` to `CLAUDE_ENV_FILE`, making `RALPH_GH_REPO` optional for users who only have one linked repo.
+
+6. **Agent prompt delegation pattern** — our agents currently embed full prompts inline. The `Read and Execute: path/to/prompt.md` pattern lets us share one prompt across multiple agent variants that differ only in `model:` or `tools:`. Worth adopting if we ship haiku/sonnet variants of the same agent.
+
+## Wild Card
+
+The `--name-agent` flag in `user_prompt_submit.py` calls a local Ollama instance (with fallback to Anthropic) to generate a one-word alphanumeric session name. This name is stored in `.claude/data/sessions/<session_id>.json` and presumably displayed in the status line. The status line (`status_line_v6.py`) presumably reads this file to show something like "Session: Phoenix" instead of a UUID. This is a clever UX trick — giving sessions memorable names makes log archaeology much easier. The Ollama-first approach means it works offline and at zero cost.
+
+## Raw Sources
+
+- [disler/claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) — complete 13-hook implementation with UV scripts
+- [.claude/settings.json](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/settings.json) — hook registration, `$CLAUDE_PROJECT_DIR` pattern
+- [.claude/hooks/setup.py](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/hooks/setup.py) — `persist_env_variable` / `CLAUDE_ENV_FILE` usage
+- [.claude/hooks/session_start.py](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/hooks/session_start.py) — `additionalContext` return pattern
+- [.claude/hooks/stop.py](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/hooks/stop.py) — TTS provider selection via `os.getenv()`, dotenv loading
+- [.claude/hooks/pre_tool_use.py](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/hooks/pre_tool_use.py) — `.env` access blocking pattern
+- [.claude/hooks/subagent_start.py](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/hooks/subagent_start.py) — sub-agent tracking, env var read for TTS selection
+- [.claude/hooks/user_prompt_submit.py](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/hooks/user_prompt_submit.py) — session naming via Ollama/Anthropic fallback
+- [.claude/agents/crypto/crypto-coin-analyzer-haiku.md](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.claude/agents/crypto/crypto-coin-analyzer-haiku.md) — agent frontmatter schema (no `env:` field), prompt delegation pattern
+- [.env.sample](https://raw.githubusercontent.com/disler/claude-code-hooks-mastery/main/.env.sample) — canonical key list: `ANTHROPIC_API_KEY`, `ELEVENLABS_API_KEY`, `OPENAI_API_KEY`, `ENGINEER_NAME`

--- a/thoughts/shared/plans/2026-03-17-GH-0588-remove-mcp-env-block.md
+++ b/thoughts/shared/plans/2026-03-17-GH-0588-remove-mcp-env-block.md
@@ -1,0 +1,252 @@
+---
+date: 2026-03-17
+status: draft
+type: plan
+tags: [mcp, configuration, env, plugin]
+github_issue: 588
+github_issues: [588]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/588
+primary_issue: 588
+---
+
+# Remove .mcp.json env block — inherit parent environment
+
+## Prior Work
+
+- builds_on:: [[2026-03-17-plugin-mcp-env-passthrough]]
+
+## Overview
+
+Remove the explicit `env` block from `plugin/ralph-hero/.mcp.json` so the MCP server inherits the full parent process environment. This eliminates the maintenance burden of enumerating every env var in two places and matches the pattern used by ralph-knowledge.
+
+## Current State Analysis
+
+The `.mcp.json` env block acts as an explicit allowlist — only listed vars reach the child process. Currently it lists 3 of 10+ vars the server reads via `resolveEnv()`. PR #589 added a 4th (`RALPH_HERO_GITHUB_TOKEN`) but the remaining optional vars (`RALPH_GH_REPO_TOKEN`, `RALPH_GH_PROJECT_TOKEN`, `RALPH_GH_PROJECT_OWNER`, `RALPH_GH_PROJECT_NUMBERS`, `RALPH_GH_TEMPLATE_PROJECT`, `RALPH_HERO_AUTO`, `RALPH_DEBUG`) are still silently dropped.
+
+The env block also contains developer-specific defaults (`cdubiel08`, `ralph-hero`, `3`) that shouldn't be in committed code — they belong in `settings.local.json`.
+
+### Key Discoveries:
+- `plugin/ralph-knowledge/.mcp.json` has no env block and works correctly
+- Claude Code's env block is designed to MERGE with the parent environment (per official docs)
+- `resolveEnv()` in `index.ts:31-36` already handles the case where vars are missing or unexpanded
+- The setup skill already directs users to put all vars in `settings.local.json`
+- `release.yml` runs `sed` on `.mcp.json` to update the version pin — unaffected by removing the env block
+
+## Desired End State
+
+`.mcp.json` has no `env` block. The MCP server inherits all environment variables from Claude Code's process, which includes everything from `settings.local.json`. All documentation reflects this change.
+
+### How to verify:
+1. Set `RALPH_HERO_GITHUB_TOKEN` and `RALPH_GH_OWNER` in `settings.local.json` only
+2. Restart Claude Code
+3. MCP server connects successfully
+4. `npm test` passes
+
+## What We're NOT Doing
+
+- Migrating to HTTP transport (future consideration)
+- Adding a `requiredEnv` field to `plugin.json` (doesn't exist in the schema)
+- Changing how `resolveEnv()` works (still needed for edge cases)
+- Updating the version pin (`@2.5.13` → latest) — separate concern
+
+## Implementation Approach
+
+Remove the env block, update documentation to reflect that the env block no longer exists, and update the contract test to document the new pattern.
+
+## Phase 1: Remove env block from .mcp.json
+
+### Overview
+Remove the `env` key from the MCP server config, keeping `command`, `args`, and `cwd`.
+
+### Changes Required:
+
+#### 1. Plugin .mcp.json
+**File**: `plugin/ralph-hero/.mcp.json`
+**Changes**: Remove the `env` block entirely
+
+Before:
+```json
+{
+  "mcpServers": {
+    "ralph-github": {
+      "command": "npx",
+      "args": ["-y", "ralph-hero-mcp-server@2.5.13"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}",
+      "env": {
+        "RALPH_GH_OWNER": "${RALPH_GH_OWNER:-cdubiel08}",
+        "RALPH_GH_REPO": "${RALPH_GH_REPO:-ralph-hero}",
+        "RALPH_GH_PROJECT_NUMBER": "${RALPH_GH_PROJECT_NUMBER:-3}"
+      }
+    }
+  }
+}
+```
+
+After:
+```json
+{
+  "mcpServers": {
+    "ralph-github": {
+      "command": "npx",
+      "args": ["-y", "ralph-hero-mcp-server@2.5.13"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+    }
+  }
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `npm run build` passes in `plugin/ralph-hero/mcp-server/`
+- [ ] `npm test` passes in `plugin/ralph-hero/mcp-server/`
+
+#### Manual Verification:
+- [ ] Set env vars only in `settings.local.json`, restart Claude Code, verify MCP server connects
+
+---
+
+## Phase 2: Update documentation
+
+### Overview
+Update CLAUDE.md and the setup skill to reflect that there is no longer an env block in `.mcp.json`.
+
+### Changes Required:
+
+#### 1. CLAUDE.md
+**File**: `CLAUDE.md`
+**Changes**: Update the `resolveEnv()` gotcha (line 128) and the token warning (line 149)
+
+Line 128 — update from:
+```
+- **`resolveEnv()` pattern**: Claude Code passes unexpanded `${VAR}` literals for unset env vars in `.mcp.json`. The `resolveEnv()` function in `index.ts` filters these out. Only non-sensitive defaults with fallbacks belong in `.mcp.json`.
+```
+To:
+```
+- **`resolveEnv()` pattern**: The MCP server inherits env vars from Claude Code's process (set via `settings.local.json`). `resolveEnv()` in `index.ts` filters out unexpanded `${VAR}` literals that may appear when vars are unset. The `.mcp.json` has no `env` block — all configuration flows through `settings.local.json`.
+```
+
+Line 149 — update from:
+```
+**Do NOT put tokens in `.mcp.json`** — the `env` block can overwrite inherited values with unexpanded `${VAR}` literals.
+```
+To:
+```
+**Do NOT put tokens in `.mcp.json`** — all env vars should be set in `.claude/settings.local.json` (gitignored). The `.mcp.json` has no `env` block; the MCP server inherits the parent environment.
+```
+
+#### 2. Setup skill
+**File**: `plugin/ralph-hero/skills/setup/SKILL.md`
+**Changes**: Update the three `.mcp.json` warnings (lines 54, 275, 327)
+
+Line 54 — update from:
+```
+- **Don't put tokens in `.mcp.json`** — the `env` block can overwrite inherited values with unexpanded literals
+```
+To:
+```
+- **Don't put tokens in `.mcp.json`** — all env vars belong in `settings.local.json`, not in the plugin config
+```
+
+Lines 275 and 327 — update from:
+```
+**Important**: Do NOT put tokens in `.mcp.json` — the env block can mask inherited values.
+```
+To:
+```
+**Important**: Do NOT put tokens in `.mcp.json` — all env vars belong in `settings.local.json`.
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] No broken markdown (visual check)
+
+#### Manual Verification:
+- [ ] CLAUDE.md accurately describes current behavior
+- [ ] Setup skill warnings are still clear and correct
+
+---
+
+## Phase 3: Update contract test
+
+### Overview
+Update the `.mcp.json contract` test to document that env vars are inherited (no env block) rather than explicitly passed.
+
+### Changes Required:
+
+#### 1. Contract test
+**File**: `plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts`
+**Changes**: Update the `.mcp.json contract` describe block (lines 138-169)
+
+Update the test description and add a comment documenting the new contract:
+
+```typescript
+describe(".mcp.json contract", () => {
+  it("should only accept RALPH_-prefixed env vars", () => {
+    // Contract: .mcp.json has no env block — the MCP server inherits
+    // the parent environment. Only RALPH_-prefixed vars are read by
+    // resolveEnv(). This test documents which vars the server accepts.
+    const acceptedVars = [
+      "RALPH_GH_REPO_TOKEN",
+      "RALPH_GH_PROJECT_TOKEN",
+      "RALPH_HERO_GITHUB_TOKEN",
+      "RALPH_GH_OWNER",
+      "RALPH_GH_REPO",
+      "RALPH_GH_PROJECT_OWNER",
+      "RALPH_GH_PROJECT_NUMBER",
+      "RALPH_GH_PROJECT_NUMBERS",
+      "RALPH_GH_TEMPLATE_PROJECT",
+      "RALPH_HERO_AUTO",
+      "RALPH_DEBUG",
+    ];
+
+    const forbiddenVars = [
+      "GITHUB_TOKEN",
+      "GH_TOKEN",
+      "GITHUB_PERSONAL_ACCESS_TOKEN",
+      "GITHUB_OWNER",
+      "GITHUB_REPO",
+    ];
+
+    for (const forbidden of forbiddenVars) {
+      expect(acceptedVars).not.toContain(forbidden);
+    }
+
+    for (const accepted of acceptedVars) {
+      expect(accepted).toMatch(/^RALPH_/);
+    }
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `npm test` passes in `plugin/ralph-hero/mcp-server/`
+- [ ] `npm run build` passes in `plugin/ralph-hero/mcp-server/`
+
+#### Manual Verification:
+- [ ] Test accurately documents all env vars the server reads
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- Existing token resolution tests remain valid (no changes needed)
+- Contract test updated to reflect full list of accepted vars
+
+### Manual Testing Steps:
+1. Remove any env exports from shell profile
+2. Set `RALPH_HERO_GITHUB_TOKEN`, `RALPH_GH_OWNER`, `RALPH_GH_PROJECT_NUMBER` in `settings.local.json` only
+3. Restart Claude Code
+4. Verify MCP server connects and tools work
+
+## References
+
+- Original issue: #588
+- PR #589 (superseded by this approach)
+- Research: `thoughts/shared/research/2026-03-17-plugin-mcp-env-passthrough.md`
+- ralph-knowledge model: `plugin/ralph-knowledge/.mcp.json`

--- a/thoughts/shared/plans/2026-03-19-GH-0615-rest-view-creation.md
+++ b/thoughts/shared/plans/2026-03-19-GH-0615-rest-view-creation.md
@@ -1,0 +1,526 @@
+---
+date: 2026-03-19
+status: draft
+type: plan
+tags: [mcp-server, github-api, projects-v2, views, rest-api]
+github_issue: 615
+github_issues: [615]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/615
+primary_issue: 615
+last_updated: 2026-03-19
+last_updated_note: "Revised after code review — explicit GitHubClient interface update, fetchProjectViews returns ownerType to eliminate extra round-trip, toRestLayout typed as ProjectV2ViewLayout, camelCase fix, pure-function tests added"
+---
+
+# REST View Creation — `create_views` Tool Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-03-19-github-projects-v2-view-api-exhaustive]]
+- builds_on:: [[2026-02-20-GH-0162-copy-project-v2-setup-project]]
+- builds_on:: [[view-recipes]]
+- builds_on:: [[golden-project-views]]
+
+## Overview
+
+Add a `ralph_hero__create_views` MCP tool that reads views from a source project via GraphQL and creates them in a target project via the GitHub Projects V2 REST API. Requires adding REST call capability to the GitHub client (currently GraphQL-only).
+
+## Current State Analysis
+
+- `github-client.ts` uses `@octokit/graphql` exclusively — no REST support (`github-client.ts:81-97`)
+- `GitHubClient` interface declared inline in `github-client.ts:29-72` — **must be updated alongside the implementation** (both the interface block and the return object)
+- `ProjectV2View` interface is defined in `types.ts:175-181` with `id`, `name`, `number`, `layout`, `filter` fields
+- `ProjectV2ViewLayout` is a union type at `types.ts:170-173`: `"BOARD_LAYOUT" | "TABLE_LAYOUT" | "ROADMAP_LAYOUT"`
+- `views: Connection<ProjectV2View>` exists on the `ProjectV2` interface (`types.ts:196`) but is never queried
+- `fetchProject()` in `project-tools.ts:507-605` uses a user→org fallback pattern for GraphQL that must be replicated for views
+- Tool registration follows the `registerXyzTools(server, client, fieldCache)` pattern; `index.ts` wires them all together
+- Node 18/20/22 are all CI targets — native `globalThis.fetch` is available
+
+### Key Discoveries
+
+- `github-client.ts:29-72` — `GitHubClient` interface is declared inline in the same file as `createGitHubClient()`; both must be updated together for TypeScript to accept the new method
+- `github-client.ts:81-97` — dual-token setup: `token` (repo) and `projectToken` (project); the `create_views` tool should use the project token for REST calls
+- REST layout values are lowercase (`table`, `board`, `roadmap`); GraphQL returns uppercase with `_LAYOUT` suffix — conversion required; `toRestLayout` should accept `ProjectV2ViewLayout` (not `string`) so TypeScript enforces exhaustiveness
+- `filter` from GraphQL is a plain top-level string (e.g. `"assignee:@me is:open"`) matching what the REST POST body expects as `filter` — confirmed by the REST API docs and research doc
+- `@octokit/rest` is not installed; native `fetch` is the right choice (no new deps)
+
+## Desired End State
+
+After this plan is implemented:
+
+```
+ralph_hero__create_views({
+  sourceProjectNumber: 3,
+  targetProjectNumber: 7
+})
+```
+
+Reads all views from project #3 via GraphQL, then POSTs each to project #7 via REST, returning:
+
+```json
+{
+  "created": [
+    { "name": "Active Work", "layout": "board", "id": "PVV_..." },
+    { "name": "Backlog", "layout": "table", "id": "PVV_..." }
+  ],
+  "count": 2,
+  "sourceProject": 3,
+  "targetProject": 7
+}
+```
+
+Verify by calling `ralph_hero__get_project` on #7 and confirming views are present (or querying GitHub UI).
+
+## What We're NOT Doing
+
+- No `updateProjectV2View` or `deleteProjectV2View` — these don't exist in any API
+- No inline view recipe array parameter — source-copy mode only (keeps scope at S)
+- No sort/group configuration — the REST POST endpoint only supports name, layout, filter, visible_fields
+- No modification to `setup_project` to auto-call `create_views` (can be a follow-up)
+- No pagination of views beyond `first: 50` — projects with >50 views are not a realistic concern
+- No caching in `fetchProjectViews` — intentional; this is a one-shot setup tool
+
+## Implementation Approach
+
+Four phases:
+1. Add `restPost()` to **both** the `GitHubClient` interface (lines 29–72) and `createGitHubClient()` return object using native `fetch`
+2. Add `fetchProjectViews()` GraphQL helper (user/org fallback, returns views AND resolved `ownerType` — eliminates a separate owner-detection round-trip)
+3. Implement `create_views` tool in new `view-tools.ts` using `ownerType` from phase 2
+4. Wire into `index.ts` and add tests (source-inspection + pure-function for `toRestLayout`)
+
+---
+
+## Phase 1: Add `restPost()` to GitHubClient
+
+### Overview
+Extend **both** the `GitHubClient` interface declaration (lines 29–72 of `github-client.ts`) and the object returned by `createGitHubClient()`. Both live in the same file. Using native `fetch` keeps token management centralised and adds no new dependencies.
+
+### Changes Required
+
+#### 1. `github-client.ts` — interface declaration
+
+**File**: `plugin/ralph-hero/mcp-server/src/github-client.ts`
+
+Add inside the `GitHubClient` interface block (lines 29–72), alongside the existing method signatures:
+
+```typescript
+restPost<T>(path: string, body: unknown, useProjectToken?: boolean): Promise<T>;
+```
+
+#### 2. `github-client.ts` — implementation
+
+Add to the object returned by `createGitHubClient()`, alongside `query`, `mutate`, `projectQuery`, `projectMutate`, etc.:
+
+```typescript
+async restPost<T>(
+  path: string,
+  body: unknown,
+  useProjectToken = true,
+): Promise<T> {
+  const token = useProjectToken
+    ? (clientConfig.projectToken ?? clientConfig.token)
+    : clientConfig.token;
+
+  const url = `https://api.github.com${path}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `GitHub REST API error ${response.status} for ${path}: ${text}`,
+    );
+  }
+
+  return response.json() as Promise<T>;
+},
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npm run build` — TypeScript compiles without errors
+- [ ] `GitHubClient` type includes `restPost` method
+
+#### Manual Verification
+- [ ] No new runtime deps required (native `fetch` only)
+
+**Implementation Note**: Pause after this phase and verify TypeScript compiles cleanly before proceeding.
+
+---
+
+## Phase 2: Add `fetchProjectViews()` GraphQL Helper
+
+### Overview
+Add a helper that reads all views from a project via GraphQL with the user→org fallback. Returns `{ views, ownerType }` so the caller knows which REST path to use without a second API round-trip.
+
+### Changes Required
+
+#### 1. `project-tools.ts`
+
+**File**: `plugin/ralph-hero/mcp-server/src/tools/project-tools.ts`
+
+Add after `fetchProject()` (around line 605). Ensure `ProjectV2View` and `ProjectV2ViewLayout` are imported from `../types.js`.
+
+```typescript
+interface ViewsQueryResult {
+  user?: { projectV2: { views: { nodes: ProjectV2View[] } } | null } | null;
+  organization?: {
+    projectV2: { views: { nodes: ProjectV2View[] } } | null;
+  } | null;
+}
+
+const VIEWS_QUERY_USER = `
+  query($login: String!, $number: Int!) {
+    user(login: $login) {
+      projectV2(number: $number) {
+        views(first: 50) {
+          nodes { id name number layout filter }
+        }
+      }
+    }
+  }
+`;
+
+const VIEWS_QUERY_ORG = `
+  query($login: String!, $number: Int!) {
+    organization(login: $login) {
+      projectV2(number: $number) {
+        views(first: 50) {
+          nodes { id name number layout filter }
+        }
+      }
+    }
+  }
+`;
+
+export interface FetchProjectViewsResult {
+  views: ProjectV2View[];
+  ownerType: "users" | "orgs";
+}
+
+// Returns views AND the resolved ownerType so callers can construct the
+// correct REST path without a separate round-trip.
+export async function fetchProjectViews(
+  client: GitHubClient,
+  owner: string,
+  projectNumber: number,
+): Promise<FetchProjectViewsResult> {
+  // Try user first
+  try {
+    const result = await client.projectQuery<ViewsQueryResult>(
+      VIEWS_QUERY_USER,
+      { login: owner, number: projectNumber },
+    );
+    const nodes = result.user?.projectV2?.views?.nodes;
+    if (nodes) return { views: nodes, ownerType: "users" };
+  } catch {
+    // fall through to org
+  }
+
+  // Try org
+  const result = await client.projectQuery<ViewsQueryResult>(
+    VIEWS_QUERY_ORG,
+    { login: owner, number: projectNumber },
+  );
+  const nodes = result.organization?.projectV2?.views?.nodes;
+  if (!nodes) {
+    throw new Error(
+      `Project #${projectNumber} not found for owner "${owner}"`,
+    );
+  }
+  return { views: nodes, ownerType: "orgs" };
+}
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npm run build` — compiles without errors
+
+#### Manual Verification
+- [ ] None required for this phase alone (tested via Phase 3)
+
+**Implementation Note**: Pause after this phase and verify TypeScript compiles cleanly before proceeding.
+
+---
+
+## Phase 3: Implement `create_views` Tool
+
+### Overview
+New `view-tools.ts` with `ralph_hero__create_views`. Uses `ownerType` returned by `fetchProjectViews()` to select the REST path — no extra round-trip. `toRestLayout` accepts `ProjectV2ViewLayout` (not `string`), giving TypeScript exhaustiveness checking.
+
+### Changes Required
+
+#### 1. New `view-tools.ts`
+
+**File**: `plugin/ralph-hero/mcp-server/src/tools/view-tools.ts`
+
+```typescript
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toolError, toolSuccess } from "../types.js";
+import type { GitHubClient } from "../github-client.js";
+import type { FieldOptionCache } from "../lib/cache.js";
+import type { ProjectV2ViewLayout } from "../types.js";
+import { fetchProjectViews } from "./project-tools.js";
+
+// All three GraphQL layout variants are handled exhaustively.
+// TypeScript will error at build time if GitHub adds a new layout variant
+// and this function is not updated.
+export function toRestLayout(
+  layout: ProjectV2ViewLayout,
+): "table" | "board" | "roadmap" {
+  switch (layout) {
+    case "TABLE_LAYOUT":
+      return "table";
+    case "BOARD_LAYOUT":
+      return "board";
+    case "ROADMAP_LAYOUT":
+      return "roadmap";
+  }
+}
+
+export function registerViewTools(
+  server: McpServer,
+  client: GitHubClient,
+  _fieldCache: FieldOptionCache,
+): void {
+  server.tool(
+    "ralph_hero__create_views",
+    "Copy views from a source GitHub Project V2 to a target project using the REST API. Reads view names, layouts, and filter strings from the source project via GraphQL, then creates matching views in the target. Note: sort/group configuration is not available via API and must be set manually after creation.",
+    {
+      owner: z
+        .string()
+        .optional()
+        .describe(
+          "GitHub owner (user or org). Defaults to RALPH_GH_OWNER env var",
+        ),
+      sourceProjectNumber: z.coerce
+        .number()
+        .describe("Project number to copy views FROM"),
+      targetProjectNumber: z.coerce
+        .number()
+        .describe("Project number to copy views INTO"),
+    },
+    async (args) => {
+      const owner =
+        args.owner ?? client.config.projectOwner ?? client.config.owner;
+      if (!owner) {
+        return toolError(
+          "owner is required — set RALPH_GH_OWNER or pass owner param",
+        );
+      }
+
+      // Read views from source project; ownerType drives REST path selection
+      let sourceViews;
+      let ownerType: "users" | "orgs";
+      try {
+        const result = await fetchProjectViews(
+          client,
+          owner,
+          args.sourceProjectNumber,
+        );
+        sourceViews = result.views;
+        ownerType = result.ownerType;
+      } catch (err) {
+        return toolError(
+          `Failed to read views from project #${args.sourceProjectNumber}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      if (sourceViews.length === 0) {
+        return toolSuccess({
+          created: [],
+          failed: [],
+          count: 0,
+          sourceProject: args.sourceProjectNumber,
+          targetProject: args.targetProjectNumber,
+          message: "Source project has no views",
+        });
+      }
+
+      // REST path uses owner login (not numeric ID).
+      // filter is a plain top-level string matching the GraphQL field value.
+      const basePath =
+        ownerType === "users"
+          ? `/users/${owner}/projectsV2/${args.targetProjectNumber}/views`
+          : `/orgs/${owner}/projectsV2/${args.targetProjectNumber}/views`;
+
+      const created: Array<{ name: string; layout: string; id: string }> = [];
+      const failed: Array<{ name: string; error: string }> = [];
+
+      for (const view of sourceViews) {
+        const body: Record<string, unknown> = {
+          name: view.name,
+          layout: toRestLayout(view.layout),
+        };
+        if (view.filter) {
+          body.filter = view.filter;
+        }
+
+        try {
+          const createdView = await client.restPost<{
+            id: string;
+            name: string;
+            layout: string;
+          }>(basePath, body);
+          created.push({
+            name: createdView.name,
+            layout: createdView.layout,
+            id: createdView.id,
+          });
+        } catch (err) {
+          failed.push({
+            name: view.name,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      return toolSuccess({
+        created,
+        failed,
+        count: created.length,
+        sourceProject: args.sourceProjectNumber,
+        targetProject: args.targetProjectNumber,
+      });
+    },
+  );
+}
+```
+
+#### 2. `index.ts` — Register the new tool module
+
+**File**: `plugin/ralph-hero/mcp-server/src/index.ts`
+
+Add import alongside the other tool module imports:
+
+```typescript
+import { registerViewTools } from "./tools/view-tools.js";
+```
+
+Add registration call alongside the other `registerXyzTools()` calls:
+
+```typescript
+registerViewTools(server, client, fieldCache);
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npm run build` — compiles without errors
+- [ ] `npm test` — all existing tests pass
+
+#### Manual Verification
+- [ ] `ralph_hero__create_views({ sourceProjectNumber: 3, targetProjectNumber: 7 })` creates views in project #7
+- [ ] Returned `created` array lists each view with name, layout, and id
+- [ ] Views appear in the GitHub UI at https://github.com/users/cdubiel08/projects/7
+
+**Implementation Note**: Pause after this phase for manual testing of the tool against live projects before proceeding to Phase 4.
+
+---
+
+## Phase 4: Tests
+
+### Overview
+Test file for `view-tools.ts` combining source-inspection (consistent with `issue-tools.test.ts`) and pure-function tests for the exported `toRestLayout`. Note: copy the `__dirname` / import style from existing test files exactly — do not invent a new pattern.
+
+### Changes Required
+
+#### 1. New test file
+
+**File**: `plugin/ralph-hero/mcp-server/src/__tests__/view-tools.test.ts`
+
+```typescript
+import * as fs from "fs";
+import * as path from "path";
+import { describe, it, expect } from "vitest";
+import { toRestLayout } from "../tools/view-tools.js";
+
+const viewToolsSrc = fs.readFileSync(
+  path.resolve(__dirname, "../tools/view-tools.ts"),
+  "utf-8",
+);
+
+describe("view-tools source structure", () => {
+  it("registers ralph_hero__create_views tool", () => {
+    expect(viewToolsSrc).toContain("ralph_hero__create_views");
+  });
+
+  it("has sourceProjectNumber param", () => {
+    expect(viewToolsSrc).toContain("sourceProjectNumber");
+  });
+
+  it("has targetProjectNumber param", () => {
+    expect(viewToolsSrc).toContain("targetProjectNumber");
+  });
+
+  it("imports fetchProjectViews from project-tools", () => {
+    expect(viewToolsSrc).toContain("fetchProjectViews");
+  });
+
+  it("calls restPost on client", () => {
+    expect(viewToolsSrc).toContain("client.restPost");
+  });
+});
+
+describe("toRestLayout", () => {
+  it("converts TABLE_LAYOUT to table", () => {
+    expect(toRestLayout("TABLE_LAYOUT")).toBe("table");
+  });
+
+  it("converts BOARD_LAYOUT to board", () => {
+    expect(toRestLayout("BOARD_LAYOUT")).toBe("board");
+  });
+
+  it("converts ROADMAP_LAYOUT to roadmap", () => {
+    expect(toRestLayout("ROADMAP_LAYOUT")).toBe("roadmap");
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npx vitest run src/__tests__/view-tools.test.ts` — all tests pass
+- [ ] `npm test` — full suite passes
+
+#### Manual Verification
+- [ ] None required
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Source inspection: tool name, required params, `fetchProjectViews` import, `restPost` usage
+- Pure-function: `toRestLayout` covers all three layout variants (TABLE/BOARD/ROADMAP)
+
+### Manual Testing Steps
+1. Ensure project #3 has at least one view configured in GitHub UI
+2. Run `ralph_hero__create_views({ sourceProjectNumber: 3, targetProjectNumber: 7 })`
+3. Verify response `created` array matches expected view names and layouts
+4. Open https://github.com/users/cdubiel08/projects/7 and confirm views appear
+
+## Performance Considerations
+
+- Views are created serially (one REST call per view) — acceptable for typical project sizes (2–10 views)
+- Each view POST is independent; partial success handled gracefully via `failed` array
+- No caching in `fetchProjectViews` — intentional; this is a one-shot setup tool
+
+## References
+
+- Original issue: #615
+- Research: `thoughts/shared/research/2026-03-19-github-projects-v2-view-api-exhaustive.md`
+- REST endpoint docs: `POST /users/{user}/projectsV2/{n}/views` — [GitHub Docs](https://docs.github.com/en/enterprise-cloud@latest/rest/projects/views)
+- Existing pattern: `fetchProject()` at `project-tools.ts:507-605`
+- Existing pattern: `github-client.ts:29-72` (interface) and `github-client.ts:81-97` (dual-token setup)

--- a/thoughts/shared/plans/2026-03-19-GH-0616-ralph-playwright-plugin.md
+++ b/thoughts/shared/plans/2026-03-19-GH-0616-ralph-playwright-plugin.md
@@ -1,0 +1,924 @@
+---
+date: 2026-03-19
+status: draft
+type: plan
+tags: [playwright, testing, storybook, a11y, plugin, skills, agents]
+github_issue: 616
+github_issues: [616]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/616
+primary_issue: 616
+---
+
+# Ralph-Playwright Plugin Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-03-19-agent-driven-ui-testing-stochastic-exploration]]
+- builds_on:: [[2026-02-18-GH-0067-bowser-justfile-cli-patterns]]
+- builds_on:: [[2026-02-19-GH-0132-agent-skill-patterns-bowser-reference]]
+
+## Overview
+
+A new Claude Code plugin (`plugin/ralph-playwright/`) that provides polymorphic, adaptable UI testing skills as a complement to ralph-hero. Like ralph-knowledge (semantic search over docs), ralph-playwright is optional infrastructure: install it and gain Storybook + Playwright E2E + accessibility + stochastic exploration capabilities against any web application.
+
+Skills are **polymorphic**: they detect what's available (Storybook running? a11y MCP registered? Playwright Planner version?) and adapt behavior accordingly. Same skill works on any project.
+
+## Current State Analysis
+
+No UI testing skills or agents exist in the repo today. Closest prior art:
+- ralph-hero skills reference disler/bowser as a 4-layer architecture reference (GH-067, GH-132)
+- GH-602 integration testing plan covers MCP unit tests (TypeScript/Vitest) — different domain
+- The 4-layer Bowser pattern (justfile → commands → agents → skills) is documented and treated as the canonical Claude Code testing reference
+
+This plugin is the first to implement it as a reusable plugin rather than project-specific config.
+
+## Desired End State
+
+`plugin/ralph-playwright/` lives in this repo alongside ralph-knowledge. After plugin install:
+
+1. `story-gen` skill generates user story YAML from text descriptions (with automatic sad paths)
+2. `explore` skill browses a live URL → discovers flows → outputs user stories YAML
+3. `test-e2e` skill runs all story YAML files in parallel and aggregates a pass/fail report
+4. `a11y-scan` skill runs axe-core WCAG 2.2 AA audit against any URL
+5. `storybook-test` skill runs Storybook 9 + Vitest component tests
+6. `visual-diff` skill runs visual regression via Chromatic or Applitools
+
+### Verification:
+- Plugin appears in Claude Code skill list after install
+- `story-gen` produces valid YAML with happy + sad paths from a 2-sentence description
+- `test-e2e` runs example stories against a live localhost URL and produces a report
+
+## What We're NOT Doing
+
+- No Figma MCP → user stories pipeline (deferred — see Deferred section)
+- No Stagehand-based deep stochastic exploration in v1 (noted as pivot path — see Deferred)
+- No CI/CD GitHub Actions workflow (deferred)
+- No ralph-playwright MCP server (deferred — skills + agents only for now)
+- No specific target project — framework-agnostic by design
+
+## Implementation Approach
+
+**User story files** live in the consuming project at `playwright-stories/**/*.yaml`. The schema extends Bowser's minimal approach with `type` (happy/sad/edge), `persona`, and `tags`.
+
+**Execution model** follows Bowser's 4-layer pattern adapted for skills:
+- Orchestrator skill fans out one `story-runner-agent` per YAML file (all parallel)
+- Each agent uses `@playwright/mcp` tools exclusively (no direct Playwright SDK dependency)
+- A11y checks injected per-step when `a11y-mcp-server` is available
+
+**Sad path generation** is automatic: whenever `story-gen` or `explore` creates happy paths, it applies a heuristic set to produce corresponding sad paths (validation errors, auth failures, empty states, network errors, boundary values).
+
+---
+
+## Phase 1: Plugin Foundation
+
+### Overview
+Establish the plugin directory structure, user story YAML schema, example stories, and setup skill. No testing logic yet — just the scaffolding that makes the other phases installable and the schema that all phases use.
+
+### Changes Required:
+
+#### 1. Plugin registration
+
+**File**: `plugin/ralph-playwright/.claude-plugin/plugin.json`
+```json
+{
+  "name": "ralph-playwright",
+  "version": "0.1.0",
+  "description": "Polymorphic UI testing skills: story generation, E2E execution, a11y, Storybook, and visual regression",
+  "skills": [
+    "skills/setup",
+    "skills/story-gen",
+    "skills/explore",
+    "skills/test-e2e",
+    "skills/a11y-scan",
+    "skills/storybook-test",
+    "skills/visual-diff"
+  ],
+  "agents": [
+    "agents/story-runner-agent.md",
+    "agents/explorer-agent.md"
+  ]
+}
+```
+
+#### 2. User story YAML schema
+
+**File**: `plugin/ralph-playwright/schemas/user-story.schema.yaml`
+
+This is the canonical schema. All generated and hand-authored stories must conform.
+
+```yaml
+# ralph-playwright user story schema
+# Each file contains one or more stories for a feature area
+
+stories:
+  - name: string              # Human-readable story name (used for directory naming)
+    type: happy | sad | edge  # Test classification
+    url: string               # Entry URL for this story
+    persona: string           # Optional: user role ("anonymous", "admin", "registered user")
+    tags: [string]            # Optional: filter tags (e.g. ["auth", "login"])
+    workflow: |               # Plain-text natural language steps (Bowser-compatible)
+      Navigate to <url>
+      Verify <expected state>
+      <action>
+      Verify <expected outcome>
+```
+
+**Sad path heuristics** (applied automatically by `story-gen` and `explore`):
+- Required field empty → validation error appears, form not submitted
+- Invalid format (wrong email, special chars) → format validation error
+- Wrong credentials / unauthorized → error message, user stays on page
+- Already exists / duplicate submission → conflict error
+- Session expired / unauthenticated access → redirect to login
+- Rate limited / too many attempts → appropriate throttle error
+- Empty state (no items in list, first-time user) → empty state UI shown
+- Boundary values (very long strings, max-length fields) → graceful handling
+
+**File**: `plugin/ralph-playwright/schemas/example-auth.yaml`
+
+A reference example demonstrating happy, sad, and edge stories for an auth flow:
+
+```yaml
+stories:
+  - name: "Login succeeds with valid credentials"
+    type: happy
+    url: "http://localhost:3000/login"
+    persona: "registered user"
+    tags: [auth, login]
+    workflow: |
+      Navigate to http://localhost:3000/login
+      Verify login form with email and password fields is visible
+      Fill email field with "test@example.com"
+      Fill password field with "correct-password"
+      Click the Sign In button
+      Verify redirect to /dashboard occurs
+      Verify a welcome message is visible
+
+  - name: "Login fails with wrong password"
+    type: sad
+    url: "http://localhost:3000/login"
+    persona: "registered user"
+    tags: [auth, login, error-handling]
+    workflow: |
+      Navigate to http://localhost:3000/login
+      Fill email field with "test@example.com"
+      Fill password field with "wrong-password"
+      Click the Sign In button
+      Verify an "Invalid credentials" error message appears
+      Verify the user remains on the login page
+      Verify the password field is cleared
+
+  - name: "Login fails when fields are empty"
+    type: sad
+    url: "http://localhost:3000/login"
+    persona: "anonymous"
+    tags: [auth, login, validation]
+    workflow: |
+      Navigate to http://localhost:3000/login
+      Click the Sign In button without entering any values
+      Verify validation errors appear for both email and password fields
+      Verify the form was not submitted
+
+  - name: "Unauthenticated user is redirected from dashboard"
+    type: sad
+    url: "http://localhost:3000/dashboard"
+    persona: "anonymous"
+    tags: [auth, redirect]
+    workflow: |
+      Navigate directly to http://localhost:3000/dashboard without logging in
+      Verify redirect to /login occurs
+      Verify a "Please sign in" message or similar prompt is shown
+
+  - name: "Login form is keyboard-navigable and screen-reader accessible"
+    type: edge
+    url: "http://localhost:3000/login"
+    persona: "screen reader user"
+    tags: [auth, login, a11y]
+    workflow: |
+      Navigate to http://localhost:3000/login
+      Verify all form fields have associated visible or aria labels
+      Verify tab order is logical: email → password → submit button
+      Verify the submit button is operable via keyboard Enter
+      Verify error messages are associated with their fields via aria-describedby
+```
+
+#### 3. Setup skill
+
+**File**: `plugin/ralph-playwright/skills/setup/SKILL.md`
+
+```markdown
+---
+name: ralph-playwright:setup
+description: One-time setup for ralph-playwright — installs required MCPs (Playwright, a11y, Storybook), validates browser installation, and creates playwright-stories/ directory. Use when setting up ralph-playwright for the first time or diagnosing a broken install.
+---
+
+# Ralph-Playwright Setup
+
+Install and configure all MCP servers required by ralph-playwright skills.
+
+## Step 1: Required MCP — Playwright (mandatory)
+
+Add to `.claude/settings.local.json` under `env` → `mcpServers`:
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+Or via CLI:
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+## Step 2: A11y MCP (recommended)
+```bash
+claude mcp add a11y-accessibility -- npx -y a11y-mcp-server
+```
+
+## Step 3: Storybook MCP (optional — Storybook 9.1.16+ only)
+Requires Storybook dev server running. Add to your project:
+```bash
+npm install -D @storybook/addon-mcp
+```
+Register MCP (transport: http, Storybook must be running first):
+```bash
+claude mcp add storybook-mcp --transport http http://localhost:6006/mcp --scope project
+```
+
+## Step 4: Install browsers
+```bash
+npx playwright install chromium
+# Or all browsers:
+npx playwright install
+```
+
+## Step 5: Create story directory
+In your project root:
+```bash
+mkdir -p playwright-stories
+```
+
+Add to `.gitignore`:
+```
+playwright-results/
+```
+(Story YAML files in `playwright-stories/` should be committed.)
+
+## Validation
+- `npx playwright --version` → should show 1.56.0 or higher for Planner support
+- Claude Code MCP panel shows "playwright" connected
+- (Optional) "a11y-accessibility" connected
+
+## Next Steps
+- Generate stories: `/ralph-playwright:story-gen`
+- Explore a URL: `/ralph-playwright:explore http://localhost:3000`
+- Run tests: `/ralph-playwright:test-e2e`
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `plugin/ralph-playwright/.claude-plugin/plugin.json` is valid JSON
+- [ ] `schemas/user-story.schema.yaml` is valid YAML
+- [ ] `schemas/example-auth.yaml` is valid YAML and conforms to the schema
+
+#### Manual Verification:
+- [ ] Setup skill clearly describes all install commands
+- [ ] Example stories include happy, sad, AND edge stories
+- [ ] Schema documents all fields with types and examples
+
+---
+
+## Phase 2: Story Generation
+
+### Overview
+Two skills to create user stories YAML from different inputs. Both automatically generate contextually appropriate sad paths.
+
+### Changes Required:
+
+#### 1. story-gen skill
+
+**File**: `plugin/ralph-playwright/skills/story-gen/SKILL.md`
+
+```markdown
+---
+name: ralph-playwright:story-gen
+description: Generate user stories YAML from plain-text descriptions, feature requirements, or PRDs. Automatically includes happy paths AND contextually relevant sad paths (validation errors, auth failures, empty states, network errors, boundary values). Saves to playwright-stories/<feature-name>.yaml. Use when you want to create test stories from a description rather than by exploring a live site.
+---
+
+# Story Generation — Text → User Stories YAML
+
+## Process
+
+### Step 1: Gather input
+Ask for (or use provided arguments):
+- Feature or page description (minimum 1-2 sentences)
+- Target URL or URL pattern
+- User personas if known (defaults: anonymous, registered user)
+- Any known edge cases to include explicitly
+
+### Step 2: Generate stories via structured output
+
+Produce stories in these categories:
+
+**Happy paths** — all primary success flows:
+- Primary user goal fully achieved
+- Optional features/variants exercised
+- Multi-step workflows completed
+
+**Sad paths** — automatically derived, apply ALL applicable heuristics:
+- Required field left empty → validation error, form not submitted
+- Invalid format → format error shown
+- Wrong credentials → error, user stays on page, sensitive data cleared
+- Unauthenticated access to protected resource → redirect to login
+- Duplicate/already-exists submission → conflict error
+- Too many attempts / rate limited → throttle message
+- Network error mid-flow → graceful error, no data loss (if applicable)
+
+**Edge paths** — include at minimum:
+- Empty/zero state (no items, first-time user)
+- Maximum/boundary input values
+- Accessibility story (keyboard nav, screen reader labels, focus management)
+
+### Step 3: Output YAML
+
+Save to `playwright-stories/<feature-kebab-name>.yaml` following the canonical schema.
+Each story must have: name, type, url, tags, workflow.
+Persona is optional but recommended.
+
+### Step 4: Present and iterate
+Show the generated file path and count:
+- N happy paths, N sad paths, N edge paths
+- Ask: any missing cases? Should we run them now? (`/ralph-playwright:test-e2e`)
+```
+
+#### 2. explore skill
+
+**File**: `plugin/ralph-playwright/skills/explore/SKILL.md`
+
+```markdown
+---
+name: ralph-playwright:explore
+description: Explore a running website to discover user flows and generate user story YAML files. Uses Playwright Planner agent (v1.56+) as the primary path. Falls back to @playwright/mcp direct navigation if Planner is unavailable. Pivot path to Stagehand documented below. Works on localhost or any accessible URL. Automatically augments discovered flows with sad paths.
+---
+
+# Explore — Live URL → User Stories YAML
+
+## Prerequisites
+- Target app must be running (e.g. `npm run dev` → `http://localhost:3000`)
+- `@playwright/mcp` installed and registered in Claude Code
+
+## Process
+
+### Step 1: Check Playwright version
+```bash
+npx playwright --version
+```
+- v1.56.0+: use **Playwright Planner** (primary path)
+- Older: use **@playwright/mcp direct navigation** (fallback path)
+
+---
+
+### Primary Path: Playwright Planner Agent (v1.56+)
+
+```bash
+npx playwright init-agents --loop=claude
+```
+
+The Planner agent browses the target URL, discovers interactive elements and navigation paths, and produces a structured Markdown test plan.
+
+After Planner completes:
+1. Parse the Markdown test plan
+2. Convert each discovered flow to a user story using the canonical schema
+3. Infer `type`: success flows → `happy`, error states found → `sad`
+4. Save to `playwright-stories/<page-name>-discovered.yaml`
+
+---
+
+### Fallback Path: @playwright/mcp Direct Navigation
+
+When Planner is unavailable, spawn `explorer-agent` with the target URL.
+
+The explorer agent:
+1. Navigates to the URL and takes an accessibility tree snapshot
+2. Identifies all interactive elements, forms, and navigation links
+3. Follows unique paths up to 2 levels deep (max 20 flows)
+4. Records each unique path as a user story
+
+---
+
+### Step 2: Augment with sad paths
+
+After flow discovery, automatically generate sad paths:
+- For each **form** found: invalid input story + empty submission story
+- For each **auth-protected page** found: unauthenticated access story
+- For each **destructive action** found: confirmation/cancellation story
+- For each **data-loading component**: empty state + error state story
+
+### Step 3: Output and summary
+Save all stories to `playwright-stories/` and report:
+- N happy paths discovered
+- N sad paths generated
+- Suggest: `/ralph-playwright:test-e2e` to run them
+
+---
+
+## Pivot Note: Stagehand (when to switch)
+
+If Playwright Planner produces insufficient coverage (< 5 flows on a complex SPA, or misses dynamically rendered content):
+
+```bash
+npm install @browserbasehq/stagehand
+```
+
+Use `stagehand.observe()` to enumerate all available actions at each page state, then `stagehand.agent()` for a full autonomous loop. This gives richer exploration at the cost of a Browserbase dependency and higher token usage. See Deferred section for full implementation notes.
+```
+
+#### 3. explorer-agent
+
+**File**: `plugin/ralph-playwright/agents/explorer-agent.md`
+
+```markdown
+---
+name: explorer-agent
+description: Fallback exploration agent. Navigates a web app via @playwright/mcp, maps interactive elements and navigation paths up to 2 levels deep, and returns structured flow data for conversion to user stories.
+model: claude-sonnet-4-6
+---
+
+# Explorer Agent
+
+You are a web application flow mapper. Your job: systematically explore a running app and return all discoverable user flows as structured data.
+
+## Instructions
+
+Given a starting URL:
+
+1. Navigate to the URL with `browser_navigate`
+2. Take accessibility tree snapshot with `browser_snapshot`
+3. Identify all:
+   - Navigation links (header, sidebar, footer)
+   - Buttons and CTAs
+   - Forms and their fields
+   - Interactive components (dropdowns, modals, tabs)
+4. Follow each unique link/button (track visited URLs to avoid loops)
+5. For each destination page, repeat steps 2-3 (max 2 levels deep)
+6. Stop after 20 unique flows
+
+## Output Format
+
+Return a JSON array:
+```json
+[
+  {
+    "name": "User views product list",
+    "startUrl": "http://localhost:3000",
+    "steps": [
+      "Navigate to http://localhost:3000",
+      "Click the Products link in the navigation",
+      "Verify product list loads with at least one item"
+    ],
+    "type": "happy",
+    "formFound": false
+  },
+  {
+    "name": "User submits contact form",
+    "startUrl": "http://localhost:3000/contact",
+    "steps": [
+      "Navigate to http://localhost:3000/contact",
+      "Fill name field with 'Test User'",
+      "Fill email field with 'test@example.com'",
+      "Fill message field with 'Hello'",
+      "Click Submit",
+      "Verify success message appears"
+    ],
+    "type": "happy",
+    "formFound": true
+  }
+]
+```
+
+Do not get stuck in loops. Track all visited URLs. Stop at 20 flows or 2 levels deep.
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `story-gen` skill produces valid YAML when given a text description
+- [ ] Generated YAML contains at least 1 sad path for any login/form feature
+- [ ] `explore` skill runs without error against a public URL
+
+#### Manual Verification:
+- [ ] `story-gen` on "a login page" produces at least: successful login, wrong password, empty fields, unauthenticated redirect
+- [ ] `explore` on a running dev server produces multiple flows with correct schema
+- [ ] Explorer agent stays within bounds (≤20 flows, no URL loops)
+
+---
+
+## Phase 3: Story Execution
+
+### Overview
+The core testing loop: discover all YAML story files, fan out parallel agents (one per file), execute each via Playwright MCP, inject a11y checks, aggregate results.
+
+### Changes Required:
+
+#### 1. test-e2e skill
+
+**File**: `plugin/ralph-playwright/skills/test-e2e/SKILL.md`
+
+```markdown
+---
+name: ralph-playwright:test-e2e
+description: Run all user story YAML files in playwright-stories/ in parallel using isolated Playwright agents. Aggregates pass/fail results with screenshots and a11y violations. Optionally filter by type (happy/sad/edge) or tags. Use when you want to run your full story suite or a filtered subset.
+---
+
+# Test E2E — Run All User Stories
+
+## Process
+
+### Step 1: Discover stories
+Glob all `playwright-stories/**/*.yaml` files.
+
+If none found, suggest:
+- `/ralph-playwright:story-gen` to create stories from a description
+- `/ralph-playwright:explore <url>` to generate stories by exploring a site
+
+Optional filters (from arguments):
+- `--type happy|sad|edge` — run only stories of that type
+- `--tags auth,login` — run only stories with matching tags
+- `--story "Login succeeds"` — run a specific story by name
+
+### Step 2: Fan out parallel agents
+Spawn one `story-runner-agent` per YAML file simultaneously.
+Each agent gets its own named Playwright session — fully isolated.
+
+### Step 3: Wait and aggregate
+Wait for all agents to complete, then produce a unified report:
+
+```
+== ralph-playwright E2E Report ==
+Stories: 5 | ✅ Pass: 4 | ❌ Fail: 1 | ⏭ Skip: 0
+A11y violations: 2
+
+PASSED:
+  ✅ auth — "Login succeeds with valid credentials" (3.2s)
+  ✅ auth — "Login fails with wrong password" (2.1s)
+  ✅ auth — "Login fails when fields are empty" (1.8s)
+  ✅ auth — "Login form is keyboard-navigable" (2.9s)
+
+FAILED:
+  ❌ auth — "Unauthenticated user is redirected from dashboard"
+     Step 2: Expected redirect to /login — page stayed at /dashboard
+     Screenshot: playwright-results/unauthenticated-redirect_a1b2c3d4/02_navigate.png
+     Console errors: []
+
+A11Y VIOLATIONS:
+  - auth/login — Missing label on #email-field (WCAG 1.3.1, serious)
+  - auth/login — Color contrast insufficient on .error-text (WCAG 1.4.3, serious)
+```
+
+Results directory `playwright-results/` is created automatically.
+```
+
+#### 2. story-runner-agent
+
+**File**: `plugin/ralph-playwright/agents/story-runner-agent.md`
+
+```markdown
+---
+name: story-runner-agent
+description: Executes a single user story YAML via @playwright/mcp. Captures screenshots per step, captures console errors on failure, runs axe-core a11y check at the end (if a11y MCP available), and returns a structured pass/fail result.
+model: claude-sonnet-4-6
+---
+
+# Story Runner Agent
+
+You execute a single user story and return a structured result.
+
+## Input
+A user story object: { name, type, url, persona, workflow }
+
+## Execution
+
+### Session setup
+Create a named Playwright session: `story-<story-name-kebab>-<8-char-uuid>`
+Create screenshot directory: `playwright-results/<story-name-kebab>_<uuid>/`
+
+### Execute each step
+Parse the `workflow` field line by line. For each non-empty line:
+1. Interpret the natural language instruction
+2. Use `browser_snapshot` to get the current accessibility tree (before acting)
+3. Find the target element contextually by label, role, or text — NOT by CSS selectors
+4. Execute the action: navigate, click, fill, type, or verify
+5. Take screenshot: `playwright-results/<dir>/<index>_<step-slug>.png`
+6. Verify assertion steps using the snapshot state
+
+On step failure:
+- Record failure message and expected vs actual state
+- Capture JS console errors via `browser_evaluate("(window.__consoleErrors || [])")`
+- Mark all remaining steps as SKIPPED
+- Stop execution immediately
+
+### A11y check (when available)
+After the final step (or after failure), if the `a11y-accessibility` MCP is registered:
+```
+test_accessibility(url: <current page URL>)
+```
+Attach WCAG violations to the result.
+
+### Output (JSON)
+```json
+{
+  "story": "Login succeeds with valid credentials",
+  "type": "happy",
+  "status": "pass",
+  "duration": 3241,
+  "steps": [
+    { "step": "Navigate to login", "status": "pass", "screenshot": "00_navigate.png" },
+    { "step": "Verify form visible", "status": "pass", "screenshot": "01_verify-form.png" },
+    { "step": "Fill email", "status": "pass", "screenshot": "02_fill-email.png" },
+    { "step": "Click Sign In", "status": "fail", "error": "Button not found in snapshot", "consoleErrors": [] }
+  ],
+  "a11yViolations": [
+    { "rule": "label", "impact": "serious", "description": "Form field has no label", "wcag": "1.3.1" }
+  ]
+}
+```
+```
+
+#### 3. a11y-scan skill
+
+**File**: `plugin/ralph-playwright/skills/a11y-scan/SKILL.md`
+
+```markdown
+---
+name: ralph-playwright:a11y-scan
+description: Run a standalone WCAG 2.2 AA accessibility audit against a URL or set of URLs using axe-core via a11y-mcp-server. Reports violations by severity. Use for a quick a11y check without running full story execution. Requires a11y-mcp-server to be registered.
+---
+
+# A11y Scan — Standalone Accessibility Audit
+
+## Prerequisites
+`a11y-mcp-server` registered in Claude Code (see `/ralph-playwright:setup`).
+
+## Process
+
+### Step 1: Target URL(s)
+From arguments or ask. Multiple URLs run in parallel.
+
+### Step 2: Run axe-core checks
+For each URL:
+```
+test_accessibility(url)         → WCAG rule violations
+check_color_contrast(url)       → contrast ratios
+check_aria_attributes(url)      → ARIA validity
+```
+
+### Step 3: Report
+```
+== A11y Scan: http://localhost:3000/login ==
+WCAG 2.2 AA | axe-core | 3 violations
+
+🔴 CRITICAL (1):
+  - Interactive element not keyboard accessible: .modal-close-btn
+    → Add tabindex="0" and keydown handler (WCAG 2.1.1)
+
+🟠 SERIOUS (1):
+  - Form field missing label: <input id="email">
+    → Add <label for="email"> or aria-label (WCAG 1.3.1)
+
+🟡 MODERATE (1):
+  - Color contrast insufficient: .helper-text ratio 2.8:1, needs 4.5:1
+    → Darken text color (WCAG 1.4.3)
+```
+
+Severities: 🔴 critical, 🟠 serious, 🟡 moderate, ⚪ minor.
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `test-e2e` skill discovers YAML files in `playwright-stories/`
+- [ ] `story-runner-agent` executes a simple story against a live URL (e.g. a public site)
+- [ ] A11y violations appear in the result JSON from story-runner-agent
+
+#### Manual Verification:
+- [ ] Multiple stories run simultaneously (check timestamps overlap)
+- [ ] Each story produces screenshots in its own `playwright-results/<uuid>/` directory
+- [ ] A sad path story correctly fails when the expected error message is not shown
+- [ ] `a11y-scan` identifies at least one real violation on a page with known issues
+
+---
+
+## Phase 4: Storybook Integration
+
+### Overview
+Component-level testing via Storybook 9. Complements Phase 3 (page-level E2E) with component-level interaction and a11y assurance.
+
+### Changes Required:
+
+#### 1. storybook-test skill
+
+**File**: `plugin/ralph-playwright/skills/storybook-test/SKILL.md`
+
+```markdown
+---
+name: ralph-playwright:storybook-test
+description: Run Storybook 9 component tests (interaction + a11y) using Vitest browser mode or legacy test-runner. Detects which runner is installed and adapts. Optionally uses Storybook MCP to validate component usage. Requires Storybook 9+ with @storybook/addon-vitest or @storybook/test-runner.
+---
+
+# Storybook Component Testing
+
+## Step 1: Detect Storybook setup
+```bash
+npx storybook --version          # needs 9.x
+cat package.json | grep -E "addon-vitest|test-runner"
+```
+
+- `@storybook/addon-vitest` found → **Vitest mode** (Storybook 9, recommended)
+- `@storybook/test-runner` found → **Legacy mode** (older Storybook)
+- Neither → show install instructions
+
+## Step 2: Run tests
+
+**Vitest mode:**
+```bash
+npx vitest --project=storybook
+```
+
+**Legacy mode:**
+```bash
+npx test-storybook --url http://localhost:6006
+```
+
+## Step 3: Storybook MCP enrichment (optional)
+If Storybook MCP is registered (`http://localhost:6006/mcp`):
+- Call `list-all-components` to enumerate all components
+- Cross-reference with test results
+- Flag any components with no stories (coverage gap)
+
+## Step 4: Report
+```
+== Storybook Component Tests ==
+Components: 24 | Stories: 87 | ✅ Pass: 85 | ❌ Fail: 2
+
+FAILED:
+  ❌ Button/Primary — Interaction: onClick not called after keyboard Enter
+  ❌ Form/LoginForm — A11y: missing label on password field (WCAG 1.3.1)
+
+A11y summary: 1 violation across 1 component
+Coverage gaps: 0 components have no stories
+```
+```
+
+#### 2. visual-diff skill
+
+**File**: `plugin/ralph-playwright/skills/visual-diff/SKILL.md`
+
+```markdown
+---
+name: ralph-playwright:visual-diff
+description: Run visual regression testing using Chromatic (default, free tier available) or Applitools Eyes (AI-based, better for dynamic content). Detects unintended UI changes across Storybook stories. Use after visual changes to verify intentional vs unintentional diffs.
+---
+
+# Visual Diff — Visual Regression Testing
+
+## Tool Detection
+Check what's configured:
+```bash
+cat package.json | grep -E "chromatic|@applitools"
+```
+
+- `chromatic` found → **Chromatic mode** (pixel-perfect)
+- `@applitools/eyes-storybook` found → **Applitools mode** (AI-based)
+- Neither → guide through Chromatic setup (recommended default)
+
+## Chromatic (default)
+```bash
+npm install --save-dev chromatic
+npx chromatic --project-token=<token-from-chromatic.com>
+```
+Free tier: 5,000 snapshots/month. Pixel-perfect diffing. Good for stable UIs.
+
+## Applitools Eyes (alternative)
+```bash
+npm install --save-dev @applitools/eyes-storybook
+npx eyes-storybook
+```
+AI-powered visual perception. Ignores rendering noise (anti-aliasing, sub-pixel differences). Better for UIs with dynamic content or cross-browser inconsistencies.
+
+## When to choose Applitools over Chromatic
+- Getting excessive false positives from Chromatic on animations or dynamic content
+- Need cross-browser visual comparison (Chromatic uses one browser)
+- Have Storybook stories with real data that varies slightly between runs
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `storybook-test` skill detects and uses the correct runner (Vitest vs legacy)
+- [ ] A11y violations at component level are surfaced in the report
+
+#### Manual Verification:
+- [ ] Storybook test run completes and shows per-story pass/fail
+- [ ] `visual-diff` runs Chromatic against a Storybook 9 project and produces a diff report
+
+---
+
+## Deferred Work
+
+Explicitly out of scope for this plan but documented for future implementation:
+
+### D1: Figma MCP → User Stories Pipeline
+**Why deferred**: Figma integration adds significant scope (token chunking, reactions field parsing, Jira sync) and requires Figma file access not available as a generic framework feature.
+
+**Approach when implemented**:
+1. Connect Figma MCP (`https://mcp.figma.com/mcp`)
+2. Extract `reactions` field from prototype nodes for the interaction graph
+3. Chunk large Figma files (token limit constraint — required for any file > ~20 frames)
+4. LLM structured output (Zod schema) → `UserStory[]` matching ralph-playwright schema
+5. Add `story-gen-figma` skill variant: accepts Figma file key → outputs YAML
+
+### D2: Stagehand-Based Deep Stochastic Exploration
+**When to pivot from Playwright Planner**:
+- Planner produces < 5 flows on a complex SPA
+- Highly dynamic applications where accessibility tree is insufficient
+- Need true open-ended exploration without predefined goals
+
+**Approach**:
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+const stagehand = new Stagehand({ env: "LOCAL" }); // or "BROWSERBASE" for cloud
+await stagehand.init();
+const page = stagehand.page;
+
+// observe() → all available actions at current state (no goal needed)
+const actions = await stagehand.observe();
+
+// agent() → fully autonomous multi-step loop
+await stagehand.agent({
+  task: "Explore this page and find any error states or broken interactions"
+});
+```
+Add `explore-stagehand` skill variant as opt-in. Requires Browserbase account for cloud execution.
+
+### D3: CI/CD GitHub Actions Integration
+Standard workflow pattern:
+```yaml
+# .github/workflows/ralph-playwright.yml
+on: [pull_request]
+jobs:
+  e2e:
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run build && npm run dev &
+      - run: npx claude --skill ralph-playwright:test-e2e
+```
+
+### D4: Ralph-Playwright MCP Server
+If test state management becomes complex, a lightweight MCP server would expose:
+- `get_story_results` — latest run results per story
+- `update_story_status` — mark stories as approved/known-failure
+- `list_stories` — enumerate all YAML files with metadata + last run status
+
+Would follow the ralph-knowledge MCP pattern (Hono server, SQLite, npx install).
+
+---
+
+## Testing Strategy
+
+### Phase 1 (Foundation):
+- Manual: parse YAML files, read skills — no logic to test
+- Check: all files are valid YAML/JSON
+
+### Phase 2 (Story Generation):
+- Manual: run `story-gen` against "a login page" description
+- Verify: output contains ≥1 happy, ≥2 sad, ≥1 edge story
+- Manual: run `explore` against https://playwright.dev (public, stable URL)
+- Verify: produces valid YAML with correct schema
+
+### Phase 3 (Story Execution):
+- Manual: run `test-e2e` against example stories on any localhost app
+- Verify: screenshots appear per step in `playwright-results/`
+- Verify: a sad path story correctly fails when expected error not shown
+- Manual: run `a11y-scan` on a page known to have issues
+
+### Phase 4 (Storybook):
+- Manual: requires a Storybook 9 project — run `storybook-test` against it
+- Verify: per-story pass/fail reported with a11y violations
+
+## References
+
+- Research: `thoughts/shared/research/2026-03-19-agent-driven-ui-testing-stochastic-exploration.md`
+- Bowser reference: https://github.com/disler/bowser
+- Playwright MCP: https://github.com/microsoft/playwright-mcp
+- Playwright Test Agents: https://playwright.dev/docs/test-agents
+- Storybook addon-mcp: https://github.com/storybookjs/addon-mcp
+- A11y MCP: https://github.com/ronantakizawa/a11ymcp
+- Stagehand: https://github.com/browserbase/stagehand
+- Applitools Eyes Storybook: https://applitools.com/docs/eyes/sdks/storybook
+- Chromatic: https://chromatic.com

--- a/thoughts/shared/plans/2026-03-19-knowledge-type-inference-and-frontmatter-fix.md
+++ b/thoughts/shared/plans/2026-03-19-knowledge-type-inference-and-frontmatter-fix.md
@@ -1,0 +1,239 @@
+---
+date: 2026-03-19
+status: draft
+type: plan
+tags: [ralph-knowledge, obsidian, indexer, frontmatter, type-inference]
+---
+
+# Knowledge Type Inference & Frontmatter Fix — Implementation Plan
+
+## Overview
+
+36 documents appear in `_uncategorized.md` in the Obsidian vault despite having obvious types derivable from their directory path or containing `type: spec` which the indexer doesn't recognize. This plan fixes the indexer to infer type from path, adds `spec` as a first-class type, then bulk-patches frontmatter on existing docs for correctness.
+
+## Current State Analysis
+
+`parser.ts:58` sets `type: frontmatter.type ?? null` — no fallback. If a doc lacks `type:` frontmatter, it gets `null` and lands in `_uncategorized.md`.
+
+`generate-indexes.ts:254–260` only recognizes: `research`, `plan`, `idea`, `review`, `report`. Any other value (e.g., `spec`) also lands in uncategorized.
+
+**36 affected documents:**
+
+| Directory | Count | Inferred type |
+|-----------|-------|---------------|
+| `shared/reports/` | 16 | `report` |
+| `shared/plans/` | 11 | `plan` |
+| `ideas/` + `shared/ideas/` | 5 | `idea` |
+| `shared/research/` | 2 | `research` |
+| `shared/plans/` (`type: spec`) | 1 | `spec` (new first-class type) |
+
+## Desired End State
+
+- `_uncategorized.md` is not generated (or is empty) after reindex
+- `_index.md` does not link to `_uncategorized`
+- All 36 docs appear in their correct type indexes
+- New docs added without `type:` frontmatter are automatically categorized by directory
+- Plugin tests cover the inference logic
+
+### Verification
+- [ ] `_uncategorized.md` does not exist after reindex
+- [ ] `_plans.md` includes the 11 formerly-uncategorized plan docs (not the spec)
+- [ ] `_specs.md` exists and includes the `debug-mode-observability-spec` doc
+- [ ] `_reports.md` includes all 16 ralph-team session reports
+- [ ] `_ideas.md` includes the 5 formerly-uncategorized idea docs
+- [ ] `_index.md` lists `_specs` in Browse by Type
+
+## What We're NOT Doing
+
+- Not creating a `thoughts/shared/specs/` directory — specs can live in any directory and are typed by frontmatter
+- Not changing the directory structure of `thoughts/`
+- Not touching `shared/research/` docs that already have correct frontmatter
+
+## Implementation Approach
+
+Three-part fix:
+1. **Plugin code** — add path-based type inference in `parser.ts`, add `spec` as a first-class type in `generate-indexes.ts`
+2. **Frontmatter patch** — add `type:` to the 35 affected docs so they're correct even without inference
+3. **Obsidian config** — add `spec` to graph color groups and Dataview queries
+
+---
+
+## Phase 1: Add type inference to parser.ts
+
+### Changes Required
+
+**File**: `plugin/ralph-knowledge/src/parser.ts`
+
+Add a `inferTypeFromPath()` helper and call it when `frontmatter.type` is absent:
+
+```typescript
+const PATH_TYPE_MAP: Array<{ segment: string; type: string }> = [
+  { segment: "/research/", type: "research" },
+  { segment: "/plans/",    type: "plan" },
+  { segment: "/ideas/",    type: "idea" },
+  { segment: "/reviews/",  type: "review" },
+  { segment: "/reports/",  type: "report" },
+];
+
+function inferTypeFromPath(path: string): string | null {
+  for (const { segment, type } of PATH_TYPE_MAP) {
+    if (path.includes(segment)) return type;
+  }
+  return null;
+}
+```
+
+Then in `parseDocument`, replace:
+```typescript
+type: frontmatter.type ?? null,
+```
+with:
+```typescript
+type: (typeof frontmatter.type === "string" && frontmatter.type.length > 0)
+  ? frontmatter.type
+  : inferTypeFromPath(path),
+```
+
+Note: no aliasing — `type: spec` stays as `"spec"` and is handled as a first-class type.
+
+**File**: `plugin/ralph-knowledge/src/generate-indexes.ts`
+
+Add `spec` to all three type registries:
+
+```typescript
+// In TYPE_HEADINGS (line 55-61):
+const TYPE_HEADINGS: Record<string, string> = {
+  research: "Research",
+  plan: "Plans",
+  spec: "Specs",        // NEW
+  idea: "Ideas",
+  review: "Reviews",
+  report: "Reports",
+};
+
+// In TYPE_INDEX_CONFIG (line 254-260):
+const TYPE_INDEX_CONFIG: Array<{ type: string; filename: string; heading: string }> = [
+  { type: "research", filename: "research", heading: "Research Documents" },
+  { type: "plan", filename: "plans", heading: "Implementation Plans" },
+  { type: "spec", filename: "specs", heading: "Specifications" },  // NEW
+  { type: "idea", filename: "ideas", heading: "Ideas & Drafts" },
+  { type: "review", filename: "reviews", heading: "Reviews" },
+  { type: "report", filename: "reports", heading: "Reports" },
+];
+```
+
+Also update `writeMasterIndex` (line 138-144) to add a `_specs` entry:
+```typescript
+"- [[_specs]] — Specifications",
+```
+
+**File**: `plugin/ralph-knowledge/src/__tests__/generate-indexes.test.ts` (or a new `parser.test.ts`)
+
+Add tests covering:
+- `inferTypeFromPath("shared/plans/foo.md")` → `"plan"`
+- `inferTypeFromPath("shared/research/foo.md")` → `"research"`
+- `inferTypeFromPath("shared/reports/foo.md")` → `"report"`
+- `type: spec` in frontmatter → stays as `"spec"` (no aliasing)
+- Unknown path with no type → `null`
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `npm test` passes in `plugin/ralph-knowledge/`
+- [ ] `npm run build` (TypeScript) passes
+
+#### Manual Verification:
+- [ ] Run reindex: `node /tmp/node_modules/ralph-hero-knowledge-index/dist/reindex.js thoughts/`
+- [ ] `_uncategorized.md` is absent or empty
+
+---
+
+## Phase 2: Bulk-patch frontmatter on 36 existing docs
+
+Add `type:` frontmatter to each affected file so they're correct in git history independently of inference logic. This is a mechanical sed/script operation.
+
+**Files to patch** (add `type: plan`):
+- `thoughts/shared/plans/2026-02-20-ralph-team-worker-redesign.md`
+- `thoughts/shared/plans/2026-02-26-GH-0418-interactive-ralph-parity.md`
+- `thoughts/shared/plans/2026-02-27-GH-0433-auto-mode-pipeline-detection.md`
+- `thoughts/shared/plans/2026-02-27-mcp-toolspace-consolidation.md`
+- `thoughts/shared/plans/2026-02-27-ralph-cli-qol-improvements.md`
+- `thoughts/shared/plans/2026-02-28-ralph-protocol-specs.md`
+- `thoughts/shared/plans/2026-03-02-builder-main-branch-guard.md`
+- `thoughts/shared/plans/2026-03-03-group-GH-0519-parent-advancement-dashboard-fix.md`
+- `thoughts/shared/plans/2026-03-05-GH-0539-cross-repo-dependency-tooling.md`
+- `thoughts/shared/plans/2026-03-18-group-GH-0604-demo-cli-greeting.md`
+
+Note: `2026-02-21-debug-mode-observability-spec.md` already has `type: spec` — no change needed (now a recognized type).
+
+**Files to patch** (add `type: report`):
+- `thoughts/shared/reports/2026-02-21-weekly-ship-report.md`
+- `thoughts/shared/reports/2026-02-25-idea-hunt-team-diagnostic.md`
+- `thoughts/shared/reports/2026-02-27-ralph-team-GH-451.md`
+- `thoughts/shared/reports/2026-03-01-ralph-team-431-464-466.md`
+- `thoughts/shared/reports/2026-03-01-ralph-team-bugs-and-triage.md`
+- `thoughts/shared/reports/2026-03-01-ralph-team-GH-433.md`
+- `thoughts/shared/reports/2026-03-01-ralph-team-GH-467.md`
+- `thoughts/shared/reports/2026-03-01-ralph-team-GH-477.md`
+- `thoughts/shared/reports/2026-03-01-ralph-team-plugin-cleanup.md`
+- `thoughts/shared/reports/2026-03-01-ralph-team-triage-oldest-5.md`
+- `thoughts/shared/reports/2026-03-02-ralph-team-464-466.md`
+- `thoughts/shared/reports/2026-03-02-ralph-team-GH-493.md`
+- `thoughts/shared/reports/2026-03-03-ralph-team-gh-0480.md`
+- `thoughts/shared/reports/2026-03-04-ralph-team-gh-0519.md`
+- `thoughts/shared/reports/2026-03-04-ralph-team-gh-514-515-516.md`
+- `thoughts/shared/reports/2026-03-04-ralph-team-pir-batch.md`
+- `thoughts/shared/reports/2026-03-05-ralph-team-gh-541-worktree-lifecycle.md`
+- `thoughts/shared/reports/2026-03-18-ralph-team-GH-604-demo-cli.md`
+- `thoughts/shared/reports/2026-03-19-ralph-team-GH-604-demo-cli-merge.md`
+
+**Files to patch** (add `type: idea`):
+- `thoughts/ideas/2026-02-18-github-projects-v2-docs-deep-dive.md`
+- `thoughts/ideas/2026-02-21-showcase-demo-onboarding.md`
+- `thoughts/ideas/2026-02-22-orchestrator-no-message-on-task-assign.md`
+- `thoughts/shared/ideas/2026-02-25-idea-hunt-synthesis.md`
+- `thoughts/shared/ideas/2026-03-01-hello-session-briefing.md`
+
+**Files to patch** (add `type: research`):
+- `thoughts/shared/research/2026-02-18-GH-0066-github-projects-v2-docs-guidance.md`
+- `thoughts/shared/research/2026-02-20-GH-0199-cross-project-sync-audit-trail.md`
+
+### Patch strategy
+
+Insert `type: <TYPE>` after the opening `---` line using a targeted edit for each file. No sed — use Edit tool per file to avoid frontmatter corruption.
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `grep -rL "^type:" thoughts/shared/plans/ thoughts/shared/reports/ thoughts/ideas/ thoughts/shared/ideas/ thoughts/shared/research/` returns no files
+
+#### Manual Verification:
+- [ ] Git diff shows only frontmatter additions, no content changes
+
+---
+
+## Phase 3: Reindex and verify
+
+```bash
+node /tmp/node_modules/ralph-hero-knowledge-index/dist/reindex.js thoughts/
+```
+
+Check output:
+- No `missing frontmatter: type` warnings for the 36 patched files
+- `_uncategorized.md` is absent
+- `_plans.md`, `_reports.md`, `_ideas.md` lists grow by expected counts
+
+Then rebuild the npm package and publish:
+```bash
+cd plugin/ralph-knowledge && npm run build && npm test
+```
+
+CI will handle publish on merge to main.
+
+---
+
+## References
+
+- `plugin/ralph-knowledge/src/parser.ts:58` — type field assignment
+- `plugin/ralph-knowledge/src/generate-indexes.ts:254–260` — TYPE_INDEX_CONFIG
+- `plugin/ralph-knowledge/src/generate-indexes.ts:269` — uncategorized filter

--- a/thoughts/shared/plans/2026-03-19-port-hello-fix-to-hero-skill.md
+++ b/thoughts/shared/plans/2026-03-19-port-hello-fix-to-hero-skill.md
@@ -1,0 +1,112 @@
+---
+date: 2026-03-19
+status: draft
+type: plan
+tags: [skills, hero, context-mode, fix]
+---
+
+# Port Hello Skill Fix to Hero Skill
+
+## Prior Work
+
+- builds_on:: commit `7488ef4` — "fix(hello): switch to inline context so AskUserQuestion works (#603)"
+
+## Overview
+
+The hello skill was fixed by switching from `context: fork` to `context: inline`, removing `model: sonnet`, removing hooks, and adding `AskUserQuestion`. Hero needs the same class of fix but must retain its hooks because `RALPH_COMMAND=hero` is required by `skill-precondition.sh` to allow MCP tool calls.
+
+## Current State Analysis
+
+**hero/SKILL.md frontmatter (broken):**
+```yaml
+model: sonnet              # forces model — likely spawns subprocess like fork
+allowed-tools: [...]       # missing AskUserQuestion
+hooks:                     # SessionStart sets RALPH_COMMAND=hero; PreToolUse validates tasks
+```
+
+No `context:` field (defaults to inline), but `model: sonnet` may cause subprocess behavior that breaks interactive tool access.
+
+**hello/SKILL.md frontmatter (working, post-fix):**
+```yaml
+context: inline            # explicit inline
+allowed-tools:             # includes AskUserQuestion
+  - AskUserQuestion
+  - ...
+```
+
+No `model:`, no `hooks:`.
+
+### Key Constraint
+
+Hero's `hooks.SessionStart` sets `RALPH_COMMAND=hero` via `set-skill-env.sh`. This is **critical** — `skill-precondition.sh` hard-blocks `ralph_hero__get_issue` and `ralph_hero__list_issues` if unset. Hero calls `get_issue` in Step 1 before any sub-skills. The hooks block must be retained.
+
+## What We're NOT Doing
+
+- Removing the hooks block (hero depends on RALPH_COMMAND being set)
+- Changing the skill body/logic
+- Modifying any other skills
+
+## Implementation Approach
+
+Apply the hello changes that are safe for hero: add explicit `context: inline`, remove `model: sonnet`, add `AskUserQuestion` to allowed-tools. Keep the hooks block intact.
+
+## Phase 1: Update Hero Skill Frontmatter
+
+### Changes Required:
+
+**File**: `plugin/ralph-hero/skills/hero/SKILL.md`
+
+1. Add `context: inline` after `argument-hint`
+2. Remove `model: sonnet`
+3. Add `AskUserQuestion` to `allowed-tools`
+
+**Before:**
+```yaml
+---
+description: ...
+argument-hint: <issue-number>
+model: sonnet
+allowed-tools:
+  - Read
+  - Write
+  ...
+hooks:
+  SessionStart: ...
+  PreToolUse: ...
+---
+```
+
+**After:**
+```yaml
+---
+description: ...
+argument-hint: <issue-number>
+context: inline
+allowed-tools:
+  - Read
+  - Write
+  ...
+  - AskUserQuestion
+hooks:
+  SessionStart: ...
+  PreToolUse: ...
+---
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep -c "context: inline" plugin/ralph-hero/skills/hero/SKILL.md` returns 1
+- [ ] `grep -c "model:" plugin/ralph-hero/skills/hero/SKILL.md` returns 0
+- [ ] `grep -c "AskUserQuestion" plugin/ralph-hero/skills/hero/SKILL.md` returns 1
+- [ ] Hooks block still present: `grep -c "SessionStart" plugin/ralph-hero/skills/hero/SKILL.md` returns 1
+
+#### Manual Verification:
+- [ ] `/ralph-hero:hero` invocation works — can reach Step 1 and call MCP tools
+- [ ] Interactive prompts (e.g., "Would you like to process this issue?") function correctly
+
+## Testing Strategy
+
+### Manual Testing Steps:
+1. Invoke `/ralph-hero:hero` without an issue number — verify it can call `pick_actionable_issue` and present interactive choice
+2. Invoke `/ralph-hero:hero 123` with a known issue — verify it reaches pipeline detection and calls `get_issue`

--- a/thoughts/shared/plans/2026-03-24-GH-0674-agent-per-phase-architecture.md
+++ b/thoughts/shared/plans/2026-03-24-GH-0674-agent-per-phase-architecture.md
@@ -1,0 +1,772 @@
+---
+date: 2026-03-24
+last_updated: 2026-04-01
+last_updated_note: "Updated line references to match current codebase; marked Phase 1 items 1-2 as complete"
+status: draft
+type: plan
+tags: [architecture, agents, skills, hooks, env-vars, hero-dispatch]
+github_issue: 674
+github_issues: [674]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/674
+primary_issue: 674
+---
+
+# Agent-Per-Phase Architecture Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-03-24-agent-env-propagation-token-scope]]
+- builds_on:: [[2026-04-01-GH-0674-agent-per-phase-still-needed]]
+- builds_on:: [[2026-03-19-GH-0637-hero-dispatch-model]]
+- builds_on:: [[2026-02-20-GH-0231-skill-subagent-team-context-pollution]]
+
+## Overview
+
+Replace the broken wrapper-agent architecture (ralph-analyst/ralph-builder/ralph-integrator → Skill()) with per-phase agents that preload skill content via the `skills:` field. This fixes three compounding issues: silent model downgrades from nested sub-agent prohibition, unexpandable `$VAR` references causing "token scope" errors, and silently ignored plugin sub-agent hooks.
+
+## Current State Analysis
+
+### What's broken
+
+The current dispatch chain:
+```
+hero → Agent("ralph-analyst") → Skill("ralph-research")
+         ├── context:fork → BLOCKED (no nested sub-agents)
+         ├── model:opus → IGNORED (agent is sonnet)
+         └── SessionStart → CLAUDE_ENV_FILE may be empty → RALPH_COMMAND not set
+```
+
+Three wrapper agents (ralph-analyst, ralph-builder, ralph-integrator) each just check TaskList and call Skill(). This creates nested sub-agent issues:
+- Skills with `context: fork` silently run inline, losing model overrides
+- Plugin sub-agent hooks in frontmatter are silently ignored
+- `$RALPH_GH_OWNER`/`$RALPH_GH_REPO` in skill prompts are literal text LLMs can't expand
+
+### Key Discoveries
+
+- Sub-agent `tools:` is a **hard allowlist** (enforced) vs skill `allowed-tools:` is a **permission grant** (not enforced as restriction)
+- Sub-agent `skills:` field **preloads full skill content** into agent context with backtick preprocessing
+- Backtick preprocessing (`` !`echo $RALPH_GH_OWNER` ``) **works in preloaded skills** (tested 2026-03-24)
+- Plugin agents support `tools`, `model`, `skills`, `memory`, `background`, `isolation` — but NOT `hooks`, `mcpServers`, `permissionMode`
+- Plugin-level hooks in `hooks.json` fire for all contexts including sub-agents
+- Hook input JSON includes `agent_type` field when firing inside sub-agents
+
+## Desired End State
+
+Hero dispatches per-phase agents directly:
+```
+hero → Agent("ralph-hero:research-agent", prompt="Research issue #42")
+         ├── tools: hard allowlist from agent frontmatter
+         ├── model: sonnet (from agent, honored)
+         ├── skills: [ralph-hero:ralph-research] (preloaded with resolved env vars)
+         └── plugin hooks.json fires with agent_type="research-agent"
+```
+
+### Verification
+
+- Hero dispatches to per-phase agents without wrapper agents
+- Agents run with correct model (opus for impl/plan/plan-epic/review/split, sonnet for research/triage, haiku for pr/merge/val)
+- Skill content is preloaded with resolved env var values (no `$VAR` literals)
+- MCP tool calls work without explicit `owner`/`repo` params
+- Plugin-level hooks discriminate by `agent_type`
+- Skills remain independently invocable for interactive use
+- All existing tests pass: `cd plugin/ralph-hero/mcp-server && npm test`
+
+## What We're NOT Doing
+
+- Changing the MCP server — `resolveConfig()` defaults already work correctly
+- Removing skills — they're kept for interactive use and as the single source of truth for workflow instructions
+- Adding hooks to agent frontmatter — plugin agents can't have them; we use hooks.json instead
+- Changing the skill frontmatter (hooks, context, model) — it's ignored when preloaded but still works for direct invocation
+- Rewriting hook scripts — we're adding `agent_type` awareness, not replacing existing logic
+- Compacting skill prompt sizes — context window pressure from large preloaded skills is a real concern but is a separate effort
+
+## Known Risks
+
+### Risk 1: Artifact path passing via natural language prompts
+Hero currently passes `--research-doc` and `--plan-doc` flags via structured Skill() prompts. In the new architecture, these become natural language in the Agent() prompt (e.g., "Research doc: thoughts/shared/research/..."). Whether the preloaded skill instructions reliably extract paths from natural language prompts vs CLI-style flags is untested. Mitigation: monitor during Phase 7 manual testing, consider structured prompt format if unreliable.
+
+### Risk 2: Context window pressure from skill preloading
+Some skills are large (ralph-impl ~570 lines, ralph-review ~440 lines). When preloaded via `skills:`, the full content is injected before the agent does any work. For haiku agents with smaller context windows, this could be a problem. Mitigation: monitor during Phase 7, consider a separate skill prompt compaction effort if needed.
+
+### Risk 3: Double hook firing for direct skill invocations
+When a user directly invokes a skill (e.g., `/ralph-hero:ralph-research`), both the skill's frontmatter hooks AND the new hooks.json `agent-phase-gate.sh` will fire. The gate script checks `agent_type` — if empty (not in a sub-agent), it allows and exits. This should be harmless but could cause confusing duplicate block messages if both the skill hook and the plugin hook match the same tool. Mitigation: `agent-phase-gate.sh` skips entirely when `RALPH_COMMAND` is set (indicating a skill is handling its own hooks).
+
+## Implementation Approach
+
+**Worktree isolation required** — this is a massive cross-cutting change touching agents, skills, hooks, hero dispatch, and specs. All work MUST be done in a dedicated worktree branch (e.g., `feat/agent-per-phase`) to avoid destabilizing main.
+
+Seven phases. Phases 1 and 2 can run in parallel. Phases 3–7 are sequential.
+
+---
+
+## Phase 1: Hook Infrastructure — `agent_type` Awareness
+
+- **depends_on**: null
+
+### Overview
+
+Add `agent_type` support to hook-utils.sh and skill-precondition.sh so plugin-level hooks can discriminate by agent type. Migrate phase-specific hooks from skill frontmatter to hooks.json with `agent_type` case dispatch.
+
+### Changes Required
+
+#### 1. ~~Add `get_agent_type()` to hook-utils.sh~~ DONE
+**File**: `plugin/ralph-hero/hooks/scripts/hook-utils.sh`
+**Status**: Already implemented at lines 35-37. Uses `get_field '.agent_type'` (delegating to the `get_field()` helper at lines 19-22). Located after `get_tool_input()` (line 30).
+
+```bash
+# Extract agent_type from hook input (present when firing inside a sub-agent)
+get_agent_type() {
+  get_field '.agent_type'
+}
+```
+
+#### 2. ~~Modify skill-precondition.sh for agent_type fallback~~ DONE
+**File**: `plugin/ralph-hero/hooks/scripts/skill-precondition.sh`
+**Status**: Already implemented at lines 25-36. When `RALPH_COMMAND` is empty, it calls `get_agent_type()` (line 28) and allows if non-empty (line 30). Only falls through to `block()` (line 32) if both `RALPH_COMMAND` and `agent_type` are empty. GitHub owner/repo checks follow at lines 38-47, project number check at lines 49-56.
+
+```bash
+# Current implementation (lines 25-36):
+command="${RALPH_COMMAND:-}"
+if [[ -z "$command" ]]; then
+  agent_type=$(get_agent_type)
+  if [[ -n "$agent_type" ]]; then
+    allow
+    exit 0
+  fi
+  block "Skill precondition failed: RALPH_COMMAND not set
+  ..."
+fi
+```
+
+#### 3. Create agent-phase-gate.sh dispatch script
+**File**: `plugin/ralph-hero/hooks/scripts/agent-phase-gate.sh`
+**Changes**: New file — routes to phase-specific hooks based on `agent_type`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+agent_type=$(get_agent_type)
+
+# Skip when RALPH_COMMAND is set (skill is handling its own hooks)
+[[ -n "${RALPH_COMMAND:-}" ]] && { allow; exit 0; }
+
+# Only apply phase gates when running inside a per-phase agent
+[[ -z "$agent_type" ]] && { allow; exit 0; }
+
+tool_name=$(get_tool_name)
+
+case "$agent_type" in
+  impl-agent)
+    case "$tool_name" in
+      Write|Edit)
+        exec "$(dirname "$0")/impl-plan-required.sh"
+        ;;
+      Bash)
+        exec "$(dirname "$0")/impl-branch-gate.sh"
+        ;;
+    esac
+    ;;
+  research-agent|plan-agent|plan-epic-agent|triage-agent|split-agent|review-agent)
+    case "$tool_name" in
+      Bash)
+        exec "$(dirname "$0")/branch-gate.sh"
+        ;;
+    esac
+    ;;
+esac
+
+allow
+```
+
+**Important**: The `exec` delegation relies on `RALPH_HOOK_INPUT` being exported by `read_input()`. The child script calls `read_input()` again but sees the cached env var (non-empty guard) rather than re-reading exhausted stdin. This MUST be verified with a test.
+
+#### 4. Add to hooks.json
+**File**: `plugin/ralph-hero/hooks/hooks.json`
+
+Add to PreToolUse section:
+```json
+{
+  "matcher": "Write|Edit|Bash",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/agent-phase-gate.sh"
+    }
+  ]
+}
+```
+
+Similarly create `agent-postcondition.sh` for Stop hooks and add to hooks.json.
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] `bash plugin/ralph-hero/hooks/scripts/hook-utils.sh` sources without error (confirmed 2026-04-01)
+- [x] skill-precondition.sh allows when agent_type is present in mock input (confirmed 2026-04-01)
+- [ ] `cd plugin/ralph-hero/mcp-server && npm test` passes (no server changes)
+- [ ] **exec delegation test**: `agent-phase-gate.sh` → child script receives `RALPH_HOOK_INPUT` correctly via exported env var (not exhausted stdin)
+
+#### Manual Verification:
+- [ ] Direct skill invocation (`/ralph-hero:ralph-research`) still works with RALPH_COMMAND
+- [ ] Hook scripts are executable (`chmod +x`)
+
+---
+
+## Phase 2: Skill Env Var Modernization
+
+- **depends_on**: null
+
+### Overview
+
+Add a resolved configuration block to skill content and remove explicit `owner`/`repo` params from MCP tool call instructions. URL templates keep `$RALPH_GH_OWNER`/`$RALPH_GH_REPO` references but the LLM uses resolved values from the config block.
+
+### Changes Required
+
+#### 1. Add resolved config section to autonomous skills
+
+Add a configuration block near the top of each autonomous skill (after the frontmatter) that provides resolved values:
+
+```markdown
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+
+Use these resolved values when constructing GitHub URLs or referencing the repository.
+```
+
+This is the single source of truth for env var values. The LLM reads this block and uses the resolved values throughout. No need to replace every `$RALPH_GH_OWNER` inline — the config block provides the values once.
+
+#### 2. Remove explicit `owner`/`repo` from MCP tool call instructions
+
+**Pattern B — MCP tool call instructions** (remove owner/repo params entirely):
+```markdown
+# Before
+ralph_hero__get_issue(owner, repo, number)
+   - owner: $RALPH_GH_OWNER
+   - repo: $RALPH_GH_REPO
+   - number: NNN
+
+# After
+ralph_hero__get_issue(number=NNN)
+```
+
+The MCP server's `resolveConfig()` (helpers.ts:550-566) correctly defaults to `client.config.owner`/`client.config.repo` from settings.local.json when params are omitted.
+
+#### 3. Files to modify (17 files)
+
+| File | Changes |
+|------|---------|
+| ralph-research/SKILL.md | Config block + remove owner/repo from tool calls |
+| ralph-impl/SKILL.md | Config block + remove owner/repo from tool calls |
+| ralph-review/SKILL.md | Config block + remove owner/repo from tool calls |
+| ralph-plan/SKILL.md | Config block |
+| ralph-plan-epic/SKILL.md | Config block |
+| ralph-split/SKILL.md | Config block |
+| ralph-triage/SKILL.md | Config block |
+| ralph-merge/SKILL.md | Config block |
+| ralph-pr/SKILL.md | Config block |
+| ralph-val/SKILL.md | Config block |
+| iterate/SKILL.md | Config block + remove owner/repo from tool calls |
+| form/SKILL.md | Config block + remove owner/repo from tool calls |
+| impl/SKILL.md | Config block + remove owner/repo from tool calls |
+| hero/SKILL.md | Config block |
+| plan/SKILL.md | Config block |
+| research/SKILL.md | Config block |
+| bridge-artifact/SKILL.md | Config block |
+| setup-repos/SKILL.md | Remove owner/repo from tool calls |
+| shared/fragments/escalation-steps.md | Config block |
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] No remaining explicit `owner: $RALPH_GH_OWNER` or `repo: $RALPH_GH_REPO` as MCP tool call params in any skill
+- [ ] All modified skills have a `## Configuration` block with backtick preprocessing
+- [ ] `cd plugin/ralph-hero/mcp-server && npm test` passes
+
+#### Manual Verification:
+- [ ] Direct skill invocation resolves config block values (test with `/ralph-hero:status` or similar)
+
+---
+
+## Phase 3: Create Per-Phase Agents
+
+- **depends_on**: [phase-1, phase-2]
+
+### Overview
+
+Create 10 new agent definitions in `plugin/ralph-hero/agents/` that preload skill content via `skills:` and define hard tool allowlists.
+
+### Changes Required
+
+#### 1. Agent definitions
+
+Create the following files in `plugin/ralph-hero/agents/`:
+
+**research-agent.md**
+```yaml
+---
+name: research-agent
+description: Research issues — investigates codebase, creates findings doc, updates workflow state
+tools: Read, Write, Glob, Grep, Bash, Agent, WebSearch, WebFetch,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_comment, ralph_hero__add_dependency, ralph_hero__remove_dependency
+model: sonnet
+skills:
+  - ralph-hero:ralph-research
+---
+
+You are a research agent. Follow the preloaded ralph-research instructions to investigate the issue specified in your task prompt.
+```
+
+**plan-agent.md**
+```yaml
+---
+name: plan-agent
+description: Create implementation plans — reads research, writes phased plans, updates GitHub
+tools: Read, Write, Glob, Grep, Bash, Agent,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_comment
+model: opus
+skills:
+  - ralph-hero:ralph-plan
+---
+
+You are a planning agent. Follow the preloaded ralph-plan instructions to create an implementation plan for the issue specified in your task prompt.
+```
+
+**plan-epic-agent.md**
+```yaml
+---
+name: plan-epic-agent
+description: Strategic planning for complex multi-tier work — writes plan-of-plans, creates feature children, orchestrates wave planning
+tools: Read, Write, Glob, Grep, Bash, Agent,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_issue, ralph_hero__create_comment,
+       ralph_hero__add_sub_issue, ralph_hero__add_dependency,
+       ralph_hero__remove_dependency, ralph_hero__list_sub_issues,
+       ralph_hero__decompose_feature
+model: opus
+skills:
+  - ralph-hero:ralph-plan-epic
+---
+
+You are a strategic planning agent. Follow the preloaded ralph-plan-epic instructions to create a plan-of-plans for the issue specified in your task prompt.
+```
+
+**split-agent.md**
+```yaml
+---
+name: split-agent
+description: Split large issues into smaller sub-issues for atomic implementation
+tools: Read, Glob, Grep, Bash, Agent,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_issue, ralph_hero__add_sub_issue,
+       ralph_hero__add_dependency, ralph_hero__remove_dependency, ralph_hero__list_sub_issues
+model: opus
+skills:
+  - ralph-hero:ralph-split
+---
+
+You are a splitting agent. Follow the preloaded ralph-split instructions to decompose the issue specified in your task prompt.
+```
+
+**triage-agent.md**
+```yaml
+---
+name: triage-agent
+description: Triage issues from backlog — assess validity, route to research or close
+tools: Read, Glob, Grep, Bash,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_comment
+model: sonnet
+skills:
+  - ralph-hero:ralph-triage
+---
+
+You are a triage agent. Follow the preloaded ralph-triage instructions to assess the issue specified in your task prompt.
+```
+
+**review-agent.md**
+```yaml
+---
+name: review-agent
+description: Review implementation plans before coding begins
+tools: Read, Write, Glob, Grep, Bash, Agent,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_comment
+model: opus
+skills:
+  - ralph-hero:ralph-review
+---
+
+You are a review agent. Follow the preloaded ralph-review instructions to review the plan for the issue specified in your task prompt.
+```
+
+**impl-agent.md**
+```yaml
+---
+name: impl-agent
+description: Implement one phase of an approved plan in an isolated worktree
+tools: Read, Write, Edit, Glob, Grep, Bash, Agent,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_comment, ralph_hero__list_sub_issues
+model: opus
+skills:
+  - ralph-hero:ralph-impl
+---
+
+You are an implementation agent. Follow the preloaded ralph-impl instructions to implement the issue specified in your task prompt.
+```
+
+**pr-agent.md**
+```yaml
+---
+name: pr-agent
+description: Create pull requests for completed implementations
+tools: Read, Glob, Grep, Bash,
+       ralph_hero__get_issue, ralph_hero__save_issue, ralph_hero__create_comment,
+       ralph_hero__advance_issue
+model: haiku
+skills:
+  - ralph-hero:ralph-pr
+---
+
+You are a PR agent. Follow the preloaded ralph-pr instructions to create a pull request for the issue specified in your task prompt.
+```
+
+**merge-agent.md**
+```yaml
+---
+name: merge-agent
+description: Merge approved pull requests and clean up
+tools: Read, Glob, Grep, Bash,
+       ralph_hero__get_issue, ralph_hero__save_issue, ralph_hero__create_comment,
+       ralph_hero__advance_issue, ralph_hero__list_sub_issues, ralph_hero__list_dependencies
+model: haiku
+skills:
+  - ralph-hero:ralph-merge
+---
+
+You are a merge agent. Follow the preloaded ralph-merge instructions to merge the PR for the issue specified in your task prompt.
+```
+
+**val-agent.md**
+```yaml
+---
+name: val-agent
+description: Validate implementation against plan requirements
+tools: Read, Glob, Grep, Bash,
+       ralph_hero__get_issue, ralph_hero__save_issue, ralph_hero__create_comment,
+       ralph_hero__list_sub_issues
+model: haiku
+skills:
+  - ralph-hero:ralph-val
+---
+
+You are a validation agent. Follow the preloaded ralph-val instructions to validate the implementation for the issue specified in your task prompt.
+```
+
+Plugin agents support `name`, `description`, `model`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, `isolation`, `effort`, and `maxTurns`. Only `hooks`, `mcpServers`, and `permissionMode` are excluded.
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] All 10 agent files exist in `plugin/ralph-hero/agents/`
+- [ ] All agent files have valid YAML frontmatter
+- [ ] `cd plugin/ralph-hero/mcp-server && npm test` passes
+
+#### Manual Verification:
+- [ ] `/reload-plugins` picks up new agents (count increases)
+- [ ] `@research-agent` is invocable and preloads skill content
+- [ ] Preloaded skill content shows resolved env vars (not `$VAR` literals)
+
+---
+
+## Phase 4: Update Hero Dispatch
+
+- **depends_on**: [phase-3]
+
+### Overview
+
+Rewrite hero SKILL.md dispatch sections to use per-phase agents instead of wrapper agents.
+
+### Changes Required
+
+#### 1. Update dispatch patterns in hero/SKILL.md
+**File**: `plugin/ralph-hero/skills/hero/SKILL.md`
+**Current dispatch lines**: 246 (SPLIT), 309 (RESEARCH), 323-332 (PLAN variants), 340 (REVIEW), 354-358 (IMPLEMENT). Agent Dispatch Notes section at lines 361-368.
+
+Replace all wrapper-agent dispatches:
+
+```markdown
+# Before (SPLIT — line 246)
+Agent(subagent_type="ralph-hero:ralph-analyst", prompt="Run /ralph-hero:ralph-split NNN", description="Split GH-NNN")
+
+# After
+Agent(subagent_type="ralph-hero:split-agent", prompt="Split issue #NNN", description="Split GH-NNN")
+```
+
+```markdown
+# Before (RESEARCH — line 309)
+Agent(subagent_type="ralph-hero:ralph-analyst", prompt="Run /ralph-hero:ralph-research NNN", description="Research GH-NNN")
+
+# After
+Agent(subagent_type="ralph-hero:research-agent", prompt="Research issue #NNN", description="Research GH-NNN")
+```
+
+```markdown
+# Before (PLAN — lines 323-332, four variants: L/XL epic, M/S/XS with doc, M/S/XS without, multi-issue group)
+Agent(subagent_type="ralph-hero:ralph-analyst", prompt="Run /ralph-hero:ralph-plan NNN --research-doc ...", description="Plan GH-NNN")
+
+# After
+Agent(subagent_type="ralph-hero:plan-agent", prompt="Plan issue #NNN. Research doc: thoughts/shared/research/...", description="Plan GH-NNN")
+```
+
+```markdown
+# Before (PLAN — L/XL epics, line 323)
+Agent(subagent_type="ralph-hero:ralph-analyst", prompt="Run /ralph-hero:ralph-plan-epic NNN", description="Plan epic GH-NNN")
+
+# After
+Agent(subagent_type="ralph-hero:plan-epic-agent", prompt="Plan epic issue #NNN", description="Plan epic GH-NNN")
+```
+
+```markdown
+# Before (REVIEW — line 340)
+Agent(subagent_type="ralph-hero:ralph-builder", prompt="Run /ralph-hero:ralph-review NNN --plan-doc ...", description="Review GH-NNN")
+
+# After
+Agent(subagent_type="ralph-hero:review-agent", prompt="Review plan for issue #NNN. Plan doc: thoughts/shared/plans/...", description="Review GH-NNN")
+```
+
+```markdown
+# Before (IMPLEMENT — lines 354/358)
+Agent(subagent_type="ralph-hero:ralph-builder", prompt="Run /ralph-hero:ralph-impl NNN --plan-doc ...", description="Implement GH-NNN")
+
+# After
+Agent(subagent_type="ralph-hero:impl-agent", prompt="Implement issue #NNN. Plan doc: thoughts/shared/plans/...", description="Implement GH-NNN")
+```
+
+#### 2. Update Agent Dispatch Notes section
+
+Replace the existing dispatch notes:
+```markdown
+### Agent Dispatch Notes
+
+Per-phase agents preload skill content via the `skills:` field — no Skill() calls needed:
+- Each agent has a hard tool allowlist in its `tools:` frontmatter
+- Each agent's `model:` field is honored (opus for impl/plan/plan-epic/review/split, sonnet for research/triage, haiku for pr/merge/val)
+- Skill content is preprocessed: env vars are resolved before the agent sees them
+- Plugin-level hooks fire with `agent_type` for phase-specific gating
+- Artifact paths (research docs, plan docs) are passed as natural language in the Agent() prompt
+```
+
+#### 3. Remove references to ralph-analyst, ralph-builder, ralph-integrator
+
+Search hero SKILL.md for any remaining references to the old wrapper agents and update them.
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] No references to `ralph-analyst`, `ralph-builder`, or `ralph-integrator` in hero SKILL.md
+- [ ] All dispatch patterns use new per-phase agent names
+- [ ] `cd plugin/ralph-hero/mcp-server && npm test` passes
+
+#### Manual Verification:
+- [ ] `/ralph-hero:hero NNN` dispatches to correct per-phase agents
+- [ ] Research phase runs on sonnet, impl phase runs on opus
+
+---
+
+## Phase 5: Cleanup — Remove Wrapper Agents & Deprecate Team
+
+- **depends_on**: [phase-4]
+
+### Overview
+
+Remove wrapper agents and deprecate team skill. This happens BEFORE docs update so specs reflect the final state.
+
+### Changes Required
+
+#### 1. Remove wrapper agent files
+```
+rm plugin/ralph-hero/agents/ralph-analyst.md
+rm plugin/ralph-hero/agents/ralph-builder.md
+rm plugin/ralph-hero/agents/ralph-integrator.md
+```
+
+#### 2. Deprecate team skill
+**File**: `plugin/ralph-hero/skills/team/SKILL.md` (roster table at lines 91-93)
+
+Add deprecation notice to frontmatter and top of content:
+```yaml
+---
+description: "[DEPRECATED] Use /ralph-hero:hero instead. ..."
+---
+
+> **DEPRECATED**: This skill uses the old wrapper-agent architecture.
+> Use `/ralph-hero:hero` for orchestrated pipeline execution.
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `ralph-analyst.md`, `ralph-builder.md`, `ralph-integrator.md` no longer exist
+- [ ] `cd plugin/ralph-hero/mcp-server && npm test` passes
+- [ ] No remaining references to removed agents in any skill or hook file
+
+#### Manual Verification:
+- [ ] `/reload-plugins` loads without errors
+
+---
+
+## Phase 6: Docs & Specs Update
+
+- **depends_on**: [phase-5]
+
+### Overview
+
+Update CLAUDE.md and specs/ to reflect the final architecture (old agents already removed).
+
+### Changes Required
+
+#### 1. Update CLAUDE.md
+**File**: `CLAUDE.md`
+
+Update the Architecture section to describe the new agent-per-phase model:
+- Replace the description of wrapper agents with per-phase agents
+- Document the `skills:` preload pattern
+- Document backtick preprocessing for env vars
+- Update the agent list with the 10 new agents and their roles/models
+- Note that plugin agents can't have `hooks`, `mcpServers`, or `permissionMode`
+
+#### 2. Update specs/agent-permissions.md
+**File**: `specs/agent-permissions.md`
+
+- Update "Agent" definition: agents are now per-phase containers, not skill orchestrators
+- Update the permission layering model:
+  - Layer 1: Agent `tools:` (hard allowlist — this is now the primary enforcement)
+  - Layer 2: Skill `allowed-tools:` is a **permission grant** (auto-approve), NOT a hard restriction
+  - Layer 3: Plugin-level hooks discriminate by `agent_type` (replaces RALPH_COMMAND for agent invocations)
+- Add note about plugin agent frontmatter limitations
+
+#### 3. Update specs/skill-permissions.md
+**File**: `specs/skill-permissions.md`
+
+- Correct the `allowed-tools` definition: it's a permission grant, not a whitelist enforced by runtime
+- Add agent tool matrices alongside skill tool matrices
+- Note that when skills are preloaded via `skills:`, the agent's `tools:` field is the enforcement boundary
+
+#### 4. Update specs/skill-io-contracts.md
+**File**: `specs/skill-io-contracts.md`
+
+- Update RALPH_COMMAND documentation: set by SessionStart for direct invocation, inferred from `agent_type` for agent-based invocation
+- Add note about backtick preprocessing resolving env vars at load time
+- Update the `$RALPH_GH_OWNER`/`$RALPH_GH_REPO` contract: skills use config block with backtick preprocessing, MCP tools use server defaults
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] No stale references to ralph-analyst, ralph-builder, ralph-integrator in CLAUDE.md or specs/
+
+#### Manual Verification:
+- [ ] CLAUDE.md architecture section accurately describes current system
+- [ ] Specs reflect actual enforcement behavior (permission grant vs hard restriction)
+
+---
+
+## Phase 7: Manual Integration Testing
+
+- **depends_on**: [phase-6]
+
+### Overview
+
+End-to-end manual verification using `--plugin-dir` to test the full plugin outside the development environment before merging.
+
+### Test Procedure
+
+#### 1. Plugin namespace skill reference test
+Verify that `skills: [ralph-hero:ralph-research]` in plugin agent frontmatter correctly resolves and preloads the plugin-namespaced skill content.
+
+```bash
+# From a separate directory (e.g., ralph-engine repo):
+claude --plugin-dir /path/to/ralph-hero/plugin/ralph-hero
+```
+
+Then: "Use the research-agent to run diagnostics" — verify skill content is preloaded with resolved env vars.
+
+#### 2. Per-phase agent invocation
+Test each agent type can be invoked:
+- `@research-agent` — verify sonnet model, skill content present
+- `@impl-agent` — verify opus model, skill content present
+- `@pr-agent` — verify haiku model, skill content present
+
+#### 3. Hook discrimination
+Verify hooks.json hooks fire with correct `agent_type`:
+- Inside `@impl-agent`, attempt a Write — verify `agent-phase-gate.sh` routes to `impl-plan-required.sh`
+- Inside `@research-agent`, attempt a Bash — verify `branch-gate.sh` fires
+
+#### 4. Hero end-to-end
+Run `/ralph-hero:hero NNN` with a real issue through at least the research phase. Verify:
+- Correct agent dispatched
+- Correct model used
+- Env vars resolved in preloaded content
+- MCP tools work without owner/repo params
+- Hooks fire appropriately
+
+#### 5. Direct skill invocation backward compatibility
+Verify interactive skills still work:
+- `/ralph-hero:ralph-research NNN` — direct invocation with RALPH_COMMAND via SessionStart
+- Hooks from skill frontmatter fire (not double-blocked by hooks.json)
+
+#### 6. Cross-repo verification
+Test in the ralph-engine repo to verify env vars resolve to ralph-engine values (not ralph-hero):
+```bash
+cd /Users/dubiel/projects/ralph-engine
+claude --plugin-dir /path/to/ralph-hero/plugin/ralph-hero
+# Use research-agent, verify Owner=cdubiel08, Repo=ralph-engine, Project=7
+```
+
+### Success Criteria
+
+#### Manual Verification:
+- [ ] Plugin skill namespace reference works (`skills: [ralph-hero:ralph-research]`)
+- [ ] All 10 agents are invocable with correct models
+- [ ] Hook `agent_type` discrimination works
+- [ ] Hero dispatches correctly end-to-end
+- [ ] Direct skill invocation backward compatible
+- [ ] Cross-repo env var resolution correct
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Hook scripts: mock hook input JSON with/without `agent_type` field, verify correct allow/block behavior
+- Exec delegation chain: verify `RALPH_HOOK_INPUT` env var survives exec to child script
+
+### Integration Tests
+- Hero dispatch: run `/ralph-hero:hero` with a test issue, verify per-phase agents are invoked
+- Skill preloading: verify `@research-agent` sees resolved env vars in preloaded skill content
+
+### Manual Testing Steps (Phase 7)
+1. Plugin skill namespace resolution via `--plugin-dir`
+2. Per-phase agent invocation with correct models
+3. Hook `agent_type` discrimination
+4. `/ralph-hero:hero NNN` end-to-end pipeline
+5. Direct skill invocation backward compatibility
+6. Cross-repo env var resolution in ralph-engine
+
+## References
+
+- Original research: `thoughts/shared/research/2026-03-24-agent-env-propagation-token-scope.md`
+- Re-validation (2026-04-01): `thoughts/shared/research/2026-04-01-GH-0674-agent-per-phase-still-needed.md`
+- Claude Code Sub-agents Docs: https://code.claude.com/docs/en/sub-agents
+- Claude Code Skills Docs: https://code.claude.com/docs/en/skills
+- Claude Code Plugins Reference: https://code.claude.com/docs/en/plugins-reference
+- Claude Code Hooks Docs: https://code.claude.com/docs/en/hooks

--- a/thoughts/shared/plans/2026-03-25-GH-0684-userconfig-healthcheck-setup-rewrite.md
+++ b/thoughts/shared/plans/2026-03-25-GH-0684-userconfig-healthcheck-setup-rewrite.md
@@ -1,0 +1,764 @@
+---
+date: 2026-03-25
+status: draft
+type: plan
+tags: [userConfig, health-check, setup, tokens, security, WSL2]
+github_issue: 684
+github_issues: [684]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/684
+primary_issue: 684
+---
+
+# Plugin userConfig + health_check Hardening + Setup Skill Rewrite
+
+## Prior Work
+
+- builds_on:: [[2026-03-25-token-management-setup-skill-improvement]]
+- builds_on:: [[2026-03-25-github-token-management-across-tools]]
+- builds_on:: [[2026-03-24-agent-env-propagation-token-scope]]
+- builds_on:: [[2026-03-19-GH-0634-doctor-settings-local-json-fallback]]
+- builds_on:: [[2026-03-17-GH-0588-remove-mcp-env-block]]
+- builds_on:: [[2026-03-21-secret-protection-gitignore-enforcement]]
+
+## Overview
+
+Adopt Claude Code's `userConfig` manifest feature (v2.1.83+) so that the GitHub PAT is stored in the macOS Keychain (or `~/.claude/.credentials.json` with mode `0600` on WSL2/Linux) instead of plaintext `settings.local.json`. Only `github_token` goes into `userConfig` (sensitive: true). Owner, repo, and project number remain interactive setup-skill concerns written to `settings.local.json`. The health_check tool is extracted, enhanced with token source reporting and better error messages, and given full test coverage. The setup skill is rewritten to use `userConfig` as THE token delivery path with no manual fallback.
+
+## Current State Analysis
+
+### Token Storage
+- Tokens live in `.claude/settings.local.json` under `"env"` — plaintext JSON, protected only by gitignore
+- Users must manually create/edit this file, know the exact env var names, and restart Claude Code
+- Consumer repos may lack `.gitignore` entries for `*.local.json`
+
+### health_check Tool
+- Anonymous handler inside `registerCoreTools()` at `index.ts:137-284` — not extractable for testing
+- Auth check uses `viewer { login }` which succeeds with any valid token regardless of scopes
+- Does not report which env var the token came from (only logs to stderr at startup)
+- Zero test coverage — no test file exercises any health_check path
+- `@octokit/graphql` strips HTTP response headers on success, so `X-OAuth-Scopes` is inaccessible
+
+### Setup Skill
+- 628-line `SKILL.md` with 7 steps + optional routing setup
+- Guides users through manual `settings.local.json` editing
+- Handles simple, split-owner, and dual-token flows
+- No awareness of `userConfig` or `claude plugin configure`
+
+### Key Discoveries
+- `resolveEnv()` at `index.ts:33-38` already filters `${...}` literals — unresolved `${user_config.*}` values get filtered to `undefined` automatically
+- Token resolution chain: `RALPH_GH_REPO_TOKEN` → `RALPH_HERO_GITHUB_TOKEN` → exit(1)
+- `initGitHubClient()` is not exported and calls `process.exit(1)` — tests mirror logic locally
+- Test patterns: `mockClient()` with `as unknown as GitHubClient` cast, env var clone-restore in beforeEach/afterEach
+- `CLAUDE_PLUGIN_OPTION_*` env vars are auto-injected but not used anywhere in the codebase
+
+## Desired End State
+
+1. `plugin.json` declares `github_token` as `sensitive: true` userConfig — prompted at plugin enable time, stored in Keychain/credentials file
+2. `.mcp.json` maps `${user_config.github_token}` → `RALPH_HERO_GITHUB_TOKEN` via env block
+3. `health_check` is an exported, tested function that reports token source, gives clear scope-failure messages, and has full path coverage
+4. Setup skill uses `claude plugin configure ralph-hero` for token delivery, interactive prompts for owner/repo/project, writes non-sensitive config to `settings.local.json`
+5. WSL2 works correctly with file-based credential storage
+
+### Verification
+- `npm test` passes with new health_check tests covering success, fail, skip, and wrong-scopes paths
+- `npm run build` passes with no type errors
+- `ralph_hero__health_check` output includes `tokenSource` field
+- Plugin enable flow prompts for token and stores it in Keychain (macOS) or `.credentials.json` (WSL2/Linux)
+- Setup skill guides through interactive config without mentioning manual `settings.local.json` token editing
+
+## What We're NOT Doing
+
+- Adding `userConfig` for non-sensitive vars (owner, repo, project number) — these are setup-skill interactive concerns
+- Adding `userConfig` to ralph-knowledge — no sensitive data, has sensible defaults
+- Reading `X-OAuth-Scopes` headers — `@octokit/graphql` strips them; actual access testing is more reliable
+- Adding `CLAUDE_PLUGIN_OPTION_*` reads to the MCP server — the `.mcp.json` env block mapping is cleaner
+- Changing the token resolution chain in `initGitHubClient()` — it works as-is
+- Dual-token `userConfig` fields — advanced users configure `RALPH_GH_REPO_TOKEN`/`RALPH_GH_PROJECT_TOKEN` via `settings.local.json` as before
+
+## Implementation Approach
+
+Three phases, each independently shippable. Phase 1 is pure manifest/config. Phase 2 is MCP server refactor + tests. Phase 3 is skill rewrite. No phase depends on another being deployed first — `resolveEnv()` handles both old (`settings.local.json`) and new (`userConfig` via env block) paths transparently.
+
+---
+
+## Phase 1: `userConfig` Manifest + `.mcp.json` Wiring
+
+### Overview
+Add `github_token` as a sensitive userConfig field to the plugin manifest and wire it through the `.mcp.json` env block to the existing `RALPH_HERO_GITHUB_TOKEN` env var.
+
+### Changes Required
+
+#### 1. Plugin Manifest
+**File**: `plugin/ralph-hero/.claude-plugin/plugin.json`
+**Changes**: Add `userConfig` section with `github_token` field
+
+```json
+{
+  "name": "ralph-hero",
+  "version": "2.5.49",
+  "description": "...",
+  "userConfig": {
+    "github_token": {
+      "description": "GitHub Personal Access Token with repo + project scopes (create at https://github.com/settings/tokens)",
+      "sensitive": true
+    }
+  },
+  "author": { ... },
+  ...
+}
+```
+
+#### 2. MCP Server Config
+**File**: `plugin/ralph-hero/.mcp.json`
+**Changes**: Add `env` block mapping userConfig to the existing RALPH env var
+
+```json
+{
+  "mcpServers": {
+    "ralph-github": {
+      "command": "npx",
+      "args": ["-y", "ralph-hero-mcp-server@2.5.42"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}",
+      "env": {
+        "RALPH_HERO_GITHUB_TOKEN": "${user_config.github_token}"
+      }
+    }
+  }
+}
+```
+
+**Why only one env var in the block**: The old GH-588 problem was an env block that acted as an allowlist, silently dropping vars. This new block is additive — it maps one `userConfig` value while all other `RALPH_*` vars still inherit from the parent environment (`settings.local.json`). The `resolveEnv()` filter handles the case where `${user_config.github_token}` is unresolved (user hasn't configured yet) — it starts with `${` and gets filtered to `undefined`, then the parent-environment fallback kicks in.
+
+#### 3. Contract Test Update
+**File**: `plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts`
+**Changes**: Add a test documenting that `userConfig`-delivered tokens flow through the same `RALPH_HERO_GITHUB_TOKEN` env var
+
+```typescript
+describe("userConfig delivery path", () => {
+  it("token from userConfig arrives as RALPH_HERO_GITHUB_TOKEN", () => {
+    // userConfig.github_token is mapped to RALPH_HERO_GITHUB_TOKEN
+    // via .mcp.json env block: "${user_config.github_token}"
+    // resolveEnv filters unresolved ${...} literals to undefined
+    process.env.RALPH_HERO_GITHUB_TOKEN = "ghp_from_userconfig";
+    const { repoToken } = resolveTokens();
+    expect(repoToken).toBe("ghp_from_userconfig");
+  });
+
+  it("unresolved userConfig template is filtered by resolveEnv", () => {
+    process.env.RALPH_HERO_GITHUB_TOKEN = "${user_config.github_token}";
+    const { repoToken } = resolveTokens();
+    expect(repoToken).toBeUndefined();
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `npm run build` passes with no type errors
+- [ ] `npm test` passes — new contract tests pass
+- [ ] `plugin.json` is valid JSON with `userConfig.github_token.sensitive === true`
+
+#### Manual Verification:
+- [ ] On macOS: `claude plugin install` prompts for GitHub token, stores in Keychain
+- [ ] On WSL2/Linux: `claude plugin install` prompts for token, stores in `~/.claude/.credentials.json` with mode `0600`
+- [ ] MCP server starts and reads token from `RALPH_HERO_GITHUB_TOKEN` env var
+- [ ] Existing `settings.local.json` users still work (parent env inheritance)
+- [ ] `ralph_hero__health_check` returns `auth: ok` with userConfig-delivered token
+
+---
+
+## Phase 2: Extract and Harden health_check
+
+### Overview
+Extract the health_check handler into an exported, testable function. Add token source reporting to the output. Improve error messages for "auth passes but access denied" scenarios. Write comprehensive tests for all paths.
+
+### Changes Required
+
+#### 1. Extract health_check Handler
+**File**: `plugin/ralph-hero/mcp-server/src/index.ts`
+**Changes**: Extract the anonymous handler into an exported function in a new module
+
+**New File**: `plugin/ralph-hero/mcp-server/src/lib/health-check.ts`
+
+```typescript
+import type { GitHubClient } from "../github-client.js";
+import { resolveProjectOwner } from "../types.js";
+import { toolSuccess } from "../types.js";
+import type { ToolResult } from "../types.js";
+
+export interface HealthCheckResult {
+  status: "ok" | "issues_found";
+  checks: Record<string, { status: string; detail?: string }>;
+  config: {
+    repoOwner: string;
+    repo: string;
+    projectOwner: string;
+    projectNumber: number | string;
+    tokenMode: "single-token" | "dual-token";
+    tokenSource: string;
+  };
+}
+
+export async function runHealthCheck(
+  client: GitHubClient,
+  tokenSource: string,
+): Promise<HealthCheckResult> {
+  const checks: Record<string, { status: string; detail?: string }> = {};
+
+  // 1. Auth check (repo token)
+  try {
+    const login = await client.getAuthenticatedUser();
+    checks.auth = { status: "ok", detail: `Authenticated as ${login}` };
+  } catch (e) {
+    checks.auth = {
+      status: "fail",
+      detail: `Auth failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  // 2. Repo access check
+  if (client.config.owner && client.config.repo) {
+    try {
+      await client.query<{ repository: { nameWithOwner: string } | null }>(
+        `query($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) { nameWithOwner }
+        }`,
+        { owner: client.config.owner, repo: client.config.repo },
+      );
+      checks.repoAccess = {
+        status: "ok",
+        detail: `${client.config.owner}/${client.config.repo}`,
+      };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      checks.repoAccess = {
+        status: "fail",
+        detail: checks.auth.status === "ok"
+          ? `Authenticated successfully, but cannot access repo ${client.config.owner}/${client.config.repo}. Token likely lacks 'repo' scope or org SSO authorization. Re-run /ralph-hero:setup to reconfigure.`
+          : `Cannot access repo: ${msg}`,
+      };
+    }
+  } else {
+    checks.repoAccess = {
+      status: "skip",
+      detail: "RALPH_GH_OWNER/RALPH_GH_REPO not set",
+    };
+  }
+
+  // 3. Project access check (uses project token + project owner)
+  const projOwner = resolveProjectOwner(client.config);
+  const projNum = client.config.projectNumber;
+  if (projOwner && projNum) {
+    try {
+      let project: {
+        title: string;
+        fields: { nodes: Array<{ name: string }> };
+      } | null = null;
+
+      for (const ownerType of ["user", "organization"]) {
+        try {
+          const result = await client.projectQuery<
+            Record<
+              string,
+              {
+                projectV2: {
+                  title: string;
+                  fields: { nodes: Array<{ name: string }> };
+                } | null;
+              }
+            >
+          >(
+            `query($owner: String!, $number: Int!) {
+              ${ownerType}(login: $owner) {
+                projectV2(number: $number) {
+                  title
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2FieldCommon { name }
+                      ... on ProjectV2SingleSelectField { name }
+                    }
+                  }
+                }
+              }
+            }`,
+            { owner: projOwner, number: projNum },
+          );
+          project = result[ownerType]?.projectV2 ?? null;
+          if (project) break;
+        } catch {
+          // Try next owner type
+        }
+      }
+
+      if (project) {
+        checks.projectAccess = {
+          status: "ok",
+          detail: `${project.title} (#${projNum})`,
+        };
+
+        // 4. Required fields check
+        const requiredFields = ["Workflow State", "Priority", "Estimate"];
+        const fieldNames = project.fields.nodes.map((f) => f.name);
+        const missing = requiredFields.filter(
+          (f) => !fieldNames.includes(f),
+        );
+        if (missing.length === 0) {
+          checks.requiredFields = {
+            status: "ok",
+            detail: "All required fields present",
+          };
+        } else {
+          checks.requiredFields = {
+            status: "fail",
+            detail: `Missing fields: ${missing.join(", ")}. Run /ralph-hero:setup.`,
+          };
+        }
+      } else {
+        checks.projectAccess = {
+          status: "fail",
+          detail: `Project #${projNum} not found for owner "${projOwner}". Check RALPH_GH_PROJECT_OWNER.`,
+        };
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      checks.projectAccess = {
+        status: "fail",
+        detail: checks.auth.status === "ok"
+          ? `Authenticated successfully, but cannot access project #${projNum}. Token likely lacks 'project' scope. Re-run /ralph-hero:setup to reconfigure.`
+          : `Project access failed: ${msg}`,
+      };
+    }
+  } else {
+    checks.projectAccess = {
+      status: "skip",
+      detail: "RALPH_GH_PROJECT_NUMBER not set",
+    };
+  }
+
+  // Summary
+  const allOk = Object.values(checks).every(
+    (c) => c.status === "ok" || c.status === "skip",
+  );
+
+  return {
+    status: allOk ? "ok" : "issues_found",
+    checks,
+    config: {
+      repoOwner: client.config.owner || "(not set)",
+      repo: client.config.repo || "(not set)",
+      projectOwner: resolveProjectOwner(client.config) || "(not set)",
+      projectNumber: client.config.projectNumber || "(not set)",
+      tokenMode:
+        client.config.projectToken &&
+        client.config.projectToken !== client.config.token
+          ? "dual-token"
+          : "single-token",
+      tokenSource,
+    },
+  };
+}
+```
+
+#### 2. Update `registerCoreTools` to Use Extracted Function
+**File**: `plugin/ralph-hero/mcp-server/src/index.ts`
+**Changes**: Replace inline handler with call to `runHealthCheck()`, pass `tokenSource` string computed during `initGitHubClient()`
+
+In `initGitHubClient()`, compute and return `tokenSource`:
+```typescript
+const tokenSource = resolveEnv("RALPH_GH_REPO_TOKEN")
+  ? "RALPH_GH_REPO_TOKEN"
+  : "RALPH_HERO_GITHUB_TOKEN";
+```
+
+Store `tokenSource` on client config or pass through to `registerCoreTools`. In the tool registration:
+
+```typescript
+import { runHealthCheck } from "./lib/health-check.js";
+
+function registerCoreTools(server: McpServer, client: GitHubClient, tokenSource: string): void {
+  server.tool(
+    "ralph_hero__health_check",
+    "Validate GitHub API connectivity, token permissions, repo access, project access, and required fields",
+    {},
+    async () => {
+      const result = await runHealthCheck(client, tokenSource);
+      return toolSuccess(result);
+    },
+  );
+}
+```
+
+#### 3. Add `tokenSource` to `GitHubClientConfig`
+**File**: `plugin/ralph-hero/mcp-server/src/types.ts`
+**Changes**: Add optional `tokenSource` field to `GitHubClientConfig`
+
+```typescript
+export interface GitHubClientConfig {
+  token: string;
+  projectToken?: string;
+  owner?: string;
+  repo?: string;
+  // ... existing fields ...
+  tokenSource?: string; // "RALPH_GH_REPO_TOKEN" | "RALPH_HERO_GITHUB_TOKEN"
+}
+```
+
+This lets `tokenSource` flow through `client.config.tokenSource` instead of requiring a separate parameter chain. Update `initGitHubClient()` to set `config.tokenSource` and `registerCoreTools` to read `client.config.tokenSource`.
+
+#### 4. Comprehensive Test Suite
+**New File**: `plugin/ralph-hero/mcp-server/src/__tests__/health-check.test.ts`
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { runHealthCheck } from "../lib/health-check.js";
+import type { GitHubClient } from "../github-client.js";
+import type { GitHubClientConfig } from "../types.js";
+
+function mockClient(
+  config: Partial<GitHubClientConfig>,
+  overrides: {
+    getAuthenticatedUser?: () => Promise<string>;
+    query?: (...args: unknown[]) => Promise<unknown>;
+    projectQuery?: (...args: unknown[]) => Promise<unknown>;
+  } = {},
+): GitHubClient {
+  return {
+    config: {
+      token: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      projectNumber: 3,
+      projectOwner: "test-owner",
+      ...config,
+    },
+    getAuthenticatedUser: overrides.getAuthenticatedUser ?? vi.fn().mockResolvedValue("test-user"),
+    query: overrides.query ?? vi.fn().mockResolvedValue({ repository: { nameWithOwner: "test-owner/test-repo" } }),
+    projectQuery: overrides.projectQuery ?? vi.fn().mockResolvedValue({
+      user: {
+        projectV2: {
+          title: "Test Project",
+          fields: {
+            nodes: [
+              { name: "Workflow State" },
+              { name: "Priority" },
+              { name: "Estimate" },
+            ],
+          },
+        },
+      },
+    }),
+  } as unknown as GitHubClient;
+}
+
+describe("runHealthCheck", () => {
+  describe("all checks pass", () => {
+    it("returns ok status with all checks green", async () => {
+      const client = mockClient({});
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.status).toBe("ok");
+      expect(result.checks.auth.status).toBe("ok");
+      expect(result.checks.auth.detail).toContain("test-user");
+      expect(result.checks.repoAccess.status).toBe("ok");
+      expect(result.checks.projectAccess.status).toBe("ok");
+      expect(result.checks.requiredFields.status).toBe("ok");
+    });
+
+    it("includes tokenSource in config output", async () => {
+      const client = mockClient({});
+      const result = await runHealthCheck(client, "RALPH_GH_REPO_TOKEN");
+
+      expect(result.config.tokenSource).toBe("RALPH_GH_REPO_TOKEN");
+      expect(result.config.tokenMode).toBe("single-token");
+    });
+
+    it("reports dual-token mode when project token differs", async () => {
+      const client = mockClient({ projectToken: "different-token" });
+      const result = await runHealthCheck(client, "RALPH_GH_REPO_TOKEN");
+
+      expect(result.config.tokenMode).toBe("dual-token");
+    });
+  });
+
+  describe("auth failure", () => {
+    it("returns fail with error message", async () => {
+      const client = mockClient({}, {
+        getAuthenticatedUser: vi.fn().mockRejectedValue(new Error("Bad credentials")),
+      });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.status).toBe("issues_found");
+      expect(result.checks.auth.status).toBe("fail");
+      expect(result.checks.auth.detail).toContain("Bad credentials");
+    });
+  });
+
+  describe("repo access failure with auth success", () => {
+    it("gives scope-specific error message", async () => {
+      const client = mockClient({}, {
+        query: vi.fn().mockRejectedValue(new Error("Resource not accessible")),
+      });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.checks.auth.status).toBe("ok");
+      expect(result.checks.repoAccess.status).toBe("fail");
+      expect(result.checks.repoAccess.detail).toContain("Authenticated successfully");
+      expect(result.checks.repoAccess.detail).toContain("'repo' scope");
+    });
+  });
+
+  describe("project access failure with auth success", () => {
+    it("gives scope-specific error message", async () => {
+      const client = mockClient({}, {
+        projectQuery: vi.fn().mockRejectedValue(new Error("Resource not accessible")),
+      });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.checks.auth.status).toBe("ok");
+      expect(result.checks.projectAccess.status).toBe("fail");
+      expect(result.checks.projectAccess.detail).toContain("Authenticated successfully");
+      expect(result.checks.projectAccess.detail).toContain("'project' scope");
+    });
+  });
+
+  describe("missing required fields", () => {
+    it("reports which fields are missing", async () => {
+      const client = mockClient({}, {
+        projectQuery: vi.fn().mockResolvedValue({
+          user: {
+            projectV2: {
+              title: "Test Project",
+              fields: {
+                nodes: [{ name: "Workflow State" }],
+              },
+            },
+          },
+        }),
+      });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.checks.requiredFields.status).toBe("fail");
+      expect(result.checks.requiredFields.detail).toContain("Priority");
+      expect(result.checks.requiredFields.detail).toContain("Estimate");
+    });
+  });
+
+  describe("skip conditions", () => {
+    it("skips repo access when owner/repo not set", async () => {
+      const client = mockClient({ owner: undefined, repo: undefined });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.checks.repoAccess.status).toBe("skip");
+    });
+
+    it("skips project access when project number not set", async () => {
+      const client = mockClient({ projectNumber: undefined });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.checks.projectAccess.status).toBe("skip");
+    });
+
+    it("skipped checks still count as ok in summary", async () => {
+      const client = mockClient({ owner: undefined, repo: undefined, projectNumber: undefined });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.status).toBe("ok");
+    });
+  });
+
+  describe("project not found (null after trying user + org)", () => {
+    it("reports project not found with owner hint", async () => {
+      const client = mockClient({}, {
+        projectQuery: vi.fn().mockResolvedValue({ user: { projectV2: null } }),
+      });
+      const result = await runHealthCheck(client, "RALPH_HERO_GITHUB_TOKEN");
+
+      expect(result.checks.projectAccess.status).toBe("fail");
+      expect(result.checks.projectAccess.detail).toContain("not found");
+      expect(result.checks.projectAccess.detail).toContain("RALPH_GH_PROJECT_OWNER");
+    });
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `npm run build` passes — new module compiles, imports resolve
+- [ ] `npm test` passes — all health-check test paths green
+- [ ] `npx vitest run src/__tests__/health-check.test.ts` — at least 8 tests covering success, auth fail, repo fail with scope hint, project fail with scope hint, missing fields, skip owner, skip project, project not found
+
+#### Manual Verification:
+- [ ] `ralph_hero__health_check` output includes `tokenSource` field showing which env var delivered the token
+- [ ] When auth passes but repo access fails, error message says "Authenticated successfully, but cannot access repo..." with scope guidance
+- [ ] When auth passes but project access fails, error message says "Authenticated successfully, but cannot access project..." with scope guidance
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
+---
+
+## Phase 3: Rewrite Setup Skill
+
+### Overview
+Rewrite `plugin/ralph-hero/skills/setup/SKILL.md` to use `userConfig` as THE token delivery path. Two interactive flows: simple owner (same owner for repo and project) and split-owner (org repo + personal project). Token via `claude plugin configure ralph-hero`. Non-sensitive config (owner, repo, project number) written to `settings.local.json` interactively. WSL2-specific notes included.
+
+### Changes Required
+
+#### 1. Setup Skill Rewrite
+**File**: `plugin/ralph-hero/skills/setup/SKILL.md`
+**Changes**: Full rewrite. Key structural changes:
+
+**New Step 1: Detect Token**
+- Call `ralph_hero__health_check`
+- If `auth: ok` → token is already configured, skip to Step 3
+- If `auth: fail` → guide through `claude plugin configure ralph-hero`
+- Display platform-specific note:
+  ```
+  Your token will be stored securely:
+  - macOS: System Keychain (encrypted, OS-managed)
+  - WSL2/Linux: ~/.claude/.credentials.json (mode 0600, user-only access)
+  ```
+- After token is configured, tell user to restart Claude Code, then re-run `/ralph-hero:setup`
+
+**New Step 2: Choose Setup Mode**
+- Ask using AskUserQuestion:
+  - **"Same owner for repo and project"** — single GitHub user/org owns both
+  - **"Split setup (org repo + personal project)"** — org owns the repo, personal account owns the project
+- Record the chosen mode
+
+**New Step 3: Collect Configuration**
+- For **simple mode**: ask for owner, repo name(s), project number (or offer to create)
+- For **split mode**: ask for org owner, repo name(s), personal GitHub username, project number (or offer to create)
+- Write non-sensitive config to `.claude/settings.local.json`:
+  ```json
+  {
+    "env": {
+      "RALPH_GH_OWNER": "[owner]",
+      "RALPH_GH_REPO": "[repo]",
+      "RALPH_GH_PROJECT_NUMBER": "[number]"
+    }
+  }
+  ```
+- For split mode, also include:
+  ```json
+  {
+    "env": {
+      "RALPH_GH_PROJECT_OWNER": "[personal-username]"
+    }
+  }
+  ```
+- Tell user to restart Claude Code after writing settings
+
+**New Step 4: Create or Verify Project** (same as current Step 3)
+- Call `ralph_hero__setup_project` if no project exists
+- Verify required fields if project exists
+
+**New Step 5: Store Configuration** (same as current Step 5, minus token instructions)
+- Write `.claude/ralph-hero.local.md` with project settings, workflow states
+- No token references in the local config file
+
+**New Step 6: Verify Setup** (same as current Step 6)
+- Call `ralph_hero__health_check` — all checks must pass
+- Report `tokenSource` from health_check output to confirm token delivery path
+
+**New Step 6b: Enable Routing & Sync** (same as current Step 6b)
+- Unchanged — ROUTING_PAT secret, repo variables, routing config
+
+**New Step 7: Final Report**
+- Show setup summary including:
+  ```
+  Token: Stored securely via plugin config (tokenSource: RALPH_HERO_GITHUB_TOKEN)
+  ```
+- Next steps (same as current, minus "verify settings.local.json has your token")
+
+**WSL2 Notes** (included in Step 1 token guidance):
+```
+WSL2 Users:
+- Your token is stored in ~/.claude/.credentials.json (not Windows Credential Manager)
+- File permissions: mode 0600 (only your user can read)
+- If the OAuth browser flow fails, press 'c' to copy the URL and paste into your Windows browser
+- Set BROWSER="/mnt/c/Program Files/Google/Chrome/Application/chrome.exe" for auto-open
+```
+
+**Dual-Token Note** (included in split-owner flow):
+```
+Advanced: Dual-Token Setup
+If your org requires separate tokens for repo and project access:
+1. Configure the primary token via plugin config (already done above)
+2. Add the second token to .claude/settings.local.json:
+   {
+     "env": {
+       "RALPH_GH_REPO_TOKEN": "ghp_org_repo_token",
+       "RALPH_GH_PROJECT_TOKEN": "ghp_personal_project_token"
+     }
+   }
+3. Restart Claude Code
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `SKILL.md` is valid markdown with correct YAML frontmatter
+- [ ] All tool references in `allowed-tools` match existing MCP tool names
+- [ ] No references to manual token editing in `settings.local.json` as a primary path
+
+#### Manual Verification:
+- [ ] Fresh setup on macOS: prompted for token via `claude plugin configure`, guided through owner/repo/project interactively, health_check passes
+- [ ] Fresh setup on WSL2: prompted for token, stored in `~/.claude/.credentials.json`, health_check passes
+- [ ] Existing user upgrade: health_check passes with token from `settings.local.json` (backward compatible)
+- [ ] Split-owner flow: org owner for repo, personal owner for project, both accessible
+- [ ] Project creation flow: `setup_project` creates project when none exists
+- [ ] Routing setup flow: ROUTING_PAT guidance, repo variables, routing config stub
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Phase 2):
+- `health-check.test.ts` — all paths: success, auth fail, repo fail with scope hint, project fail with scope hint, missing fields, skip conditions, project not found, dual-token mode, tokenSource reporting
+- `init-config.test.ts` — new tests for userConfig delivery path and unresolved template filtering
+
+### Integration Tests:
+- Manual: `claude plugin install` → token prompt → MCP server starts → health_check passes
+- Manual: WSL2 end-to-end with file-based credential storage
+
+### Manual Testing Steps:
+1. Fresh macOS install: enable plugin → prompted for token → setup skill → health_check all green
+2. Fresh WSL2 install: enable plugin → prompted for token → verify `~/.claude/.credentials.json` exists with `0600` → setup skill → health_check all green
+3. Existing user: no `userConfig` configured → `settings.local.json` token still works → health_check reports correct `tokenSource`
+4. Wrong scopes: valid token with no `repo` scope → health_check reports "Authenticated successfully, but cannot access repo..."
+5. Split-owner: org repo + personal project → both accessible → health_check all green
+
+## Performance Considerations
+
+None. The health_check extraction adds no overhead — same logic, same queries, just in a separate module.
+
+## Migration Notes
+
+**Backward compatibility**: Existing users with tokens in `settings.local.json` continue to work with no changes. The `resolveEnv()` chain resolves `RALPH_HERO_GITHUB_TOKEN` from whichever source provides it first — `userConfig` via `.mcp.json` env block, or parent environment via `settings.local.json`. No migration required.
+
+**Consumer repos**: The setup skill rewrite benefits consumer repos most — they get the same `claude plugin configure` flow without needing to know about `settings.local.json` or env var names.
+
+## Platform Behavior Matrix
+
+| Platform | Token Storage | Protection | OAuth Flow | Known Issues |
+|----------|--------------|------------|------------|--------------|
+| macOS | System Keychain | OS-encrypted | Browser redirect | None |
+| WSL2 | `~/.claude/.credentials.json` | mode `0600` | May need manual URL copy | [#20756](https://github.com/anthropics/claude-code/issues/20756) |
+| Linux | `~/.claude/.credentials.json` | mode `0600` | Browser redirect | None known |
+| Windows (native) | `~/.claude/.credentials.json` | NTFS ACLs | May not persist | [#29049](https://github.com/anthropics/claude-code/issues/29049) |
+
+## References
+
+- Research: `thoughts/shared/research/2026-03-25-token-management-setup-skill-improvement.md`
+- Research: `thoughts/shared/research/2026-03-25-github-token-management-across-tools.md`
+- Claude Code docs: [Plugins Reference — User configuration](https://code.claude.com/docs/en/plugins-reference#user-configuration)
+- Claude Code docs: [Authentication](https://code.claude.com/docs/en/authentication)
+- Current setup skill: `plugin/ralph-hero/skills/setup/SKILL.md`
+- health_check impl: `plugin/ralph-hero/mcp-server/src/index.ts:131-286`
+- Token resolution: `plugin/ralph-hero/mcp-server/src/index.ts:33-125`
+- Contract tests: `plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts`

--- a/thoughts/shared/plans/2026-03-27-GH-0694-cli-env-scope-parity.md
+++ b/thoughts/shared/plans/2026-03-27-GH-0694-cli-env-scope-parity.md
@@ -1,0 +1,755 @@
+---
+date: 2026-03-27
+status: draft
+type: plan
+tags: [cli, env-resolution, setup, scope-detection, settings]
+github_issue: 694
+github_url: https://github.com/cdubiel08/ralph-hero/issues/694
+---
+
+# CLI Environment Resolution Scope Parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `ralph` CLI work from any directory when the plugin is installed at user scope, by writing env vars to the scope-appropriate Claude Code settings file and teaching all CLI paths to read from the full settings hierarchy.
+
+**Architecture:** Extract `read_settings_env()` into a shared shell library (`scripts/resolve-env.sh`). Update the justfile `doctor`, `_mcp_call`, and `cli-dispatch.sh` `run_quick` to source it and bridge env vars before spawning the MCP server. Update the setup skill to write config to the correct file based on plugin install scope.
+
+**Tech Stack:** Bash (shell scripts, justfile recipes), BATS (tests), SKILL.md (setup skill)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `plugin/ralph-hero/scripts/resolve-env.sh` | Create | Shared shell library: `ralph_resolve_env()` and `ralph_detect_scope()` |
+| `plugin/ralph-hero/scripts/__tests__/resolve-env.bats` | Create | BATS tests for resolve-env.sh |
+| `plugin/ralph-hero/scripts/cli-dispatch.sh` | Modify | Source resolve-env.sh, bridge env in `run_quick` |
+| `plugin/ralph-hero/justfile` | Modify | Replace inline `read_settings_env()` in doctor, add env bridging to `_mcp_call` |
+| `plugin/ralph-hero/skills/setup/SKILL.md` | Modify | Scope-aware config file targeting |
+| `plugin/ralph-hero/mcp-server/src/lib/helpers.ts` | Modify | Improve error messages with scope-aware guidance |
+| `plugin/ralph-hero/scripts/__tests__/doctor.bats` | Modify | Add tests for new search paths |
+
+---
+
+### Task 1: Create `resolve-env.sh` Shared Shell Library
+
+**Files:**
+- Create: `plugin/ralph-hero/scripts/resolve-env.sh`
+- Test: `plugin/ralph-hero/scripts/__tests__/resolve-env.bats`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugin/ralph-hero/scripts/__tests__/resolve-env.bats`:
+
+```bash
+#!/usr/bin/env bats
+# resolve-env.bats — Unit tests for resolve-env.sh
+
+setup() {
+    set +u
+    source "${BATS_TEST_DIRNAME}/../resolve-env.sh"
+    # Create temp dirs for test fixtures
+    TEST_TMPDIR=$(mktemp -d)
+    mkdir -p "$TEST_TMPDIR/project/.claude"
+    mkdir -p "$TEST_TMPDIR/home/.claude"
+    mkdir -p "$TEST_TMPDIR/home/.claude/plugins"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# --- ralph_resolve_env ---
+
+@test "ralph_resolve_env returns value from shell env" {
+    export TEST_VAR="from-shell"
+    run ralph_resolve_env "TEST_VAR" "$TEST_TMPDIR/project" "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "from-shell" ]
+    unset TEST_VAR
+}
+
+@test "ralph_resolve_env finds value in repo settings.local.json" {
+    cat > "$TEST_TMPDIR/project/.claude/settings.local.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"from-local"}}
+JSON
+    unset RALPH_GH_OWNER 2>/dev/null || true
+    run ralph_resolve_env "RALPH_GH_OWNER" "$TEST_TMPDIR/project" "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "from-local" ]
+}
+
+@test "ralph_resolve_env finds value in repo settings.json" {
+    cat > "$TEST_TMPDIR/project/.claude/settings.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"from-project"}}
+JSON
+    unset RALPH_GH_OWNER 2>/dev/null || true
+    run ralph_resolve_env "RALPH_GH_OWNER" "$TEST_TMPDIR/project" "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "from-project" ]
+}
+
+@test "ralph_resolve_env finds value in global settings.json" {
+    cat > "$TEST_TMPDIR/home/.claude/settings.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"from-global"}}
+JSON
+    unset RALPH_GH_OWNER 2>/dev/null || true
+    run ralph_resolve_env "RALPH_GH_OWNER" "$TEST_TMPDIR/project" "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "from-global" ]
+}
+
+@test "ralph_resolve_env respects priority order: local > project > global" {
+    cat > "$TEST_TMPDIR/project/.claude/settings.local.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"from-local"}}
+JSON
+    cat > "$TEST_TMPDIR/project/.claude/settings.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"from-project"}}
+JSON
+    cat > "$TEST_TMPDIR/home/.claude/settings.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"from-global"}}
+JSON
+    unset RALPH_GH_OWNER 2>/dev/null || true
+    run ralph_resolve_env "RALPH_GH_OWNER" "$TEST_TMPDIR/project" "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "from-local" ]
+}
+
+@test "ralph_resolve_env returns 1 when not found anywhere" {
+    unset RALPH_GH_OWNER 2>/dev/null || true
+    run ralph_resolve_env "RALPH_GH_OWNER" "$TEST_TMPDIR/project" "$TEST_TMPDIR/home"
+    [ "$status" -eq 1 ]
+}
+
+@test "ralph_resolve_env filters unexpanded template literals" {
+    cat > "$TEST_TMPDIR/project/.claude/settings.local.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"${user_config.owner}"}}
+JSON
+    unset RALPH_GH_OWNER 2>/dev/null || true
+    run ralph_resolve_env "RALPH_GH_OWNER" "$TEST_TMPDIR/project" "$TEST_TMPDIR/home"
+    [ "$status" -eq 1 ]
+}
+
+# --- ralph_detect_scope ---
+
+@test "ralph_detect_scope returns user when scope is user" {
+    cat > "$TEST_TMPDIR/home/.claude/plugins/installed_plugins.json" <<'JSON'
+{"ralph-hero@ralph-hero":[{"scope":"user","installPath":"/fake"}]}
+JSON
+    run ralph_detect_scope "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user" ]
+}
+
+@test "ralph_detect_scope returns project when scope is project" {
+    cat > "$TEST_TMPDIR/home/.claude/plugins/installed_plugins.json" <<'JSON'
+{"ralph-hero@ralph-hero":[{"scope":"project","installPath":"/fake"}]}
+JSON
+    run ralph_detect_scope "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "project" ]
+}
+
+@test "ralph_detect_scope returns unknown when registry missing" {
+    run ralph_detect_scope "$TEST_TMPDIR/home"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+# --- ralph_bridge_env ---
+
+@test "ralph_bridge_env exports resolved vars" {
+    cat > "$TEST_TMPDIR/home/.claude/settings.json" <<'JSON'
+{"env":{"RALPH_GH_OWNER":"test-owner","RALPH_GH_PROJECT_NUMBER":"42"}}
+JSON
+    unset RALPH_GH_OWNER RALPH_GH_PROJECT_NUMBER RALPH_GH_REPO RALPH_HERO_GITHUB_TOKEN 2>/dev/null || true
+    ralph_bridge_env "" "$TEST_TMPDIR/home"
+    [ "$RALPH_GH_OWNER" = "test-owner" ]
+    [ "$RALPH_GH_PROJECT_NUMBER" = "42" ]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd plugin/ralph-hero && bats scripts/__tests__/resolve-env.bats`
+Expected: FAIL — `resolve-env.sh` does not exist
+
+- [ ] **Step 3: Write the implementation**
+
+Create `plugin/ralph-hero/scripts/resolve-env.sh`:
+
+```bash
+#!/usr/bin/env bash
+# resolve-env.sh — Shared env var resolution for Ralph CLI
+# Sources: shell env → repo settings.local.json → repo settings.json → ~/.claude/settings.json
+#
+# Usage:
+#   source "$(dirname "$0")/resolve-env.sh"   # or absolute path
+#   val=$(ralph_resolve_env "RALPH_GH_OWNER" "$repo_root" "$HOME")
+
+# Read a single env var from a JSON settings file.
+# Filters unexpanded ${VAR} template literals.
+# Returns 0 + prints value on success, 1 on failure.
+_ralph_read_json_env() {
+    local var="$1" file="$2"
+    [ -f "$file" ] || return 1
+    local val
+    val=$(node -e "
+        const s = JSON.parse(require('fs').readFileSync('$file','utf8'));
+        const v = (s.env || {})['$var'] || '';
+        if (!v || v.startsWith('\${')) process.exit(1);
+        process.stdout.write(v);
+    " 2>/dev/null) || return 1
+    echo "$val"
+}
+
+# Resolve an env var from the full settings hierarchy.
+# Args: VAR_NAME [REPO_ROOT] [HOME_DIR]
+# Search order:
+#   1. Shell environment
+#   2. <repo>/.claude/settings.local.json
+#   3. <repo>/.claude/settings.json
+#   4. ~/.claude/settings.json
+ralph_resolve_env() {
+    local var="$1"
+    local repo_root="${2:-}"
+    local home_dir="${3:-$HOME}"
+
+    # 1. Shell environment
+    local shell_val="${!var:-}"
+    if [ -n "$shell_val" ]; then
+        echo "$shell_val"
+        return 0
+    fi
+
+    # 2. Repo settings.local.json (project-scoped secrets)
+    if [ -n "$repo_root" ]; then
+        local val
+        val=$(_ralph_read_json_env "$var" "$repo_root/.claude/settings.local.json") && {
+            echo "$val"; return 0
+        }
+    fi
+
+    # 3. Repo settings.json (project-scoped committed config)
+    if [ -n "$repo_root" ]; then
+        local val
+        val=$(_ralph_read_json_env "$var" "$repo_root/.claude/settings.json") && {
+            echo "$val"; return 0
+        }
+    fi
+
+    # 4. Global settings.json (user-scoped config)
+    local val
+    val=$(_ralph_read_json_env "$var" "$home_dir/.claude/settings.json") && {
+        echo "$val"; return 0
+    }
+
+    return 1
+}
+
+# Detect plugin install scope from installed_plugins.json.
+# Args: [HOME_DIR]
+# Returns: "user", "project", or "unknown"
+ralph_detect_scope() {
+    local home_dir="${1:-$HOME}"
+    local registry="$home_dir/.claude/plugins/installed_plugins.json"
+    if [ ! -f "$registry" ]; then
+        echo "unknown"
+        return 0
+    fi
+    local scope
+    scope=$(node -e "
+        const r = JSON.parse(require('fs').readFileSync('$registry','utf8'));
+        const entries = r['ralph-hero@ralph-hero'] || [];
+        const latest = entries[entries.length - 1];
+        if (latest && latest.scope) process.stdout.write(latest.scope);
+        else process.exit(1);
+    " 2>/dev/null) || { echo "unknown"; return 0; }
+    echo "$scope"
+}
+
+# Bridge env vars for direct MCP calls (run_quick / _mcp_call).
+# Resolves and exports RALPH_* vars if not already in shell env.
+# Args: [REPO_ROOT] [HOME_DIR]
+ralph_bridge_env() {
+    local repo_root="${1:-}"
+    local home_dir="${2:-$HOME}"
+
+    # Auto-detect repo root if not provided
+    if [ -z "$repo_root" ]; then
+        repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    fi
+
+    local var val
+    for var in RALPH_HERO_GITHUB_TOKEN RALPH_GH_OWNER RALPH_GH_REPO RALPH_GH_PROJECT_NUMBER; do
+        val="${!var:-}"
+        if [ -z "$val" ]; then
+            val=$(ralph_resolve_env "$var" "$repo_root" "$home_dir") || continue
+            export "$var=$val"
+        fi
+    done
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd plugin/ralph-hero && bats scripts/__tests__/resolve-env.bats`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/ralph-hero/scripts/resolve-env.sh plugin/ralph-hero/scripts/__tests__/resolve-env.bats
+git commit -m "feat(cli): add resolve-env.sh shared shell library for settings hierarchy
+
+Extracts env var resolution into a reusable library with full search order:
+shell env → repo settings.local.json → repo settings.json → ~/.claude/settings.json
+
+Includes scope detection from installed_plugins.json and env bridging
+for direct MCP calls. GH-694"
+```
+
+---
+
+### Task 2: Wire Env Bridging into `cli-dispatch.sh` and Justfile `_mcp_call`
+
+**Files:**
+- Modify: `plugin/ralph-hero/scripts/cli-dispatch.sh:1-5` (add source)
+- Modify: `plugin/ralph-hero/scripts/cli-dispatch.sh:163-190` (`run_quick`)
+- Modify: `plugin/ralph-hero/justfile:576-601` (`_mcp_call`)
+- Modify: `plugin/ralph-hero/scripts/__tests__/cli-dispatch.bats` (add test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `plugin/ralph-hero/scripts/__tests__/cli-dispatch.bats`:
+
+```bash
+# --- Env bridging ---
+
+@test "run_quick calls ralph_bridge_env before mcp" {
+    bridged=false
+    ralph_bridge_env() { bridged=true; }
+    mcp() { echo '{"content":[{"text":"ok"}]}'; }
+    export -f mcp
+    QUICK_TOOL="ralph_hero__pipeline_dashboard"
+    QUICK_PARAMS='{}'
+    run_quick "$QUICK_TOOL" "$QUICK_PARAMS"
+    [ "$bridged" = "true" ]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd plugin/ralph-hero && bats scripts/__tests__/cli-dispatch.bats`
+Expected: FAIL — `ralph_bridge_env` not called
+
+- [ ] **Step 3: Add source line to `cli-dispatch.sh`**
+
+Add after line 4 of `plugin/ralph-hero/scripts/cli-dispatch.sh`:
+
+```bash
+# Source shared env resolution
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/resolve-env.sh"
+```
+
+- [ ] **Step 4: Add `ralph_bridge_env` call to `run_quick` in `cli-dispatch.sh`**
+
+Add before the `mcp call` at line 174 of `plugin/ralph-hero/scripts/cli-dispatch.sh`, inside `run_quick()`:
+
+```bash
+    # Bridge env vars from settings files for direct MCP calls
+    ralph_bridge_env
+```
+
+So `run_quick` becomes:
+
+```bash
+run_quick() {
+    local tool="$1"
+    local params="$2"
+    if ! command -v mcp &>/dev/null; then
+        echo "Error: mcptools not installed."
+        echo "Install: brew tap f/mcptools && brew install mcp"
+        echo "   or: go install github.com/f/mcptools/cmd/mcptools@latest"
+        exit 1
+    fi
+    # Bridge env vars from settings files for direct MCP calls
+    ralph_bridge_env
+    local raw
+    raw=$(mcp call "$tool" --params "$params" \
+        npx -y "ralph-hero-mcp-server@${MCP_VERSION}") || {
+        echo "Error: MCP call to $tool failed." >&2
+        echo "Run: ralph doctor" >&2
+        exit 1
+    }
+    # ... rest unchanged
+```
+
+- [ ] **Step 5: Add `ralph_bridge_env` to justfile `_mcp_call`**
+
+The justfile's `_mcp_call` recipe at line 576 also spawns `mcp call` directly. Add env bridging before the call. Replace lines 576-586 with:
+
+```bash
+_mcp_call tool params:
+    #!/usr/bin/env bash
+    set -eu
+    if ! command -v mcp &>/dev/null; then
+        echo "Error: mcptools not installed."
+        echo "Install: brew tap f/mcptools && brew install mcp"
+        echo "   or: go install github.com/f/mcptools/cmd/mcptools@latest"
+        exit 1
+    fi
+    # Bridge env vars from settings hierarchy
+    source "{{justfile_directory()}}/scripts/resolve-env.sh"
+    ralph_bridge_env
+    raw=$(mcp call "{{tool}}" --params '{{params}}' \
+        npx -y "ralph-hero-mcp-server@${RALPH_MCP_VERSION:-latest}")
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd plugin/ralph-hero && bats scripts/__tests__/cli-dispatch.bats`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugin/ralph-hero/scripts/cli-dispatch.sh plugin/ralph-hero/justfile plugin/ralph-hero/scripts/__tests__/cli-dispatch.bats
+git commit -m "feat(cli): bridge env vars for direct MCP calls
+
+run_quick (cli-dispatch.sh) and _mcp_call (justfile) now source
+resolve-env.sh and call ralph_bridge_env() before spawning the MCP
+server via mcptools. This resolves RALPH_GH_OWNER and other vars
+from the full settings hierarchy. GH-694"
+```
+
+---
+
+### Task 3: Update Doctor Recipe to Search Full Settings Hierarchy
+
+**Files:**
+- Modify: `plugin/ralph-hero/justfile:224-400` (doctor recipe)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `plugin/ralph-hero/scripts/__tests__/doctor.bats` (or create if it only has basic tests):
+
+```bash
+@test "doctor checks settings.json (not just settings.local.json)" {
+    # This test verifies doctor's output mentions settings.json paths
+    # The actual doctor recipe runs with just, so we test the output format
+    run grep -c "settings.json" <<'OUTPUT'
+FAIL: RALPH_GH_OWNER — not found in:
+      - shell environment
+      - .claude/settings.local.json (repo)
+      - .claude/settings.json (repo)
+      - ~/.claude/settings.json (global)
+OUTPUT
+    [ "$output" = "2" ]
+}
+```
+
+- [ ] **Step 2: Replace `read_settings_env` in doctor with shared library**
+
+Replace the inline `read_settings_env()` definition (justfile lines 228-268) and the env var resolution loop (lines 269-309) with:
+
+```bash
+    # Source shared env resolution
+    source "{{justfile_directory()}}/scripts/resolve-env.sh"
+    resolved_token=""
+    resolved_owner=""
+    resolved_project=""
+    echo "=== Ralph Doctor ==="
+    echo ""
+    echo "--- Environment Variables ---"
+    _repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    _scope=$(ralph_detect_scope)
+    if [ "$_scope" != "unknown" ]; then
+        echo "  Plugin scope: $_scope"
+    fi
+    for var in RALPH_HERO_GITHUB_TOKEN RALPH_GH_OWNER RALPH_GH_PROJECT_NUMBER; do
+        val=""
+        source_label=""
+        # Check shell env first
+        shell_val="${!var:-}"
+        if [ -n "$shell_val" ]; then
+            val="$shell_val"
+            source_label=" (from shell env)"
+        fi
+        # Check settings hierarchy with source tracking
+        if [ -z "$val" ] && [ -n "$_repo_root" ] && [ -f "$_repo_root/.claude/settings.local.json" ]; then
+            val=$(_ralph_read_json_env "$var" "$_repo_root/.claude/settings.local.json") && source_label=" (from .claude/settings.local.json)" || val=""
+        fi
+        if [ -z "$val" ] && [ -n "$_repo_root" ] && [ -f "$_repo_root/.claude/settings.json" ]; then
+            val=$(_ralph_read_json_env "$var" "$_repo_root/.claude/settings.json") && source_label=" (from .claude/settings.json)" || val=""
+        fi
+        if [ -z "$val" ] && [ -f "$HOME/.claude/settings.json" ]; then
+            val=$(_ralph_read_json_env "$var" "$HOME/.claude/settings.json") && source_label=" (from ~/.claude/settings.json)" || val=""
+        fi
+        if [ -z "$val" ]; then
+            echo "FAIL: $var — not found in:"
+            echo "      - shell environment"
+            if [ -n "$_repo_root" ]; then
+                echo "      - .claude/settings.local.json (repo)"
+                echo "      - .claude/settings.json (repo)"
+            fi
+            echo "      - ~/.claude/settings.json (global)"
+            errors=$((errors + 1))
+            # Scope-aware hint
+            if [ "$_scope" = "user" ]; then
+                echo "      Hint: plugin is user-scoped — add to ~/.claude/settings.json for cross-repo use"
+            fi
+        else
+            if [ "$var" = "RALPH_HERO_GITHUB_TOKEN" ]; then
+                echo "  OK: $var (set, redacted)$source_label"
+                resolved_token="$val"
+            elif [ "$var" = "RALPH_GH_OWNER" ]; then
+                echo "  OK: $var = ${val}$source_label"
+                resolved_owner="$val"
+                # Scope mismatch warning
+                if [ "$_scope" = "user" ] && [[ "$source_label" == *"settings.local.json"* ]]; then
+                    echo "  WARN: user-scoped plugin but config in project-local file — CLI won't work outside this repo"
+                    warnings=$((warnings + 1))
+                fi
+            elif [ "$var" = "RALPH_GH_PROJECT_NUMBER" ]; then
+                echo "  OK: $var = ${val}$source_label"
+                resolved_project="$val"
+            fi
+        fi
+    done
+```
+
+- [ ] **Step 3: Run doctor manually to verify**
+
+Run: `cd plugin/ralph-hero && just doctor`
+Expected: Output shows scope detection and new search paths. No errors if vars are set.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/ralph-hero/justfile plugin/ralph-hero/scripts/__tests__/doctor.bats
+git commit -m "feat(cli): doctor searches full settings hierarchy with scope diagnostics
+
+Doctor now checks: shell env → settings.local.json → settings.json → ~/.claude/settings.json.
+Reports plugin install scope, warns on scope/config mismatch. GH-694"
+```
+
+---
+
+### Task 4: Update Setup Skill for Scope-Aware Config Writing
+
+**Files:**
+- Modify: `plugin/ralph-hero/skills/setup/SKILL.md`
+
+- [ ] **Step 1: Read the full setup skill**
+
+Run: Read `plugin/ralph-hero/skills/setup/SKILL.md` to understand the full flow before modifying.
+
+- [ ] **Step 2: Add scope detection step to setup skill**
+
+After the project creation/validation step, add a new step that detects install scope and determines the target config file. Insert before the "Add to Claude Code Settings" section:
+
+```markdown
+### 1b. Detect Install Scope
+
+Before writing configuration, determine where to write it:
+
+1. Read `~/.claude/plugins/installed_plugins.json`
+2. Find the `ralph-hero@ralph-hero` entry
+3. Check the `"scope"` field of the latest entry
+
+**If scope is `"user"`:**
+- Write non-sensitive env vars to `~/.claude/settings.json` under `"env"`
+- Write token to `~/.claude/settings.local.json` under `"env"` (gitignored by default in home dir)
+- Tell the user: "Ralph is installed at user scope — config will be written to ~/.claude/settings.json so the CLI works from any directory."
+
+**If scope is `"project"`:**
+- Write all env vars to `<project>/.claude/settings.local.json` under `"env"`
+- Tell the user: "Ralph is installed at project scope — config will be written to .claude/settings.local.json. The CLI will only work from this project directory."
+
+**If scope cannot be determined:**
+- Fall back to current behavior (`settings.local.json`)
+- Warn: "Could not detect install scope. Writing to .claude/settings.local.json (project-scoped)."
+```
+
+- [ ] **Step 3: Update all `settings.local.json` references in the skill**
+
+Replace hardcoded `settings.local.json` references with scope-conditional language:
+
+- Section "2. Add to Claude Code Settings" — show both paths based on scope detection
+- Section "Where NOT to put tokens" — keep as-is (tokens always go in local/gitignored files)
+- Section "Advanced: Split-Owner / Dual-Token" — add scope note
+- All "Next steps" sections — replace `"Verify .claude/settings.local.json"` with scope-conditional: `"Verify your config file (see above for location)"`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/ralph-hero/skills/setup/SKILL.md
+git commit -m "feat(setup): scope-aware config file targeting
+
+Setup skill now detects plugin install scope (user vs project) and
+writes non-sensitive env vars to the appropriate settings file.
+User-scoped: ~/.claude/settings.json. Project-scoped: settings.local.json.
+GH-694"
+```
+
+---
+
+### Task 5: Improve MCP Server Error Messages
+
+**Files:**
+- Modify: `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:556-558`
+- Modify: `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:580-582`
+- Test: `plugin/ralph-hero/mcp-server/src/__tests__/helpers-resolve-config.test.ts` (create or extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Create or extend a test file for `resolveConfig` error messages:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { resolveConfig, resolveConfigOptionalRepo } from "../lib/helpers.js";
+import type { GitHubClient } from "../github-client.js";
+
+function mockClient(overrides: Partial<GitHubClient["config"]> = {}): GitHubClient {
+  return {
+    config: {
+      token: "fake",
+      ...overrides,
+    },
+  } as unknown as GitHubClient;
+}
+
+describe("resolveConfig", () => {
+  it("throws with scope-aware message when owner is missing", () => {
+    const client = mockClient({ owner: undefined });
+    expect(() => resolveConfig(client, {})).toThrow(
+      "owner is required",
+    );
+    expect(() => resolveConfig(client, {})).toThrow(
+      "~/.claude/settings.json",
+    );
+  });
+});
+
+describe("resolveConfigOptionalRepo", () => {
+  it("throws with scope-aware message when owner is missing", () => {
+    const client = mockClient({ owner: undefined });
+    expect(() => resolveConfigOptionalRepo(client, {})).toThrow(
+      "owner is required",
+    );
+    expect(() => resolveConfigOptionalRepo(client, {})).toThrow(
+      "~/.claude/settings.json",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd plugin/ralph-hero/mcp-server && npx vitest run src/__tests__/helpers-resolve-config.test.ts`
+Expected: FAIL — current error message doesn't mention `~/.claude/settings.json`
+
+- [ ] **Step 3: Update error messages in helpers.ts**
+
+At `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:556-558`, change:
+
+```typescript
+  if (!owner)
+    throw new Error(
+      "owner is required (set RALPH_GH_OWNER env var or pass explicitly)",
+    );
+```
+
+To:
+
+```typescript
+  if (!owner)
+    throw new Error(
+      "owner is required. Set RALPH_GH_OWNER in ~/.claude/settings.json (user-scoped) " +
+      "or .claude/settings.local.json (project-scoped), or pass owner explicitly.",
+    );
+```
+
+At `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:580-582`, apply the same change.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd plugin/ralph-hero/mcp-server && npx vitest run src/__tests__/helpers-resolve-config.test.ts`
+Expected: PASS
+
+Run: `cd plugin/ralph-hero/mcp-server && npm test`
+Expected: Full suite PASS (no regressions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/ralph-hero/mcp-server/src/lib/helpers.ts plugin/ralph-hero/mcp-server/src/__tests__/helpers-resolve-config.test.ts
+git commit -m "fix(mcp): improve owner-missing error with scope-aware config guidance
+
+Error messages now mention both ~/.claude/settings.json (user-scoped)
+and .claude/settings.local.json (project-scoped) so users know where
+to add their config. GH-694"
+```
+
+---
+
+### Task 6: Manual Verification
+
+- [ ] **Step 1: Run all BATS tests**
+
+```bash
+cd plugin/ralph-hero && bats scripts/__tests__/resolve-env.bats scripts/__tests__/cli-dispatch.bats scripts/__tests__/doctor.bats
+```
+
+Expected: All PASS
+
+- [ ] **Step 2: Run MCP server test suite**
+
+```bash
+cd plugin/ralph-hero/mcp-server && npm test
+```
+
+Expected: All PASS
+
+- [ ] **Step 3: Build MCP server**
+
+```bash
+cd plugin/ralph-hero/mcp-server && npm run build
+```
+
+Expected: No type errors
+
+- [ ] **Step 4: Test cross-repo CLI (the original reproduction)**
+
+Set `RALPH_GH_OWNER` and `RALPH_GH_PROJECT_NUMBER` in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "RALPH_GH_OWNER": "cdubiel08",
+    "RALPH_GH_PROJECT_NUMBER": "3"
+  }
+}
+```
+
+Then from a different repo:
+
+```bash
+cd ~/projects/ralph-engine
+ralph status -q
+ralph doctor
+```
+
+Expected: Both work without "owner is required" error.
+
+- [ ] **Step 5: Test doctor scope diagnostics**
+
+```bash
+cd plugin/ralph-hero && just doctor
+```
+
+Expected: Output shows "Plugin scope: user" and correct source labels for each var.

--- a/thoughts/shared/plans/2026-04-02-GH-0714-skill-mcp-tool-name-fix.md
+++ b/thoughts/shared/plans/2026-04-02-GH-0714-skill-mcp-tool-name-fix.md
@@ -1,0 +1,339 @@
+---
+date: 2026-04-02
+status: draft
+type: plan
+tags: [skills, mcp, tool-names, bug-fix]
+github_issue: 714
+github_issues: [714]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/714
+primary_issue: 714
+---
+
+# Fix Skill MCP Tool Name Resolution Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-04-01-skill-mcp-tool-name-mismatch]]
+
+## Overview
+
+All 26 skills that reference ralph-hero MCP tools use short-form names (`ralph_hero__get_issue`) that ToolSearch cannot resolve to the actual deferred names (`mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue`). This plan fixes the `allowed-tools` frontmatter (mechanical) and rewrites inline body references from tool-name literals to natural language (durable, improves with model capability).
+
+## Current State Analysis
+
+- **26 skills** have `allowed-tools` entries using short-form ralph-hero tool names
+- **1 skill** (`ralph-postmortem`) uses a bare knowledge tool name (`knowledge_record_outcome`) with no prefix at all
+- **3 skills** (`prove-claim`, `hero`, `ralph-plan-epic`) correctly use long-form names for ralph-knowledge tools
+- **Agent definitions** already use correct fully-qualified names in `tools:` frontmatter and natural language in body text — this is the target pattern
+- **Inline body references** use 4 syntactic patterns across all skills, totaling 200+ occurrences
+
+### Key Discoveries:
+- The `allowed-tools` frontmatter is a permission gate only — it does not auto-load deferred tools
+- ToolSearch indexes tools by fully-qualified name; short names produce no matches
+- Agent bodies already demonstrate the natural language approach works well — agents reference tools by intent, not by name
+- Pattern D (pseudo-YAML labeled-list) is the most common inline pattern in autonomous skills (`ralph-impl`, `ralph-triage`, `ralph-split`, `ralph-review`, `ralph-research`)
+
+## Desired End State
+
+Every skill file follows this convention:
+1. **`allowed-tools` frontmatter** uses fully-qualified MCP tool names (e.g., `mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue`)
+2. **Body text** uses natural language to describe actions, carrying critical parameter values (workflow states, commands, profiles) but never tool name literals
+3. **No `ralph_hero__*` or bare `knowledge_*` literals** appear anywhere in body text
+
+### Verification:
+- `grep -r "ralph_hero__" plugin/ralph-hero/skills/` returns hits only in `allowed-tools:` frontmatter lines
+- `grep -r "knowledge_search\|knowledge_traverse\|knowledge_record_outcome" plugin/ralph-hero/skills/` returns zero hits (all moved to long-form in frontmatter, natural language in body)
+- Invoking `/ralph-hero:plan #714` in a fresh session (no pre-loaded MCP tools) successfully calls MCP tools via ToolSearch
+
+## What We're NOT Doing
+
+- Not changing agent definitions — they already use correct names
+- Not changing MCP server tool registration names (`ralph_hero__*` prefix stays)
+- Not changing hook `matcher:` fields — hooks receive the short name in their JSON payload
+- Not changing the `specs/skill-permissions.md` document (informational, not functional)
+- Not adding any new tools or changing tool behavior
+
+## Implementation Approach
+
+Two phases editing SKILL.md files only. Phase 1 is a mechanical find-and-replace of frontmatter. Phase 2 is a creative rewrite of inline body text guided by clear principles and pattern-specific examples. Both phases edit the same files in `plugin/ralph-hero/skills/` (and one file in `plugin/ralph-knowledge/skills/`).
+
+All skill files live at: `plugin/ralph-hero/skills/{skill-name}/SKILL.md`
+
+## Phase 1: Update `allowed-tools` Frontmatter
+
+### Overview
+Mechanical replacement of short-form tool names with fully-qualified names in `allowed-tools` arrays across all 26 affected skills (plus 1 ralph-knowledge skill).
+
+### Tool Name Mapping
+
+Apply these substitutions to every `allowed-tools` entry:
+
+**ralph-hero tools** — prefix `ralph_hero__` becomes `mcp__plugin_ralph-hero_ralph-github__ralph_hero__`:
+```
+ralph_hero__get_issue          → mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+ralph_hero__list_issues        → mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+ralph_hero__create_issue       → mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+ralph_hero__save_issue         → mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+ralph_hero__create_comment     → mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+ralph_hero__add_sub_issue      → mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
+ralph_hero__list_sub_issues    → mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
+ralph_hero__add_dependency     → mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
+ralph_hero__remove_dependency  → mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
+ralph_hero__list_dependencies  → mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_dependencies
+ralph_hero__advance_issue      → mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue
+ralph_hero__decompose_feature  → mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
+ralph_hero__detect_stream_positions → mcp__plugin_ralph-hero_ralph-github__ralph_hero__detect_stream_positions
+ralph_hero__pick_actionable_issue   → mcp__plugin_ralph-hero_ralph-github__ralph_hero__pick_actionable_issue
+ralph_hero__pipeline_dashboard → mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+ralph_hero__project_hygiene    → mcp__plugin_ralph-hero_ralph-github__ralph_hero__project_hygiene
+ralph_hero__archive_items      → mcp__plugin_ralph-hero_ralph-github__ralph_hero__archive_items
+ralph_hero__create_status_update → mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_status_update
+ralph_hero__health_check       → mcp__plugin_ralph-hero_ralph-github__ralph_hero__health_check
+ralph_hero__get_project        → mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_project
+ralph_hero__setup_project      → mcp__plugin_ralph-hero_ralph-github__ralph_hero__setup_project
+ralph_hero__sync_plan_graph    → mcp__plugin_ralph-hero_ralph-github__ralph_hero__sync_plan_graph
+```
+
+**ralph-knowledge bare names** (only in `ralph-postmortem`):
+```
+knowledge_record_outcome → mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+```
+
+### Skills to Edit (26 total — `prove-claim` already correct):
+
+bridge-artifact, form, hello, hero, impl, iterate, plan, ralph-hygiene, ralph-impl, ralph-merge, ralph-plan, ralph-plan-epic, ralph-postmortem, ralph-pr, ralph-research, ralph-review, ralph-split, ralph-triage, ralph-val, record-demo, report, research, setup, setup-repos, status, team
+
+### Changes Required:
+
+For each skill, replace every `ralph_hero__*` entry in the `allowed-tools:` YAML array with its fully-qualified equivalent using the mapping above. Also replace the bare `knowledge_record_outcome` in `ralph-postmortem`.
+
+Do NOT change:
+- Built-in tool names (Read, Write, Bash, etc.)
+- ralph-knowledge tools that already use long form (in `hero`, `ralph-plan-epic`, `prove-claim`)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep -rn "^  - ralph_hero__" plugin/ralph-hero/skills/` returns zero matches
+- [ ] `grep -rn "^  - knowledge_" plugin/ralph-hero/skills/` returns zero matches
+- [ ] `grep -rn "mcp__plugin_ralph-hero_ralph-github__ralph_hero__" plugin/ralph-hero/skills/` returns 75+ matches (one per frontmatter entry)
+- [ ] Every skill file is valid YAML frontmatter (no parse errors when the skill is invoked)
+
+#### Manual Verification:
+- [ ] Invoke one skill (e.g., `/ralph-hero:status`) in a fresh session and confirm MCP tools resolve via ToolSearch
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
+---
+
+## Phase 2: Rewrite Inline Body References to Natural Language
+
+### Overview
+Replace all inline MCP tool name literals in skill body text with natural language descriptions that carry critical parameter values but not tool names. This makes skills more durable — models improve at tool selection from natural language, and prose won't break if tool names change.
+
+### Rewrite Principles
+
+1. **Describe the intent, not the tool**: "Fetch the issue details" not "Call `ralph_hero__get_issue`"
+2. **Preserve critical parameter values**: Workflow states (`"Plan in Review"`, `"__LOCK__"`), commands (`"ralph_plan"`), profiles (`"builder-active"`), and field values (`estimate: "XS"`) must appear verbatim in the rewritten text
+3. **Use action verbs**: fetch, update, create, post, search, list, add, remove, advance, lock
+4. **Keep structure where it helps**: Numbered steps and bullets are fine — just remove tool names from them
+5. **Trust the model**: The `allowed-tools` frontmatter tells the model which tools are available. Natural language intent + available tools = correct tool selection.
+
+### Pattern-Specific Rewrite Examples
+
+#### Pattern A: Fenced block with call syntax → Natural language directive
+
+**Before:**
+```
+   ```
+   ralph_hero__get_issue(number=NNN)
+   ```
+```
+
+**After:**
+```
+Fetch the full issue details (title, body, comments, workflow state, relationships).
+```
+
+**Before:**
+```
+   ```
+   ralph_hero__create_comment(number=NNN, body="## Implementation Plan\n\nhttps://github.com/...")
+   ```
+```
+
+**After:**
+```
+Post an Artifact Comment on the issue:
+   ```markdown
+   ## Implementation Plan
+
+   https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/[plan-path]
+
+   Summary: [1-3 line summary]
+   ```
+```
+
+#### Pattern B: Inline backtick with params → Prose with values
+
+**Before:**
+```
+- Use `ralph_hero__list_issues(query=...)` to find related issues directly
+```
+
+**After:**
+```
+- Search for related issues by keyword
+```
+
+**Before:**
+```
+If option 1: `ralph_hero__save_issue(number=NNN, workflowState="Plan in Review")`
+```
+
+**After:**
+```
+If option 1: Update the issue workflow state to "Plan in Review"
+```
+
+#### Pattern C: Inline backtick name-only → Action description
+
+**Before:**
+```
+Query siblings via `ralph_hero__list_sub_issues` on the epic.
+```
+
+**After:**
+```
+Query sibling issues under the epic.
+```
+
+#### Pattern D: Pseudo-YAML labeled-list → Structured natural language
+
+**Before:**
+```
+   ```
+   ralph_hero__save_issue
+   - number: [issue-number]
+   - workflowState: "__LOCK__"
+   - command: "ralph_research"
+   ```
+```
+
+**After:**
+```
+Lock the issue (set workflowState to "__LOCK__" with command "ralph_research").
+```
+
+**Before (multi-step D blocks):**
+```
+   ```
+   ralph_hero__create_issue
+   - title: [Descriptive title]
+   - body: [Scope, references, acceptance criteria]
+   - labels: [inherit from parent]
+
+   ralph_hero__add_sub_issue
+   - parentNumber: [original-issue-number]
+   - childNumber: [new-issue-number]
+
+   ralph_hero__save_issue
+   - number: [new-issue-number]
+   - estimate: "XS"
+   ```
+```
+
+**After:**
+```
+For each new sub-issue:
+1. Create a GitHub issue with a descriptive title, scoped body, and labels inherited from the parent
+2. Link it as a sub-issue of the original
+3. Set the estimate to "XS"
+```
+
+#### Knowledge tool references → Natural language
+
+**Before:**
+```
+   knowledge_search(query="research [topic keywords]", type="research", limit=5)
+```
+
+**After:**
+```
+Search the knowledge graph for related research documents on [topic keywords].
+```
+
+### Skills to Edit
+
+Edit all 27 skills that have inline tool references. Process in this order (high-traffic interactive skills first, then autonomous pipeline skills, then supporting skills):
+
+**Interactive skills (6):**
+1. `plan` — 9 inline refs (Pattern A/B)
+2. `research` — 4 inline refs (Pattern B/C)
+3. `impl` — 6 inline refs (Pattern A)
+4. `form` — 10 inline refs (Pattern A/B/D)
+5. `hero` — 3 inline refs (Pattern A/B)
+6. `iterate` — 8 inline refs (Pattern D)
+
+**Autonomous pipeline skills (11):**
+7. `ralph-impl` — 7 inline refs (Pattern A/C/D)
+8. `ralph-plan` — 13 inline refs (Pattern A/B/C)
+9. `ralph-research` — 7 inline refs (Pattern B/C/D)
+10. `ralph-review` — 15 inline refs (Pattern A/D)
+11. `ralph-triage` — 25+ inline refs (Pattern B/D) — heaviest rewrite
+12. `ralph-split` — 20+ inline refs (Pattern D) — heavy rewrite
+13. `ralph-merge` — 5 inline refs (Pattern A)
+14. `ralph-pr` — 4 inline refs (Pattern A)
+15. `ralph-val` — 2 inline refs (Pattern A/C)
+16. `ralph-plan-epic` — 12 inline refs (Pattern A/B/C)
+17. `ralph-postmortem` — 3 inline refs (Pattern C)
+
+**Supporting skills (10):**
+18. `hello` — 1 inline ref (Pattern A/D)
+19. `status` — 2 inline refs (Pattern C)
+20. `report` — 2 inline refs (Pattern C)
+21. `setup` — 5 inline refs (Pattern C)
+22. `setup-repos` — 7 inline refs (Pattern C)
+23. `ralph-hygiene` — 3 inline refs (Pattern A/C)
+24. `team` — 2 inline refs (Pattern A)
+25. `bridge-artifact` — 2 inline refs (Pattern A/B)
+26. `record-demo` — 2 inline refs (Pattern B)
+27. `prove-claim` — 12 inline refs (Pattern C) — knowledge tools only
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep -rn "ralph_hero__" plugin/ralph-hero/skills/` returns matches ONLY in `allowed-tools:` frontmatter lines (not in body text)
+- [ ] `grep -rn "knowledge_search\|knowledge_traverse\|knowledge_record_outcome\|knowledge_paths\|knowledge_common\|knowledge_central\|knowledge_bridges\|knowledge_communities" plugin/ralph-hero/skills/` returns zero body-text matches (only frontmatter)
+- [ ] No SKILL.md files have broken markdown (fenced blocks properly closed, lists properly indented)
+
+#### Manual Verification:
+- [ ] Invoke `/ralph-hero:plan` with an issue argument in a fresh session — confirm it fetches issue details and posts comments via MCP tools
+- [ ] Invoke `/ralph-hero:status` in a fresh session — confirm pipeline dashboard tool is called
+- [ ] Invoke `/ralph-hero:research` with a question — confirm it can search/list issues
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to commit.
+
+---
+
+## Testing Strategy
+
+### Automated:
+- grep verification commands listed in each phase's success criteria
+- YAML frontmatter parse validation (invoke each skill and confirm no parse errors)
+
+### Manual Testing Steps:
+1. Start a fresh Claude Code session (no prior MCP tool usage in conversation)
+2. Run `/ralph-hero:status` — should call `pipeline_dashboard` successfully
+3. Run `/ralph-hero:plan #714` — should fetch issue #714 via MCP and proceed normally
+4. Run `/ralph-hero:research "how does caching work"` — should be able to search issues if needed
+
+### Regression Check:
+- Autonomous skills (`ralph-impl`, `ralph-triage`, etc.) are tested via `/ralph-hero:hero` or `/ralph-hero:team` which invoke them as sub-skills
+
+## References
+
+- Research: `thoughts/shared/research/2026-04-01-skill-mcp-tool-name-mismatch.md`
+- Issue: #714
+- Agent definitions (correct pattern): `plugin/ralph-hero/agents/ralph-analyst.md`, `ralph-builder.md`

--- a/thoughts/shared/plans/2026-04-03-GH-0731-complete-autonomous-loop.md
+++ b/thoughts/shared/plans/2026-04-03-GH-0731-complete-autonomous-loop.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-03
+date: 2026-04-07
 status: approved
 type: plan
 tags: [ralph-hero, autonomous-mode, loop-runner, code-review, integrator]
@@ -16,6 +16,7 @@ primary_issue: 731
 
 - builds_on:: [[2026-01-19-naive-hero-autonomous-loop]]
 - builds_on:: [[2026-02-13-group-LAN-361-ralph-github-plugin]]
+- supersedes:: prior approved plan (2026-04-03) — updated to reflect PRs #743 and #757
 
 ## Overview
 
@@ -30,21 +31,24 @@ Complete the ralph-hero autonomous loop (`ralph-loop.sh`) so it drives issues fr
 - All analyst/builder skills (`ralph-triage` through `ralph-impl`) are `context: fork` with hooks
 - `ralph-pr`, `ralph-val`, `ralph-merge` skills exist but are NOT in the loop
 - `code-review:code-review` plugin runs headlessly and posts PR comments
+- `finish` skill (PR #743) chains val → merge → CI watch with a code-review fix cycle
+- `ralph-merge` (PR #757) already handles `RALPH_REVIEW_MODE=auto` — runs code review headlessly and outputs `CODE_REVIEW_FEEDBACK` status when changes requested
 
 **What's broken/missing:**
-1. **Queue-empty text mismatch** — `run_claude` greps for `"Queue empty"` but `ralph-triage` outputs `"Triage complete"` (never signals empty to the loop)
-2. **Review defaults to `skip`** — Full auto should default to `auto` (Opus auto-approves good plans)
-3. **No integrator phases** — After impl, issues sit in "In Review" with no PR, no code review, no merge
-4. **`ralph-merge` is interactive** — Step 4 uses `AskUserQuestion` which blocks headless execution
-5. **No `ralph-code-review` skill** — Nothing orchestrates: find PR → run code-review → address feedback → re-review loop
-6. **Integrator placeholder** — `ralph-loop.sh:220-223` has `# Future: run_claude "/ralph-hero:ralph-integrate"` but no implementation
+1. **Queue-empty text mismatch** — `run_claude` greps for `"Queue empty"` (`ralph-loop.sh:128`) but `ralph-triage` outputs `"Triage complete"` (`ralph-triage/SKILL.md:93`), never signaling empty to the loop
+2. **Review defaults to `interactive`** — `ralph-loop.sh:54` has `RALPH_REVIEW_MODE:-interactive`; justfile has `review="skip"` (`justfile:203`). Full auto should default to `auto` in both places.
+3. **No integrator phases** — After impl, issues sit in "In Progress" with no validation, PR, code review, or merge. `ralph-loop.sh:220-223` is a stub.
+4. **No queue-picking in integrator skills** — `ralph-val`, `ralph-pr`, `ralph-merge` all require an explicit issue number; none have `list_issues` in allowed-tools.
+5. **No `ralph-code-review` skill** — Nothing orchestrates: find PR → run code-review → address feedback → re-review. (The `finish` skill handles this for single-issue use, but the loop needs a standalone per-phase skill.)
+6. **No autonomous merge gate** — `ralph-merge` merges without checking CI status. Need `RALPH_AUTO_MERGE` flag with CI validation.
 
 ### Key Discoveries:
 - `ralph-impl` Step 2 already detects "In Review" + PR comments → enters **Address Mode** automatically (`ralph-impl/SKILL.md:88-95`)
-- `code-review:code-review` auto-detects PR from `gh` context, posts comments above confidence 80, uses 5 parallel Sonnet reviewers (`commands/code-review.md`)
-- `ralph-merge` checks `gh pr view NNN --json reviewDecision` for approval status (`ralph-merge/SKILL.md:86-89`)
-- `ralph-pr` is model `haiku` — lightweight, just pushes branch + creates PR via `gh` (`ralph-pr/SKILL.md:6`)
-- `ralph-val` runs automated verification from the plan document before PR creation (`ralph-val/SKILL.md:100-110`)
+- `code-review:code-review` auto-detects PR from `gh` context, posts comments above confidence 80, uses 5 parallel Sonnet reviewers
+- `ralph-merge` Step 4 already handles `RALPH_REVIEW_MODE=auto` for code review (`ralph-merge/SKILL.md:107-127`). The `RALPH_AUTO_MERGE` flag is a separate concern — CI gate for the merge itself.
+- `ralph-pr` is model `haiku` — lightweight, just pushes branch + creates PR via `gh`
+- `ralph-val` runs automated verification from the plan document before PR creation
+- Agent tools lists and skill allowed-tools both need updating — loop invokes skills via `claude -p`, hero/finish dispatches agents via `Agent()`
 
 ## Desired End State
 
@@ -67,12 +71,14 @@ hygiene → triage → split → research → plan → review → impl → val �
 - No postmortem generation at loop completion (exists as a skill, wire later)
 - No parallel ticket processing within a single phase (one ticket per phase per iteration)
 - No GitHub Actions integration for CI triggering (we rely on existing CI via `gh pr checks`)
-- No changes to the hero orchestrator skill — this plan targets `ralph-loop.sh` only
-- No new MCP server tools — all needed tools already exist
+- No changes to the hero orchestrator skill or finish skill — this plan targets `ralph-loop.sh` and integrator skills only
+- No new MCP server tools — all needed tools already exist (but `state-resolution.ts` needs a new command entry for `ralph_code_review`)
 
 ## Implementation Approach
 
-One new skill (`ralph-code-review`), queue-picking logic added to three existing skills (`ralph-val`, `ralph-pr`, `ralph-merge`), and loop script extension. The queue-picking additions are mechanical — each skill gets a "If no issue number" branch that queries `list_issues` for the appropriate workflow state, identical to the pattern used by `ralph-impl` and `ralph-research`.
+One new skill (`ralph-code-review`), one new agent (`code-review-agent`), queue-picking logic added to three existing skills + agents (`ralph-val`, `ralph-pr`, `ralph-merge`), and loop script extension. The queue-picking additions are mechanical — each skill gets a "If no issue number" branch that queries `list_issues` for the appropriate workflow state, identical to the pattern used by `ralph-impl` and `ralph-research`.
+
+**Relationship to finish skill**: The `finish` skill already chains val→merge→CI with a code-review fix cycle for single-issue use (hero/interactive). The loop uses individual phases so different issues can be at different pipeline stages. These stay fully separate — no changes to `finish` or `hero`.
 
 ---
 
@@ -99,26 +105,38 @@ No untriaged issues in Backlog. Queue empty.
 #### 2. Note: `ralph-hygiene` is always-run (no queue-empty needed)
 `ralph-hygiene` is a board-scanning skill that always produces an archive eligibility report. It has no concept of "no work" — it always runs. The loop already handles it correctly: line 149 calls `run_claude` without checking the return value for queue-empty, and `work_done=true` is set unconditionally. **No changes needed for hygiene.**
 
-#### 3. Change review default from `skip` to `auto` (script AND justfile together)
+#### 3. Change review default from `interactive` to `auto` (script AND justfile together)
 **File**: `plugin/ralph-hero/scripts/ralph-loop.sh`
 **Changes**: Line 54 — change `REVIEW_MODE` default:
 
 ```bash
-# Before
-REVIEW_MODE="${RALPH_REVIEW_MODE:-skip}"
+# Before (line 54)
+REVIEW_MODE="${RALPH_REVIEW_MODE:-interactive}"
 
 # After
 REVIEW_MODE="${RALPH_REVIEW_MODE:-auto}"
 ```
 
-This means `just loop` now auto-reviews plans instead of skipping review. Users who want to skip can still pass `--review=skip`.
+Also update the usage comment at line 14:
+```bash
+# Before
+#   --review=skip        Skip review phase (default, backwards compatible)
+# After
+#   --review=auto        Opus critiques plan automatically (default)
+```
 
-#### 4. Change justfile `loop` recipe review default to match
+This means `just loop` now auto-reviews plans instead of using interactive review. Users who want the old behavior can pass `--review=interactive` or `--review=skip`.
+
+#### 4. Change justfile `loop` recipe review default and budget
 **File**: `plugin/ralph-hero/justfile`
-**Changes**: In the `loop` recipe (around line 203), change the `review` parameter default from `"skip"` to `"auto"`:
+**Changes**: Line 203 — change the `review` default from `"skip"` to `"auto"` and bump budget from `"5.00"` to `"8.00"`:
 
 ```just
-loop mode="all" review="auto" split="auto" ...
+# Before (line 203)
+loop mode="all" review="skip" split="auto" hygiene="auto" budget="5.00" timeout="60m":
+
+# After
+loop mode="all" review="auto" split="auto" hygiene="auto" budget="8.00" timeout="60m":
 ```
 
 This keeps the script default and justfile default in sync (both changed in Phase 1).
@@ -132,18 +150,18 @@ This keeps the script default and justfile default in sync (both changed in Phas
 if echo "$output" | grep -qi "Queue empty"; then
 
 # After
-if echo "$output" | grep -qiE "Queue empty|No .* issues|Triage complete"; then
+if echo "$output" | grep -qiE "Queue empty|Triage complete"; then
 ```
 
-This catches existing skills that haven't been updated yet and provides a safety net.
+This catches ralph-triage's legacy output as a safety net. We intentionally do NOT use a broad pattern like `No .* issues` — it would false-positive on normal skill output (e.g., "No substantive issues found" in val reports), causing the loop to misinterpret successful work as "queue empty".
 
 ### Success Criteria:
 
 #### Automated Verification:
 - [ ] `grep -c "Queue empty" plugin/ralph-hero/skills/ralph-triage/SKILL.md` returns ≥1
-- [ ] `grep 'REVIEW_MODE.*:-' plugin/ralph-hero/scripts/ralph-loop.sh` shows `auto` not `skip`
+- [ ] `grep 'REVIEW_MODE.*:-' plugin/ralph-hero/scripts/ralph-loop.sh` shows `auto` not `interactive`
 - [ ] `grep 'review="auto"' plugin/ralph-hero/justfile` confirms justfile default matches
-- [ ] `grep -E 'Queue empty|No .* issues' plugin/ralph-hero/scripts/ralph-loop.sh` matches the broadened pattern
+- [ ] `grep -E 'Queue empty\|Triage complete' plugin/ralph-hero/scripts/ralph-loop.sh` matches the safety-net pattern
 
 #### Manual Verification:
 - [ ] Run `just triage` on an empty backlog — output includes "Queue empty"
@@ -156,23 +174,24 @@ This catches existing skills that haven't been updated yet and provides a safety
 ### Overview
 `ralph-val`, `ralph-pr`, and `ralph-merge` all require an issue number argument and have no self-selection logic. The loop invokes skills without arguments (like `ralph-triage` and `ralph-impl` which self-select). Add "If no issue number" queue-picking branches to each skill, following the same pattern used by `ralph-impl` Step 1.
 
-**Note**: Each skill also needs `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` added to its `allowed-tools` frontmatter to support the queue-picking queries.
+Each skill needs `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` added to its `allowed-tools` frontmatter (for loop invocation via `claude -p`). Each corresponding agent definition needs `list_issues` added to its `tools:` field (for hero/finish invocation via `Agent()`).
 
 ### Changes Required:
 
 #### 1. Add queue-picking to `ralph-val`
 **File**: `plugin/ralph-hero/skills/ralph-val/SKILL.md`
-**Changes**: Add `list_issues` to `allowed-tools` frontmatter. In Step 1, add a fallback when no issue number is provided:
+**Changes**: Add `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` to `allowed-tools` frontmatter (after line 23). In Step 1, add a fallback when no issue number is provided:
 
 ```markdown
-**If no issue number**: List issues in "In Progress" state where all plan phases
-are complete (all automated verification checkboxes checked), XS/Small, ordered
-by priority, limit 1.
+**If no issue number**: List issues in "In Progress" state, ordered by priority, limit 10.
 
-Use profile "builder-active" (workflowState: "In Progress").
+Use: `list_issues(workflowState: "In Progress", limit: 10)`
 
-For each candidate, check if a worktree exists at `$GIT_ROOT/worktrees/GH-NNN`.
-Skip candidates without worktrees.
+For each candidate:
+1. Check if a worktree exists at `worktrees/GH-NNN` (relative to git root)
+2. Skip candidates without worktrees (not yet implemented)
+
+Select the first candidate that has a worktree.
 
 If no eligible issues:
 ```
@@ -181,20 +200,23 @@ No issues ready for validation. Queue empty.
 Then STOP.
 ```
 
+**File**: `plugin/ralph-hero/agents/val-agent.md`
+**Changes**: Add `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` to the `tools:` field (line 5).
+
 #### 2. Add queue-picking to `ralph-pr`
 **File**: `plugin/ralph-hero/skills/ralph-pr/SKILL.md`
-**Changes**: Add `list_issues` to `allowed-tools` frontmatter. In Step 1, add a fallback when no issue number is provided:
+**Changes**: Add `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` to `allowed-tools` frontmatter (after line 26). In Step 1, add a fallback when no issue number is provided:
 
 ```markdown
-**If no issue number**: List issues in "In Progress" state, XS/Small, ordered
-by priority, limit 10.
+**If no issue number**: List issues in "In Progress" state, ordered by priority, limit 10.
+
+Use: `list_issues(workflowState: "In Progress", limit: 10)`
 
 For each candidate:
-1. Check if a worktree exists at `$GIT_ROOT/worktrees/GH-NNN`
+1. Check if a worktree exists at `worktrees/GH-NNN`
 2. Check if there is NO existing open PR: `gh pr list --head feature/GH-NNN --json number --jq length` returns 0
-3. Check if all plan phases are complete (read plan, verify all automated checkboxes checked)
 
-Select the first candidate that passes all checks.
+Select the first candidate that has a worktree and no open PR.
 
 If no eligible issues:
 ```
@@ -203,21 +225,23 @@ No issues ready for PR creation. Queue empty.
 Then STOP.
 ```
 
+**File**: `plugin/ralph-hero/agents/pr-agent.md`
+**Changes**: Add `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` to the `tools:` field (line 5).
+
 #### 3. Add queue-picking to `ralph-merge`
 **File**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
-**Changes**: Add `list_issues` to `allowed-tools` frontmatter. In Step 1, add a fallback when no issue number is provided:
+**Changes**: Add `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` to `allowed-tools` frontmatter (after line 28). Insert queue-picking logic before Step 2, as a new fallback in Step 1:
 
 ```markdown
-**If no issue number**: List issues in "In Review" state, XS/Small, ordered
-by priority, limit 10.
+**If no issue number**: List issues in "In Review" state, ordered by priority, limit 10.
+
+Use: `list_issues(workflowState: "In Review", limit: 10)`
 
 For each candidate:
 1. Find its PR: `gh pr list --head feature/GH-NNN --json number,state --jq '.[0]'`
 2. Skip if no open PR exists
-3. Check merge readiness: `gh pr view NNN --json mergeable,reviewDecision,state`
-4. Skip if not mergeable
 
-Select the first candidate with an open, mergeable PR.
+Select the first candidate with an open PR.
 
 If no eligible issues:
 ```
@@ -225,6 +249,9 @@ No issues ready for merge. Queue empty.
 ```
 Then STOP.
 ```
+
+**File**: `plugin/ralph-hero/agents/merge-agent.md`
+**Changes**: Add `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues` to the `tools:` field (line 5).
 
 ### Success Criteria:
 
@@ -237,12 +264,14 @@ Then STOP.
 - [ ] `grep -c "list_issues" plugin/ralph-hero/skills/ralph-val/SKILL.md` returns ≥1
 - [ ] `grep -c "list_issues" plugin/ralph-hero/skills/ralph-pr/SKILL.md` returns ≥1
 - [ ] `grep -c "list_issues" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥1
+- [ ] `grep -c "list_issues" plugin/ralph-hero/agents/val-agent.md` returns ≥1
+- [ ] `grep -c "list_issues" plugin/ralph-hero/agents/pr-agent.md` returns ≥1
+- [ ] `grep -c "list_issues" plugin/ralph-hero/agents/merge-agent.md` returns ≥1
 
 #### Manual Verification:
-- [ ] `just val` (no args) with no "In Progress" issues → outputs "Queue empty"
+- [ ] `just val` (no args, via justfile recipe added in Phase 4) with no "In Progress" issues → outputs "Queue empty"
 - [ ] `just pr` (no args) with no eligible issues → outputs "Queue empty"
 - [ ] `just merge` (no args) with no "In Review" issues → outputs "Queue empty"
-- [ ] `just val` (no args) with one eligible issue → validates that issue
 
 **Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
 
@@ -252,6 +281,8 @@ Then STOP.
 
 ### Overview
 New skill that picks an "In Review" issue with a PR, runs code review on it, and orchestrates a fix loop (address feedback via `ralph-impl` address mode, then re-review) until the PR is clean or max attempts reached. On 3-round exhaustion, moves issue to "Human Needed" to prevent infinite retry across loop iterations.
+
+**Why not use `finish` or `ralph-merge`'s built-in code review?** The `finish` skill chains val→merge→CI — it's a single-issue shortcut. `ralph-merge` runs code review as part of its merge gate. The loop needs a **standalone** code-review phase so different issues can be at different pipeline stages within the same loop iteration.
 
 ### Changes Required:
 
@@ -295,7 +326,7 @@ until the PR is clean (max 3 rounds).
 ## Step 1: Select Issue
 
 **If issue number provided**: Fetch it directly.
-**If no issue number**: List issues in "In Review" state, XS/Small, ordered by priority, limit 1.
+**If no issue number**: List issues in "In Review" state, ordered by priority, limit 10.
 
 If no eligible issues:
 ```
@@ -440,23 +471,28 @@ Status: [Clean / Issues remain]
 name: code-review-agent
 description: Runs code review on PRs and orchestrates fix loops
 model: sonnet
+tools: Read, Glob, Grep, Bash, Agent, Skill, mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
 skills:
   - ralph-hero:ralph-code-review
-tools:
-  - Read
-  - Glob
-  - Grep
-  - Bash
-  - Agent
-  - Skill
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
 ---
+
+You are a code review agent. Follow the preloaded ralph-code-review instructions to review the PR for the issue specified in your task prompt.
 ```
 
-**Note on nested tool permissions**: The `ralph-code-review` skill invokes `impl-agent` (via `Agent()`) for address mode. The `impl-agent` has its own `allowed-tools` including Write, Edit, etc. — these are resolved at the agent level, not inherited from the calling skill. The `code-review-agent` does NOT need Write/Edit because it never writes files itself; only the nested `impl-agent` does. This chain works because each agent resolves its own tool permissions independently.
+#### 4a. Register `ralph_code_review` command in state-resolution.ts
+**File**: `plugin/ralph-hero/mcp-server/src/lib/state-resolution.ts`
+**Changes**: Add `ralph_code_review` to `COMMAND_ALLOWED_STATES` (after line 52) and to `SEMANTIC_INTENTS.__ESCALATE__` is already `"*"` so no change needed there:
+
+```typescript
+// Add to COMMAND_ALLOWED_STATES:
+ralph_code_review: ["In Review", "Human Needed"],
+```
+
+This allows the skill to call `save_issue(command="ralph_code_review", workflowState="Human Needed")` when escalating after 3 failed review rounds.
+
+Also update `plugin/ralph-hero/hooks/scripts/ralph-command-contracts.json` if command contracts are enforced for this command.
+
+**Note on nested tool permissions**: The `ralph-code-review` skill invokes `impl-agent` (via `Agent()`) for address mode. The `impl-agent` has its own tools including Write, Edit, etc. — resolved at the agent level, not inherited from the calling skill. The `code-review-agent` does NOT need Write/Edit because it never writes files itself; only the nested `impl-agent` does.
 
 #### 4. Justfile recipe
 **File**: `plugin/ralph-hero/justfile`
@@ -482,6 +518,8 @@ code-review *args:
 - [ ] `test -f plugin/ralph-hero/agents/code-review-agent.md`
 - [ ] `grep -c "code-review" plugin/ralph-hero/justfile` returns ≥1
 - [ ] Skill frontmatter has `context: fork` and `user-invocable: false`
+- [ ] `grep -c "list_issues" plugin/ralph-hero/skills/ralph-code-review/SKILL.md` returns ≥1
+- [ ] `grep -c "list_issues" plugin/ralph-hero/agents/code-review-agent.md` returns ≥1
 
 #### Manual Verification:
 - [ ] `just code-review NNN` on an issue with an open PR runs code review and reports results
@@ -556,7 +594,8 @@ export RALPH_AUTO_MERGE="$AUTO_MERGE"
         fi
     fi
 
-    # Auto-merge phase (only when flag is set)
+    # Auto-merge phase (only when --auto-merge flag is set)
+    # NOTE: --merge-only also requires --auto-merge to have any effect
     if [ "$AUTO_MERGE" = "true" ]; then
         if [ "$MODE" = "all" ] || [ "$MODE" = "--merge-only" ] || [ "$MODE" = "--integrator-only" ]; then
             echo "--- Integrator: Auto-Merge Phase ---"
@@ -579,7 +618,7 @@ export RALPH_AUTO_MERGE="$AUTO_MERGE"
 
 #### 4. Update justfile `loop` recipe with auto-merge parameter
 **File**: `plugin/ralph-hero/justfile`
-**Changes**: Update the loop recipe signature (around line 203):
+**Changes**: Update the loop recipe (lines 201-209). The `review` default and `budget` were already changed in Phase 1. Add `auto-merge` parameter:
 
 ```just
 # Sequential autonomous loop - full pipeline through PR + code review + optional merge
@@ -593,8 +632,6 @@ loop mode="all" review="auto" split="auto" hygiene="auto" budget="8.00" timeout=
     if [ "{{auto-merge}}" = "true" ]; then args="$args --auto-merge"; fi
     RALPH_BUDGET="{{budget}}" TIMEOUT="{{timeout}}" "{{justfile_directory()}}"/scripts/ralph-loop.sh $args
 ```
-
-Note: `review` default already changed to `"auto"` in Phase 1. Budget bumped from `5.00` to `8.00` to accommodate code-review + address rounds.
 
 #### 5. Add justfile recipes for new individual phases
 **File**: `plugin/ralph-hero/justfile`
@@ -652,23 +689,25 @@ merge *args:
 
 ---
 
-## Phase 5: Make `ralph-merge` Headless-Compatible
+## Phase 5: Add Autonomous Merge Gate
 
 ### Overview
-The merge skill's Step 4 uses `AskUserQuestion` to prompt about code review before merge. In autonomous mode (`RALPH_AUTO_MERGE=true`), skip the interactive prompt and enforce: merge only if `reviewDecision == "APPROVED"` AND `gh pr checks` all pass.
+Add `RALPH_AUTO_MERGE` support to `ralph-merge`. When set, the skill enforces strict merge criteria (review approved + CI passing) before merging, without human confirmation. Without it, behavior is unchanged (interactive code review gate via AskUserQuestion).
+
+**Scope note**: This phase does NOT touch the existing `RALPH_REVIEW_MODE=auto` code review path in ralph-merge Step 4 — that already works correctly for the `finish` skill (PR #757). `RALPH_AUTO_MERGE` is a separate concern: whether to proceed with the merge itself after the code review gate passes.
 
 ### Changes Required:
 
-#### 1. Add autonomous mode detection to ralph-merge
+#### 1. Add autonomous merge gate to ralph-merge
 **File**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
-**Changes**: In Step 4 (Code Review Gate), add an autonomous path before the AskUserQuestion block.
-
-Insert before the existing `**If no review decision exists**` section:
+**Changes**: Insert a new Step 4a between the existing Step 4 (Code Review Gate) and Step 5 (Check PR Readiness):
 
 ```markdown
-**Autonomous mode** (when `RALPH_AUTO_MERGE` env var is `true`):
+## Step 4a: Autonomous Merge Gate
 
-Skip the AskUserQuestion entirely. Apply strict merge criteria:
+**Only when `RALPH_AUTO_MERGE` env var is `true`:**
+
+Apply strict merge criteria before proceeding:
 
 1. Check review decision:
    ```bash
@@ -677,15 +716,14 @@ Skip the AskUserQuestion entirely. Apply strict merge criteria:
 
 2. Check CI status:
    ```bash
-   gh pr checks PR_NUMBER --json name,state,conclusion --jq '[.[] | select(.state == "completed" and .conclusion == "success")] | length'
-   gh pr checks PR_NUMBER --json name,state --jq '[.[] | select(.state != "completed")] | length'
+   gh pr checks PR_NUMBER --json name,state,conclusion
    ```
 
 3. Merge criteria (ALL must be true):
-   - `reviewDecision` is `"APPROVED"` or issue estimate is `"XS"` with no review comments
-   - All CI checks are completed
-   - All CI checks have conclusion `"success"`
-   - PR state is `OPEN` and `mergeable` is `MERGEABLE`
+   - `reviewDecision` is `"APPROVED"`, or no review comments exist (XS issue, clean)
+   - All CI checks have `state: "completed"`
+   - All CI checks have `conclusion: "success"`
+   - PR is `OPEN` and `mergeable` is `MERGEABLE`
 
 4. If criteria not met:
    ```
@@ -698,27 +736,18 @@ Skip the AskUserQuestion entirely. Apply strict merge criteria:
    ```
    STOP. (The next loop iteration will retry.)
 
-5. If all criteria met: proceed to Step 5 (merge).
+5. If all criteria met: proceed to Step 5 (existing merge flow).
+
+**When `RALPH_AUTO_MERGE` is not set or `false`**: skip this step entirely (existing behavior).
 ```
 
-#### 2. Add `AskUserQuestion` to allowed-tools only in interactive mode
-**File**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
-**Changes**: `AskUserQuestion` is already in allowed-tools. The skill text should check `RALPH_AUTO_MERGE` at runtime and skip the interactive prompt. No frontmatter change needed — the autonomous path simply doesn't call `AskUserQuestion`.
-
-#### 3. Ensure the merge skill outputs "Queue empty" when no mergeable issues exist
-**File**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
-**Changes**: Add a queue-empty path at Step 2. If the issue is not in "In Review":
-
-```
-No issues ready for auto-merge. Queue empty.
-```
+No frontmatter changes needed — `RALPH_AUTO_MERGE` is read from the environment at runtime.
 
 ### Success Criteria:
 
 #### Automated Verification:
 - [ ] `grep -c "RALPH_AUTO_MERGE" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥2
 - [ ] `grep -c "AUTO-MERGE BLOCKED" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥1
-- [ ] `grep -c "Queue empty" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥1
 - [ ] `grep -c "gh pr checks" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥1
 
 #### Manual Verification:
@@ -737,14 +766,17 @@ No issues ready for auto-merge. Queue empty.
 4. Run `just loop --plan-only` → plan created, issue at Plan in Review
 5. Run `just loop --review-only` → auto-approved, issue at In Progress
 6. Run `just loop --impl-only` → implementation complete, all phases checked
-7. Run `just loop --integrator-only` → val passes, PR created, code review runs, feedback addressed
-8. Run `just loop --merge-only` → (should block without `--auto-merge`, or skip)
-9. Run `just loop auto-merge=true --merge-only` → merges PR, issue at Done
+7. Run `just loop --val-only` → validation passes
+8. Run `just loop --pr-only` → PR created, issue at In Review
+9. Run `just loop --code-review-only` → code review runs, feedback addressed
+10. Run `just loop auto-merge=true --merge-only` → merges PR, issue at Done
 
 ### Regression Tests:
 - `just loop --triage-only` with empty backlog → exits after 1 iteration
 - `just loop --review=skip` → skips review phase (backwards compatible)
+- `just loop --review=interactive` → uses interactive review (backwards compatible)
 - `just loop` (no args) → runs full pipeline with auto review (new default)
+- `just merge NNN` without RALPH_AUTO_MERGE → interactive behavior unchanged
 
 ### Unit-Level Verification:
 - Each new phase's "Queue empty" output matches the grep pattern in `run_claude`
@@ -754,16 +786,18 @@ No issues ready for auto-merge. Queue empty.
 ## Performance Considerations
 
 - `code-review:code-review` spawns 5 parallel Sonnet reviewers — budget ~$2-3 per review round
-- Address mode via `ralph-impl` uses `impl-agent` which is **Opus** (`impl-agent.md:model: opus`). Each address round could cost $3-5, not $2-3. Worst case with 3 rounds: ~$9-15 for address mode alone.
+- Address mode via `ralph-impl` uses `impl-agent` (Opus). Each address round could cost $3-5.
 - Max 3 review rounds = worst case ~$24 total (3× review at $3 + 3× address at $5)
-- The `ralph-code-review` justfile recipe sets `DEFAULT_BUDGET=8.00` and `DEFAULT_TIMEOUT=30m`.
-- Loop `budget=8.00` is per-task, but code-review + address spans multiple internal agent invocations within a single `claude -p` call. The `--max-budget-usd` flag applies to the entire session, so $8 should cover 1-2 rounds. For 3 rounds, the session may hit budget limits. Consider `DEFAULT_BUDGET=15.00` for the code-review recipe if budget isn't a concern.
+- The `ralph-code-review` justfile recipe sets `DEFAULT_BUDGET=8.00` and `DEFAULT_TIMEOUT=30m`. This covers 1-2 rounds comfortably. For 3 rounds, the session may hit budget limits — the skill exits cleanly on budget exhaustion.
+- Loop per-task budget bumped from $5 to $8 to accommodate integrator phases.
 
 ## Migration Notes
 
 - **Backwards compatible**: `just loop --review=skip` still works. `--auto-merge` is opt-in.
-- **Default behavior change**: Review mode defaults to `auto` instead of `skip`. Users who relied on the skip default should add `--review=skip` explicitly or set `RALPH_REVIEW_MODE=skip`.
+- **Default behavior change**: Review mode defaults to `auto` instead of `interactive`/`skip`. Users who want the old behavior: `--review=interactive` or `--review=skip`.
 - **No schema changes**: No MCP server changes, no new GitHub Project fields.
+- **No changes to finish or hero**: These skills are unaffected. Note: the loop exports `RALPH_REVIEW_MODE=auto` which ralph-merge reads at load time — this is intentional within the loop (merge runs headless code review). Standalone `just merge` does not set this export, so interactive behavior is preserved.
+- **`--merge-only` requires `auto-merge=true`**: The merge phase is gated behind the auto-merge flag. Running `just loop --merge-only` without `auto-merge=true` is a no-op by design.
 
 ## File Ownership Summary
 
@@ -772,16 +806,22 @@ No issues ready for auto-merge. Queue empty.
 | `skills/ralph-triage/SKILL.md` | 1 | Edit queue-empty text |
 | `scripts/ralph-loop.sh` | 1, 4 | Fix defaults, add integrator phases, add flags |
 | `justfile` | 1, 3, 4 | Fix review default, add recipes, update loop recipe |
-| `skills/ralph-val/SKILL.md` | 2 | Add queue-picking + "Queue empty" path + `list_issues` tool |
-| `skills/ralph-pr/SKILL.md` | 2 | Add queue-picking + "Queue empty" path + `list_issues` tool |
-| `skills/ralph-merge/SKILL.md` | 2, 5 | Add queue-picking + "Queue empty" path + `list_issues` tool; add autonomous mode |
+| `skills/ralph-val/SKILL.md` | 2 | Add queue-picking + `list_issues` tool |
+| `agents/val-agent.md` | 2 | Add `list_issues` tool |
+| `skills/ralph-pr/SKILL.md` | 2 | Add queue-picking + `list_issues` tool |
+| `agents/pr-agent.md` | 2 | Add `list_issues` tool |
+| `skills/ralph-merge/SKILL.md` | 2, 5 | Add queue-picking + `list_issues` tool; add autonomous merge gate |
+| `agents/merge-agent.md` | 2 | Add `list_issues` tool |
 | `skills/ralph-code-review/SKILL.md` | 3 | **New file** |
 | `agents/code-review-agent.md` | 3 | **New file** |
+| `mcp-server/src/lib/state-resolution.ts` | 3 | Add `ralph_code_review` command |
+| `docs/cli.md` | 1 | Update review default from `skip` to `auto` |
 
 ## References
 
-- Original naive hero loop: `landcrawler-ai/scripts/ralph-loop.sh` (Linear-backed, archived)
-- Original design: `thoughts/shared/plans/2026-01-19-naive-hero-autonomous-loop.md`
-- GitHub migration plan: `thoughts/shared/plans/2026-02-13-group-LAN-361-ralph-github-plugin.md`
+- Original issue: #731
+- Original naive hero loop: `thoughts/shared/plans/2026-01-19-naive-hero-autonomous-loop.md`
+- Finish skill: `plugin/ralph-hero/skills/finish/SKILL.md` (PR #743)
+- Code review gate in merge: `plugin/ralph-hero/skills/ralph-merge/SKILL.md` (PR #757)
 - Current loop: `plugin/ralph-hero/scripts/ralph-loop.sh`
 - Code review plugin: `~/.claude/plugins/cache/claude-plugins-official/code-review/unknown/commands/code-review.md`

--- a/thoughts/shared/plans/2026-04-05-GH-0743-finish-skill.md
+++ b/thoughts/shared/plans/2026-04-05-GH-0743-finish-skill.md
@@ -1,0 +1,452 @@
+---
+date: 2026-04-05
+status: draft
+type: plan
+tags: [finish, orchestration, ci-watch, code-review, integrator]
+github_issue: 743
+github_issues: [743]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/743
+primary_issue: 743
+---
+
+# Finish Skill Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[hero orchestrator SKILL.md]]
+- builds_on:: [[ralph-val SKILL.md]]
+- builds_on:: [[ralph-merge SKILL.md]]
+- builds_on:: [[code-review plugin]]
+
+## Overview
+
+Add a `/ralph-hero:finish` skill that chains validate → code-review → fix-loop → merge → CI watch into a single orchestrated pipeline. Wire it as the final step in hero's task graph, replacing the current "report and wait for human merge" terminal state.
+
+## Current State Analysis
+
+- Hero pipeline ends at PR creation (`ralph-pr`) with issues in "In Review"
+- `ralph-val`, `code-review:code-review`, and `ralph-merge` exist as standalone skills but are never chained
+- Hero's INTEGRATOR phase at `hero/SKILL.md:83-88` is a placeholder: `(future: auto-merge if RALPH_AUTO_MERGE=true)`
+- `ralph-merge` already has a code-review gate (Step 4, `ralph-merge/SKILL.md:82-153`) that asks the user whether to review before merging — finish subsumes this by always running code review first
+
+### Key Discoveries:
+- `ralph-val` does NOT change workflow state (`ralph-val/SKILL.md:186`) — it only produces a PASS/FAIL verdict and posts a GitHub comment
+- `ralph-merge` handles all state transitions (Done), worktree cleanup, parent advancement, and cross-repo unblock
+- `code-review:code-review` posts findings as a PR comment (not a formal GitHub review), so `reviewDecision` stays null after it runs
+- `merge-pr.sh` at repo root handles the actual `gh pr merge --merge --delete-branch` with worktree cleanup
+- Hero dispatches skills via `Skill()` inline (single-session mode) — skill hooks fire in the dispatched context
+- State gate hooks use `RALPH_VALID_OUTPUT_STATES` env var set by `set-skill-env.sh` in SessionStart
+
+## Desired End State
+
+A user can run `/ralph-hero:finish #123` to:
+1. Validate the implementation against the plan (automated checks)
+2. Run code review on the PR
+3. Auto-fix simple issues (≤3 localized issues), iterate up to 2 times
+4. Merge the PR
+5. Watch CI checks until they pass or fail
+6. Report final status with CI results
+
+Hero's pipeline extends through merge + CI verification instead of stopping at "In Review".
+
+### Verification:
+- `/ralph-hero:finish #NNN` on an issue in "In Review" with a PR runs the full chain
+- Hero's task graph includes a Finish task after Create PR
+- CI watch reports check status before completing
+- Fix loop handles code-review findings and re-pushes when fixable
+
+## What We're NOT Doing
+
+- CD monitoring (only PR checks, not post-merge release workflows)
+- Formal GitHub review API integration (code-review plugin posts comments, not reviews)
+- New MCP server tools (finish is pure skill orchestration)
+- Changing ralph-val, ralph-merge, or code-review internals
+- Creating a dedicated state-gate hook script (finish reuses merge's valid states since merge is the step that transitions)
+
+## Implementation Approach
+
+Finish is an **orchestrator skill** that delegates to existing skills/agents. It doesn't directly manipulate workflow state — it relies on `ralph-merge` for state transitions and `ralph-val` for validation. The fix loop is the only novel logic: parsing code-review output, assessing complexity, and dispatching a sonnet Agent to make targeted fixes.
+
+## Phase 1: Create the Finish Skill
+
+### Overview
+Create `plugin/ralph-hero/skills/finish/SKILL.md` — a user-invocable skill that chains the full post-PR pipeline.
+
+### Changes Required:
+
+#### 1. Skill Definition
+**File**: `plugin/ralph-hero/skills/finish/SKILL.md` (new)
+
+```markdown
+---
+description: Validate, code-review, fix, merge, and watch CI for a completed implementation. Chains ralph-val → code-review → fix-loop → ralph-merge → CI watch into one command.
+user-invocable: true
+argument-hint: <issue-number> [--pr-url url] [--plan-doc path]
+context: fork
+model: sonnet
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=finish RALPH_VALID_OUTPUT_STATES='Done,Human Needed'"
+  PreToolUse:
+    - matcher: "ralph_hero__save_issue|ralph_hero__advance_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/merge-state-gate.sh"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - Skill
+  - AskUserQuestion
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_dependencies
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+---
+```
+
+The skill body follows this flow:
+
+**Step 1: Parse Arguments**
+
+Extract issue number and optional `--pr-url`, `--plan-doc` flags from args. Export `RALPH_TICKET_ID="GH-NNN"`.
+
+**Step 2: Fetch Issue & Find PR**
+
+Fetch issue details. Verify issue is in "In Review" state. Find the PR via `--pr-url` or `gh pr list --head feature/GH-NNN`. Stop if no PR found.
+
+**Step 3: Validate (dispatch ralph-val)**
+
+```
+Skill("ralph-hero:ralph-val", args="NNN --plan-doc {plan_doc}")
+```
+
+If ralph-val outputs `VALIDATION FAIL`: stop with the validation report. The implementation must pass automated checks before proceeding.
+
+If ralph-val outputs `VALIDATION PASS`: continue to Step 4.
+
+**Step 4: Code Review**
+
+Check if the `code-review:code-review` skill is available.
+
+- **If available**: invoke `Skill("code-review:code-review", "PR_NUMBER")` where PR_NUMBER is the PR number (not the issue number).
+- **If not available**: log that code review was skipped and proceed to Step 6 (merge).
+
+After code review completes, check the PR for the review comment:
+
+```bash
+gh pr view PR_NUMBER --json comments --jq '.comments[-1].body'
+```
+
+Parse the last code-review comment. Look for the pattern `Found N issues:` to determine if issues were found.
+
+- If `No issues found`: proceed to Step 6 (merge).
+- If issues found: proceed to Step 5 (fix loop).
+
+**Step 5: Fix Loop (max 2 iterations)**
+
+Assess the code-review findings using LLM judgment (not keyword matching):
+
+1. Count the number of issues
+2. Check if all issues reference files in the PR diff (`gh pr diff PR_NUMBER --name-only`)
+3. Classify each issue as **auto-fixable** or **escalate**:
+
+**Auto-fixable** (all must be true):
+- ≤3 issues total
+- All issues reference files within the PR diff
+- Issues are localized code fixes (typos, missing checks, wrong values, style issues)
+
+**Escalate** (any one triggers escalation):
+- More than 3 issues
+- Issues reference files outside the PR diff
+- Architectural or design concerns (restructuring, API design, abstraction choices)
+- Operational or cloud infrastructure decisions (permissions, IAM, deploying new GCP/AWS APIs, provisioning cloud managed services, secrets management, networking, CI/CD pipeline changes)
+- Security concerns that require human judgment
+- Any issue where the fix could have unintended side effects beyond the immediate code
+
+This classification is an **LLM judgment call** — evaluate the semantic intent of each finding, not surface-level keywords.
+
+**If escalate**: present choice to human.
+
+```
+AskUserQuestion(
+  questions=[{
+    "question": "Code review found issues that may need human judgment. Review the PR comments and decide how to proceed.",
+    "header": "Complex Code Review Findings",
+    "options": [
+      {"label": "I'll fix manually", "description": "Stop here — you'll address the feedback yourself"},
+      {"label": "Try auto-fix anyway", "description": "Attempt to fix all issues automatically"},
+      {"label": "Merge anyway", "description": "Skip fixes and proceed to merge"}
+    ],
+    "multiSelect": false
+  }]
+)
+```
+
+**If simple**: dispatch a sonnet Agent to fix the issues in the worktree:
+
+```
+Agent(
+  subagent_type="general-purpose",
+  model="sonnet",
+  prompt="You are fixing code review issues in a worktree.
+
+  Worktree: worktrees/GH-NNN
+  PR: #PR_NUMBER
+  
+  Code review found these issues:
+  [paste parsed issues from the code-review comment]
+  
+  For each issue:
+  1. Read the referenced file in the worktree
+  2. Make the minimal fix
+  3. Do NOT refactor surrounding code or add unrelated changes
+  
+  After all fixes, from the worktree directory:
+  1. Stage the changed files: git add [specific files]
+  2. Commit: git commit -m 'fix: address code review findings'
+  3. Push: git push
+  
+  Report what you fixed."
+)
+```
+
+After the fix agent completes, re-run code review: `Skill("code-review:code-review", "PR_NUMBER")`.
+
+Re-parse findings. If still issues and iteration < 2: repeat. If iteration >= 2 or still complex: escalate to human with the same AskUserQuestion above.
+
+**Step 6: Merge (dispatch ralph-merge)**
+
+```
+Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")
+```
+
+ralph-merge handles: PR readiness check, merge via `merge-pr.sh`, worktree cleanup, state transition to Done, parent advancement, cross-repo unblock, and posting the Merged comment.
+
+If ralph-merge outputs `MERGE BLOCKED` or `MERGE NOT READY`: report the status and stop.
+
+**Step 7: CI Watch**
+
+After merge completes, watch CI checks on the merge commit:
+
+```bash
+# Get the merge commit SHA
+MERGE_SHA=$(gh pr view PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
+
+# Watch checks (blocks until all complete, 10 min timeout)
+gh run list --commit "$MERGE_SHA" --json status,conclusion,name,url --limit 10
+```
+
+Poll every 30 seconds for up to 10 minutes:
+- If all checks pass (conclusion=success): report success
+- If any check fails: report failure with links to the failed runs
+- If timeout: report that checks are still running with links
+
+**Step 8: Report Final Status**
+
+```
+FINISHED
+Issue: #NNN
+PR: https://github.com/OWNER/REPO/pull/PR_NUMBER
+Validation: PASS
+Code Review: [PASS / SKIPPED / N issues fixed]
+Merge: Done
+CI: [PASS / FAIL / PENDING (timeout)]
+[If CI FAIL: links to failed runs]
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] File exists: `plugin/ralph-hero/skills/finish/SKILL.md`
+- [ ] Skill frontmatter has `user-invocable: true`
+- [ ] Skill frontmatter lists all required tools in `allowed-tools`
+- [ ] Skill reuses `merge-state-gate.sh` (no new hook script)
+- [ ] Build passes: `cd plugin/ralph-hero/mcp-server && npm run build`
+
+#### Manual Verification:
+- [ ] `/ralph-hero:finish #NNN` on an issue in "In Review" runs the full pipeline
+- [ ] Validation failure stops the pipeline early
+- [ ] Code review findings trigger the fix loop
+- [ ] Fix loop dispatches a sonnet agent and re-pushes
+- [ ] Merge + CI watch complete successfully
+
+---
+
+## Phase 2: Wire Finish into Hero
+
+### Overview
+Modify the hero orchestrator to dispatch `:finish` as the final pipeline step after PR creation, replacing the "report and wait" terminal.
+
+### Changes Required:
+
+#### 1. Hero Skill
+**File**: `plugin/ralph-hero/skills/hero/SKILL.md`
+
+**Change 1 — State machine diagram** (around line 83-88):
+
+Replace the INTEGRATOR phase placeholder:
+```
+  INTEGRATOR PHASE
+    |- Report PR URLs and "In Review" status
+    |- (future: auto-merge if RALPH_AUTO_MERGE=true)
+```
+
+With:
+```
+  INTEGRATOR PHASE
+    |- Finish GH-[PRIMARY] (validate, review, fix, merge, CI watch)
+    |- via Skill("ralph-hero:finish", args="#NNN")
+```
+
+**Change 2 — Task graph templates** (lines 154-192):
+
+Add a Finish task after every `Create PR` task in all graph variants:
+
+Starting from RESEARCH:
+```
+T-M+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-M+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+Starting from PLAN:
+```
+T-N+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-N+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+Starting from REVIEW/HUMAN_GATE:
+```
+T-N+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-N+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+Starting from IMPLEMENT:
+```
+T-N+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-N+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+**Change 3 — Execution loop dispatch** (after line 387):
+
+Add FINISH task dispatch:
+
+```
+#### FINISH tasks
+Skill("ralph-hero:finish", args="#NNN")
+```
+
+After finish completes, report final status including CI results.
+
+**Change 4 — INTEGRATOR COMPLETE section** (lines 390-394):
+
+Replace:
+```
+Report PR URLs and final status. All issues should be in "In Review".
+
+Future: When `RALPH_AUTO_MERGE=true`, automatically merge approved PRs via `gh pr merge`. For now, report and wait for human merge.
+```
+
+With:
+```
+After finish completes, all issues should be in "Done" with CI verified.
+
+Report final status: issue numbers, PR URLs, merge status, CI results.
+```
+
+**Change 5 — `allowed-tools`** (line 1-31):
+
+Add `Skill` to hero's allowed-tools if not already present (it is already listed at line 13 — confirmed).
+
+No new tools needed — hero dispatches finish via `Skill()`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `hero/SKILL.md` contains `Finish GH-` in all 4 task graph templates
+- [ ] `hero/SKILL.md` contains `Skill("ralph-hero:finish"` dispatch
+- [ ] No `(future: auto-merge` placeholder remains
+- [ ] Build passes: `cd plugin/ralph-hero/mcp-server && npm run build`
+
+#### Manual Verification:
+- [ ] `/ralph-hero #NNN` on a fresh issue processes through to merge + CI watch
+- [ ] Hero's task list includes a Finish task blocked by PR task
+- [ ] Pipeline completes with issues in "Done" instead of "In Review"
+
+---
+
+## Phase 3: Add Finish Agent
+
+### Overview
+Create the `finish-agent` definition for team-mode dispatch consistency.
+
+### Changes Required:
+
+#### 1. Agent Definition
+**File**: `plugin/ralph-hero/agents/finish-agent.md` (new)
+
+```markdown
+---
+name: finish-agent
+description: Finish pipeline - validates implementation, runs code review, fixes simple issues, merges PR, watches CI
+model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash, Agent, Skill, AskUserQuestion, mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues, mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_dependencies, mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+skills:
+  - ralph-hero:finish
+---
+
+You are a finish agent. Follow the preloaded finish instructions to validate, review, merge, and watch CI for the issue specified in your task prompt.
+```
+
+Key differences from other integrator agents:
+- **Model: sonnet** (not haiku) — needs code comprehension for the fix loop
+- **Has Write, Edit, Agent** — required for the fix loop to dispatch sub-agents and for worktree edits
+- **Has Skill** — dispatches ralph-val, code-review:code-review, and ralph-merge as sub-skills
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] File exists: `plugin/ralph-hero/agents/finish-agent.md`
+- [ ] Agent frontmatter has `model: sonnet`
+- [ ] Agent preloads `ralph-hero:finish` via `skills:` field
+- [ ] Agent tools are a superset of val-agent + merge-agent tools plus Write, Edit, Agent, Skill
+
+#### Manual Verification:
+- [ ] Agent can be dispatched via `Agent(subagent_type="ralph-hero:finish-agent", ...)`
+- [ ] Preloaded skill content is visible in agent context
+
+---
+
+## Testing Strategy
+
+### Integration Testing:
+- End-to-end: Create a test issue with implementation + PR, run `/ralph-hero:finish`, verify full chain executes
+- Validation failure: Create a PR that fails plan checks, verify finish stops at validation
+- Code review fix loop: Create a PR with a known issue, verify fix agent runs and re-pushes
+- CI watch: Verify checks are polled after merge and status reported
+- Hero integration: Run `/ralph-hero` on a fresh issue, verify finish task appears and executes after PR
+
+### Edge Cases:
+- code-review plugin not installed — finish should skip review and proceed to merge
+- No worktree found — ralph-val handles this (VALIDATION FAIL)
+- PR already merged — ralph-merge handles this (MERGE BLOCKED)
+- CI checks timeout — finish should report pending status, not fail
+
+## References
+
+- Hero orchestrator: `plugin/ralph-hero/skills/hero/SKILL.md`
+- Validation skill: `plugin/ralph-hero/skills/ralph-val/SKILL.md`
+- Merge skill: `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
+- Code review plugin: `~/.claude/plugins/marketplaces/claude-plugins-official/plugins/code-review/commands/code-review.md`
+- PR merge script: `scripts/merge-pr.sh`
+- State gate hook: `plugin/ralph-hero/hooks/scripts/merge-state-gate.sh`
+- Env setup hook: `plugin/ralph-hero/hooks/scripts/set-skill-env.sh`

--- a/thoughts/shared/plans/2026-04-06-auto-code-review-impl-fix-loop.md
+++ b/thoughts/shared/plans/2026-04-06-auto-code-review-impl-fix-loop.md
@@ -1,0 +1,414 @@
+---
+date: 2026-04-06
+status: draft
+type: plan
+tags: [code-review, ralph-merge, finish, impl-agent, automation, plan-skill, auto-mode]
+github_issues: [756]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/756
+primary_issue: 756
+github_issue: 756
+---
+
+# Auto Mode Pipeline Gaps — Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-04-05-env-var-backtick-resolution]]
+- builds_on:: [[2026-04-05-hero-pipeline-handoff-ux-inventory]]
+
+## Overview
+
+Close two gaps where `auto` mode env vars don't flow through to downstream skills:
+
+1. **`RALPH_REVIEW_MODE=auto` → ralph-merge**: The code review gate always prompts via AskUserQuestion. Should auto-run `code-review:code-review` and dispatch impl-agent if issues are flagged.
+2. **`RALPH_REVIEW_PLAN=auto` → plan skill Step 6**: The plan skill skips human review (Step 5) but then presents a prose menu at Step 6 (GitHub Integration). Should auto-search for matching issues, link or create, and auto-advance without prompting.
+
+## Current State Analysis
+
+- `RALPH_REVIEW_MODE` is resolved in `hero/SKILL.md:49` via backtick preprocessing, defaults to `interactive`
+- `ralph-merge/SKILL.md:81-153` has the Code Review Gate (Step 4) — always prompts via AskUserQuestion when no review decision exists
+- `finish/SKILL.md:94-106` already has a val→fix→re-val cycle pattern (max 1 fix cycle)
+- `ralph-impl/SKILL.md:410-441` has Address Mode — activated when issue is "In Review" with open PR + review comments. Gathers comments, classifies MUST_FIX/SHOULD_FIX/DISCUSS, pushes fixes, replies to PR comments
+- Neither ralph-merge nor finish currently reference `RALPH_REVIEW_MODE`
+
+### Key Discoveries:
+- `finish/SKILL.md:105` — existing fix cycle pattern: "Dispatch impl-agent to apply the listed fix commands in the worktree, commit, then re-run val-agent. Max 1 fix cycle"
+- `ralph-merge/SKILL.md:124` — when code-review flags issues: "output the review findings and stop"
+- `ralph-impl/SKILL.md:91-95` — Address Mode detection: issue in "In Review" + open PR with review comments → auto-activates
+- `RALPH_REVIEW_MODE` flows through process environment, so ralph-merge and finish can read it without explicit arg passing
+
+## Desired End State
+
+When `RALPH_REVIEW_MODE=auto`:
+1. ralph-merge auto-runs `code-review:code-review` when no review decision exists (no AskUserQuestion)
+2. If code-review flags issues, ralph-merge returns `CODE_REVIEW_FEEDBACK` (not `MERGE BLOCKED`)
+3. finish catches `CODE_REVIEW_FEEDBACK`, dispatches impl-agent in Address Mode, then re-runs ralph-merge
+4. Max 1 fix cycle — if code-review still flags issues after the fix, finish stops
+
+When `RALPH_REVIEW_MODE=interactive` (default): behavior is unchanged.
+
+### Verification:
+- Read `ralph-merge/SKILL.md` Step 4 and confirm auto path skips AskUserQuestion
+- Read `finish/SKILL.md` Step 4 and confirm `CODE_REVIEW_FEEDBACK` handling exists with impl-agent dispatch
+- Confirm human-reviewer `CHANGES_REQUESTED` still produces `MERGE BLOCKED` (not `CODE_REVIEW_FEEDBACK`)
+
+## What We're NOT Doing
+
+- Not changing how `RALPH_REVIEW_MODE` controls the hero orchestrator's merge gate (that's already correct)
+- Not adding `RALPH_REVIEW_MODE` as a CLI flag — it remains an env var only
+- Not changing the interactive-mode behavior (AskUserQuestion stays for interactive)
+- Not auto-fixing human reviewer feedback — only automated code-review feedback triggers the fix cycle
+- Not changing the val→fix→re-val cycle in finish (Phase 2 adds a parallel pattern, doesn't modify it)
+- Not changing the autonomous `ralph-plan` skill — it's already fully autonomous via hero dispatch
+
+## Implementation Approach
+
+Phase 1 modifies ralph-merge to read `RALPH_REVIEW_MODE` and branch on it in Step 4. Phase 2 modifies finish to handle the new `CODE_REVIEW_FEEDBACK` output status. Phase 3 makes the plan skill's Step 6 fully autonomous when `RALPH_REVIEW_PLAN=auto`. Phase 4 updates documentation.
+
+## Phase 1: ralph-merge — Auto Code Review Gate
+
+### Overview
+Teach ralph-merge to read `RALPH_REVIEW_MODE` and, when `auto`, run `code-review:code-review` without prompting. Introduce `CODE_REVIEW_FEEDBACK` as a new output status for automated review findings.
+
+### Changes Required:
+
+#### 1. Add RALPH_REVIEW_MODE to configuration section
+**File**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
+**Lines**: 31-36 (Configuration section)
+**Changes**: Add review mode resolution
+
+```markdown
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+- Review mode: !`echo ${RALPH_REVIEW_MODE:-interactive}`
+
+Use these resolved values when constructing GitHub URLs or referencing the repository.
+```
+
+#### 2. Rewrite Step 4: Code Review Gate
+**File**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
+**Lines**: 81-153 (entire Step 4)
+**Changes**: Replace the current Step 4 with a version that branches on review mode. The full replacement:
+
+```markdown
+## Step 4: Code Review Gate
+
+Check whether the PR has received a code review:
+
+\`\`\`bash
+gh pr view NNN --json reviewDecision
+\`\`\`
+
+**If `reviewDecision` is `APPROVED`**: a code review has been performed and approved. Proceed to Step 5.
+
+**If `reviewDecision` is `CHANGES_REQUESTED`**: a code review was performed but the reviewer requested changes. Output:
+
+\`\`\`
+MERGE BLOCKED
+Issue: #NNN
+PR: #PR_NUMBER
+Reason: Reviewer requested changes — address feedback before merging.
+\`\`\`
+
+And stop.
+
+**If no review decision exists** (`reviewDecision` is null or empty):
+
+1. Check if the `code-review:code-review` skill is available by looking for it in the available skills list (it is an official Anthropic plugin).
+
+2. **If the skill is available AND review mode is "auto":**
+
+   Run code review automatically — do NOT prompt the user:
+
+   \`\`\`
+   Skill("code-review:code-review", "PR_NUMBER")
+   \`\`\`
+
+   After the review completes, re-check `reviewDecision` via `gh pr view`.
+
+   - If the PR was approved: continue to Step 5.
+   - If changes were requested: output the review findings with a distinct status so the caller (finish) can dispatch a fix cycle:
+
+   \`\`\`
+   CODE_REVIEW_FEEDBACK
+   Issue: #NNN
+   PR: #PR_NUMBER
+   Reason: Automated code review flagged issues — impl-agent fix cycle available.
+   \`\`\`
+
+   And stop. Do NOT output `MERGE BLOCKED` for automated review feedback — the `CODE_REVIEW_FEEDBACK` status signals that finish should attempt a fix cycle.
+
+3. **If the skill is available AND review mode is "interactive" (default):**
+
+   Present a choice:
+
+   !cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
+
+   \`\`\`
+   AskUserQuestion(
+     questions=[{
+       "question": "This PR has no code review yet. Would you like to run one before merging?",
+       "header": "Code Review",
+       "options": [
+         {"label": "Run code review", "description": "Invoke /code-review:code-review on PR #NNN before merging"},
+         {"label": "Merge without review", "description": "Skip code review and proceed to merge"}
+       ],
+       "multiSelect": false
+     }]
+   )
+   \`\`\`
+
+   - If user selects **"Run code review"**: invoke `Skill("code-review:code-review", "PR_NUMBER")` where PR_NUMBER is the PR number obtained in Step 3 (not the issue number). After the review completes, re-check `reviewDecision` via `gh pr view`. If the PR was approved, continue to Step 5. If changes were requested, output the review findings and stop — the user needs to address feedback first.
+   - If user selects **"Merge without review"**: proceed to Step 5.
+   - If user selects **"Other"**: stop.
+
+4. **If the skill is NOT available**, inform the user:
+
+   \`\`\`
+   This PR has no code review. Consider installing the code-review plugin:
+     claude plugins install @anthropic/code-review
+   \`\`\`
+
+   Then present:
+
+   \`\`\`
+   AskUserQuestion(
+     questions=[{
+       "question": "Proceed without code review?",
+       "header": "No Code Review Plugin",
+       "options": [
+         {"label": "Merge without review", "description": "Skip code review and proceed to merge"},
+         {"label": "Stop", "description": "Stop here — install the code-review plugin first"}
+       ],
+       "multiSelect": false
+     }]
+   )
+   \`\`\`
+
+   - If user selects **"Merge without review"**: proceed to Step 5.
+   - If user selects **"Stop"** or **"Other"**: stop.
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `ralph-merge/SKILL.md` contains `RALPH_REVIEW_MODE` in configuration section
+- [x] `ralph-merge/SKILL.md` Step 4 contains `CODE_REVIEW_FEEDBACK` output block
+- [x] `ralph-merge/SKILL.md` Step 4 contains "review mode is \"auto\"" branch
+- [x] `ralph-merge/SKILL.md` Step 4 still contains AskUserQuestion for interactive mode
+- [x] `ralph-merge/SKILL.md` Step 4 still contains `MERGE BLOCKED` for human reviewer CHANGES_REQUESTED
+
+#### Manual Verification:
+- [ ] Read through Step 4 and confirm the auto/interactive/no-plugin branches are logically correct
+- [ ] Confirm the `CODE_REVIEW_FEEDBACK` status is only emitted from the auto code review path
+
+---
+
+## Phase 2: finish — Code Review Fix Cycle
+
+### Overview
+Add a code-review fix cycle to finish, mirroring the existing val FIX pattern. When ralph-merge returns `CODE_REVIEW_FEEDBACK`, dispatch impl-agent in Address Mode then re-run ralph-merge. Max 1 fix cycle.
+
+### Changes Required:
+
+#### 1. Update finish Step 4 description
+**File**: `plugin/ralph-hero/skills/finish/SKILL.md`
+**Lines**: 108-121 (Step 4: Merge)
+**Changes**: Replace Step 4 with version that handles `CODE_REVIEW_FEEDBACK`:
+
+```markdown
+## Step 4: Merge (dispatch ralph-merge)
+
+Build args for ralph-merge — always pass the PR URL to avoid redundant lookup:
+
+\`\`\`
+Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")
+\`\`\`
+
+ralph-merge handles: code review gate (including optional `code-review:code-review` dispatch), PR readiness check, merge via `merge-pr.sh`, worktree cleanup, state transition to Done, parent advancement, cross-repo unblock, and posting the Merged comment.
+
+Check the skill output:
+
+- If output contains `MERGE BLOCKED` or `MERGE NOT READY`: report the status and stop.
+- If output contains `MERGED`: continue to Step 5.
+- If output contains `CODE_REVIEW_FEEDBACK`: automated code review flagged issues. Proceed to Step 4a.
+
+## Step 4a: Code Review Fix Cycle
+
+Dispatch impl-agent in Address Mode to fix the flagged issues. The issue is already "In Review" with an open PR that has review comments — impl-agent will auto-detect Address Mode.
+
+\`\`\`
+Agent(subagent_type="ralph-hero:impl-agent", prompt="Address PR review feedback for GH-NNN. The automated code review flagged issues on PR #PR_NUMBER. Fix the MUST_FIX and SHOULD_FIX items, push, and reply to comments.")
+\`\`\`
+
+After impl-agent completes, re-run ralph-merge:
+
+\`\`\`
+Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")
+\`\`\`
+
+Check the output again:
+
+- If `MERGED`: continue to Step 5.
+- If `MERGE BLOCKED`, `MERGE NOT READY`, or `CODE_REVIEW_FEEDBACK` again: stop. Max 1 fix cycle — report the status and let the human intervene.
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `finish/SKILL.md` contains `CODE_REVIEW_FEEDBACK` handling
+- [x] `finish/SKILL.md` contains `Step 4a: Code Review Fix Cycle`
+- [x] `finish/SKILL.md` contains impl-agent dispatch with Address Mode prompt
+- [x] `finish/SKILL.md` contains "Max 1 fix cycle" constraint
+
+#### Manual Verification:
+- [ ] Read through Steps 4 and 4a and confirm the flow is logically correct
+- [ ] Confirm impl-agent dispatch matches the Address Mode activation pattern (issue in "In Review" + open PR)
+- [ ] Confirm the max-1-cycle guard prevents infinite loops
+
+---
+
+## Phase 3: Plan Skill — Auto Mode GitHub Integration (#756)
+
+### Overview
+When `RALPH_REVIEW_PLAN=auto`, the plan skill's Step 6 (GitHub Integration) should be fully autonomous: search for matching issues, link or create, auto-advance, and continue without prompting. Currently it presents a prose menu that defeats auto mode.
+
+### Changes Required:
+
+#### 1. Rewrite Step 5 auto path to include GitHub Integration
+**File**: `plugin/ralph-hero/skills/plan/SKILL.md`
+**Location**: Step 5 (Review) — the auto-mode branch currently says "skip human review, proceed directly to Step 6"
+**Changes**: When auto, instead of just skipping to Step 6 (which then prompts), merge Steps 5+6 into a single autonomous flow:
+
+```markdown
+If plan review is "auto", skip human review and proceed to autonomous GitHub integration:
+
+1. **Search for matching open issues**: Use `list_issues` to search by keywords from the plan title. Look for issues in Backlog, Research Needed, or Ready for Plan states that match the plan's scope.
+
+2. **If a matching issue exists**: Link the plan to it:
+   - Rename the plan file to include `GH-NNNN` if not already present
+   - Update plan frontmatter with `github_issue`, `github_issues`, `github_urls`, `primary_issue`
+   - Post an Artifact Comment on the issue (per the Artifact Comment Protocol):
+     ```markdown
+     ## Implementation Plan
+
+     https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/thoughts/shared/plans/[filename].md
+
+     Summary: [1-3 line summary of the plan]
+     ```
+
+3. **If no matching issue exists**: Create a new issue:
+   - Create a GitHub issue with the plan summary as the body
+   - Set estimate based on plan complexity (XS/S/M)
+   - Rename the plan file to include the new issue number
+   - Post the Artifact Comment (same as above)
+   - Update plan frontmatter with the new issue reference
+
+4. **Auto-advance**: Update the issue workflow state to "Plan in Review" so the review-agent can pick it up.
+
+5. **Report result**:
+   ```
+   Plan linked to GitHub issue: #NNN
+   URL: https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/issues/NNN
+   State: Plan in Review
+   Ready for review. Use /ralph-hero:ralph-review #NNN or /ralph-hero:impl #NNN after approval.
+   ```
+```
+
+#### 2. Keep Step 6 for interactive mode only
+**File**: `plugin/ralph-hero/skills/plan/SKILL.md`
+**Location**: Step 6 (GitHub Integration)
+**Changes**: Add a guard at the top of Step 6:
+
+```markdown
+### Step 6: GitHub Integration (Interactive Mode Only)
+
+> This step only applies when plan review is "interactive". When "auto", GitHub integration is handled in Step 5.
+```
+
+The rest of Step 6 (AskUserQuestion pickers for link/create/skip) remains unchanged for interactive mode.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `plan/SKILL.md` Step 5 auto path contains `list_issues` search
+- [x] `plan/SKILL.md` Step 5 auto path contains issue creation logic
+- [x] `plan/SKILL.md` Step 5 auto path contains auto-advance to "Plan in Review"
+- [x] `plan/SKILL.md` Step 6 is guarded with "Interactive Mode Only"
+- [x] `plan/SKILL.md` Step 6 AskUserQuestion pickers remain intact for interactive mode
+
+#### Manual Verification:
+- [ ] Run `/plan` with `RALPH_REVIEW_PLAN=auto` — verify no prompts, issue auto-created/linked, state advanced
+- [ ] Run `/plan` with `RALPH_REVIEW_PLAN=interactive` — verify AskUserQuestion pickers still work
+
+---
+
+## Phase 4: Documentation Updates
+
+### Overview
+Update hero skill env var table and finish skill description to document the new behavior.
+
+### Changes Required:
+
+#### 1. Update hero env var table
+**File**: `plugin/ralph-hero/skills/hero/SKILL.md`
+**Lines**: 510-513 (Environment Variables table)
+**Changes**: Expand `RALPH_REVIEW_MODE` description:
+
+```markdown
+| `RALPH_REVIEW_MODE` | `interactive` | Merge review: `interactive` (stop at PR, prompt for code review), `auto` (auto-run code review, fix flagged issues via impl-agent, merge) |
+```
+
+#### 2. Update finish skill description
+**File**: `plugin/ralph-hero/skills/finish/SKILL.md`
+**Lines**: 2 (description in frontmatter)
+**Changes**: Mention code review fix cycle:
+
+```yaml
+description: Validate, merge, and watch CI for a completed implementation. Chains ralph-val → ralph-merge → CI watch into one command. Code review is handled by ralph-merge's built-in gate; when RALPH_REVIEW_MODE=auto and code review flags issues, dispatches impl-agent to fix them.
+```
+
+#### 3. Update finish preamble
+**File**: `plugin/ralph-hero/skills/finish/SKILL.md`
+**Lines**: 43 (preamble text)
+**Changes**: Update to reflect new behavior:
+
+```markdown
+Validate, merge, and watch CI for a completed implementation. Code review is handled by ralph-merge's built-in gate — when `RALPH_REVIEW_MODE=auto`, finish also orchestrates a code-review → impl-fix → re-merge cycle if the automated review flags issues (max 1 fix cycle).
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `hero/SKILL.md` env var table mentions "auto-run code review" and "impl-agent"
+- [x] `finish/SKILL.md` description mentions `RALPH_REVIEW_MODE=auto`
+- [x] `finish/SKILL.md` preamble mentions code-review fix cycle
+
+#### Manual Verification:
+- [ ] Documentation accurately describes the implemented behavior
+
+---
+
+## Testing Strategy
+
+### Manual Testing Steps:
+1. Set `RALPH_REVIEW_MODE=auto` in settings, run `/ralph-hero:finish NNN` on a PR with no review — verify code-review runs automatically
+2. If code-review flags issues, verify impl-agent is dispatched in Address Mode
+3. After impl-agent pushes fixes, verify ralph-merge is re-invoked
+4. Set `RALPH_REVIEW_MODE=interactive` (or unset), verify AskUserQuestion still appears
+5. Have a human reviewer request changes on a PR, verify `MERGE BLOCKED` (not `CODE_REVIEW_FEEDBACK`)
+
+## References
+
+- ralph-merge code review gate: `plugin/ralph-hero/skills/ralph-merge/SKILL.md:81-153`
+- finish val fix cycle pattern: `plugin/ralph-hero/skills/finish/SKILL.md:105`
+- impl Address Mode: `plugin/ralph-hero/skills/ralph-impl/SKILL.md:410-441`
+- hero env vars: `plugin/ralph-hero/skills/hero/SKILL.md:508-517`
+- plan skill Step 5/6: `plugin/ralph-hero/skills/plan/SKILL.md` (Steps 5-6)
+- #756: Plan skill auto mode GitHub Integration
+- #745: Mode-aware pipeline handoff UX (prior art, completed)
+- Backtick resolution plan: `thoughts/shared/plans/2026-04-05-env-var-backtick-resolution.md`

--- a/thoughts/shared/plans/2026-04-06-haiku-skill-to-agent-dispatch.md
+++ b/thoughts/shared/plans/2026-04-06-haiku-skill-to-agent-dispatch.md
@@ -1,0 +1,166 @@
+---
+date: 2026-04-06
+status: draft
+type: plan
+tags: [hero, dispatch, agents, context-window, haiku]
+---
+
+# Haiku Skill-to-Agent Dispatch Fix
+
+## Overview
+
+Convert haiku-model integrator-phase `Skill()` calls to `Agent()` dispatches in hero and finish skills. When hero (running in Opus 1M context) invokes `Skill("ralph-hero:ralph-pr")`, the skill content loads into the current context window — then the haiku model tries to execute within a context that was built for 1M tokens, causing context crashes. The fix: dispatch these as `Agent()` calls so they run in isolated haiku-sized context windows.
+
+## Current State Analysis
+
+The hero orchestrator has an inconsistent dispatch pattern:
+
+| Phase | Current Dispatch | Model | Problem? |
+|-------|-----------------|-------|----------|
+| Research | `Skill()` inline | sonnet | No — same context family |
+| Plan | `Skill()` inline | opus | No — same context |
+| Review | `Skill()` inline | opus | No — same context |
+| Impl | `Agent()` ✓ | opus | No — already correct |
+| PR | `Skill()` ✗ | **haiku** | **YES — context crash** |
+| Val | `Agent()` ✓ | haiku | No — already correct |
+| Merge | `Skill()` ✗ (inside finish) | **haiku** | **YES — context crash** |
+| Finish | `Skill()` inline | sonnet | No — orchestrator, stays as Skill |
+
+The `pr-agent` and `merge-agent` definitions already exist with correct tool allowlists and preloaded skills. They're just not being used in single-session mode.
+
+## Desired End State
+
+- `ralph-pr` is always dispatched as `Agent(subagent_type="ralph-hero:pr-agent")` — never `Skill()`
+- `ralph-merge` is always dispatched as `Agent(subagent_type="ralph-hero:merge-agent")` — never `Skill()`
+- `finish` remains a `Skill()` that orchestrates agent dispatches underneath
+- The dispatch architecture docs reflect the actual pattern
+
+### How to verify:
+- `grep -n 'Skill.*ralph-pr' plugin/ralph-hero/skills/*/SKILL.md` returns zero matches
+- `grep -n 'Skill.*ralph-merge' plugin/ralph-hero/skills/*/SKILL.md` returns zero matches
+- `grep -n 'Agent.*pr-agent' plugin/ralph-hero/skills/hero/SKILL.md` returns the PR dispatch
+- `grep -n 'Agent.*merge-agent' plugin/ralph-hero/skills/finish/SKILL.md` returns the merge dispatch
+
+## What We're NOT Doing
+
+- NOT converting analyst-phase Skill() calls (research, plan, review) — they benefit from inline context sharing at opus/sonnet model
+- NOT converting finish to an Agent dispatch — it's an orchestrator that dispatches agents underneath
+- NOT changing agent definitions — pr-agent.md and merge-agent.md are already correct
+
+## Phase 1: Convert PR dispatch in hero
+
+### Changes Required:
+
+#### 1. hero/SKILL.md — PR tasks section (~line 441-444)
+
+**File**: `plugin/ralph-hero/skills/hero/SKILL.md`
+
+Replace:
+```
+#### PR tasks
+```
+Skill("ralph-hero:ralph-pr", args="NNN")
+```
+```
+
+With:
+```
+#### PR tasks
+```
+Agent(subagent_type="ralph-hero:pr-agent", prompt="Create PR for GH-NNN. Worktree: worktrees/GH-NNN", description="PR for GH-NNN")
+```
+```
+
+#### 2. hero/SKILL.md — Dispatch Architecture section (~lines 425-437)
+
+**File**: `plugin/ralph-hero/skills/hero/SKILL.md`
+
+Replace the dispatch architecture explanation. Current text describes "single-session mode uses Skill() for everything" vs "team mode uses agents." New text should explain the actual pattern:
+
+- Analyst/builder phases (research, plan, review): `Skill()` inline — these are opus/sonnet and benefit from context sharing
+- Implementation: `Agent()` dispatch — impl-agent runs in isolated worktree
+- Integrator leaf tasks (PR, merge, val): `Agent()` dispatch — these are haiku and must run in isolated context
+- Finish: `Skill()` inline — orchestrator that dispatches agents underneath
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep -rn 'Skill.*ralph-pr' plugin/ralph-hero/skills/hero/SKILL.md` returns no matches
+- [ ] `grep -rn 'Agent.*pr-agent' plugin/ralph-hero/skills/hero/SKILL.md` returns the PR dispatch line
+
+#### Manual Verification:
+- [ ] Run `/ralph-hero:hero` on a test issue through PR creation — pr-agent dispatches as isolated agent, no context crash
+
+---
+
+## Phase 2: Convert merge dispatch in finish
+
+### Changes Required:
+
+#### 1. finish/SKILL.md — Step 4 heading and dispatch (~lines 108-121)
+
+**File**: `plugin/ralph-hero/skills/finish/SKILL.md`
+
+Replace:
+```markdown
+## Step 4: Merge (dispatch ralph-merge)
+
+Build args for ralph-merge — always pass the PR URL to avoid redundant lookup:
+
+```
+Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")
+```
+
+ralph-merge handles: code review gate (including optional `code-review:code-review` dispatch), PR readiness check, merge via `merge-pr.sh`, worktree cleanup, state transition to Done, parent advancement, cross-repo unblock, and posting the Merged comment.
+
+Check the skill output:
+
+- If output contains `MERGE BLOCKED` or `MERGE NOT READY`: report the status and stop.
+- If output contains `MERGED`: continue to Step 5.
+```
+
+With:
+```markdown
+## Step 4: Merge (dispatch merge-agent)
+
+Dispatch merge as an agent — always pass the PR URL to avoid redundant lookup:
+
+```
+Agent(subagent_type="ralph-hero:merge-agent", prompt="Merge PR for GH-NNN. PR URL: PR_URL", description="Merge GH-NNN")
+```
+
+merge-agent handles: code review gate (including optional `code-review:code-review` dispatch), PR readiness check, merge via `merge-pr.sh`, worktree cleanup, state transition to Done, parent advancement, cross-repo unblock, and posting the Merged comment.
+
+Check the agent output:
+
+- If output contains `MERGE BLOCKED` or `MERGE NOT READY`: report the status and stop.
+- If output contains `MERGED`: continue to Step 5.
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep -rn 'Skill.*ralph-merge' plugin/ralph-hero/skills/finish/SKILL.md` returns no matches
+- [ ] `grep -rn 'Agent.*merge-agent' plugin/ralph-hero/skills/finish/SKILL.md` returns the merge dispatch line
+
+#### Manual Verification:
+- [ ] Run `/ralph-hero:finish` on a test issue — merge-agent dispatches as isolated agent, no context crash
+
+---
+
+## Testing Strategy
+
+### Smoke test:
+1. Pick a test issue that's in "In Review" state
+2. Run `/ralph-hero:finish NNN` — verify val-agent and merge-agent both dispatch as isolated agents
+3. Check that the finish skill's context window doesn't bloat with haiku skill content
+
+### Regression check:
+- Hero pipeline end-to-end: `/ralph-hero:hero NNN` through PR creation → verify pr-agent dispatches correctly
+- Finish pipeline: verify the val → merge → CI watch chain still works
+
+## References
+
+- Agent definitions: `plugin/ralph-hero/agents/pr-agent.md`, `plugin/ralph-hero/agents/merge-agent.md`
+- Hero skill: `plugin/ralph-hero/skills/hero/SKILL.md:425-463`
+- Finish skill: `plugin/ralph-hero/skills/finish/SKILL.md:108-121`

--- a/thoughts/shared/plans/2026-04-12-GH-0758-finish-skill-hang-fix.md
+++ b/thoughts/shared/plans/2026-04-12-GH-0758-finish-skill-hang-fix.md
@@ -1,0 +1,179 @@
+---
+date: 2026-04-12
+status: draft
+type: plan
+tags: [finish, skill, fork, inline, hang]
+github_issue: 758
+github_issues: [758]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/758
+primary_issue: 758
+---
+
+# Finish Skill Hang Fix — Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-04-05-GH-0743-finish-skill]]
+
+## Overview
+
+The `/ralph-hero:finish` skill hangs at "Initializing…" when invoked directly. The root cause is `context: fork` — the skill forks a new context to run, and something in that fork initialization hangs indefinitely with no error feedback. Finish is an orchestrator (dispatches val-agent, ralph-merge, impl-agent) and should use `context: inline` like the `hero` orchestrator.
+
+## Current State Analysis
+
+- `finish/SKILL.md:5` has `context: fork` and `model: sonnet`
+- `hero/SKILL.md:4` has `context: inline` with no `model:` — the working reference pattern for orchestrators
+- Hero uses SessionStart hooks with inline (`hero/SKILL.md:6-9`) — proves inline + SessionStart hooks works
+- The finish skill body contains zero self-referential calls — the recursion observed in the UI (`Skill(finish)` → `Skill(ralph-hero:finish)`) comes from the fork initialization, not from skill code
+- `prune-merged-worktrees.sh:23` does `git fetch origin main` with no timeout on every fork SessionStart — secondary hang risk for all fork skills
+- `skill-vs-agent-dispatch.md:14-25` dispatch table is missing finish-agent
+
+### Key Discoveries:
+- `hero/SKILL.md:4-9` — inline + SessionStart + PreToolUse hooks is a proven pattern
+- `skill-precondition.sh:25-36` — checks `RALPH_COMMAND` on `get_issue`; if unset and no `agent_type`, blocks. SessionStart must fire to set this.
+- `merge-state-gate.sh:20` — defaults `RALPH_VALID_OUTPUT_STATES` to `'Done,Human Needed'` which matches what finish sets, so the default is safe
+- `finish-agent.md` — preloads finish via `skills:` field; agents always fork regardless of skill `context`, so this is unaffected by the change
+- `impl/SKILL.md:236` — interactive impl dispatches `Skill("ralph-hero:finish")` from its "Run finish" picker; will work correctly with inline
+
+## Desired End State
+
+`/ralph-hero:finish NNN` loads instantly and executes the validate → merge → CI watch pipeline without hanging. The skill runs inline in the caller's context.
+
+### Verification:
+- `/ralph-hero:finish NNN` on an issue in "In Review" runs the full chain without hanging
+- Hero dispatching `Skill("ralph-hero:finish")` still works (inline → inline)
+- `finish-agent` via `Agent(subagent_type="ralph-hero:finish-agent")` still works (agent fork is independent of skill context)
+
+## What We're NOT Doing
+
+- Changing finish's execution logic (steps 1-6 unchanged)
+- Modifying ralph-merge, ralph-val, or impl-agent
+- Investigating Claude Code's fork initialization internals (out of scope — we're removing the fork)
+- Changing any other skill's context mode
+
+## Implementation Approach
+
+Minimal change — update frontmatter and fix the secondary hang risk. No logic changes to the skill body.
+
+## Phase 1: Change Finish Skill to Inline
+
+### Overview
+Switch the finish skill from `context: fork` to `context: inline` and remove the `model:` override (inline skills inherit the caller's model).
+
+### Changes Required:
+
+#### 1. Finish Skill Frontmatter
+**File**: `plugin/ralph-hero/skills/finish/SKILL.md`
+**Lines**: 5-6
+
+Replace:
+```yaml
+context: fork
+model: sonnet
+```
+
+With:
+```yaml
+context: inline
+```
+
+This matches the pattern used by `hero/SKILL.md:4` (the other orchestrator skill).
+
+#### 2. Finish Agent — Add Model Override
+**File**: `plugin/ralph-hero/agents/finish-agent.md`
+**Line**: 3
+
+The agent already has `model: sonnet` — no change needed. When dispatched via `Agent(subagent_type="ralph-hero:finish-agent")`, the agent creates its own forked context with the sonnet model regardless of the skill's `context` field.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep -c 'context: inline' plugin/ralph-hero/skills/finish/SKILL.md` returns 1
+- [ ] `grep -c 'context: fork' plugin/ralph-hero/skills/finish/SKILL.md` returns 0
+- [ ] `grep -c 'model: sonnet' plugin/ralph-hero/skills/finish/SKILL.md` returns 0
+- [ ] Build passes: `cd plugin/ralph-hero/mcp-server && npm run build`
+
+#### Manual Verification:
+- [ ] `/ralph-hero:finish NNN` loads without hanging at "Initializing…"
+- [ ] The full pipeline (validate → merge → CI watch) executes
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
+---
+
+## Phase 2: Add Timeout to prune-merged-worktrees.sh
+
+### Overview
+The `git fetch origin main` call in the SessionStart hook has no timeout. If the network is unreachable, it hangs ALL fork skills until the OS TCP timeout fires (potentially minutes). Add a timeout.
+
+### Changes Required:
+
+#### 1. Add Timeout to git fetch
+**File**: `plugin/ralph-hero/hooks/scripts/prune-merged-worktrees.sh`
+**Line**: 23
+
+Replace:
+```bash
+git fetch origin main --quiet 2>/dev/null || exit 0
+```
+
+With:
+```bash
+timeout 10 git fetch origin main --quiet 2>/dev/null || exit 0
+```
+
+10 seconds is generous for a fetch — if the remote isn't reachable by then, it won't be reachable at all. The `|| exit 0` ensures the hook exits cleanly on timeout.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep 'timeout 10 git fetch' plugin/ralph-hero/hooks/scripts/prune-merged-worktrees.sh` matches
+
+#### Manual Verification:
+- [ ] Fork skills (e.g., `/ralph-hero:status`) still load normally
+
+---
+
+## Phase 3: Update Dispatch Fragment
+
+### Overview
+Add finish-agent to the canonical dispatch table in the shared fragment.
+
+### Changes Required:
+
+#### 1. Dispatch Table
+**File**: `plugin/ralph-hero/skills/shared/fragments/skill-vs-agent-dispatch.md`
+**Line**: 25 (after val-agent row)
+
+Add row:
+```
+| `ralph-hero:finish-agent` | finish | sonnet |
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `grep 'finish-agent' plugin/ralph-hero/skills/shared/fragments/skill-vs-agent-dispatch.md` matches
+
+---
+
+## Testing Strategy
+
+### Manual Testing:
+1. Invoke `/ralph-hero:finish NNN` directly on an issue in "In Review" with a PR — verify no hang
+2. Run `/ralph-hero:hero NNN` through to the INTEGRATOR phase — verify finish dispatches correctly
+3. Run `/ralph-hero:status` — verify fork skills still work (prune hook timeout doesn't break anything)
+
+### Edge Cases:
+- Network offline: `prune-merged-worktrees.sh` should timeout after 10s and exit cleanly
+- No worktrees directory: hook exits early (line 17-19), timeout is irrelevant
+
+## References
+
+- Finish skill: `plugin/ralph-hero/skills/finish/SKILL.md`
+- Hero orchestrator: `plugin/ralph-hero/skills/hero/SKILL.md`
+- Finish agent: `plugin/ralph-hero/agents/finish-agent.md`
+- Prune hook: `plugin/ralph-hero/hooks/scripts/prune-merged-worktrees.sh`
+- Dispatch fragment: `plugin/ralph-hero/skills/shared/fragments/skill-vs-agent-dispatch.md`
+- Original finish plan: `thoughts/shared/plans/2026-04-05-GH-0743-finish-skill.md`

--- a/thoughts/shared/research/2026-03-18-catppuccin-mocha-obsidian-theme.md
+++ b/thoughts/shared/research/2026-03-18-catppuccin-mocha-obsidian-theme.md
@@ -1,0 +1,110 @@
+---
+date: 2026-03-18
+topic: "Can we add Catppuccin Mocha theme to the Obsidian vault?"
+tags: [research, obsidian, catppuccin, theme, appearance]
+status: complete
+type: research
+git_commit: f627eb067498a5316d8422f2bb98fda467d1af13
+---
+
+# Research: Adding Catppuccin Mocha Theme to Obsidian
+
+## Prior Work
+
+- builds_on:: [[2026-03-17-GH-0582-obsidian-integration]] (setup-obsidian skill)
+
+## Research Question
+
+Notes and markdown in Obsidian are a wall of text and hard to read. Can we add the Catppuccin Mocha color theme to improve readability?
+
+## Summary
+
+Yes — Catppuccin Mocha can be installed programmatically with three file operations and zero GUI interaction. Mocha is the **default dark flavor** of the Catppuccin theme, so no additional plugins (like Style Settings) are needed. The entire `thoughts/.obsidian/` directory is already gitignored, so this is a local-only change that won't affect the repository.
+
+## Detailed Findings
+
+### Current Obsidian Appearance State
+
+The vault at `thoughts/.obsidian/` has an empty `appearance.json` (`{}`), meaning Obsidian uses its default theme. No custom theme is installed. The `setup-obsidian` skill (`plugin/ralph-knowledge/skills/setup-obsidian/SKILL.md`) provisions `app.json` and `graph.json` but has no theme-related logic.
+
+### Catppuccin Obsidian Theme
+
+- **Official repo**: [catppuccin/obsidian](https://github.com/catppuccin/obsidian)
+- **Theme type**: Single theme with four flavor variants (Latte, Frappe, Macchiato, Mocha)
+- **Mocha is the default** when dark mode is active — no Style Settings plugin required
+
+The theme uses Obsidian 1.0+ format requiring two files in a named subdirectory:
+
+```
+thoughts/.obsidian/themes/Catppuccin/
+├── manifest.json    # Theme metadata (name, version, author)
+└── theme.css        # All four flavors' CSS variables + styles
+```
+
+### Installation Requirements
+
+Three file operations total:
+
+1. **Download `theme.css`** from `https://raw.githubusercontent.com/catppuccin/obsidian/main/theme.css`
+2. **Download `manifest.json`** from `https://raw.githubusercontent.com/catppuccin/obsidian/main/manifest.json`
+3. **Update `appearance.json`** to activate the theme:
+
+```json
+{
+  "cssTheme": "Catppuccin",
+  "theme": "obsidian"
+}
+```
+
+- `cssTheme` must exactly match the `name` field in the theme's `manifest.json` (i.e., `"Catppuccin"`)
+- `theme: "obsidian"` forces dark mode (which defaults to Mocha)
+- `theme: "moonstone"` would force light mode (defaults to Latte)
+
+### Flavor Selection Without Style Settings
+
+| Flavor | Mode | Default? |
+|--------|------|----------|
+| Latte | Light | Yes (when `theme: "moonstone"`) |
+| Frappe | Dark | No |
+| Macchiato | Dark | No |
+| Mocha | Dark | **Yes** (when `theme: "obsidian"`) |
+
+To switch to Frappe or Macchiato, the [obsidian-style-settings](https://github.com/obsidian-community/obsidian-style-settings) community plugin is needed. For Mocha, no extra plugin is necessary.
+
+### Git Impact
+
+`thoughts/.gitignore` contains `.obsidian/`, so the theme files and appearance changes are purely local. No repository changes needed.
+
+### Setup Skill Compatibility
+
+The `setup-obsidian` skill uses additive merging for `app.json` — it only writes keys that don't already exist. It does not touch `appearance.json` at all. Adding the theme will not conflict with re-running the setup skill.
+
+## Code References
+
+- `thoughts/.obsidian/appearance.json` — currently `{}`, needs `cssTheme` and `theme` keys
+- `thoughts/.obsidian/app.json` — unaffected (wikilinks + frontmatter config)
+- `thoughts/.gitignore:3` — `.obsidian/` is gitignored
+- `plugin/ralph-knowledge/skills/setup-obsidian/SKILL.md` — no theme logic, no conflict
+
+## Installation Script
+
+```bash
+mkdir -p thoughts/.obsidian/themes/Catppuccin
+curl -sL "https://raw.githubusercontent.com/catppuccin/obsidian/main/theme.css" \
+  -o thoughts/.obsidian/themes/Catppuccin/theme.css
+curl -sL "https://raw.githubusercontent.com/catppuccin/obsidian/main/manifest.json" \
+  -o thoughts/.obsidian/themes/Catppuccin/manifest.json
+```
+
+Then update `thoughts/.obsidian/appearance.json`:
+```json
+{
+  "cssTheme": "Catppuccin",
+  "theme": "obsidian"
+}
+```
+
+## Open Questions
+
+- Should the setup-obsidian skill be updated to provision Catppuccin Mocha as a default theme during setup?
+- Would accent color customization be useful? (Catppuccin supports custom accent colors via Style Settings)

--- a/thoughts/shared/research/2026-03-18-justfile-cli-setup-fallbacks.md
+++ b/thoughts/shared/research/2026-03-18-justfile-cli-setup-fallbacks.md
@@ -1,0 +1,191 @@
+---
+date: 2026-03-18
+topic: "Justfile CLI setup, fallbacks, and intuitiveness for ralph-hero"
+tags: [research, cli, justfile, setup, fallbacks, ralph-cli, doctor, dispatch]
+status: complete
+type: research
+git_commit: 894be29768c771f71204e6f5e9f091704efbe106
+---
+
+# Research: Justfile CLI Setup, Fallbacks, and Intuitiveness
+
+## Research Question
+
+Is there a setup-cli skill for ralph-hero? Do we have elegant fallbacks and is the CLI intuitive to use?
+
+## Summary
+
+There is **no skill named `setup-cli`**. The two setup skills are `setup` (GitHub Project V2 creation) and `setup-repos` (multi-repo bootstrap). CLI installation is handled entirely by the justfile via `just install-cli`. The system has a layered fallback architecture across `ralph-cli.sh`, `cli-dispatch.sh`, and the `doctor` recipe — but the entry point for getting `ralph` available globally requires the user to know to run `just install-cli` first, which is the main friction point.
+
+## Detailed Findings
+
+### Skills That Exist for Setup
+
+| Skill | Purpose |
+|-------|---------|
+| `/ralph-hero:setup` | One-time GitHub Project V2 creation with interactive health checks, field configuration, split-owner/dual-token support, routing setup. |
+| `/ralph-hero:setup-repos` | Bootstrap `.ralph-repos.yml` for multi-repo portfolio tracking. |
+
+There is **no `setup-cli` skill**. CLI installation is a justfile concern, not a skill.
+
+### How Global CLI Installation Works
+
+`plugin/ralph-hero/justfile:246-271` — `install-cli` recipe in the `[group('setup')]` section:
+
+```bash
+just install-cli
+```
+
+- Copies `scripts/ralph-cli.sh` to `~/.local/bin/ralph`
+- Guarded by a `[confirm(...)]` attribute requiring user approval
+- Warns if `~/.local/bin` is not in `$PATH`
+- Shows usage examples after install
+- Suggests `just install-completions bash` (or `zsh`) as a follow-up
+
+To uninstall: `just uninstall-cli` (also confirm-guarded).
+
+Shell completions: `just install-completions bash` or `just install-completions zsh` — copies completion scripts to the appropriate platform directories.
+
+### How `ralph-cli.sh` Works (the Global Wrapper)
+
+`plugin/ralph-hero/scripts/ralph-cli.sh` — resolves the latest plugin version at runtime:
+
+1. Scans `~/.claude/plugins/cache/ralph-hero/ralph-hero/` for the latest version via `ls | sort -V | tail -1`
+2. Reads version from `.claude-plugin/plugin.json` (via `jq`) — falls back to directory name
+3. Handles `--version`/`-V`: prints `ralph version X.Y.Z` and exits
+4. Handles `--help`/`-h`: prints a full usage summary with common commands, options, and examples
+5. **First-run welcome banner**: checks `~/.ralph/welcomed` — if absent, prints a welcome message and creates the file. Shows once only.
+6. **Missing justfile fallback**: if the plugin cache doesn't exist, prints clear error + install instruction (`claude plugin install ...`)
+7. Delegates to `just --justfile <path> "$@"` — all args passed through to justfile
+
+### Fallback Architecture in `cli-dispatch.sh`
+
+`plugin/ralph-hero/scripts/cli-dispatch.sh` — sourced by every LLM-powered justfile recipe:
+
+**Three modes** parsed from args:
+
+| Flag | Mode | Behavior |
+|------|------|---------|
+| (none) | headless | Runs `claude -p` non-interactively with streaming output |
+| `-i` / `--interactive` | interactive | Opens a full Claude Code session |
+| `-q` / `--quick` | quick | Direct MCP tool call via mcptools, no AI |
+
+**`no_mode()` function** (`cli-dispatch.sh:193-203`): when a recipe doesn't support the requested mode, it explicitly tells the user what modes ARE available and how to use them. Example:
+```
+Error: 'triage' does not support quick mode.
+Try: ralph triage (headless) or ralph triage -i (interactive)
+```
+
+**Headless run error handling** (`cli-dispatch.sh:57-65`):
+- Exit 0: `--- done (Ns) ---`
+- Exit 124 (timeout): `--- timed out after $TIMEOUT ---` + `Try: --timeout=30m`
+- Other exits: `--- failed (exit N) ---` + `Run: ralph doctor`
+
+**Summary footer** (`cli-dispatch.sh:74-139`): after every headless run, an `awk` filter collects GitHub URLs, `thoughts/shared/*` file paths (as `vscode://file/` links), and state transitions (e.g., `Backlog → Research Needed`) from the output stream, then prints them as a structured footer.
+
+**`run_quick()` fallback** (`cli-dispatch.sh:164-190`): if mcptools is not installed, prints clear error with install instructions. If `jq` is not available, falls back to raw output.
+
+### `doctor` Recipe — Comprehensive Diagnostics
+
+`plugin/ralph-hero/justfile:148-244` — runs entirely in bash with no AI or MCP calls:
+
+**What it checks:**
+
+| Category | Items |
+|----------|-------|
+| Environment Variables | `RALPH_HERO_GITHUB_TOKEN`, `RALPH_GH_OWNER`, `RALPH_GH_PROJECT_NUMBER` |
+| Dependencies | `just`, `npx`, `node` (errors); `mcp` (mcptools, warning); `claude` CLI (warning) |
+| Plugin Files | `.claude-plugin/plugin.json` (valid JSON?), `.mcp.json` (valid JSON?) |
+| API Health | Calls `ralph_hero__health_check` via `just _mcp_call` — **skipped** if mcptools or token unavailable |
+| WSL2 | Detects `/proc/version` microsoft string; checks if tempdir is mounted `noexec` |
+
+- Exits with code 1 on errors; warnings (missing optional deps) do NOT cause non-zero exit
+- Missing mcptools: warns but continues, marks API health as `SKIP`
+
+### `default` Recipe — fzf-aware
+
+`plugin/ralph-hero/justfile:20-26`:
+```bash
+default:
+    if command -v fzf >/dev/null 2>&1; then
+        just --choose   # interactive fuzzy picker
+    else
+        just --list     # plain recipe list
+    fi
+```
+
+Running `just` with no args shows an interactive recipe picker if `fzf` is installed, otherwise a plain list.
+
+### `_mcp_call` Private Recipe — jq-aware
+
+`plugin/ralph-hero/justfile:420-445` — used by all `quick-*` recipes:
+- If mcptools not installed: clear error + two install methods (brew, go install)
+- If jq not available: falls back to raw output (no crash)
+- Error response detection via `jq -e '.isError // false'`
+- Pretty-prints JSON nested text when possible
+
+### Recipe Groups
+
+Justfile organizes recipes into four groups:
+
+| Group | Recipes |
+|-------|---------|
+| `workflow` | triage, split, research, plan, review, impl, hygiene, status, report |
+| `orchestrate` | team, hero, loop |
+| `setup` | setup, doctor, install-cli, uninstall-cli, install-completions, completions |
+| `quick` | quick-status, quick-move, quick-pick, quick-assign, quick-issue, quick-info, quick-comment, quick-draft |
+
+### Key Friction Points with Justfile Access
+
+1. **Must run from `plugin/ralph-hero/`** — justfile recipes use `{{justfile_directory()}}` to find scripts. Running `just` from the repo root or any other directory fails.
+2. **Global `ralph` command requires explicit installation** — `just install-cli` must be run first. The user must know this step exists.
+3. **`just install-cli` requires knowing to go to `plugin/ralph-hero/` first** — bootstrapping paradox: to install the CLI, you need to be in the plugin directory already.
+4. **PATH warning only shown at install time** — if `~/.local/bin` isn't in PATH, the warning appears once then never again.
+
+## Code References
+
+- `plugin/ralph-hero/justfile:1-26` — Header, aliases, default recipe with fzf fallback
+- `plugin/ralph-hero/justfile:139-271` — `[group('setup')]` recipes: setup, doctor, install-cli, uninstall-cli, install-completions, completions
+- `plugin/ralph-hero/justfile:420-445` — `_mcp_call` private recipe
+- `plugin/ralph-hero/scripts/ralph-cli.sh:1-96` — Global CLI wrapper with version, help, welcome banner, fallback errors
+- `plugin/ralph-hero/scripts/cli-dispatch.sh:1-203` — Three-mode dispatch, output filter, `no_mode()` error handler
+- `plugin/ralph-hero/skills/setup/SKILL.md` — GitHub Project V2 setup skill (not CLI setup)
+- `docs/cli.md` — CLI reference documentation for quick-* recipes and doctor
+
+## Architecture
+
+```
+User
+  │
+  ├─ via global `ralph` command
+  │   └─ ~/.local/bin/ralph (ralph-cli.sh)
+  │       ├─ --version / --help (handled inline)
+  │       ├─ first-run banner (one-time, ~/.ralph/welcomed)
+  │       ├─ missing plugin: clear error + install hint
+  │       └─ delegates to: just --justfile <plugin-cache>/justfile "$@"
+  │
+  └─ via `just` directly from plugin/ralph-hero/
+      └─ justfile recipes
+          ├─ [group('setup')]: setup, doctor, install-cli, uninstall-cli, install-completions
+          ├─ [group('workflow')]: triage, research, plan, impl, etc.
+          │   └─ source cli-dispatch.sh → dispatch()
+          │       ├─ headless: claude -p + output filter + summary footer
+          │       ├─ interactive: exec claude (full session)
+          │       └─ quick: mcp call → raw/jq output
+          └─ [group('quick')]: quick-status, quick-move, quick-pick, etc.
+              └─ just _mcp_call → mcptools → MCP server
+```
+
+## Historical Context
+
+Per thoughts/ documents:
+- `2026-02-18-GH-0067` — initial justfile vs shell script design tradeoffs
+- `2026-02-21-group-GH-0281` — global CLI access via symlink (later changed to copy)
+- `2026-02-27-ralph-cli-qol-improvements.md` — added `--budget`, `--timeout` flags
+- `2026-03-18-GH-0606` — `--version` / `--help` flags added to `ralph-cli.sh`
+- `2026-03-18-GH-0607` — `--help` usage summary added
+
+## Open Questions
+
+- Is there a way to bootstrap `just install-cli` without being in `plugin/ralph-hero/` first? (e.g., a post-plugin-install hook or a one-liner in plugin docs)
+- Should `ralph-cli.sh` also accept `ralph doctor` to run the doctor check from anywhere? (It does — `ralph doctor` works today via justfile delegation.)

--- a/thoughts/shared/research/2026-03-18-obsidian-catppuccin-pill-styling.md
+++ b/thoughts/shared/research/2026-03-18-obsidian-catppuccin-pill-styling.md
@@ -1,0 +1,106 @@
+---
+date: 2026-03-18
+topic: "How to restore Obsidian default pill styling for tags in Catppuccin Mocha"
+tags: [research, obsidian, catppuccin, css, tags, typography]
+status: complete
+type: research
+git_commit: 92b4a482b0950876bfb0155bdd6bce3e779af43c
+---
+
+# Research: Restoring Pill Tag Styling in Catppuccin Mocha
+
+## Prior Work
+
+- builds_on:: [[2026-03-18-catppuccin-mocha-obsidian-theme]]
+
+## Research Question
+
+The default Obsidian theme has pill-shaped tag badges. Catppuccin Mocha removes them. How do we restore just the pill styling without changing anything else?
+
+## Summary
+
+Catppuccin intentionally flattens tag styling by zeroing out padding and making the background transparent. The fix is a 5-line CSS snippet overriding four `--tag-*` CSS variables — the exact same values Catppuccin ships as its opt-in `.ctp-tag-pill` class. No selector hacks, no `!important`, no plugin required.
+
+## Detailed Findings
+
+### What Obsidian Default Pill Tags Look Like
+
+The default Obsidian theme styles `a.tag` and `.cm-hashtag-*` spans via CSS variables:
+
+```css
+--tag-background:   hsla(var(--interactive-accent-hsl), 0.1);
+--tag-padding-x:    0.65em;
+--tag-padding-y:    0.25em;
+--tag-radius:       2em;       /* 2em on a small element = full capsule/pill */
+--tag-border-width: 0px;
+```
+
+The `2em` radius on an element with `0.25em` vertical padding produces the characteristic capsule shape.
+
+### What Catppuccin Does to Tags
+
+Catppuccin's base `:root` block (theme.css lines 488–505) overrides all four properties:
+
+| Variable | Obsidian default | Catppuccin override |
+|----------|-----------------|---------------------|
+| `--tag-background` | `hsla(accent, 0.1)` | `transparent` |
+| `--tag-background-hover` | `hsla(accent, 0.2)` | `0` |
+| `--tag-padding-x` | `0.65em` | `0` |
+| `--tag-padding-y` | `0.25em` | `0` |
+| `--tag-radius` | `2em` | `0.8em` |
+
+The result: no background, no padding — tags look like accented underlined text. The `0.8em` radius has no visible effect because there's nothing to round without padding + background.
+
+### Catppuccin's Own Pill Toggle
+
+Catppuccin actually ships this restoration as an opt-in toggle via the Style Settings plugin. The `.ctp-tag-pill` body class (theme.css lines 2377–2390) restores exactly Obsidian's defaults:
+
+```css
+.ctp-tag-pill {
+  --tag-size:             var(--font-smaller);
+  --tag-background:       hsla(var(--interactive-accent-hsl), 0.1);
+  --tag-background-hover: hsla(var(--interactive-accent-hsl), 0.2);
+  --tag-border-color:     hsla(var(--interactive-accent-hsl), 0.15);
+  --tag-border-color-hover: hsla(var(--interactive-accent-hsl), 0.15);
+  --tag-border-width:     0px;
+  --tag-padding-x:        0.65em;
+  --tag-padding-y:        0.25em;
+  --tag-radius:           2em;
+  --tag-weight:           inherit;
+}
+```
+
+This is confirmed working because Catppuccin ships and tests it themselves.
+
+### Fix: CSS Snippet (No Plugin Needed)
+
+Rather than installing Style Settings, simply adding a CSS snippet with the same variable overrides on `body` achieves identical results:
+
+```css
+/* Restore Obsidian default pill styling for tags */
+body {
+  --tag-background:       hsla(var(--interactive-accent-hsl), 0.1);
+  --tag-background-hover: hsla(var(--interactive-accent-hsl), 0.2);
+  --tag-border-width:     0px;
+  --tag-padding-x:        0.65em;
+  --tag-padding-y:        0.25em;
+  --tag-radius:           2em;
+}
+```
+
+This overrides Catppuccin's `:root` defaults. No `!important` needed — `body` specificity beats `:root`.
+
+## Code References
+
+- `thoughts/.obsidian/themes/Catppuccin/theme.css:488–505` — Catppuccin's `:root` tag variable overrides
+- `thoughts/.obsidian/themes/Catppuccin/theme.css:2377–2390` — Catppuccin's `.ctp-tag-pill` opt-in class
+- `thoughts/.obsidian/snippets/typography.css` — existing snippet to extend with pill rules
+
+## Implementation Options
+
+1. **Add to existing `typography.css` snippet** — keeps all appearance tweaks in one file
+2. **New `tag-pills.css` snippet** — more surgical, easier to toggle on/off independently
+
+## Open Questions
+
+- None — the fix is fully known and confirmed by Catppuccin's own source.

--- a/thoughts/shared/research/2026-03-19-agent-color-palette-inverse-roygbiv.md
+++ b/thoughts/shared/research/2026-03-19-agent-color-palette-inverse-roygbiv.md
@@ -1,0 +1,126 @@
+---
+date: 2026-03-19
+topic: "Claude Code agent colors: available palette and inverse ROY G BIV assignment plan"
+tags: [research, agents, colors, claude-code, plugin-configuration]
+status: complete
+type: research
+git_commit: 81baef11ccfeebb9391f23197c61b1eafd8b31dc
+---
+
+# Research: Claude Code Agent Colors & Inverse ROY G BIV Spectrum
+
+## Prior Work
+
+None found — first research on agent color theming.
+
+## Research Question
+
+What colors are available in Claude Code agent definitions, and how can they be assigned to all ralph-hero marketplace plugin subagents using an inverse ROY G BIV spectrum?
+
+## Summary
+
+Claude Code supports exactly **8 hardcoded colors** in agent frontmatter: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`. There are **13 agents** across 2 plugins (ralph-hero: 11, ralph-playwright: 2). Currently only 5 of 13 have colors assigned. The inverse ROY G BIV spectrum maps naturally to the available palette as: `purple → blue → cyan → green → yellow → orange → pink → red`.
+
+## Detailed Findings
+
+### Available Colors
+
+The `color` field in agent `.md` frontmatter accepts exactly these 8 values:
+
+| Color | ANSI mapping |
+|-------|-------------|
+| `purple` | Violet/magenta |
+| `blue` | Full-brightness blue |
+| `cyan` | Full-brightness cyan |
+| `green` | Full-brightness green |
+| `yellow` | Full-brightness yellow |
+| `orange` | Full-brightness orange |
+| `pink` | Full-brightness pink |
+| `red` | Full-brightness red |
+
+Custom values (hex codes, tmux 256-color numbers, CSS colors) are **silently ignored** with no warning. Sources: [Claude Code docs](https://code.claude.com/docs/en/sub-agents), [anthropics/claude-code#23691](https://github.com/anthropics/claude-code/issues/23691), [cclint linter](https://github.com/carlrannaberg/cclint).
+
+### Inverse ROY G BIV → Available Palette Mapping
+
+Standard ROY G BIV: Red → Orange → Yellow → Green → Blue → Indigo → Violet
+
+**Inverse** (walking from violet to red): Violet → Indigo → Blue → Green → Yellow → Orange → [Rose] → Red
+
+Mapped to available Claude Code colors:
+
+```
+purple → blue → cyan → green → yellow → orange → pink → red
+  (V)     (I)    (B)    (G)     (Y)      (O)    (rose)  (R)
+```
+
+### Current Agent Inventory (13 agents, 2 plugins)
+
+#### ralph-hero plugin — 11 agents
+
+| Agent | Model | Current color | Has hooks |
+|-------|-------|--------------|-----------|
+| `ralph-analyst` | sonnet | `green` | yes |
+| `ralph-builder` | sonnet | `cyan` | yes |
+| `ralph-integrator` | haiku | `orange` | yes |
+| `github-analyzer` | sonnet | `orange` | no |
+| `github-lister` | sonnet | `cyan` | no |
+| `codebase-analyzer` | sonnet | — | no |
+| `codebase-locator` | haiku | — | no |
+| `codebase-pattern-finder` | haiku | — | no |
+| `thoughts-analyzer` | sonnet | — | no |
+| `thoughts-locator` | haiku | — | no |
+| `web-search-researcher` | sonnet | — | no |
+
+#### ralph-playwright plugin — 2 agents
+
+| Agent | Model | Current color |
+|-------|-------|--------------|
+| `explorer-agent` | sonnet | — |
+| `story-runner-agent` | sonnet | — |
+
+### Proposed Color Assignments — Inverse Spectrum Walk
+
+Walking the inverse spectrum across functional groups, cool-to-warm:
+
+| Spectrum position | Color | Agent | Rationale |
+|------------------|-------|-------|-----------|
+| Violet (coolest) | `purple` | `ralph-analyst` | Strategic analysis — deep thought at the violet end |
+| Indigo | `blue` | `ralph-builder` | Construction — building in the deep blue |
+| Blue | `cyan` | `ralph-integrator` | Integration — bridge between cool analysis and warm execution |
+| Green | `green` | `codebase-locator` | Finding paths through the code forest |
+| Green | `green` | `codebase-pattern-finder` | Spotting patterns in the canopy |
+| Yellow | `yellow` | `codebase-analyzer` | Illuminating code — casting light on implementation |
+| Yellow | `yellow` | `thoughts-locator` | Discovering knowledge — lantern in the archive |
+| Orange | `orange` | `thoughts-analyzer` | Warm synthesis of found knowledge |
+| Orange | `orange` | `web-search-researcher` | Warm outward reach into the web |
+| Pink (rose) | `pink` | `github-lister` | Scanning the horizon — dawn-colored discovery |
+| Pink (rose) | `pink` | `explorer-agent` | UI exploration — roaming the pink edge |
+| Red (warmest) | `red` | `github-analyzer` | Hot distillation of findings |
+| Red (warmest) | `red` | `story-runner-agent` | Test execution fire — pass/fail at the red end |
+
+**Design principles:**
+- Related agents share colors (pairs within functional groups)
+- The 3 Ralph Team workers each get unique colors (purple/blue/cyan) for instant identification
+- The spectrum walks cool→warm from strategic→tactical→execution
+- 8 colors across 13 agents = max 2 agents per color, grouped by function
+
+## Code References
+
+- `plugin/ralph-hero/agents/ralph-analyst.md:6` — current `color: green`
+- `plugin/ralph-hero/agents/ralph-builder.md:6` — current `color: cyan`
+- `plugin/ralph-hero/agents/ralph-integrator.md:6` — current `color: orange`
+- `plugin/ralph-hero/agents/github-analyzer.md:6` — current `color: orange`
+- `plugin/ralph-hero/agents/github-lister.md:6` — current `color: cyan`
+- `plugin/ralph-hero/agents/codebase-analyzer.md` — no color field
+- `plugin/ralph-hero/agents/codebase-locator.md` — no color field
+- `plugin/ralph-hero/agents/codebase-pattern-finder.md` — no color field
+- `plugin/ralph-hero/agents/thoughts-analyzer.md` — no color field
+- `plugin/ralph-hero/agents/thoughts-locator.md` — no color field
+- `plugin/ralph-hero/agents/web-search-researcher.md` — no color field
+- `plugin/ralph-playwright/agents/explorer-agent.md` — no color field
+- `plugin/ralph-playwright/agents/story-runner-agent.md` — no color field
+
+## Open Questions
+
+- Should the 3 Ralph Team workers maintain unique colors as proposed, or share a single team color?
+- Future agents: where on the spectrum should new agents land?

--- a/thoughts/shared/research/2026-03-19-agent-driven-ui-testing-stochastic-exploration.md
+++ b/thoughts/shared/research/2026-03-19-agent-driven-ui-testing-stochastic-exploration.md
@@ -1,0 +1,360 @@
+---
+date: 2026-03-19
+topic: "Agent-driven UI testing: stochastic exploration, user story generation, and the existing tool landscape"
+tags: [research, ui-testing, playwright, storybook, a11y, agent-testing, stochastic, user-stories, figma, mcp]
+status: complete
+type: research
+git_commit: f03ace1844b662086d18d6fc45448b1cbdb64ade
+---
+
+# Research: Agent-Driven UI Testing — Stochastic Exploration, User Story Generation, and Existing Tool Landscape
+
+## Prior Work
+
+- builds_on:: [[2026-02-18-GH-0067-bowser-justfile-cli-patterns]]
+- builds_on:: [[2026-02-19-GH-0132-agent-skill-patterns-bowser-reference]]
+- builds_on:: [[2026-03-18-GH-0602-integration-testing]]
+
+## Research Question
+
+How can we build a robust UI testing pipeline combining Storybook component testing, Playwright E2E + a11y testing, and stochastic agent-based website exploration for happy/sad path coverage? Specifically:
+1. What does disler/bowser teach us about agent-based UI testing architecture?
+2. Can user stories be generated from YAML/JSON based on Figma designs, text descriptions, or website crawling?
+3. What official skills, MCP servers, and existing tools already solve these problems?
+4. What's the gap between what exists and a full stochastic exploration pipeline?
+
+## Summary
+
+The landscape has matured significantly. **Playwright v1.56+ has built-in Test Agents** (Planner/Generator/Healer) that explore live sites and generate tests. **Bowser** by disler/IndyDevDan provides a proven 4-layer Claude Code architecture for parallel agent-based QA using YAML user stories. **Official MCP servers** exist for Playwright, Storybook, Chrome DevTools, and accessibility (axe-core). User story generation from Figma, text, and website crawling is achievable by composing existing tools — no single end-to-end solution exists, but the building blocks are production-ready.
+
+The key insight: **true stochastic/random exploration doesn't exist in web testing** — what tools call "autonomous exploration" is actually goal-directed agent crawling. This is actually more useful than random fuzzing for web UIs.
+
+---
+
+## Detailed Findings
+
+### 1. Bowser Architecture (disler/IndyDevDan)
+
+**Repo**: [github.com/disler/bowser](https://github.com/disler/bowser)
+
+Bowser is an agentic browser automation and UI testing framework built on Claude Code with a **four-layer composable architecture**:
+
+```
+Layer 4: justfile          — One command to run everything
+Layer 3: commands/         — Discover stories, fan out agents, collect results
+Layer 2: agents/           — Parallel execution, isolated sessions, structured reporting
+Layer 1: skills/           — Drive the browser via playwright-cli or Chrome MCP
+```
+
+#### User Story Schema (YAML)
+
+Stories live in `ai_review/user_stories/*.yaml`. The schema is intentionally minimal and prose-driven:
+
+```yaml
+stories:
+  - name: "Front page loads with posts"
+    url: "https://news.ycombinator.com/"
+    workflow: |
+      Navigate to https://news.ycombinator.com/
+      Verify the front page loads successfully
+      Verify at least 10 posts are visible, each with a title and a link
+
+  - name: "Login flow completes"
+    url: "http://localhost:3000/login"
+    workflow: |
+      Navigate to http://localhost:3000/login
+      Verify the login page loads with email and password fields
+      Fill in email with "test@example.com"
+      Fill in password with "password123"
+      Click the login/submit button
+      Verify the page redirects to a dashboard or authenticated view
+```
+
+Key design choices:
+- `workflow` is **plain-text natural language** — no assertion DSL; the agent interprets prose
+- New stories are added by dropping a `.yaml` file — auto-discovered by the `ui-review` command
+- Accepts multiple formats: imperative steps, BDD Given/When/Then, checklists
+
+#### Execution Model
+
+1. `ui-review` command globs all `*.yaml` files
+2. One `bowser-qa-agent` spawned per story file — all run **in parallel** with isolated Playwright sessions
+3. Agent uses `playwright-cli` accessibility tree snapshots (not CSS selectors) for contextual element finding
+4. Screenshots captured per step: `./screenshots/bowser-qa/<story-kebab>_<uuid>/00_step-name.png`
+5. On failure: JS console errors captured, remaining steps marked SKIPPED
+6. Results aggregated into unified pass/fail report
+
+#### Key Skills
+
+- **playwright-bowser**: Wraps `playwright-cli`; navigates via accessibility tree; named sessions (`-s=<name>`) for isolation; optional `--headed` and vision modes
+- **claude-bowser**: Uses real Chrome browser with existing auth sessions (not for CI)
+
+#### What Bowser Is NOT
+
+Bowser is **not stochastic exploration**. It's natural-language-driven deterministic-ish execution. The "agentic" quality is that element identification is contextual and LLM-driven, making it resilient to UI changes — but the test paths are defined by the user stories.
+
+---
+
+### 2. Playwright v1.56+ Test Agents (Official)
+
+**Docs**: [playwright.dev/docs/test-agents](https://playwright.dev/docs/test-agents)
+
+This is the most directly relevant feature for stochastic exploration. Three built-in agents:
+
+| Agent | Purpose |
+|-------|---------|
+| **Planner** | Explores a live app through a real browser, discovers user flows, produces structured Markdown test plans |
+| **Generator** | Reads plans, verifies selectors against real DOM, writes test files with stable locators |
+| **Healer** | Executes test suite, analyzes failure traces, auto-repairs broken tests |
+
+**Setup**: `npx playwright init-agents --loop=claude` (or `--loop=vscode`, `--loop=opencode`)
+
+The Planner agent is the closest thing to autonomous site exploration — it maps user flows by actually browsing the application.
+
+---
+
+### 3. The AI Testing Tool Landscape
+
+#### Tier 1: Autonomous SaaS Platforms
+
+| Tool | Key Feature | Link |
+|------|-------------|------|
+| **Applitools Autonomous** | Enter URL → crawl sitemap → auto-generate test suite | [applitools.com/platform/autonomous](https://applitools.com/platform/autonomous/) |
+| **Momentic** (YC W24) | "Explore" agent maps user flows, generates and maintains tests | [momentic.ai](https://momentic.ai/) |
+| **Katalon Scout/TrueTest** | Captures real production interactions → generates tests | [katalon.com](https://katalon.com/) |
+| **Mabl** | Autonomous test creation from intent/user stories; 85% maintenance reduction | [mabl.com](https://www.mabl.com/) |
+| **QA Wolf** | Multi-agent: Orchestrator + Outliner + Code Writer + Verifier | [qawolf.com](https://www.qawolf.com/) |
+| **QA.tech** | Goal-driven agents learn the site like a human | [qa.tech](https://qa.tech/) |
+| **OctoMind** | Auto-discover + generate Playwright tests | [octomind.dev](https://octomind.dev/) |
+| **Autify Nexus/Genesis** | PRD → test cases; Natural-Language Recorder | [autify.com](https://autify.com/) |
+
+#### Tier 2: Open-Source Browser Agents
+
+| Tool | Stars | Key Feature | Link |
+|------|-------|-------------|------|
+| **browser-use** | 78K+ | Python autonomous browser agent; qa-use sub-project for QA | [github.com/browser-use/browser-use](https://github.com/browser-use/browser-use) |
+| **Stagehand** (Browserbase) | 21K+ | `act()`, `extract()`, `observe()`, `agent()` primitives | [github.com/browserbase/stagehand](https://github.com/browserbase/stagehand) |
+| **Skyvern** | Active | Vision-LLM approach; 85.8% WebVoyager benchmark | [github.com/Skyvern-AI/skyvern](https://github.com/Skyvern-AI/skyvern) |
+
+#### Tier 3: Playwright + AI Integrations
+
+| Tool | Type | Link |
+|------|------|------|
+| **@playwright/mcp** | Official MS Playwright MCP server (29K+ stars) | [github.com/microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) |
+| **Shortest** (Antiwork/Linear) | Plain English tests → Claude + Playwright | [github.com/antiwork/shortest](https://github.com/antiwork/shortest) |
+| **ZeroStep** | `ai("Click Login")` drops into Playwright tests | [github.com/zerostep-ai/zerostep](https://github.com/zerostep-ai/zerostep) |
+| **auto-playwright** | Open-source ZeroStep alternative (OpenAI) | [github.com/lucgagan/auto-playwright](https://github.com/lucgagan/auto-playwright) |
+| **Qodo Gen** | IDE plugin with "Explore agent" that crawls app → generates tests | [qodo.ai](https://www.qodo.ai/) |
+
+#### Tier 4: Storybook + AI Testing
+
+| Tool | Key Feature | Link |
+|------|-------------|------|
+| **Storybook 9** | Vitest browser mode; built-in a11y panel (axe-core); test codegen addon | [storybook.js.org](https://storybook.js.org/) |
+| **@storybook/addon-mcp** | MCP server inside Storybook exposing component knowledge to AI | [github.com/storybookjs/addon-mcp](https://github.com/storybookjs/addon-mcp) |
+| **Chromatic** | Pixel-perfect snapshot diffing (no AI diffing) | [chromatic.com](https://www.chromatic.com/) |
+| **Applitools Eyes** | AI Visual Testing inside Storybook; filters rendering noise | [applitools.com/docs/eyes/sdks/storybook](https://applitools.com/docs/eyes/sdks/storybook) |
+| **Percy** (BrowserStack) | Visual Review Agent; AI-powered diff analysis; 40% false positive reduction | [percy.io](https://percy.io/) |
+
+---
+
+### 4. Existing MCP Servers and Claude Code Skills
+
+#### Official
+
+| Tool | Package | Setup |
+|------|---------|-------|
+| **Playwright MCP** (Microsoft) | `@playwright/mcp` | `claude mcp add playwright npx @playwright/mcp@latest` |
+| **Storybook MCP** | `@storybook/addon-mcp` | `claude mcp add storybook-mcp --transport http http://localhost:6006/mcp` |
+| **webapp-testing skill** (Anthropic) | — | [anthropics/skills/webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) |
+
+#### Community Skills for Playwright
+
+| Skill | Key Feature | Link |
+|-------|-------------|------|
+| **az9713/playwright-ui-testing** | 16 skills, 482 test cases, zero-config; `/test-all` orchestrator | [github.com/az9713/playwright-ui-testing](https://github.com/az9713/playwright-ui-testing) |
+| **neonwatty/claude-qa-skills** | Generator + converter + runner for QA workflows | [github.com/neonwatty/claude-qa-skills](https://github.com/neonwatty/claude-qa-skills) |
+| **lackeyjb/playwright-skill** | Model-invoked; auto-writes + executes Playwright code | [github.com/lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill) |
+| **firstloophq/claude-code-test-runner** | NL test definitions in JSON; Docker CI/CD ready | [github.com/firstloophq/claude-code-test-runner](https://github.com/firstloophq/claude-code-test-runner) |
+
+#### Accessibility MCP Servers
+
+| Tool | Package | Key Feature |
+|------|---------|-------------|
+| **a11ymcp** | `a11y-mcp-server` | axe-core + Puppeteer; WCAG 2.0-2.2; color contrast | [github.com/ronantakizawa/a11ymcp](https://github.com/ronantakizawa/a11ymcp) |
+| **playwright-axe-mcp** | — | Playwright + axe-core; NL component testing | [github.com/PashaBoiko/playwright-axe-mcp](https://github.com/PashaBoiko/playwright-axe-mcp) |
+| **chrome-devtools-mcp** | `chrome-devtools-mcp` | Lighthouse audits, perf tracing, network inspection | [github.com/ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) |
+
+---
+
+### 5. User Story Generation from Inputs
+
+#### From YAML/JSON — Existing Schemas
+
+**AWS agent-evaluation** ([awslabs/agent-evaluation](https://github.com/awslabs/agent-evaluation)) — production-proven YAML schema:
+```yaml
+tests:
+  checkout_flow:
+    steps:
+      - Ask agent to add item SKU-123 to cart
+      - Confirm cart contents
+      - Proceed to checkout
+    expected_results:
+      - Agent confirms item was added
+      - Agent lists cart with correct item
+      - Agent confirms order placement
+```
+
+**Zerocode YAML DSL** ([zerocode wiki](https://github.com/authorjapps/zerocode/wiki/YAML-DSL-For-Test-Scenarios)) — API/integration testing:
+```yaml
+scenarioName: "User can retrieve profile"
+steps:
+  - name: get_profile
+    url: /api/v1/users/42
+    method: GET
+    verify:
+      status: 200
+      body:
+        id: 42
+```
+
+**Bowser's minimal schema** is the most directly relevant for agent-driven UI testing (see Section 1).
+
+#### From Figma Designs
+
+**Figma Official MCP** (`https://mcp.figma.com/mcp`) exposes frame contents, components, layout, design variables, and prototype interaction data (`reactions` field).
+
+Figma plugins for story generation:
+- **Figflow** ([figflow.io](https://www.figflow.io/)) — design → stories + acceptance criteria + test scripts
+- **StoryCraft** — design → user story converter
+- **SpecMate** — design → user stories
+- **Figma AI Test Generator** ([figma.com/solutions/ai-test-generator](https://www.figma.com/solutions/ai-test-generator/)) — NL feature descriptions → structured stories
+
+**Documented working pipeline** (Ashay Kubal): Figma MCP → chunk design tree → LLM → epics + stories JSON → Jira creation.
+
+#### From Running Websites
+
+- **Playwright Planner Agent** (v1.56+) — explores live app, discovers flows, produces Markdown test plans
+- **Applitools Autonomous** — enter URL → crawl sitemap → auto-generate test suite
+- **Katalon TrueTest** — capture real production traffic → generate tests from actual behavior
+- **Qodo Gen Explore** — crawl running local app → Playwright/Cypress tests
+- **Crawl4AI** ([github.com/unclecode/crawl4ai](https://github.com/unclecode/crawl4ai)) — LLM-friendly crawling with schema-based extraction
+
+#### From Text Descriptions
+
+Use LLM structured output with a Zod/Pydantic schema:
+```typescript
+const UserStorySchema = z.object({
+  role: z.string(),
+  goal: z.string(),
+  benefit: z.string(),
+  acceptanceCriteria: z.array(z.object({
+    given: z.string(),
+    when: z.string(),
+    then: z.string(),
+  })),
+  priority: z.enum(["high", "medium", "low"]),
+});
+```
+
+Feed design data, PRDs, or text descriptions → structured JSON output → YAML test definitions.
+
+---
+
+### 6. Gap Analysis: What's Missing for a Full Pipeline
+
+| Gap | Current State | What's Needed |
+|-----|---------------|---------------|
+| **True stochastic exploration** | No tool does pure random input generation for web UIs. All "autonomous exploration" is goal-directed. | Random action sequences + edge case detection (drunk user testing). Could build on browser-use or Stagehand's `observe()` + `agent()` primitives. |
+| **Figma → running tests E2E** | Requires stitching Figma MCP + LLM + test framework manually | A single pipeline: Figma file key → user stories YAML → Playwright tests → execution |
+| **User story → Bowser YAML automation** | Bowser stories are hand-written | Automated generation from Figma, text, or website crawl into Bowser's YAML schema |
+| **Storybook ↔ E2E integration** | Storybook component tests and Playwright E2E are separate worlds | Unified pipeline: component-level Storybook tests → page-level Playwright E2E → site-level exploration |
+| **A11y in agent exploration** | A11y MCP servers exist but aren't integrated into exploration loops | Inject axe-core checks at each exploration step for continuous a11y validation |
+| **Sad path generation** | LLM-generated stories tend toward happy paths | Need explicit sad-path prompting patterns: invalid inputs, network failures, auth errors, edge states |
+
+---
+
+## Architecture Recommendation Summary
+
+A complete pipeline would compose three layers:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  STORY GENERATION                                    │
+│  Figma MCP / Text / Website Crawl → User Stories YAML│
+├─────────────────────────────────────────────────────┤
+│  COMPONENT TESTING                                   │
+│  Storybook 9 + Vitest + axe-core → Component a11y   │
+│  Storybook MCP → AI-validated component patterns     │
+│  Chromatic/Applitools → Visual regression             │
+├─────────────────────────────────────────────────────┤
+│  E2E + EXPLORATION                                   │
+│  Bowser-style YAML → Playwright agents (happy path)  │
+│  Playwright Planner → Flow discovery (coverage gaps) │
+│  Stochastic agent → Random exploration (edge cases)  │
+│  a11y MCP → Continuous WCAG validation               │
+└─────────────────────────────────────────────────────┘
+```
+
+## Key npm Packages
+
+```
+@playwright/mcp                          # Official Playwright MCP
+@storybook/addon-mcp                     # Official Storybook MCP
+@storybook/addon-vitest                  # Storybook 9 test runner
+@applitools/eyes-storybook               # AI visual testing
+a11y-mcp-server                          # Accessibility MCP
+chrome-devtools-mcp                      # Chrome DevTools MCP
+@antiwork/shortest                       # NL E2E tests
+@browserbasehq/stagehand                 # Browser automation SDK
+```
+
+## Code References
+
+- Bowser user stories: `ai_review/user_stories/*.yaml` in [disler/bowser](https://github.com/disler/bowser)
+- Bowser QA agent: `.claude/agents/bowser-qa-agent.md` in disler/bowser
+- Bowser playwright skill: `.claude/skills/playwright-bowser/SKILL.md` in disler/bowser
+- Playwright Test Agents: [playwright.dev/docs/test-agents](https://playwright.dev/docs/test-agents)
+- Storybook addon-mcp: [github.com/storybookjs/addon-mcp](https://github.com/storybookjs/addon-mcp)
+- AWS agent-evaluation: [awslabs/agent-evaluation](https://github.com/awslabs/agent-evaluation)
+
+## Historical Context (from thoughts/)
+
+19 related documents found. Key prior work:
+- **GH-067**: Bowser/Justfile CLI patterns — established 4-layer architecture as reference
+- **GH-132**: Agent/Skill invocation patterns — analyzed Bowser's `allowed_tools` enforcement
+- **GH-602**: Integration testing plan — covers MCP unit tests + skill smoke tests (complementary to UI testing)
+- **2026-02-24 plan**: Referenced disler/IndyDevDan for observability hooks and builder/validator patterns
+
+No prior documents exist for UI testing (Playwright/Storybook), accessibility testing, design system testing, or user story generation.
+
+## Open Questions
+
+1. **Stochastic exploration scope**: Should random exploration focus on finding crashes (monkey testing) or on discovering untested user flows (coverage expansion)?
+2. **Figma integration priority**: Is Figma MCP → user stories a day-one requirement, or can we start with text-based story generation?
+3. **Component vs E2E priority**: Should Storybook testing (component-level) or Playwright E2E (page-level) come first?
+4. **CI/CD integration**: Should exploration run on every PR, on a schedule, or on-demand?
+5. **Target project**: Is this being built as a skill/plugin for ralph-hero, or as a standalone testing framework for a specific web application?
+
+## Sources
+
+- [github.com/disler/bowser](https://github.com/disler/bowser)
+- [playwright.dev/docs/test-agents](https://playwright.dev/docs/test-agents)
+- [github.com/microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)
+- [github.com/storybookjs/addon-mcp](https://github.com/storybookjs/addon-mcp)
+- [github.com/browser-use/browser-use](https://github.com/browser-use/browser-use)
+- [github.com/browserbase/stagehand](https://github.com/browserbase/stagehand)
+- [github.com/antiwork/shortest](https://github.com/antiwork/shortest)
+- [github.com/az9713/playwright-ui-testing](https://github.com/az9713/playwright-ui-testing)
+- [github.com/neonwatty/claude-qa-skills](https://github.com/neonwatty/claude-qa-skills)
+- [github.com/ronantakizawa/a11ymcp](https://github.com/ronantakizawa/a11ymcp)
+- [github.com/awslabs/agent-evaluation](https://github.com/awslabs/agent-evaluation)
+- [github.com/unclecode/crawl4ai](https://github.com/unclecode/crawl4ai)
+- [applitools.com/platform/autonomous](https://applitools.com/platform/autonomous/)
+- [momentic.ai](https://momentic.ai/)
+- [katalon.com](https://katalon.com/)
+- [qodo.ai](https://www.qodo.ai/)
+- [figflow.io](https://www.figflow.io/)
+- [figma.com/solutions/ai-test-generator](https://www.figma.com/solutions/ai-test-generator/)
+- [chromatic.com](https://www.chromatic.com/)
+- [percy.io](https://percy.io/)

--- a/thoughts/shared/research/2026-03-19-github-projects-v2-view-api-exhaustive.md
+++ b/thoughts/shared/research/2026-03-19-github-projects-v2-view-api-exhaustive.md
@@ -1,0 +1,153 @@
+---
+date: 2026-03-19
+topic: "GitHub Projects V2 API — Exhaustive View Management Research"
+tags: [research, github-api, projects-v2, views, graphql, rest-api]
+status: complete
+type: research
+git_commit: f03ace1844b662086d18d6fc45448b1cbdb64ade
+github_issue: 615
+github_url: https://github.com/cdubiel08/ralph-hero/issues/615
+---
+
+# Research: GitHub Projects V2 API — Exhaustive View Management
+
+## Prior Work
+
+- builds_on:: [[2026-02-18-GH-0066-github-projects-v2-docs-guidance]]
+- builds_on:: [[2026-02-18-GH-0064-github-projects-v2-api-automation]]
+- builds_on:: [[2026-02-20-GH-0161-golden-project-views-documentation]]
+- builds_on:: [[2026-02-20-GH-0162-copy-project-v2-setup-project]]
+- builds_on:: [[2026-02-20-GH-0101-copy-project-mcp-tool]]
+- builds_on:: [[view-recipes]]
+- builds_on:: [[golden-project-views]]
+
+## Research Question
+
+Can GitHub Projects V2 views be created or copied programmatically via any API (GraphQL or REST)? Was the prior "it's impossible" conclusion complete? Is there a REST POST endpoint for view creation?
+
+## Summary
+
+The GitHub Projects V2 API is **asymmetric for views**: reading is fully supported via GraphQL; creating is partially supported via REST (name + layout + filter, but no sort/group configuration); updating and deleting are entirely absent from both APIs. The only way to programmatically deploy a fully-configured view set is via the `copyProjectV2` GraphQL mutation, which copies an entire project (including all its views). This is the approach the ralph-hero codebase already implements via the `templateProjectNumber` parameter in `setup_project`.
+
+**The key gap for the current problem** (adding views to an existing project #7): `copyProjectV2` creates a NEW project — it cannot retroactively add views to an existing one. However, the REST POST endpoint can create views with name, layout, and filter string, which covers the most critical configuration for the 6 views from project #3.
+
+## Detailed Findings
+
+### GraphQL API — No View Mutations Exist
+
+The official [GraphQL mutations reference](https://docs.github.com/en/graphql/reference/mutations) lists all `ProjectV2`-prefixed mutations. **None relate to views.** The complete list:
+
+- `addProjectV2DraftIssue`, `addProjectV2ItemById`
+- `archiveProjectV2Item` / `unarchiveProjectV2Item`
+- `clearProjectV2ItemFieldValue`
+- `copyProjectV2` ← copies entire project including views
+- `createProjectV2` / `deleteProjectV2`
+- `createProjectV2Field` / `deleteProjectV2Field`
+- `createProjectV2IssueField`
+- `createProjectV2StatusUpdate` / `deleteProjectV2StatusUpdate`
+- `deleteProjectV2Item`, `deleteProjectV2Workflow`
+- `linkProjectV2ToRepository` / `unlinkProjectV2FromRepository`
+- `linkProjectV2ToTeam` / `unlinkProjectV2FromTeam`
+- `markProjectV2AsTemplate` / `unmarkProjectV2AsTemplate`
+- `updateProjectV2`, `updateProjectV2ItemFieldValue`, `updateProjectV2ItemPosition`
+
+`createProjectV2View`, `updateProjectV2View`, `deleteProjectV2View`, `copyProjectV2View` — **none of these exist**. The [input objects reference](https://docs.github.com/en/graphql/reference/input-objects) similarly has no view-related input types.
+
+A [Community Discussion #153532](https://github.com/orgs/community/discussions/153532) noted that GitHub Copilot autocompletes `createProjectV2View` — this is a hallucination based on the naming pattern from `createProjectV2Field`. The mutation does not execute.
+
+### REST API — Create-Only View Endpoints (Significant Finding)
+
+The [REST API reference for Project views](https://docs.github.com/en/enterprise-cloud@latest/rest/projects/views) (documented under Enterprise Cloud, likely available broadly) exposes **two POST endpoints**:
+
+| Method | Path |
+|--------|------|
+| `POST` | `/orgs/{org}/projectsV2/{project_number}/views` |
+| `POST` | `/users/{user_id}/projectsV2/{project_number}/views` |
+
+**Parameters:**
+- `name` (string, required)
+- `layout` (string, required): `table`, `board`, or `roadmap`
+- `filter` (string, optional): filter query string
+- `visible_fields` (array of integers, optional): field IDs to show (not valid for roadmap)
+
+**Returns**: HTTP 201 with view object including `id`, `name`, `layout`, `creator`, timestamps.
+
+**What is NOT available via this endpoint:**
+- `sortBy` configuration
+- `groupBy` configuration
+- `GET` (list views) or `GET` (single view)
+- `PATCH` (update view)
+- `DELETE` (delete view)
+
+This REST endpoint was announced in the [January 2026 Hierarchy View changelog](https://github.blog/changelog/2026-01-15-hierarchy-view-now-available-in-github-projects/).
+
+### `copyProjectV2` — The Whole-Project Copy Workaround
+
+The `copyProjectV2` GraphQL mutation (also available as `gh project copy` CLI) copies an entire project including:
+- ✅ All views (with their names, layouts, filter strings, sort/group configuration)
+- ✅ Custom fields
+- ✅ Draft issues and their field values
+- ✅ Workflows (except auto-add)
+- ✅ Insights
+
+Does NOT copy:
+- ❌ Actual issues/PRs (items)
+- ❌ Collaborators
+- ❌ Team links
+- ❌ Repository links (requires separate `linkProjectV2ToRepository`)
+
+**Limitation**: Creates a NEW project. Cannot add views to an existing project.
+
+### How Ralph-Hero Already Implements This
+
+The `setup_project` tool in `plugin/ralph-hero/mcp-server/src/tools/project-tools.ts:182` has a `templateProjectNumber` parameter that triggers `copyProjectV2` instead of creating a blank project. This is the pattern: maintain a "golden project" with all views pre-configured, then copy it for new projects.
+
+The golden project workflow is documented in:
+- `thoughts/shared/research/golden-project-views.md` — step-by-step manual view setup instructions
+- `thoughts/shared/research/view-recipes.md` — comprehensive view recipe library
+
+### Codebase State — Views Are Read-Only
+
+In `plugin/ralph-hero/mcp-server/src/types.ts:170-196`:
+- `ProjectV2ViewLayout` type is defined (`BOARD_LAYOUT`, `TABLE_LAYOUT`, `ROADMAP_LAYOUT`)
+- `ProjectV2View` interface is defined (`id`, `name`, `number`, `layout`, `filter`)
+- `views: Connection<ProjectV2View>` exists in the `ProjectV2` interface
+
+However, **no GraphQL queries currently fetch the `views` field** — the type exists in the schema but is not queried by any tool today.
+
+### Feature Requests — Unanswered
+
+[Community Discussion #150130](https://github.com/orgs/community/discussions/150130) — "ProjectsV2: Manage Project Views via GraphQL" — explicitly requests `create|update|delete ProjectV2View` mutations. **Closed as inactive with no official GitHub response.**
+
+## Direct Answers
+
+| Question | Answer |
+|----------|--------|
+| `createProjectV2View` GraphQL mutation exists? | **No** — not in schema. Copilot hallucination only. |
+| `copyProjectV2View` GraphQL mutation exists? | **No** — does not exist. |
+| REST API for creating views? | **Yes** — POST `/orgs/{org}/projectsV2/{N}/views` and `/users/{user_id}/projectsV2/{N}/views` |
+| REST supports filter strings? | **Yes** — `filter` parameter accepted on POST |
+| REST supports sort/group config? | **No** — only name, layout, filter, visible_fields |
+| Can read existing views via GraphQL? | **Yes** — `project.views { nodes { id name layout filter } }` is fully queryable |
+| `copyProjectV2` copies views? | **Yes** — but creates a whole new project |
+| Can add views to existing project programmatically? | **Partially** — REST POST creates views with name/layout/filter, not full config |
+
+## Practical Implication for Project #7
+
+Since project #7 already exists with correct fields, `copyProjectV2` is not applicable. The REST POST endpoint can be used to recreate the 6 views from project #3 with their names, layouts, and filter strings. Sort/group configuration would need manual UI adjustment after API creation, but the filter strings (most critical for routing issues to correct views) are fully automatable.
+
+## Code References
+
+- `plugin/ralph-hero/mcp-server/src/types.ts:170-196` — `ProjectV2View` type definitions
+- `plugin/ralph-hero/mcp-server/src/tools/project-tools.ts:182` — `templateProjectNumber` in `setup_project`
+
+## External Links
+
+- [Mutations — GitHub Docs](https://docs.github.com/en/graphql/reference/mutations)
+- [REST API endpoints for Project views](https://docs.github.com/en/enterprise-cloud@latest/rest/projects/views)
+- [Copying an existing project — GitHub Docs](https://docs.github.com/en/issues/planning-and-tracking-with-projects/creating-projects/copying-an-existing-project)
+- [gh project copy — CLI Manual](https://cli.github.com/manual/gh_project_copy)
+- [Community Discussion #153532 — "Does GitHub's Projects V2 API have any ProjectV2View-related mutations?"](https://github.com/orgs/community/discussions/153532)
+- [Community Discussion #150130 — "ProjectsV2: Manage Project Views via GraphQL"](https://github.com/orgs/community/discussions/150130)
+- [January 2026 Hierarchy View Changelog](https://github.blog/changelog/2026-01-15-hierarchy-view-now-available-in-github-projects/)
+- [September 2025 REST API for GitHub Projects Changelog](https://github.blog/changelog/2025-09-11-a-rest-api-for-github-projects-sub-issues-improvements-and-more/)

--- a/thoughts/shared/research/2026-03-19-plan-of-plans-model-switching.md
+++ b/thoughts/shared/research/2026-03-19-plan-of-plans-model-switching.md
@@ -1,0 +1,120 @@
+---
+date: 2026-03-19
+topic: "Model switching in the plan-of-plans (ralph-plan-epic) workflow"
+tags: [research, skills, model-routing, plan-of-plans, opus, sonnet]
+status: complete
+type: research
+---
+
+# Research: Model Switching in the Plan-of-Plans Workflow
+
+## Prior Work
+
+None identified.
+
+## Research Question
+
+When working through the plan-of-plans workflow (`ralph-plan-epic`), there are situations where the model switches from opus to sonnet but doesn't switch back to opus for writing plans. The user wants the entire plan-of-plans workflow to always stay on opus.
+
+## Summary
+
+The plan-of-plans workflow involves a chain of skill invocations with mixed model assignments. Two specific switch points drop from opus to sonnet mid-workflow: `ralph-split` (called in Step 6) and the codebase research subagents. Additionally, when the workflow is invoked from `hero` or `team` orchestrators (both sonnet), there's ambiguity about whether the `context: fork` + `model: opus` frontmatter on called skills actually results in a model switch.
+
+## Detailed Findings
+
+### Complete Model Assignment Map
+
+#### Skills
+
+| Skill | Model | Context | Role in plan-of-plans |
+|-------|-------|---------|----------------------|
+| `hero` | **sonnet** | _(none)_ | Orchestrator entry point |
+| `team` | **sonnet** | _(none)_ | Orchestrator entry point |
+| `ralph-plan-epic` | **opus** | fork | Core — writes plan-of-plans |
+| `ralph-split` | **sonnet** | fork | Step 6 — creates feature children |
+| `ralph-plan` | **opus** | fork | Step 7 — plans each feature |
+| `ralph-research` | **sonnet** | fork | Pre-requisite — not called by epic planner directly |
+| `ralph-review` | **opus** | fork | Post-plan review |
+| `ralph-impl` | **opus** | fork | Implementation (post-planning) |
+| `ralph-triage` | **sonnet** | fork | Not part of plan-of-plans |
+
+#### Agents (spawned by ralph-plan-epic Steps 2-3)
+
+| Agent | Model | Role |
+|-------|-------|------|
+| `codebase-pattern-finder` | **haiku** | Context gathering |
+| `codebase-analyzer` | **sonnet** | Context gathering |
+
+### Plan-of-Plans Call Chain
+
+```
+hero (sonnet, no fork)
+  └─ Skill("ralph-plan-epic")      → opus (context: fork)       [SKILL.md:7-8]
+       ├─ Agent(codebase-pattern-finder)  → haiku                [agents/codebase-pattern-finder.md:5]
+       ├─ Agent(codebase-analyzer)        → sonnet               [agents/codebase-analyzer.md:5]
+       ├─ Steps 1-5: plan-of-plans doc    → opus (same context)
+       ├─ Step 6: Skill("ralph-split")    → sonnet (context: fork) [skills/ralph-split/SKILL.md:6]
+       │   └─ Returns to epic planner context (opus?)
+       └─ Step 7: For each wave:
+           └─ Skill("ralph-plan")         → opus (context: fork)  [skills/ralph-plan/SKILL.md:6]
+               ├─ Agent(codebase-pattern-finder) → haiku
+               ├─ Agent(codebase-analyzer)       → sonnet
+               └─ Writes feature plan             → opus
+```
+
+### Sonnet Switch Points Within the Workflow
+
+1. **`ralph-split`** — `plugin/ralph-hero/skills/ralph-split/SKILL.md:6` — `model: sonnet`
+   - Called at Step 6 of `ralph-plan-epic` to create M-sized feature children
+   - This is the primary unexpected model downgrade in the planning workflow
+
+2. **`codebase-analyzer` agent** — `plugin/ralph-hero/agents/codebase-analyzer.md:5` — `model: sonnet`
+   - Called during context gathering (Step 2) by both `ralph-plan-epic` and `ralph-plan`
+   - Runs as a subagent, so model is set by the agent definition, not the calling skill
+
+3. **`codebase-pattern-finder` agent** — `plugin/ralph-hero/agents/codebase-pattern-finder.md:5` — `model: haiku`
+   - Also called during context gathering
+   - Even lower than sonnet
+
+### Ambiguity: Does `context: fork` Actually Switch Models?
+
+The `hero` skill SKILL.md (line 359) states:
+
+> Skills invoked via `Skill()` run **inline in hero's context**, not as separate agents
+
+This raises the question: when hero (sonnet) calls `Skill("ralph-plan-epic")`, does the `context: fork` + `model: opus` on `ralph-plan-epic` actually create a new context with opus, or does it run inline on sonnet?
+
+Two interpretations:
+- **`context: fork` overrides inline behavior**: The skill forks into its own context with its own model. The hero note only applies to skills without `context: fork`.
+- **Inline always wins**: Skills always run inline regardless of `context: fork`, and the model stays as the caller's model (sonnet).
+
+If the second interpretation is correct, then `ralph-plan-epic`, `ralph-plan`, and all other skills with `model: opus` would actually run on sonnet when called from hero/team, making the `model:` frontmatter effectively decorative for orchestrator-invoked skills.
+
+### Task Complexity → Model Routing (Implementation Phase)
+
+Separately from skill-level model assignments, `ralph-plan` SKILL.md (lines 349-351) defines a complexity-to-model mapping for individual implementation tasks:
+
+```
+- low: → haiku model
+- medium: → sonnet model
+- high: → opus model
+```
+
+This affects the implementation phase (`ralph-impl` dispatching subagents per task), not the planning phase itself.
+
+## Code References
+
+- `plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md:7-8` — `model: opus`, `context: fork`
+- `plugin/ralph-hero/skills/ralph-split/SKILL.md:6` — `model: sonnet` (the switch point)
+- `plugin/ralph-hero/skills/ralph-plan/SKILL.md:6` — `model: opus`
+- `plugin/ralph-hero/skills/hero/SKILL.md:4` — `model: sonnet` (orchestrator)
+- `plugin/ralph-hero/skills/hero/SKILL.md:359` — "Skills invoked via Skill() run inline in hero's context"
+- `plugin/ralph-hero/skills/ralph-plan/SKILL.md:349-351` — Complexity Decision Guide (task-level model routing)
+- `plugin/ralph-hero/agents/codebase-analyzer.md:5` — `model: sonnet`
+- `plugin/ralph-hero/agents/codebase-pattern-finder.md:5` — `model: haiku`
+
+## Open Questions
+
+1. Does `context: fork` on a skill actually create a forked context with its own model when invoked via `Skill()` from another skill? Or does the model stay as the caller's?
+2. Should `ralph-split` be promoted to `model: opus` only when called from within the plan-of-plans workflow, or globally?
+3. Should the codebase research agents (`codebase-analyzer`, `codebase-pattern-finder`) also be promoted to opus for the planning workflow, or is sonnet/haiku acceptable for read-only research?

--- a/thoughts/shared/research/2026-03-21-secret-protection-gitignore-enforcement.md
+++ b/thoughts/shared/research/2026-03-21-secret-protection-gitignore-enforcement.md
@@ -1,0 +1,178 @@
+---
+date: 2026-03-21
+github_issue: 649
+github_url: https://github.com/cdubiel08/ralph-hero/issues/649
+topic: "Secret Protection & Gitignore Enforcement for GitHub PATs"
+tags: [research, security, gitignore, secrets, tokens, hooks]
+status: complete
+type: research
+git_commit: 74feb9c
+---
+
+# Research: Secret Protection & Gitignore Enforcement for GitHub PATs
+
+## Research Question
+
+The user has encountered GitHub PATs being committed to repos/git history twice. What protections currently exist in the ralph-hero codebase to prevent this? Specifically: is there automation or determinism to ensure `.gitignore` entries exist before sensitive local files (like `ralph-hero.local.md`) are created?
+
+## Summary
+
+The codebase relies on **three independent gitignore layers** for secret protection, but has **no automated enforcement, pre-commit scanning, or deterministic gitignore verification**. There are no pre-commit hooks, no secret scanning tools, and no hooks that inspect staged files for credentials. The protection model is entirely passive (gitignore patterns) with documentation-as-guidance.
+
+### Protection Layers That Exist
+
+| Layer | Mechanism | What It Protects | Scope |
+|-------|-----------|-----------------|-------|
+| Claude Code global gitignore | `~/.config/git/ignore` → `**/.claude/settings.local.json` | The actual token file | All repos using Claude Code |
+| Plugin `.gitignore` | `plugin/ralph-hero/.gitignore` → `*.local.md` | `ralph-hero.local.md` config template | Files under `plugin/ralph-hero/` |
+| Debug logger sanitization | `debug-logger.ts:55-68` → regex `/token\|auth\|secret\|key\|password\|credential/i` | Token values in JSONL logs | `~/.ralph-hero/logs/` |
+
+### Protection Layers That Do NOT Exist
+
+| Gap | Description |
+|-----|-------------|
+| Pre-commit secret scanning | No `.gitleaks.toml`, `.pre-commit-config.yaml`, `detect-secrets`, `trufflehog`, or `git-secrets` |
+| Pre-commit hooks | `.git/hooks/` contains only `.sample` files — no active hooks |
+| Staged-file inspection hooks | No ralph-hero hook reads `git diff --cached` or inspects staged content |
+| Gitignore enforcement hooks | No hook verifies `.gitignore` entries before creating sensitive files |
+| Root `.gitignore` coverage for `.claude/` | Root `.gitignore` has no `*.local.md`, `*.local.json`, or `.claude/` entries |
+| `.env` file protection | No `.env` or `.env.*` patterns in any `.gitignore` |
+
+## Detailed Findings
+
+### 1. Token Storage: `settings.local.json`
+
+Tokens live in `.claude/settings.local.json` under the `"env"` key. This file is gitignored by Claude Code's **global** gitignore at `~/.config/git/ignore`:
+
+```
+**/.claude/settings.local.json
+```
+
+This is a Claude Code platform convention — not a project-level protection. If a user doesn't have Claude Code's global gitignore (fresh install, different machine, non-Claude-Code contributor), the file would not be ignored.
+
+The root `.gitignore` (`/.gitignore`) contains **no entries** for `.claude/`, `settings.local.json`, `*.local.json`, or `*.local.md`.
+
+### 2. `ralph-hero.local.md` Creation Flow
+
+The setup skill (`plugin/ralph-hero/skills/setup/SKILL.md:229`) directs Claude to create `.claude/ralph-hero.local.md` via the Write tool. The file itself contains **no tokens** — only placeholder text `ghp_your_token_here` and references to where the real token is stored (`settings.local.json`).
+
+Protection comes from `plugin/ralph-hero/.gitignore:2`:
+```
+*.local.md
+```
+
+This glob is **relative to `plugin/ralph-hero/`** — it only covers files in or under that directory. The actual `ralph-hero.local.md` lives at `.claude/ralph-hero.local.md` (project root), which is **outside** the plugin `.gitignore`'s scope.
+
+The file also includes a human-readable advisory in its YAML frontmatter: `# Do not commit this file (add to .gitignore)` — but this is documentation, not enforcement.
+
+**No hook or script verifies that `.gitignore` entries exist before creating the file.**
+
+### 3. Hook System: No Secret Protection
+
+The ralph-hero hook system (50+ hooks) focuses on **workflow correctness**, not credential safety:
+
+| Hook | What It Does | Secret Protection? |
+|------|-------------|-------------------|
+| `impl-staging-gate.sh` | Blocks `git add -A`/`.`/`--all` during impl | Prevents blanket staging but doesn't inspect content |
+| `impl-branch-gate.sh` | Blocks commit/push on `main` during impl | Branch policy, not content policy |
+| `branch-gate.sh` | Enforces required branch for research/plan skills | Branch policy, not content policy |
+| `post-git-validator.sh` | Reports push/commit outcomes | Post-hoc feedback, no prevention |
+| `pre-artifact-validator.sh` | Prevents duplicate research/plan docs | Path dedup only, no content inspection |
+
+**Zero hooks** scan for tokens, check staged file paths against sensitive patterns, or validate `.gitignore` coverage.
+
+### 4. Token Flow Through the MCP Server
+
+```
+settings.local.json (on disk, gitignored)
+  → Claude Code injects env vars at MCP server spawn
+    → process.env (in-memory only)
+      → resolveEnv() filters unexpanded ${VAR} literals
+        → createGitHubClient({ token, projectToken })
+          → @octokit/graphql closures (in-memory only)
+            → HTTP Authorization header to api.github.com
+```
+
+Tokens are **never written to any output file**. The debug logger (`debug-logger.ts`) applies `sanitize()` to all logged variables, redacting any key matching `/token|auth|secret|key|password|credential/i` with `[REDACTED]`. The `health_check` tool computes `tokenMode: "dual-token" | "single-token"` without emitting values. Error messages use placeholder strings, not actual tokens.
+
+### 5. GitHub Actions Secrets
+
+Workflows use GitHub Actions repository secrets (`ROUTING_PAT`, `NPM_TOKEN`, `GITHUB_TOKEN`) — these are injected by the Actions runner and never stored in repository files.
+
+### 6. Documentation Guidance
+
+CLAUDE.md (line 153):
+> "Do NOT put tokens in `.mcp.json` — all env vars should be set in `.claude/settings.local.json` (gitignored)."
+
+The `doctor` recipe in the justfile explicitly prints `"OK: $var (set, redacted)"` instead of token values.
+
+## Code References
+
+- `~/.config/git/ignore` — Claude Code's global gitignore with `**/.claude/settings.local.json`
+- `plugin/ralph-hero/.gitignore:2` — `*.local.md` pattern
+- `plugin/ralph-hero/skills/setup/SKILL.md:229` — File creation instruction (no gitignore check)
+- `plugin/ralph-hero/mcp-server/src/index.ts:32-37` — `resolveEnv()` with `${VAR}` filter
+- `plugin/ralph-hero/mcp-server/src/github-client.ts:88-103` — Token baked into graphql closures
+- `plugin/ralph-hero/mcp-server/src/lib/debug-logger.ts:55-68` — `sanitize()` redaction
+- `plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh` — Blocks `git add -A` but no content scanning
+- `.gitignore` (root) — No `.claude/`, `*.local.md`, or `*.local.json` entries
+
+## Architecture Documentation
+
+### Current Protection Model
+
+```
+┌─────────────────────────────────────────────────────┐
+│                 PASSIVE PROTECTIONS                  │
+├─────────────────────────────────────────────────────┤
+│  Layer 1: Claude Code global gitignore              │
+│    ~/.config/git/ignore                             │
+│    **/.claude/settings.local.json                   │
+│    ⚠ Only present on machines with Claude Code      │
+│                                                     │
+│  Layer 2: Plugin-scoped gitignore                   │
+│    plugin/ralph-hero/.gitignore                     │
+│    *.local.md                                       │
+│    ⚠ Scoped to plugin/ralph-hero/ subtree only     │
+│                                                     │
+│  Layer 3: Documentation advisories                  │
+│    CLAUDE.md, setup skill prose, file comments      │
+│    ⚠ Human-readable guidance, not enforced          │
+├─────────────────────────────────────────────────────┤
+│              ACTIVE PROTECTIONS                      │
+├─────────────────────────────────────────────────────┤
+│  impl-staging-gate.sh: blocks git add -A/./--all   │
+│    ⚠ Only active during RALPH_COMMAND=impl          │
+│    ⚠ Does not inspect file content or paths         │
+│                                                     │
+│  debug-logger sanitize(): redacts token-like keys   │
+│    ✓ Active whenever RALPH_DEBUG=true               │
+│                                                     │
+│  resolveEnv(): filters unexpanded ${VAR} literals   │
+│    ✓ Active at every MCP server startup             │
+├─────────────────────────────────────────────────────┤
+│              NOT PRESENT                             │
+├─────────────────────────────────────────────────────┤
+│  ✗ Pre-commit hooks (git hooks)                     │
+│  ✗ Secret scanning tools (gitleaks, etc.)           │
+│  ✗ Staged-file content inspection                   │
+│  ✗ Gitignore-before-write verification              │
+│  ✗ Root .gitignore coverage for .claude/ dir        │
+│  ✗ .env file pattern exclusions                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### Risk Scenarios
+
+1. **Fresh clone without Claude Code** — `~/.config/git/ignore` may not exist → `settings.local.json` unprotected
+2. **`ralph-hero.local.md` in consumer repos** — when the setup skill creates `.claude/ralph-hero.local.md` in a repo that isn't ralph-hero itself, the `plugin/ralph-hero/.gitignore` is irrelevant → file not gitignored unless the consumer's own `.gitignore` covers it
+3. **`git add .` outside impl context** — `impl-staging-gate.sh` only fires when `RALPH_COMMAND=impl` → manual `git add .` in other contexts is unguarded
+4. **`.env` files** — no `.gitignore` pattern covers `.env` in any location
+
+## Open Questions
+
+1. Should the root `.gitignore` include `*.local.md` and/or `.claude/settings.local.json` as defense-in-depth?
+2. Should the setup skill verify/add gitignore entries before creating `.claude/ralph-hero.local.md`?
+3. Would a PreToolUse hook on `Bash` (matching `git add`/`git commit`) that checks `git diff --cached` for token patterns be worth adding?
+4. Should a `.pre-commit-config.yaml` with `detect-secrets` or `gitleaks` be added to the repo?
+5. For consumer repos using ralph-hero: should the setup skill append `*.local.md` and `.claude/settings.local.json` to the consumer's `.gitignore`?

--- a/thoughts/shared/research/2026-03-24-agent-env-propagation-token-scope.md
+++ b/thoughts/shared/research/2026-03-24-agent-env-propagation-token-scope.md
@@ -1,0 +1,331 @@
+---
+date: 2026-03-24
+last_updated: 2026-03-24
+last_updated_note: "Completed full architecture investigation — proposed agent-per-phase design with plugin-level hooks"
+topic: "How do environment variables and MCP tokens propagate from parent Claude agent to spawned sub-agents and skills?"
+tags: [research, codebase, env-vars, mcp, sub-agents, token-scope, plugin-system, multi-repo, architecture]
+status: complete
+type: research
+git_commit: 50d5a95
+github_issue: 674
+github_url: https://github.com/cdubiel08/ralph-hero/issues/674
+---
+
+# Research: Agent Environment Variable Propagation & Token Scope
+
+## Prior Work
+
+- builds_on:: [[2026-03-17-GH-0588-remove-mcp-env-block]]
+- builds_on:: [[2026-02-20-GH-0231-skill-subagent-team-context-pollution]]
+- builds_on:: [[2026-03-19-GH-0637-hero-dispatch-model]]
+- builds_on:: [[2026-03-19-GH-0634-doctor-settings-local-json-fallback]]
+
+## Research Question
+
+When using ralph-hero in the ralph-engine repo, sub-agents encounter token scope issues that don't happen at the parent-level Claude agent. Investigate how env vars propagate from parent → agent → skill, and identify where the chain breaks.
+
+## Summary
+
+The current wrapper-agent architecture (ralph-analyst → Skill("ralph-research")) is fundamentally broken due to Claude Code platform constraints. Three root causes compound:
+
+1. **Sub-agents cannot spawn sub-agents** — skills with `context: fork` silently run inline, losing their `model:` override
+2. **Skill prompts use unexpandable `$VAR` references** — LLMs hallucinate wrong repo values, causing "token scope" errors
+3. **Plugin sub-agent hooks are silently ignored** — `RALPH_COMMAND` is never set, causing `skill-precondition.sh` to block MCP calls
+
+The fix is a new **agent-per-phase** architecture where:
+- **Agents** provide the container (tools, model) and live in the plugin
+- **Skills** provide the instructions via the agent `skills:` preload field
+- **Backtick preprocessing** (`` !`echo $RALPH_GH_OWNER` ``) resolves env vars before the LLM sees them
+- **Plugin-level hooks** (`hooks.json`) fire for all contexts with `agent_type` discrimination
+
+## Root Cause Analysis
+
+### Cause 1: Nested Sub-Agent Prohibition
+
+> "Subagents cannot spawn other subagents." — [Claude Code Docs](https://code.claude.com/docs/en/sub-agents)
+
+The current architecture:
+```
+hero (inline) → Agent("ralph-analyst") → Skill("ralph-research")
+                                              └── context: fork → CAN'T FORK
+                                              └── model: opus → IGNORED (agent is sonnet)
+```
+
+When `context: fork` fails silently inside a sub-agent, the skill runs inline with the agent's model (sonnet), not the skill's declared model (opus). Implementation, planning, review, and splitting all lose their intended opus-level reasoning.
+
+#### Contradiction Matrix: ralph-builder (most impactful)
+
+| Parameter | ralph-builder | ralph-impl | ralph-review |
+|-----------|:---:|:---:|:---:|
+| **model** | sonnet | **opus** | **opus** |
+| **context** | (agent) | fork → **inline** | fork → **inline** |
+
+#### Contradiction Matrix: ralph-analyst
+
+| Parameter | ralph-analyst | ralph-research | ralph-plan | ralph-triage | ralph-split |
+|-----------|:---:|:---:|:---:|:---:|:---:|
+| **model** | sonnet | sonnet | **opus** | sonnet | **opus** |
+| **context** | (agent) | fork → **inline** | fork → **inline** | fork → **inline** | fork → **inline** |
+
+### Cause 2: Unexpandable Env Var References in Skill Prompts
+
+Skill prompts instruct the LLM to pass `$RALPH_GH_OWNER` and `$RALPH_GH_REPO` as MCP tool params:
+
+```markdown
+ralph_hero__get_issue(owner, repo, number)
+   - owner: $RALPH_GH_OWNER
+   - repo: $RALPH_GH_REPO
+```
+
+The LLM sees `$RALPH_GH_OWNER` as **literal text** — it cannot expand env vars. Sub-agents with narrower context windows are especially prone to guessing wrong (e.g., `repo: "ralph-hero"` because the plugin is named "ralph-hero").
+
+The MCP server's `resolveConfig()` correctly defaults to the right repo when `owner`/`repo` params are omitted. The skill prompts' insistence on passing these params explicitly creates the failure mode.
+
+### Cause 3: Plugin Sub-Agent Hooks Are Silently Ignored
+
+> "For security reasons, plugin subagents do not support the `hooks`, `mcpServers`, or `permissionMode` frontmatter fields. These fields are ignored when loading agents from a plugin." — [Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
+
+The current agents (ralph-analyst, ralph-builder, ralph-integrator) are plugin sub-agents with `hooks: Stop:` in their frontmatter. These hooks never fire. When the agent calls `Skill("ralph-impl")`, the skill's SessionStart hook calls `set-skill-env.sh` to set `RALPH_COMMAND`. But `CLAUDE_ENV_FILE` is only available in SessionStart hooks, and it's undocumented whether it exists in sub-agent contexts. If it doesn't, `set-skill-env.sh` silently no-ops and `RALPH_COMMAND` is never set.
+
+The plugin-level `skill-precondition.sh` (in `hooks.json`) blocks all `ralph_hero__get_issue`/`ralph_hero__list_issues` calls when `RALPH_COMMAND` is empty. The sub-agent LLM sees this block and may report it as a "token scope" error.
+
+## Proposed Architecture: Agent-Per-Phase with Skill Preloading
+
+### Design Principles
+
+| Concern | Owned by | Mechanism |
+|---------|----------|-----------|
+| What tools are available | Agent `tools:` | Hard allowlist (sub-agent `tools` field) |
+| What model to use | Agent `model:` | Set on agent frontmatter |
+| What to do | Skill content via agent `skills:` | Full content injected at startup |
+| Env var resolution | Skill backtick preprocessing | `` !`echo $RALPH_GH_OWNER` `` resolved before LLM sees it |
+| Safety gates | Plugin-level `hooks.json` | Fire for all contexts; discriminate via `agent_type` |
+
+### How `skills:` Preloading Works
+
+From the [Claude Code docs](https://code.claude.com/docs/en/sub-agents#preload-skills-into-subagents):
+
+| Approach | System prompt | Task | Also loads |
+|----------|---------------|------|------------|
+| Skill with `context: fork` | From agent type | SKILL.md content | CLAUDE.md |
+| **Subagent with `skills` field** | **Subagent's markdown body** | **Claude's delegation message** | **Preloaded skills + CLAUDE.md** |
+
+> "The full content of each skill is injected into the subagent's context, not just made available for invocation. Subagents don't inherit skills from the parent conversation; you must list them explicitly."
+
+The skill content is reference material injected alongside the agent's system prompt. This is NOT the same as calling `Skill()` — no fork, no nested sub-agent, no separate context. The skill content is just text in the agent's context window.
+
+### Backtick Preprocessing — Tested and Confirmed
+
+Skills support `` !`<command>` `` preprocessing that runs shell commands before content reaches the LLM. We tested this on 2026-03-24:
+
+| Test | Method | Result |
+|------|--------|--------|
+| Direct skill invocation (`/test-env-inject`) | Skill with `` !`echo $RALPH_GH_OWNER` `` | **Resolved** → `cdubiel08` |
+| Preloaded via agent `skills:` field | Agent with `skills: [test-env-inject]` | **Resolved** → `cdubiel08` |
+
+Backtick preprocessing works in both contexts. This is the solution for injecting resolved env var values into skill content that LLMs can read.
+
+**Skill changes needed:**
+1. Remove explicit `owner`/`repo` params from MCP tool call instructions — let server defaults handle it
+2. Replace `$RALPH_GH_OWNER`/`$RALPH_GH_REPO` in URL templates with `` !`echo $RALPH_GH_OWNER` ``
+
+### Plugin-Level Hooks with `agent_type` Discrimination
+
+Plugin-level hooks in `hooks/hooks.json` fire for all sessions — including sub-agent contexts. When hooks fire inside a sub-agent, the hook input JSON includes `agent_type`:
+
+> "When hooks fire inside a sub-agent, the hook input JSON includes two extra fields: `agent_id` (unique ID for the sub-agent instance) and `agent_type` (the agent type name, e.g., 'Explore')."
+
+Phase-specific hooks currently in skill frontmatter (branch-gate, impl-plan-required, etc.) can be migrated to `hooks.json` with scripts that check `agent_type` to determine which gates to apply:
+
+```bash
+# Example: hooks.json PreToolUse hook that discriminates by agent_type
+agent_type=$(echo "$RALPH_HOOK_INPUT" | jq -r '.agent_type // empty')
+
+case "$agent_type" in
+  research-agent) # apply research-specific gates ;;
+  impl-agent)     # apply impl-specific gates ;;
+  plan-agent)     # apply plan-specific gates ;;
+  *)              # fall back to RALPH_COMMAND check ;;
+esac
+```
+
+This approach:
+- Keeps agents in the plugin (portable across repos)
+- Doesn't require hooks on agent frontmatter (which plugin agents can't have)
+- Maintains backward compatibility (skills invoked directly still use RALPH_COMMAND)
+- Uses `agent_type` as the discriminator for phase-specific behavior
+
+### The Complete Agent Matrix
+
+| Agent | Model | Key Tools | Preloaded Skill | Replaces |
+|-------|-------|-----------|-----------------|----------|
+| research-agent | sonnet | Read,Write,Glob,Grep,Bash,Agent,WebSearch,WebFetch + MCP | ralph-hero:ralph-research | analyst + ralph-research |
+| plan-agent | opus | Read,Write,Glob,Grep,Bash,Agent + MCP | ralph-hero:ralph-plan | analyst + ralph-plan |
+| split-agent | opus | Read,Glob,Grep,Bash,Agent + MCP + create_issue | ralph-hero:ralph-split | analyst + ralph-split |
+| triage-agent | sonnet | Read,Glob,Grep,Bash + MCP | ralph-hero:ralph-triage | analyst + ralph-triage |
+| review-agent | opus | Read,Write,Glob,Grep,Bash,Agent + MCP | ralph-hero:ralph-review | builder + ralph-review |
+| impl-agent | opus | Read,Write,Edit,Glob,Grep,Bash,Agent + MCP | ralph-hero:ralph-impl | builder + ralph-impl |
+| pr-agent | haiku | Read,Glob,Grep,Bash + MCP | ralph-hero:ralph-pr | integrator + ralph-pr |
+| merge-agent | haiku | Read,Glob,Grep,Bash + MCP | ralph-hero:ralph-merge | integrator + ralph-merge |
+| val-agent | haiku | Read,Glob,Grep,Bash + MCP | ralph-hero:ralph-val | integrator + ralph-val |
+
+### Example Agent Definition
+
+```yaml
+# plugin/ralph-hero/agents/research-agent.md
+---
+name: research-agent
+description: Research issues — investigates codebase, creates findings doc, updates workflow state
+tools: Read, Write, Glob, Grep, Bash, Agent, WebSearch, WebFetch,
+       ralph_hero__get_issue, ralph_hero__list_issues, ralph_hero__save_issue,
+       ralph_hero__create_comment, ralph_hero__add_dependency, ralph_hero__remove_dependency
+model: sonnet
+skills:
+  - ralph-hero:ralph-research
+---
+
+You are a research agent. Follow the preloaded ralph-research instructions.
+Execute the task described in your prompt.
+```
+
+Plugin agents support `name`, `description`, `model`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, `isolation`, `effort`, and `maxTurns`. Only `hooks`, `mcpServers`, and `permissionMode` are excluded.
+
+### Hero Dispatch Changes
+
+Current:
+```
+Agent(subagent_type="ralph-hero:ralph-analyst", prompt="Run /ralph-hero:ralph-research NNN")
+```
+
+Proposed:
+```
+Agent(subagent_type="ralph-hero:research-agent", prompt="Research issue #42")
+```
+
+### Runtime Flow
+
+```
+1. User: /ralph-hero:hero 42
+
+2. Hero (inline, main context) dispatches:
+   Agent("ralph-hero:research-agent", prompt="Research issue #42")
+
+3. Claude Code creates sub-agent:
+   ├── System prompt: "You are a research agent. Follow the preloaded..."
+   ├── Preloaded skill: ralph-research SKILL.md body (preprocessed)
+   │     └── !`echo $RALPH_GH_OWNER` → "cdubiel08" (resolved)
+   │     └── !`echo $RALPH_GH_REPO`  → "ralph-engine" (resolved)
+   ├── Tools: hard allowlist from agent frontmatter
+   ├── Model: sonnet (from agent frontmatter, honored)
+   └── CLAUDE.md: loaded from project
+
+4. Sub-agent calls: ralph_hero__get_issue(number=42)
+   └── No owner/repo → MCP server uses settings.local.json defaults ✓
+   └── Plugin hooks.json fires → skill-precondition.sh
+         └── Checks agent_type="research-agent" → allows ✓
+
+5. Sub-agent completes research, returns results to hero
+```
+
+### What Gets Removed
+
+- `agents/ralph-analyst.md` — replaced by research/plan/split/triage agents
+- `agents/ralph-builder.md` — replaced by review/impl agents
+- `agents/ralph-integrator.md` — replaced by pr/merge/val agents
+- `skills/team/SKILL.md` — deprecated (unused)
+
+### What Gets Modified
+
+- **Skills**: Replace `$RALPH_GH_OWNER`/`$RALPH_GH_REPO` with backtick preprocessing; remove explicit `owner`/`repo` from MCP tool call instructions
+- **`hooks.json`**: Add `agent_type`-aware discrimination to phase-specific hooks; modify `skill-precondition.sh` to allow agent-type-based invocations
+- **`hero/SKILL.md`**: Update dispatch to use new per-phase agents
+
+### What Stays Unchanged
+
+- **MCP server**: No changes needed — `resolveConfig()` defaults already work correctly
+- **Skill content** (markdown body): Preserved as-is (just env var reference format changes)
+- **Skill frontmatter**: Kept for direct interactive invocation (ignored when preloaded)
+- **Plugin-level hooks** in `hooks.json`: Continue to fire for all contexts
+
+## Claude Code Platform Constraints (Documented)
+
+### Skill Frontmatter
+
+| Field | Type | Behavior |
+|-------|------|----------|
+| `allowed-tools` | list | **Permission grant** — auto-approves tools without prompting. NOT a hard restriction. |
+| `model` | string | Model when skill is active (works for direct invocation, ignored when preloaded) |
+| `context` | `fork` | Spawns a sub-agent. Cannot work inside a sub-agent (no nesting). |
+| `agent` | string | Which sub-agent type for `context: fork`. Built-in or custom from `.claude/agents/`. |
+| `hooks` | object | Hooks scoped to skill lifecycle. |
+
+### Sub-Agent Frontmatter
+
+| Field | Type | Behavior |
+|-------|------|----------|
+| `tools` | list | **Hard allowlist** — sub-agent can ONLY use these tools |
+| `model` | string | `sonnet`, `opus`, `haiku`, full model ID, or `inherit` (default) |
+| `skills` | list | Preload full skill content into context at startup |
+| `hooks` | object | Lifecycle hooks — **ignored for plugin sub-agents** |
+| `mcpServers` | list | Scoped MCP servers — **ignored for plugin sub-agents** |
+| `permissionMode` | string | Permission mode — **ignored for plugin sub-agents** |
+
+### Plugin Agent Supported Fields
+
+From [plugins-reference](https://code.claude.com/docs/en/plugins-reference):
+
+> Plugin agents support `name`, `description`, `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, and `isolation` frontmatter fields. For security reasons, `hooks`, `mcpServers`, and `permissionMode` are not supported for plugin-shipped agents.
+
+### `CLAUDE_ENV_FILE`
+
+- Available **only** in SessionStart hooks
+- Other hook types do not have access
+- Undocumented whether it exists in sub-agent SessionStart contexts
+
+### `hookSpecificOutput.additionalContext`
+
+SessionStart hooks can return JSON that injects text into Claude's context:
+```python
+output = {"hookSpecificOutput": {"additionalContext": "Owner: cdubiel08\nRepo: ralph-engine"}}
+```
+Pattern from [disler/claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery). Alternative to backtick preprocessing for env var injection.
+
+## Code References
+
+- `plugin/ralph-hero/mcp-server/src/index.ts:32-37` — `resolveEnv()` filters unexpanded `${VAR}` literals
+- `plugin/ralph-hero/mcp-server/src/index.ts:39-124` — `initGitHubClient()` reads RALPH_* tokens from env (once)
+- `plugin/ralph-hero/mcp-server/src/github-client.ts:84-201` — GitHubClient config frozen at construction
+- `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:550-555` — `resolveConfig()`: `args.owner || client.config.owner`
+- `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:491-544` — `resolveRepoFromProject()` inference
+- `plugin/ralph-hero/.mcp.json` — No `env` block (inherits process.env)
+- `plugin/ralph-hero/hooks/hooks.json` — Plugin-level hooks (fire for all contexts)
+- `plugin/ralph-hero/hooks/scripts/skill-precondition.sh:25-31` — Blocks when RALPH_COMMAND empty
+- `plugin/ralph-hero/hooks/scripts/set-skill-env.sh:13-16` — Guards on CLAUDE_ENV_FILE
+- `plugin/ralph-hero/agents/ralph-analyst.md` — Wrapper agent (to be replaced)
+- `plugin/ralph-hero/agents/ralph-builder.md` — Wrapper agent (to be replaced)
+- `plugin/ralph-hero/skills/ralph-research/SKILL.md:66-78` — `$RALPH_GH_OWNER` literal references
+- `.claude/skills/test-env-inject/SKILL.md` — Test fixture for backtick preprocessing
+- `.claude/agents/test-preload.md` — Test fixture for skill preloading
+
+## Related Research
+
+- [[2026-03-17-GH-0588-remove-mcp-env-block]] — Plan to remove .mcp.json env block
+- [[2026-02-20-GH-0231-skill-subagent-team-context-pollution]] — Team context leaking through forks
+- [[2026-03-19-GH-0637-hero-dispatch-model]] — Skill() vs Agent() dispatch isolation
+- [[2026-03-19-GH-0634-doctor-settings-local-json-fallback]] — Doctor can't read settings.local.json
+
+## External References
+
+- [Claude Code Sub-agents Docs](https://code.claude.com/docs/en/sub-agents)
+- [Claude Code Skills Docs](https://code.claude.com/docs/en/skills)
+- [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
+- [Claude Code Hooks Docs](https://code.claude.com/docs/en/hooks)
+- [Claude Code Environment Variables](https://code.claude.com/docs/en/env-vars)
+- [disler/claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) — Hook patterns including additionalContext and CLAUDE_ENV_FILE
+- [Issue #13254 — Background subagents cannot access MCP tools](https://github.com/anthropics/claude-code/issues/13254)
+- [Issue #17283 — context:fork ignored on Skill() invocation](https://github.com/anthropics/claude-code/issues/17283)
+- [Issue #32732 — No modelEnforcement:strict](https://github.com/anthropics/claude-code/issues/32732)
+- [Issue #18837 — allowed-tools not enforced as restriction](https://github.com/anthropics/claude-code/issues/18837)
+- [Issue #1254 — env block strips process.env](https://github.com/anthropics/claude-code/issues/1254)
+- [Issue #2065 — ${VAR} expansion for MCP env](https://github.com/anthropics/claude-code/issues/2065)
+- [Issue #24054 — Scoped MCP servers for sub-agents](https://github.com/anthropics/claude-code/issues/24054)

--- a/thoughts/shared/research/2026-03-24-knowledge-graph-plugin-comparison.md
+++ b/thoughts/shared/research/2026-03-24-knowledge-graph-plugin-comparison.md
@@ -1,0 +1,221 @@
+---
+date: 2026-03-24
+topic: "obra/knowledge-graph plugin: lessons for our superpowers ecosystem"
+tags: [research, knowledge-graph, ralph-knowledge, superpowers, plugin-architecture, graphology, semantic-search]
+status: complete
+type: research
+git_commit: 50d5a9572982c42e010447a85ecad3b673b08e90
+github_issue: 663
+github_url: https://github.com/cdubiel08/ralph-hero/issues/663
+---
+
+# Research: obra/knowledge-graph — Lessons for Superpowers
+
+## Prior Work
+
+- builds_on:: [[2026-03-15-superpowers-vs-ralph-hero-comparison]]
+- builds_on:: [[2026-03-10-multi-dir-knowledge-index]]
+- builds_on:: [[2026-03-09-GH-0549-knowledge-metadata-alignment]]
+
+## Research Question
+
+Jesse Vincent (obra) published a [knowledge-graph](https://github.com/obra/knowledge-graph) Claude Code plugin that turns an Obsidian vault (~3,300 notes) into a queryable knowledge graph with 13 MCP tools, graph algorithms, and a "prove-claim" investigative skill. What can we learn from this implementation? What are we doing better? Where are we overcomplicating things?
+
+## Summary
+
+Knowledge-graph and our ralph-knowledge plugin share the same foundation (SQLite + sqlite-vec + FTS5 + `all-MiniLM-L6-v2` embeddings) but diverge sharply in what they build on top. Knowledge-graph invests in **graph algorithms** — community detection, centrality, bridge finding, path traversal — using the graphology library. We invest in **structured metadata** — typed relationships, superseded-doc tracking, outcome ledger, hybrid RRF search. Neither is wrong; they serve different corpora. But knowledge-graph exposes capabilities we lack that would genuinely improve document discovery, and our system carries complexity that knowledge-graph's simpler choices call into question.
+
+---
+
+## Detailed Findings
+
+### What Knowledge-Graph Does
+
+Blog post: [blog.fsck.com/releases/2026/03/20/knowledge-graph](https://blog.fsck.com/releases/2026/03/20/knowledge-graph/)
+Source: [github.com/obra/knowledge-graph](https://github.com/obra/knowledge-graph)
+
+13 MCP tools built on:
+- **graphology** for Louvain community detection, PageRank, betweenness centrality, BFS neighbors, DFS path finding
+- **sqlite-vec** for cosine-similarity vector search
+- **FTS5** for keyword search
+- **`Xenova/all-MiniLM-L6-v2`** for local embeddings (identical model to ours)
+- **`gray-matter`** for frontmatter parsing
+
+The vault is treated as a directed multigraph: markdown files = nodes, wiki links = edges. Every `[[wikilink]]` becomes an edge, with the enclosing paragraph stored as `context`. The indexer tracks file mtimes for incremental updates and creates stub nodes for unresolved link targets.
+
+One skill ships: **prove-claim** — a 5-step investigative workflow (decompose claim → find entities → find connections → read evidence → report with verdict + confidence).
+
+### What We're Doing Better
+
+**1. Hybrid search with Reciprocal Rank Fusion**
+
+Knowledge-graph exposes `kg_search` with a `mode` flag: either semantic OR fulltext. The caller has to decide. Our `knowledge_search` runs both FTS5 and vector search in parallel, fuses results via RRF (K=60), and returns a single ranked list. This consistently surfaces documents that either approach alone would miss.
+
+**2. Typed, semantic relationships**
+
+Knowledge-graph stores all wiki links as untyped edges in a flat `edges` table. Every `[[link]]` is treated identically. Our `relationships` table constrains edges to explicit types: `builds_on`, `tensions`, `superseded_by`. This means our graph traversal can answer "what does this document build on?" or "what supersedes this?" — questions that matter for research provenance. Knowledge-graph can only answer "what links to what?"
+
+**3. Superseded document handling**
+
+We track `superseded_by` as a first-class relationship. `knowledge_search` defaults to filtering out superseded documents, preventing stale research from polluting results. Knowledge-graph has no concept of document lifecycle — a year-old note and today's note have equal standing.
+
+**4. Outcome ledger**
+
+Our append-only `outcome_events` table records pipeline events (triage verdicts, drift counts, blocker events) tied to GitHub issue numbers. `knowledge_search` enriches results with outcome summaries inline. Knowledge-graph has no operational history layer — it indexes content but doesn't track what happened to the work that content represents.
+
+**5. Structured document taxonomy**
+
+Our parser infers document types from path segments (`/research/`, `/plans/`, `/ideas/`, `/reviews/`, `/reports/`) and frontmatter. `knowledge_search` accepts a `type` filter. Knowledge-graph treats all vault content uniformly — no type-based filtering.
+
+**6. Tag-based filtering in search**
+
+Our search tools accept `tags` parameter for filtering. Knowledge-graph extracts inline `#hashtags` into frontmatter but doesn't expose tag-filtered search through MCP.
+
+### What We Can Learn
+
+**1. Graph algorithms are the big gap**
+
+Knowledge-graph uses graphology to answer questions we simply can't:
+
+| Capability | Knowledge-graph | ralph-knowledge |
+|---|---|---|
+| Community detection | Louvain with configurable resolution | — |
+| Centrality ranking | PageRank (with degree-centrality fallback for disconnected graphs) | — |
+| Bridge/connector nodes | Betweenness centrality | — |
+| Path finding | DFS all simple paths between two nodes | — |
+| Common connections | Set intersection of neighbor sets | — |
+| Subgraph extraction | N-hop neighborhood as nodes+edges | — |
+| Neighbor traversal | BFS at configurable depth | Recursive CTE (outgoing + incoming) |
+
+Our recursive CTE traverser handles linear chains well (`builds_on` paths), but can't identify document clusters, find the most important documents by connectivity, detect bridging documents that connect otherwise-separate topics, or extract the path of reasoning between two unrelated notes.
+
+With ~200 documents in `thoughts/` (and growing), community detection would surface organic topic clusters. Bridge detection would identify documents that connect disparate workstreams. PageRank would surface the most-referenced research. These would make `knowledge_search` results dramatically more useful.
+
+**2. Incremental indexing**
+
+Knowledge-graph maintains a `sync` table with `(path, mtime, indexed_at)`. On re-index, files whose mtime hasn't changed are skipped entirely. Only changed/new files get re-parsed and re-embedded.
+
+Our `reindex()` calls `clearAll()` then rebuilds everything from scratch every time. For 200 documents this is fast enough (~seconds), but it's wasteful — embedding is the expensive step, and unchanged documents produce identical embeddings. As the corpus grows, incremental indexing becomes essential.
+
+**3. Edge context preservation**
+
+When knowledge-graph encounters `[[Alice]]` in a paragraph about "Alice proposed the new API design," it stores that entire paragraph as the edge's `context` field. This means graph traversal results carry *why* the link exists, not just *that* it exists.
+
+Our `relationships` table stores `(source_id, target_id, type)` with no context. When we traverse a `builds_on` chain, we know Document A builds on Document B, but not what specifically it builds on. The user has to read both documents to understand the connection.
+
+**4. Stub nodes for unresolved references**
+
+Knowledge-graph creates placeholder nodes with `{ _stub: true }` for wiki link targets that don't resolve to actual files. This preserves graph structure — a document linking to `[[future-research-topic]]` creates a visible node even before that document exists.
+
+We silently discard unresolvable `[[wikilink]]` targets. This means forward references (linking to documents that don't exist yet) disappear from the graph entirely.
+
+**5. Fuzzy node resolution**
+
+Knowledge-graph implements a 5-tier name matching hierarchy: exact ID → exact title → case-insensitive title → alias → substring. All MCP tools use this resolver, so users can reference documents by approximate name.
+
+Our tools require exact document IDs. This is fine for programmatic access but poor for conversational use.
+
+**6. Write tools**
+
+Knowledge-graph includes `kg_create_node`, `kg_annotate_node`, and `kg_add_link` — tools that create and modify vault content from within the MCP server. Our knowledge plugin is strictly read-only; document creation happens through skills writing files directly.
+
+The advantage: write tools can atomically create content AND update the index in one operation, ensuring the graph is always consistent with the filesystem.
+
+**7. The prove-claim skill pattern**
+
+The `prove-claim` skill is a structured investigative workflow that leverages graph tools:
+1. Decompose claim into entities and relationships
+2. Find entities via semantic search
+3. Find connections via paths, common neighbors, neighbor traversal
+4. Read evidence (not just path existence — read actual content)
+5. Report with verdict, confidence, evidence chains, and caveats
+
+Key design insight from the skill: *"Do not stop at 'a path exists' — read the content to verify the connection is semantically relevant."* And: *"Community co-membership is not evidence; path through generic hub nodes is weaker than path through relevant summary nodes."*
+
+This is a pattern we could adopt: a skill that uses graph structure to guide focused reading rather than just returning search results.
+
+### Where We Might Be Overcomplicating
+
+**1. Relationship type constraints**
+
+We restrict relationships to exactly three types: `builds_on`, `tensions`, `superseded_by`. Knowledge-graph stores ALL wiki links as edges. This means we miss the vast majority of cross-references in our documents — any `[[wikilink]]` that isn't preceded by one of our three type prefixes is invisible to the graph.
+
+Knowledge-graph's approach captures the full link topology. Our typed relationships carry more semantic meaning per edge, but at the cost of a sparse graph. The 80/20 solution: store untyped edges for ALL wiki links, keep typed relationships as an enrichment layer on top.
+
+**2. Full rebuild indexing**
+
+As noted above, our `clearAll()` + full rebuild is simpler code but does O(n) embedding work on every index. Knowledge-graph's mtime tracking is ~30 extra lines of code and reduces re-index cost to O(changed files). This is the kind of complexity that pays for itself immediately.
+
+**3. Content truncation for embeddings**
+
+Our `prepareTextForEmbedding()` concatenates `title + content` and truncates to 500 characters. Knowledge-graph's `buildEmbeddingText()` uses `title + tags + first paragraph`. Neither is clearly superior, but:
+- We lose tag signal (which often captures the most important metadata)
+- Truncating to a fixed character count is arbitrary — first paragraph is a more semantically meaningful boundary
+- 500 chars is conservative for a 384-dim model that can handle ~512 tokens (~2000 chars)
+
+**4. No brief/full mode for document retrieval**
+
+Knowledge-graph's `kg_node` tool has a `brief` flag: brief returns metadata + connection titles only; full returns content + edge context. This is smart for LLM context management — you can explore the graph cheaply with brief lookups, then read full content only for promising nodes.
+
+Our search returns full content excerpts always. For graph-style exploration (which we don't have yet), brief mode would be essential.
+
+---
+
+## Architecture Comparison
+
+```
+┌────────────────────────────────────┬────────────────────────────────────┐
+│      obra/knowledge-graph          │       ralph-knowledge              │
+├────────────────────────────────────┼────────────────────────────────────┤
+│ Corpus: Obsidian vault (~3,300)    │ Corpus: thoughts/ dir (~200)       │
+│ Edges: ALL wiki links (untyped)    │ Edges: 3 typed rels only           │
+│ Graph: graphology (in-memory)      │ Graph: recursive CTE (SQL-only)    │
+│ Algorithms: Louvain, PageRank,     │ Algorithms: linear chain traversal │
+│   betweenness, DFS paths           │                                    │
+│ Search: separate FTS / vector      │ Search: hybrid RRF fusion          │
+│ Index: incremental (mtime)         │ Index: full rebuild                │
+│ Edge context: paragraph stored     │ Edge context: none                 │
+│ Stubs: created for broken links    │ Stubs: silently dropped            │
+│ Name resolution: 5-tier fuzzy      │ Name resolution: exact ID only     │
+│ Write: create/annotate/link tools  │ Write: none (read-only)            │
+│ Skills: 1 (prove-claim)           │ Skills: 30+ (full pipeline)        │
+│ Outcome tracking: none             │ Outcome tracking: event ledger     │
+│ Document lifecycle: none           │ Document lifecycle: superseded_by  │
+│ Type taxonomy: none                │ Type taxonomy: 5 inferred types    │
+│ GitHub integration: none           │ GitHub integration: deep           │
+└────────────────────────────────────┴────────────────────────────────────┘
+```
+
+## Actionable Ideas (Ranked by Impact)
+
+1. **Add graphology** for community detection, centrality, and bridge finding. Our corpus is small enough that in-memory graph construction on-demand is trivial. Start with `kg_communities` and `kg_central` equivalents — these unlock document cluster discovery and importance ranking.
+
+2. **Capture all wiki links as untyped edges** alongside existing typed relationships. This makes the graph dense enough for graph algorithms to work. Current typed relationships become a semantic overlay.
+
+3. **Incremental indexing with mtime tracking**. ~30 lines of code, eliminates redundant embedding computation. Add a `sync` table with `(path, mtime, indexed_at)`.
+
+4. **Store edge context** (the enclosing paragraph around each wiki link). Makes traversal results self-explanatory.
+
+5. **Add brief/full mode to search results**. Brief = title + type + tags + connections. Full = content + snippets. Enables cheap graph exploration.
+
+6. **Prove-claim style skill** that uses graph structure to guide evidence-based reasoning through our research corpus.
+
+## Related Research
+
+- [Superpowers vs Ralph-Hero Comparison](thoughts/shared/research/2026-03-15-superpowers-vs-ralph-hero-comparison.md)
+- [Knowledge Metadata Alignment Plan](thoughts/shared/plans/2026-03-09-GH-0549-knowledge-metadata-alignment.md)
+- [Multi-dir Knowledge Index Plan](thoughts/shared/plans/2026-03-10-multi-dir-knowledge-index.md)
+
+## External References
+
+- [Blog post: Knowledge Graph Tools](https://blog.fsck.com/releases/2026/03/20/knowledge-graph/) — Jesse Vincent
+- [GitHub: obra/knowledge-graph](https://github.com/obra/knowledge-graph)
+- [graphology library](https://graphology.github.io/)
+- [sqlite-vec](https://github.com/asg017/sqlite-vec)
+
+## Open Questions
+
+1. Is graphology worth adding as a dependency, or can we get 80% of the value with SQL-only algorithms (e.g., simple degree centrality via `COUNT(*)` on edges)?
+2. Should untyped edges and typed relationships coexist in the same table or separate tables?
+3. Would incremental indexing break any assumptions in our test suite or index generation?
+4. How does the prove-claim pattern adapt to our structured document types (research docs have different semantics than plan docs)?

--- a/thoughts/shared/research/2026-03-25-github-token-management-across-tools.md
+++ b/thoughts/shared/research/2026-03-25-github-token-management-across-tools.md
@@ -1,0 +1,193 @@
+---
+date: 2026-03-25
+topic: "GitHub token management across ralph-hero MCP, gh CLI, and GitHub Actions"
+tags: [research, codebase, tokens, authentication, gh-cli, mcp-server, github-actions]
+status: complete
+type: research
+---
+
+# Research: GitHub Token Management Across Tools
+
+## Prior Work
+
+- builds_on:: [[2026-02-13-setup-friction-fixes]]
+
+## Research Question
+
+How do GitHub tokens flow through ralph-hero MCP server, `gh` CLI, and GitHub Actions? Does the ralph-hero MCP server fall back to `GITHUB_TOKEN` or `GH_TOKEN`?
+
+## Summary
+
+**ralph-hero MCP does NOT fall back to `GITHUB_TOKEN` or `GH_TOKEN`.** This is an intentional design decision made during the setup-friction-fixes work (Feb 2026) to prevent token collision with the `gh` CLI. The two systems use completely independent authentication:
+
+| Tool | Token source | Configured via |
+|------|-------------|----------------|
+| ralph-hero MCP | `RALPH_GH_REPO_TOKEN` or `RALPH_HERO_GITHUB_TOKEN` | `.claude/settings.local.json` `"env"` block |
+| `gh` CLI | `gh auth login` credential store | Interactive login (keychain/config file) |
+| GitHub Actions | `secrets.ROUTING_PAT` (project ops) or `secrets.GITHUB_TOKEN` (releases) | Repository secrets |
+
+This means a user must maintain **two separate auth setups**: one for ralph-hero (env var in settings.local.json) and one for `gh` CLI (interactive login).
+
+## Detailed Findings
+
+### 1. Ralph-Hero MCP Token Resolution
+
+**File**: `plugin/ralph-hero/mcp-server/src/index.ts:33-69`
+
+The MCP server resolves tokens through a `RALPH_`-prefixed-only chain:
+
+```
+Repo token:    RALPH_GH_REPO_TOKEN  →  RALPH_HERO_GITHUB_TOKEN  →  exit(1)
+Project token: RALPH_GH_PROJECT_TOKEN  →  repoToken (from above)
+```
+
+The `resolveEnv()` function (line 33-38) filters out unexpanded `${VAR}` literals that Claude Code may pass for unset vars, treating them as undefined.
+
+**Explicitly forbidden** env vars (documented in test contract at `src/__tests__/init-config.test.ts:157-163`):
+- `GITHUB_TOKEN`
+- `GH_TOKEN`
+- `GITHUB_PERSONAL_ACCESS_TOKEN`
+- `GITHUB_OWNER`
+- `GITHUB_REPO`
+
+**Historical context**: The original implementation (pre-Feb 2026) had a 4-step fallback chain: `RALPH_HERO_GITHUB_TOKEN → GITHUB_PERSONAL_ACCESS_TOKEN → GITHUB_TOKEN → GH_TOKEN`. This was removed in the setup-friction-fixes work because setting `GITHUB_TOKEN` or `GH_TOKEN` in the MCP process environment would collide with `gh` CLI's own token resolution when Claude ran shell commands.
+
+### 2. The `.mcp.json` Has No `env` Block
+
+**File**: `plugin/ralph-hero/.mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "ralph-github": {
+      "command": "npx",
+      "args": ["-y", "ralph-hero-mcp-server@2.5.42"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+    }
+  }
+}
+```
+
+There is no `env` key. The MCP server inherits its entire environment from the Claude Code parent process. Tokens set in `.claude/settings.local.json` under `"env"` are injected into the parent process environment, which the MCP server inherits at startup.
+
+### 3. Dual-Token Architecture
+
+**File**: `plugin/ralph-hero/mcp-server/src/github-client.ts:84-104`
+
+The client creates separate `@octokit/graphql` instances when `projectToken` differs from `token`:
+
+- `query()` / `mutate()` — use repo token for repository operations (issues, PRs, comments)
+- `projectQuery()` / `projectMutate()` — use project token for Projects V2 operations (fields, workflow state)
+- `restPost()` — defaults to project token, overridable with `useProjectToken=false`
+
+When only a single token is configured, all four methods use the same token.
+
+### 4. `gh` CLI Authentication — Completely Independent
+
+The `gh` CLI is used in scripts, hooks, skills (as instructions to Claude), and agents. **None of these set a token before invoking `gh`**. Every `gh` invocation relies on the ambient `gh auth login` credential store.
+
+**Scripts using `gh`:**
+- `plugin/ralph-hero/scripts/demo-seed.sh` — checks `gh auth status` at line 35 as a prerequisite
+- `plugin/ralph-hero/scripts/demo-cleanup.sh` — no auth check
+- `scripts/merge-pr.sh` — no auth check
+- `scripts/test-memory-layer.sh` — no auth check
+
+**Skills instructing Claude to run `gh`:**
+- `skills/hello/SKILL.md` — `gh pr list`
+- `skills/ralph-impl/SKILL.md` — `gh pr create`, `gh pr view`
+- `skills/ralph-pr/SKILL.md` — `gh pr create`
+- `skills/ralph-merge/SKILL.md` — `gh pr view`, `gh pr merge`
+- `skills/setup/SKILL.md` — `gh api graphql`
+- `skills/setup-repos/SKILL.md` — `gh api graphql`, `gh api repos/...`
+- Multiple others
+
+**Hooks using `gh`:**
+- `hooks/scripts/team-stop-gate.sh` — `gh issue list` (line 32)
+
+All rely on ambient `gh` login state. No token injection.
+
+### 5. GitHub Actions Token Strategy
+
+Actions workflows use a separate token model entirely:
+
+**Project-mutating workflows** (need Projects V2 write access — `GITHUB_TOKEN` cannot do this):
+- `sync-issue-state.yml` — `GH_TOKEN: ${{ secrets.ROUTING_PAT }}`
+- `sync-pr-merge.yml` — `GH_TOKEN: ${{ secrets.ROUTING_PAT }}`
+- `advance-parent.yml` — `GH_TOKEN: ${{ secrets.ROUTING_PAT }}`
+- `route-issues.yml` — passes `ROUTING_PAT` to Node.js script (not `gh` CLI)
+- `sync-project-state.yml` — passes `SYNC_PAT` (aliased from `ROUTING_PAT`) to Node.js script
+
+**Release workflows** (repo-level only):
+- `release.yml` — `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
+- `release-knowledge.yml` — `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
+
+### 6. Startup Diagnostics
+
+**File**: `plugin/ralph-hero/mcp-server/src/index.ts:103-112`
+
+The MCP server logs which token source is in use at startup:
+```
+[ralph-hero] Repo token: RALPH_HERO_GITHUB_TOKEN
+```
+or, in dual-token mode:
+```
+[ralph-hero] Repo token: RALPH_GH_REPO_TOKEN
+[ralph-hero] Project token: RALPH_GH_PROJECT_TOKEN (separate)
+```
+
+When no token is found, a detailed error message (lines 49-68) includes a copy-pasteable `settings.local.json` template and a link to GitHub's token creation page, then exits with code 1.
+
+## Code References
+
+- `plugin/ralph-hero/mcp-server/src/index.ts:33-38` — `resolveEnv()` filters unexpanded `${VAR}` literals
+- `plugin/ralph-hero/mcp-server/src/index.ts:40-69` — `initGitHubClient()` token resolution chain
+- `plugin/ralph-hero/mcp-server/src/index.ts:103-112` — Token source logging
+- `plugin/ralph-hero/mcp-server/src/github-client.ts:84-104` — Dual-client creation
+- `plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts:138-173` — `.mcp.json` contract test (forbidden vars)
+- `plugin/ralph-hero/.mcp.json` — No `env` block; inherits parent environment
+- `plugin/ralph-hero/scripts/demo-seed.sh:35` — Only script that checks `gh auth status`
+
+## Architecture Documentation
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Claude Code Process                    │
+│                                                         │
+│  .claude/settings.local.json                            │
+│  ┌─────────────────────────────────┐                    │
+│  │ "env": {                        │                    │
+│  │   "RALPH_HERO_GITHUB_TOKEN":... │──┐                 │
+│  │   "RALPH_GH_OWNER": ...        │  │                 │
+│  │ }                               │  │                 │
+│  └─────────────────────────────────┘  │                 │
+│                                       │ inherits env    │
+│  ┌──────────────────────┐             │                 │
+│  │  MCP Server (stdio)  │◀────────────┘                 │
+│  │  index.ts             │                               │
+│  │  resolveEnv() reads   │                               │
+│  │  RALPH_* vars only    │                               │
+│  └──────────────────────┘                               │
+│                                                         │
+│  ┌──────────────────────┐                               │
+│  │  Bash tool (gh CLI)  │──── uses gh auth login store  │
+│  │  No GITHUB_TOKEN set │     (separate from MCP)       │
+│  └──────────────────────┘                               │
+└─────────────────────────────────────────────────────────┘
+```
+
+The two auth systems are fully isolated:
+1. **ralph-hero MCP**: `RALPH_*` env vars → `@octokit/graphql` with `token` header
+2. **gh CLI**: `gh auth login` → OS keychain / `~/.config/gh/hosts.yml`
+
+## Historical Context (from thoughts/)
+
+The `2026-02-13-setup-friction-fixes.md` plan documents the original problem:
+- The old `.mcp.json` passed `GITHUB_TOKEN` and `GH_TOKEN` through to the MCP server
+- This collided with `gh` CLI's OAuth token because Claude Code's Bash tool inherits the same environment
+- The fix was Phase 3 of that plan: remove all non-`RALPH_` vars from `.mcp.json` (and later remove the `env` block entirely)
+- The old fallback chain `RALPH_HERO_GITHUB_TOKEN → GITHUB_PERSONAL_ACCESS_TOKEN → GITHUB_TOKEN → GH_TOKEN` was simplified to `RALPH_GH_REPO_TOKEN → RALPH_HERO_GITHUB_TOKEN`
+
+## Open Questions
+
+- If a user has `gh auth login` configured with a token that has `project` scope, could ralph-hero be taught to optionally read from the `gh` credential store as a convenience fallback? (e.g., `gh auth token` outputs the active token)
+- The two independent auth setups mean users must configure both separately — is there a way to unify without reintroducing the collision problem?

--- a/thoughts/shared/research/2026-03-25-token-management-setup-skill-improvement.md
+++ b/thoughts/shared/research/2026-03-25-token-management-setup-skill-improvement.md
@@ -1,0 +1,222 @@
+---
+date: 2026-03-25
+topic: "Token/API key management struggles and setup skill improvement opportunities"
+tags: [research, tokens, setup, configuration, developer-experience, security]
+status: complete
+type: research
+git_commit: 1e26435
+---
+
+# Research: Token/API Key Management Struggles & Setup Skill Improvements
+
+## Prior Work
+
+- builds_on:: [[2026-03-25-github-token-management-across-tools]]
+- builds_on:: [[2026-03-24-agent-env-propagation-token-scope]]
+- builds_on:: [[2026-03-19-GH-0634-doctor-settings-local-json-fallback]]
+- builds_on:: [[2026-03-17-GH-0588-remove-mcp-env-block]]
+- builds_on:: [[2026-03-21-secret-protection-gitignore-enforcement]]
+- builds_on:: [[2026-03-24-GH-0674-agent-per-phase-architecture]]
+
+## Research Question
+
+What recent struggles have we had managing API keys and tokens, and how can we improve 'setup' skills across the plugin ecosystem?
+
+## Summary
+
+Six prior documents spanning 2026-03-17 to 2026-03-25 reveal a consistent pattern: token and configuration management has been a recurring friction source across multiple dimensions — env var propagation to sub-agents, shell vs Claude Code process isolation, secret protection gaps, and multi-tool token collision. The current setup skills handle the *initial* happy path well but don't address the ongoing operational pain of token rotation, cross-tool auth verification, consumer-repo onboarding, or diagnostic self-service.
+
+## Detailed Findings
+
+### 1. The Token Landscape (3 independent auth systems)
+
+Ralph operates across three token systems that must remain isolated:
+
+| System | Token Source | Config Location | Scope |
+|--------|-------------|-----------------|-------|
+| ralph-hero MCP | `RALPH_HERO_GITHUB_TOKEN` (or split repo/project tokens) | `.claude/settings.local.json` | `repo`, `project` |
+| `gh` CLI | `gh auth login` credential store | `~/.config/gh/hosts.yml` | Whatever user granted |
+| GitHub Actions | `secrets.ROUTING_PAT` + `secrets.GITHUB_TOKEN` | Repo Settings > Secrets | `repo`, `project` for PAT |
+
+**Key design decision**: ralph-hero intentionally refuses `GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_PERSONAL_ACCESS_TOKEN` to prevent collision with `gh` CLI (enforced by contract test at `init-config.test.ts:157-163`).
+
+### 2. Documented Pain Points (Chronological)
+
+#### 2a. Silent env var dropping (GH-588, 2026-03-17)
+**What happened**: The `.mcp.json` `env` block acted as an allowlist — only 3 of 10+ supported vars were listed. Seven optional vars (`RALPH_GH_REPO_TOKEN`, `RALPH_GH_PROJECT_TOKEN`, `RALPH_GH_PROJECT_OWNER`, `RALPH_GH_PROJECT_NUMBERS`, `RALPH_GH_TEMPLATE_PROJECT`, `RALPH_HERO_AUTO`, `RALPH_DEBUG`) silently never reached the server.
+**Resolution**: Removed the env block entirely. Server now inherits parent process environment.
+
+#### 2b. `ralph doctor` blind to settings.local.json (GH-634, 2026-03-19)
+**What happened**: `ralph doctor` runs in a shell context where `settings.local.json` env vars aren't exported — they only exist inside Claude Code's process. Doctor always reports FAIL even when everything works.
+**Resolution**: Planned `node -e` fallback to parse `settings.local.json` directly. Status: plan exists, implementation pending.
+
+#### 2c. Secret protection has gaps (GH-649, 2026-03-21)
+**What happened**: Protection relies on Claude Code's global gitignore (`~/.config/git/ignore`), which doesn't exist on fresh machines or non-Claude-Code contributors. Root `.gitignore` has no entries for `.claude/` or `*.local.json`. Historical token commits occurred.
+**Open questions**: Should root `.gitignore` include these patterns as defense-in-depth? Should setup skills verify/add `.gitignore` entries? Should a PreToolUse hook inspect `git diff --cached` for token patterns?
+
+#### 2d. Sub-agent token scope confusion (2026-03-24)
+**What happened**: Three compounding failures in wrapper-agent architecture:
+1. Sub-agents cannot spawn sub-agents (platform limitation) — `context: fork` silently runs inline
+2. `$RALPH_GH_OWNER` in skill prompts is literal text to LLMs — sub-agents hallucinate wrong repo names
+3. Plugin sub-agent hooks (`hooks:`, `mcpServers:`, `permissionMode:` in frontmatter) are silently ignored for security
+4. `skill-precondition.sh` blocks MCP calls when `RALPH_COMMAND` is empty — LLM interprets the block as a "token scope error"
+**Resolution**: Agent-per-phase architecture planned (GH-674). Backtick preprocessing validated as env var injection solution.
+
+#### 2e. No scripts check `gh auth status` (2026-03-25)
+**What happened**: Only `demo-seed.sh` verifies `gh` authentication. Scripts like `demo-cleanup.sh`, `merge-pr.sh`, and `test-memory-layer.sh` invoke `gh` with no prerequisite check — they fail with cryptic errors when not authenticated.
+
+### 3. Current Setup Skills Inventory
+
+| Skill | Plugin | What It Configures | Token Handling |
+|-------|--------|--------------------|----------------|
+| `setup` | ralph-hero | GitHub Project V2, custom fields, workflow states | Guides through PAT creation, `settings.local.json`, health check |
+| `setup-cli` | ralph-hero | Global `ralph` command, shell completions | No token handling (Bash only) |
+| `setup-repos` | ralph-hero | `.ralph-repos.yml` multi-repo registry | Uses health_check, needs existing token |
+| `setup` | ralph-knowledge | SQLite index from markdown docs | No external tokens needed |
+| `setup-obsidian` | ralph-knowledge | Obsidian vault config for thoughts/ | No external tokens needed |
+| `setup` | ralph-playwright | playwright-cli, browser binaries | No external tokens needed |
+
+### 4. Setup Skill Architecture
+
+The ralph-hero `setup` skill (`plugin/ralph-hero/skills/setup/SKILL.md`, 628 lines) is the most complex:
+- Runs as `context: fork` with `model: haiku`
+- SessionStart hook injects `RALPH_COMMAND=setup` via `set-skill-env.sh`
+- Allowed tools: `Bash`, `ralph_hero__health_check`, `ralph_hero__get_project`, `ralph_hero__setup_project`
+- 7-step workflow: health check → determine project owner → create/verify project → update colors → views (manual) → store config → verify
+- Optional Step 6b: routing & sync setup (ROUTING_PAT secret, repo variables, routing config)
+- Handles: simple setup, split-owner, dual-token
+
+### 5. Token Resolution Flow in MCP Server
+
+```
+index.ts:33-38  resolveEnv() — filters undefined and ${VAR} literals
+index.ts:40-69  initGitHubClient() — token priority chain:
+                  Repo:    RALPH_GH_REPO_TOKEN → RALPH_HERO_GITHUB_TOKEN
+                  Project: RALPH_GH_PROJECT_TOKEN → repo token
+                  Missing repo token → console.error + process.exit(1)
+index.ts:71-101 Optional vars — warnings only, no exit
+index.ts:114-124 createGitHubClient() — builds dual graphql instances
+```
+
+### 6. Existing Diagnostics
+
+- `ralph_hero__health_check` tool: validates auth, repo access, project access, required fields
+- Startup logging: reports token source, warns on missing optional vars
+- Rate limiter: proactive tracking with warn (100) and block (50) thresholds
+- `ralph doctor` CLI command: exists but can't read `settings.local.json` (GH-634)
+
+### 7. Secret Protection Mechanisms
+
+| Mechanism | Scope | Gap |
+|-----------|-------|-----|
+| Claude Code global gitignore | `*.local.json`, `*.local.md` | Not present on fresh machines |
+| `gitignore-enforcement.sh` hook | Blocks Write tool for local files not in `.gitignore` | Only catches Claude Code writes, not manual edits |
+| Root `.gitignore` | `*.local.json`, `*.local.md`, `.env*` | Present (lines 17-19) |
+| Plugin `.gitignore` | `*.local.md` | Scoped to plugin subtree only |
+
+## Improvement Opportunities
+
+### A. Cross-Plugin Setup Orchestrator
+
+Currently each plugin has independent setup skills with no coordination. A user setting up ralph-hero for the first time must run multiple separate skills. A unified "first-run" experience could:
+- Detect which plugins are installed
+- Run health checks across all plugins
+- Guide through token creation once (shared PAT)
+- Verify `.gitignore` protection before writing any local files
+- Create `settings.local.json` with all needed vars in one pass
+
+### B. Token Lifecycle Management
+
+No setup skill handles post-initial-setup scenarios:
+- **Token rotation**: No skill to update an expired token and verify the new one works
+- **Token audit**: No way to check what scopes a token has vs what's needed
+- **Token sharing**: When onboarding a contributor, no guided flow exists
+- **Expiration detection**: MCP server detects auth failures but doesn't suggest "your token may have expired"
+
+### C. Consumer-Repo Onboarding
+
+The current setup skill assumes you're in the ralph-hero repo. For consumer repos (repos that *use* ralph-hero as a plugin):
+- `.gitignore` entries for `*.local.json` may not exist
+- `ROUTING_PAT` secret needs to be created
+- Repository variables need project-specific values (not defaults)
+- The setup skill's Step 6b hard-codes `cdubiel08` and `3` as defaults in the repo variables table
+
+### D. `ralph doctor` as First-Class Diagnostic
+
+The `ralph doctor` command (`justfile:149-167`) should be the go-to diagnostic tool but is broken outside Claude Code. Fixing GH-634 (read `settings.local.json` directly) would make it useful for:
+- Pre-setup validation ("do I have everything I need?")
+- Post-rotation verification ("does my new token work?")
+- CI debugging ("why is this workflow failing?")
+- Cross-tool auth check (verify both MCP token and `gh auth` are valid)
+
+### E. Defensive `.gitignore` in Setup Flow
+
+The setup skill creates `settings.local.json` and `ralph-hero.local.md` but doesn't verify these patterns are in `.gitignore`. Adding a pre-write check would close the gap for consumer repos where Claude Code's global gitignore may not be configured.
+
+### F. Unified Auth Verification
+
+Scripts using `gh` CLI should have a common auth-check pattern. Only `demo-seed.sh` currently verifies `gh auth status`. A shared function in `hook-utils.sh` or a `gh-auth-check.sh` script could standardize this.
+
+### G. Setup Skill Composability
+
+The ralph-knowledge and ralph-playwright setup skills are lightweight and focused. The ralph-hero setup skill is 628 lines covering many scenarios. Breaking it into composable steps would allow:
+- `setup-token`: Just token creation and verification
+- `setup-project`: Just project creation/verification
+- `setup-routing`: Just routing & sync configuration
+- `setup-verify`: Just run all health checks
+
+This mirrors the existing pattern of `setup-cli` and `setup-repos` being separate focused skills.
+
+### H. Sub-Agent Environment Propagation
+
+The agent-per-phase architecture (GH-674) addresses this at the architectural level. For setup skills specifically:
+- Skills that spawn sub-agents should use backtick preprocessing for env vars
+- `skill-precondition.sh` should recognize agent contexts via `agent_type` field
+- SessionStart hooks should use `hookSpecificOutput.additionalContext` to inject resolved values
+
+## Code References
+
+- `plugin/ralph-hero/mcp-server/src/index.ts:33-69` — resolveEnv, token resolution, fatal guard
+- `plugin/ralph-hero/mcp-server/src/index.ts:132-285` — health_check tool implementation
+- `plugin/ralph-hero/mcp-server/src/github-client.ts:84-104` — dual-token client construction
+- `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:550-610` — resolveConfig, resolveFullConfig
+- `plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts:157-163` — forbidden vars contract test
+- `plugin/ralph-hero/skills/setup/SKILL.md` — main setup skill (628 lines)
+- `plugin/ralph-hero/skills/setup-cli/SKILL.md` — CLI setup skill
+- `plugin/ralph-hero/skills/setup-repos/SKILL.md` — multi-repo registry setup
+- `plugin/ralph-knowledge/skills/setup/SKILL.md` — knowledge index setup
+- `plugin/ralph-knowledge/skills/setup-obsidian/SKILL.md` — Obsidian vault setup
+- `plugin/ralph-playwright/skills/setup/SKILL.md` — Playwright browser setup
+- `plugin/ralph-hero/hooks/scripts/set-skill-env.sh` — skill environment injection
+- `plugin/ralph-hero/hooks/scripts/skill-precondition.sh` — RALPH_COMMAND validation
+- `plugin/ralph-hero/hooks/scripts/gitignore-enforcement.sh` — write protection hook
+
+## Historical Context (from thoughts/)
+
+Six documents form a clear chain:
+1. **GH-588** (Mar 17): Foundational fix — remove env block from `.mcp.json`
+2. **GH-634** (Mar 19): Downstream consequence — `ralph doctor` can't see vars without env block
+3. **GH-649** (Mar 21): Parallel concern — gitignore gaps expose secrets
+4. **Agent env propagation** (Mar 24): Research revealing sub-agent token/hook failures
+5. **GH-674** (Mar 24): Architectural fix — agent-per-phase to solve propagation
+6. **Token management survey** (Mar 25): Horizontal mapping of all three auth systems
+
+## Related Research
+
+- [[2026-03-25-github-token-management-across-tools]] — comprehensive token landscape mapping
+- [[2026-03-24-agent-env-propagation-token-scope]] — sub-agent environment failure analysis
+- [[2026-03-19-GH-0634-doctor-settings-local-json-fallback]] — doctor CLI diagnostic gap
+- [[2026-03-17-GH-0588-remove-mcp-env-block]] — env block removal plan
+- [[2026-03-21-secret-protection-gitignore-enforcement]] — gitignore enforcement research
+- [[2026-03-24-GH-0674-agent-per-phase-architecture]] — agent architecture fix plan
+
+## Open Questions
+
+1. Should ralph-hero optionally read from `gh auth token` as a convenience fallback (without reintroducing collision)?
+2. Should root `.gitignore` gain defense-in-depth entries for `.claude/settings.local.json`?
+3. Should setup skills verify `.gitignore` coverage before writing local files?
+4. Should a PreToolUse hook on Bash inspect `git diff --cached` for token patterns before commits?
+5. Is there value in a unified `setup-all` orchestrator that chains plugin setup skills?
+6. Should token expiration be detected proactively (periodic health check) rather than reactively (auth failure)?
+7. For consumer repos: should setup auto-detect missing `.gitignore` entries and offer to add them?
+8. Would a `setup-token` sub-skill for rotation/update be worth the added surface area?

--- a/thoughts/shared/research/2026-03-25-userconfig-manifest-schema-validation.md
+++ b/thoughts/shared/research/2026-03-25-userconfig-manifest-schema-validation.md
@@ -1,0 +1,89 @@
+---
+date: 2026-03-25
+topic: "userConfig manifest schema validation errors in plugin.json"
+tags: [research, plugin-manifest, userConfig, validation]
+status: complete
+type: research
+---
+
+# Research: userConfig manifest schema validation errors
+
+## Research Question
+
+PR #689 introduced a `userConfig` block to `plugin.json` for secure token storage. After merging, the plugin fails validation with two errors:
+
+```
+userConfig.github_token.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"
+userConfig.github_token.title: Invalid input: expected string, received undefined
+```
+
+What is the correct schema for `userConfig` entries?
+
+## Summary
+
+The `userConfig` entry in `plugin.json` has three required fields: `title`, `type`, and `description`. The current definition only has `description` and `sensitive`, missing the two required fields. The fix is adding `"type": "string"` and `"title": "GitHub Token"` to the entry.
+
+## Detailed Findings
+
+### Current (broken) plugin.json userConfig
+
+```json
+"userConfig": {
+  "github_token": {
+    "description": "GitHub Personal Access Token with 'repo' and 'project' scopes...",
+    "sensitive": true
+  }
+}
+```
+
+### Required userConfig entry schema
+
+| Field         | Type    | Required | Description                                                                 |
+|---------------|---------|----------|-----------------------------------------------------------------------------|
+| `title`       | string  | **Yes**  | Human-readable label shown in `claude plugin configure` prompts             |
+| `type`        | string  | **Yes**  | One of: `"string"`, `"number"`, `"boolean"`, `"directory"`, `"file"`        |
+| `description` | string  | **Yes**  | Explanation text shown to user                                              |
+| `sensitive`   | boolean | No       | If `true`, stored in system keychain (macOS) or `~/.claude/.credentials.json` (Linux). Defaults to `false` |
+
+### Corrected plugin.json userConfig
+
+```json
+"userConfig": {
+  "github_token": {
+    "title": "GitHub Token",
+    "type": "string",
+    "description": "GitHub Personal Access Token with 'repo' and 'project' scopes...",
+    "sensitive": true
+  }
+}
+```
+
+### How userConfig values flow
+
+1. User runs `claude plugin configure ralph-hero`
+2. Claude Code prompts for each `userConfig` field using `title` as the label
+3. Sensitive values go to system keychain (macOS) or `~/.claude/.credentials.json` (Linux, mode 0600)
+4. `.mcp.json` references via `${user_config.github_token}` — Claude Code substitutes the real value at MCP server startup
+5. Value arrives as `RALPH_HERO_GITHUB_TOKEN` env var in the MCP server process
+6. `resolveEnv()` in `index.ts` filters unresolved `${...}` templates when userConfig hasn't been configured yet
+
+### Additional validator findings
+
+`claude plugin validate` also flagged 3 skills with YAML frontmatter parse errors (pre-existing, not from PR #689):
+
+- `skills/ralph-postmortem/SKILL.md` — YAML parse error
+- `skills/ralph-impl/SKILL.md` — YAML parse error
+- `skills/ralph-plan/SKILL.md` — YAML parse error
+
+All three use complex nested `hooks:` structures in frontmatter. At runtime these skills load with empty metadata (all frontmatter fields silently dropped). This means hooks defined in their frontmatter are not being enforced.
+
+## Code References
+
+- `plugin/ralph-hero/.claude-plugin/plugin.json:25-30` — broken userConfig definition
+- `plugin/ralph-hero/.mcp.json` — `${user_config.github_token}` template reference
+- `plugin/ralph-hero/mcp-server/src/index.ts:34-44` — `resolveEnv()` filters unresolved templates
+- `plugin/ralph-hero/mcp-server/src/__tests__/init-config.test.ts` — userConfig delivery path tests
+
+## Open Questions
+
+- What exactly in the `hooks:` YAML structure causes the 3 skill frontmatter parse failures? Is this a known limitation of the YAML parser used by `claude plugin validate`, or are these skills genuinely losing their hook definitions at runtime?

--- a/thoughts/shared/research/2026-03-26-GH-0693-timeout-command-not-found-macos.md
+++ b/thoughts/shared/research/2026-03-26-GH-0693-timeout-command-not-found-macos.md
@@ -1,0 +1,116 @@
+---
+date: 2026-03-26
+github_issue: 693
+github_url: https://github.com/cdubiel08/ralph-hero/issues/693
+topic: "timeout command not found on macOS — ralph CLI headless mode failure"
+tags: [research, codebase, cli-dispatch, timeout, macos, coreutils]
+status: complete
+type: research
+git_commit: c4eea06e2f97fd7806ceae8258b3727f2e1c1859
+---
+
+# Research: `timeout: command not found` on macOS
+
+## Prior Work
+
+- builds_on:: [[2026-03-18-justfile-cli-setup-fallbacks]]
+- builds_on:: [[2026-03-06-GH-0546-ralph-cli-justfile-architecture]]
+- builds_on:: [[2026-02-21-GH-0293-ls-v-portability-macos]] (prior macOS/coreutils portability issue)
+
+## Research Question
+
+Running `ralph review` fails with `timeout: command not found` (exit 127) because macOS does not ship GNU `timeout`.
+
+## Summary
+
+The `timeout` command (GNU coreutils) is used in 3 active scripts to enforce time limits on headless Claude sessions. macOS does not include `timeout` in its base system — it must be installed via `brew install coreutils`, which provides it as `gtimeout` (or `timeout` if `gnubin` is on PATH). There is no fallback, no `gtimeout` check, and `ralph doctor` does not verify `timeout` is installed.
+
+## Detailed Findings
+
+### Where `timeout` is invoked
+
+| File | Line | Context |
+|------|------|---------|
+| `plugin/ralph-hero/scripts/cli-dispatch.sh` | 47 | `run_headless()` — wraps `claude -p` with timeout |
+| `plugin/ralph-hero/scripts/ralph-loop.sh` | 79 | Per-phase runner inside autonomous loop |
+| `plugin/ralph-hero/scripts/ralph-team-loop.sh` | 54 | Team orchestrator runner |
+| `plugin/ralph-hero/justfile` | ~556 | Deprecated `_run_skill` recipe (still present) |
+
+All four sites use the same pattern:
+```bash
+timeout "$TIMEOUT" claude -p "$cmd" --max-budget-usd "$BUDGET" --dangerously-skip-permissions 2>&1
+```
+
+Exit code `124` is detected as the timeout signal (cli-dispatch.sh:59, ralph-loop.sh:84, ralph-team-loop.sh:56).
+
+### Default timeout values
+
+| Script | Default | Source |
+|--------|---------|--------|
+| cli-dispatch.sh | `15m` | `DEFAULT_TIMEOUT` variable (line 11) |
+| ralph-loop.sh | `15m` | `TIMEOUT` env var (line 54) |
+| ralph-team-loop.sh | `30m` | `TIMEOUT` env var (line 30) |
+
+### macOS compatibility gap
+
+- macOS ships BSD userland — no `timeout` binary
+- GNU coreutils provides `timeout` as `gtimeout` when installed via Homebrew
+- Adding `/opt/homebrew/opt/coreutils/libexec/gnubin` to PATH makes it available as `timeout`
+- No script checks for `gtimeout` as a fallback
+- The string `gtimeout` appears zero times in the codebase
+
+### `ralph doctor` dependency checks (justfile:312-332)
+
+Currently checked:
+- `just` — hard requirement (FAIL)
+- `npx` — hard requirement (FAIL)
+- `node` — hard requirement (FAIL)
+- `mcp` (mcptools) — soft requirement (WARN)
+- `claude` — soft requirement (WARN)
+
+**`timeout` is not checked.**
+
+### Documentation (docs/cli.md:16)
+
+The only mention of timeout as a prerequisite:
+```
+3. **timeout** -- included in GNU coreutils (pre-installed on most Linux)
+```
+
+No macOS install instructions are provided.
+
+### Prior macOS portability fix
+
+GH-293 addressed a similar BSD vs GNU issue: `ls -v` (GNU natural sort) doesn't exist on macOS BSD `ls`. That was resolved by switching to `ls | sort -V`. This is the same category of problem — relying on GNU-specific commands without macOS fallbacks.
+
+## Code References
+
+- `plugin/ralph-hero/scripts/cli-dispatch.sh:11` — DEFAULT_TIMEOUT set to `15m`
+- `plugin/ralph-hero/scripts/cli-dispatch.sh:47` — `timeout "$TIMEOUT" claude -p ...` invocation
+- `plugin/ralph-hero/scripts/cli-dispatch.sh:59-61` — exit code 124 handling
+- `plugin/ralph-hero/scripts/ralph-loop.sh:79` — timeout invocation in loop
+- `plugin/ralph-hero/scripts/ralph-team-loop.sh:54` — timeout invocation in team loop
+- `plugin/ralph-hero/justfile:312-332` — doctor dependency checks (timeout absent)
+- `plugin/ralph-hero/docs/cli.md:16` — timeout prerequisite documentation
+
+## Architecture Documentation
+
+The CLI dispatch architecture uses a layered approach:
+1. `ralph` (global wrapper in `~/.local/bin/`) resolves the latest cached plugin version
+2. Delegates to `just` recipes in `plugin/ralph-hero/justfile`
+3. Recipes source `cli-dispatch.sh` for shared mode handling
+4. `dispatch()` routes to `run_headless()`, `run_interactive()`, or `run_quick()` based on flags
+5. `run_headless()` wraps the `claude` invocation with `timeout` for safety
+
+The `timeout` command is the enforcement mechanism that prevents runaway headless sessions from consuming unlimited budget/time.
+
+## Historical Context (from thoughts/)
+
+- The 3-mode dispatch system (headless/interactive/quick) was documented in the justfile CLI setup fallbacks research (2026-03-18)
+- GH-293 established precedent for fixing macOS/GNU portability issues in these scripts
+- The doctor command has been incrementally enhanced (GH-479 error counter, GH-634 settings.local.json fallback) but timeout was never added to its checks
+
+## Open Questions
+
+- Should the fix use a `gtimeout`/`timeout` detection pattern, or should it use a pure-bash alternative (e.g., background process + `kill` after delay)?
+- Should `ralph doctor` gain a `timeout` check as a hard or soft requirement?

--- a/thoughts/shared/research/2026-03-26-GH-0694-ralph-cli-env-resolution-outside-repo.md
+++ b/thoughts/shared/research/2026-03-26-GH-0694-ralph-cli-env-resolution-outside-repo.md
@@ -1,0 +1,203 @@
+---
+date: 2026-03-26
+github_issue: 694
+github_url: https://github.com/cdubiel08/ralph-hero/issues/694
+topic: "How does the ralph CLI resolve RALPH_GH_OWNER and other env vars, and why does it fail outside the ralph-hero repo?"
+tags: [research, codebase, cli, env-resolution, settings-local-json, justfile, mcp-server]
+status: complete
+type: research
+git_commit: c4eea06e2f97fd7806ceae8258b3727f2e1c1859
+---
+
+# Research: `ralph` CLI Environment Resolution Outside the ralph-hero Repo
+
+## Prior Work
+
+- builds_on:: [[2026-03-06-GH-0546-ralph-cli-justfile-architecture]]
+- builds_on:: [[2026-03-18-justfile-cli-setup-fallbacks]]
+- builds_on:: [[2026-03-24-agent-env-propagation-token-scope]]
+- builds_on:: [[2026-03-25-github-token-management-across-tools]]
+- builds_on:: [[2026-03-25-GH-0684-userconfig-healthcheck-setup-rewrite]]
+
+## Research Question
+
+Running `ralph issue "..."` from `~/projects/ralph-engine` produces:
+```
+{ "error": "Failed to create issue: owner is required (set RALPH_GH_OWNER env var or pass explicitly)" }
+```
+
+How does the `ralph` CLI resolve environment variables, and why does it fail when invoked outside the ralph-hero repo?
+
+## Summary
+
+The `ralph` CLI has **two independent env resolution paths** that both contribute to the failure:
+
+1. **Shell-side (`justfile`)**: The `read_settings_env()` bash function searches for `settings.local.json` in **the current git repo root** first, then falls back to `~/.claude/settings.local.json`. When run from `ralph-engine`, it finds no repo-local settings and the global file likely doesn't contain `RALPH_GH_OWNER`.
+
+2. **MCP-server-side**: The `ralph issue` command spawns Claude Code with `--print`, which launches the MCP server via `npx`. The MCP server reads env vars from `process.env` via `resolveEnv()`. Since Claude Code injects env vars from the **project-scoped** `settings.local.json`, running from a different project means the ralph-hero settings are not in scope.
+
+The core issue: `RALPH_GH_OWNER` is configured in ralph-hero's `.claude/settings.local.json`, which is project-scoped. The global `ralph` CLI has no mechanism to propagate ralph-hero project settings when invoked from other directories.
+
+## Detailed Findings
+
+### 1. CLI Entry Point: `ralph-cli.sh`
+
+**File**: [`plugin/ralph-hero/scripts/ralph-cli.sh`](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/scripts/ralph-cli.sh)
+
+The global `ralph` command is a bash script installed to `~/.local/bin/ralph` by the `setup-cli` skill. It:
+- Resolves the latest installed plugin version at runtime from `~/.claude/plugins/`
+- Validates the recipe name with fuzzy matching
+- Delegates to the justfile via `just` command executor
+
+The script itself does **not** resolve env vars — it delegates entirely to justfile recipes.
+
+### 2. Shell-Side Env Resolution: `read_settings_env()`
+
+**File**: [`plugin/ralph-hero/justfile:230-268`](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/justfile#L230-L268)
+
+The justfile defines `read_settings_env()`, a bash function that searches for env vars in `settings.local.json` files:
+
+```bash
+read_settings_env() {
+    local var="$1"
+    # Try repo-local first
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [ -n "$repo_root" ] && [ -f "$repo_root/.claude/settings.local.json" ]; then
+        paths+=("$repo_root/.claude/settings.local.json")
+    fi
+    # Then global
+    if [ -f "$HOME/.claude/settings.local.json" ]; then
+        paths+=("$HOME/.claude/settings.local.json")
+    fi
+    # Parse JSON with Node.js, filter ${VAR} literals
+    ...
+}
+```
+
+**Search order**:
+1. `<current-git-repo>/.claude/settings.local.json` (repo-local)
+2. `~/.claude/settings.local.json` (global)
+
+When run from `~/projects/ralph-engine`, step 1 looks for `ralph-engine/.claude/settings.local.json` (which doesn't exist or doesn't have RALPH_GH_OWNER). Step 2 checks the global file, which may also lack it.
+
+### 3. The `issue` Recipe Flow
+
+**File**: [`plugin/ralph-hero/justfile`](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/justfile)
+
+The `issue` recipe spawns a Claude Code `--print` session with a prompt to call `ralph_hero__create_issue`. This launches the MCP server, which reads env vars from the process environment injected by Claude Code.
+
+### 4. MCP Server Env Resolution: `resolveEnv()`
+
+**File**: [`plugin/ralph-hero/mcp-server/src/index.ts:33-38`](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/index.ts#L33-L38)
+
+```typescript
+function resolveEnv(name: string): string | undefined {
+  const val = process.env[name];
+  if (!val || val.startsWith("${")) return undefined;
+  return val;
+}
+```
+
+Called at startup for all RALPH_* variables ([index.ts:71-86](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/index.ts#L71-L86)):
+
+```typescript
+const owner = resolveEnv("RALPH_GH_OWNER");
+const repo = resolveEnv("RALPH_GH_REPO");
+const projectOwner = resolveEnv("RALPH_GH_PROJECT_OWNER") || owner;
+```
+
+### 5. What Happens When RALPH_GH_OWNER Is Undefined
+
+**At startup** ([index.ts:88-93](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/index.ts#L88-L93)): Non-fatal warning to stderr; server continues.
+
+**At tool invocation** ([helpers.ts:554-558](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/lib/helpers.ts#L554-L558)): `resolveConfig()` throws:
+```
+"owner is required (set RALPH_GH_OWNER env var or pass explicitly)"
+```
+
+This is the exact error seen in the reproduction.
+
+**Repo inference** ([helpers.ts:491-540](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/lib/helpers.ts#L491-L540)): `resolveRepoFromProject()` also requires `RALPH_GH_OWNER` to query the project's linked repos. Without it, inference cannot run.
+
+### 6. The Config Resolver Functions
+
+Three functions in `helpers.ts` gate tool execution:
+
+| Function | Line | Behavior when owner missing |
+|----------|------|-----------------------------|
+| `resolveConfig()` | [554](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/lib/helpers.ts#L554) | Throws "owner is required" |
+| `resolveConfigOptionalRepo()` | [579](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/lib/helpers.ts#L579) | Throws "owner is required" |
+| `resolveFullConfig()` | [596](https://github.com/cdubiel08/ralph-hero/blob/c4eea06e2f97fd7806ceae8258b3727f2e1c1859/plugin/ralph-hero/mcp-server/src/lib/helpers.ts#L596) | Calls resolveConfig(), same error |
+
+All tools that create/read issues call one of these, making the entire CLI non-functional without `RALPH_GH_OWNER`.
+
+### 7. How Claude Code Provides Env to the MCP Server
+
+Claude Code reads `settings.local.json` and merges the `"env"` object into the child process environment before launching MCP servers via `npx`. The `.mcp.json` has **no `env` block** — the server inherits the parent process environment.
+
+**Key constraint**: Claude Code loads `settings.local.json` from the **current project's** `.claude/` directory. When `ralph` spawns Claude Code from `ralph-engine`, it uses `ralph-engine/.claude/settings.local.json` (or global), not `ralph-hero/.claude/settings.local.json`.
+
+### 8. Global Settings Fallback
+
+The `read_settings_env()` function does check `~/.claude/settings.local.json` as a fallback. If `RALPH_GH_OWNER` were set there, the shell-side resolution would work. However, the MCP server path through Claude Code `--print` depends on Claude Code's own project resolution, which is directory-dependent.
+
+## Code References
+
+- `plugin/ralph-hero/scripts/ralph-cli.sh` — CLI entry point, recipe dispatch
+- `plugin/ralph-hero/justfile:230-268` — `read_settings_env()` shell function
+- `plugin/ralph-hero/mcp-server/src/index.ts:33-38` — `resolveEnv()` MCP-side
+- `plugin/ralph-hero/mcp-server/src/index.ts:71-93` — Owner/config reading + warning
+- `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:491-540` — Repo inference from project
+- `plugin/ralph-hero/mcp-server/src/lib/helpers.ts:554-600` — Config resolver functions (error source)
+- `plugin/ralph-hero/mcp-server/src/types.ts:283-294` — `GitHubClientConfig` type
+- `plugin/ralph-hero/mcp-server/src/types.ts:296-300` — `resolveProjectOwner()`
+- `plugin/ralph-hero/skills/setup-cli/SKILL.md` — CLI installation procedure
+
+## Architecture Documentation
+
+### Env Resolution Flow (Current)
+
+```
+ralph issue "..."  (from ~/projects/ralph-engine)
+  └─ ralph-cli.sh
+      └─ just issue "..."  (justfile from plugin cache)
+          ├─ read_settings_env("RALPH_GH_OWNER")
+          │   ├─ Try: ralph-engine/.claude/settings.local.json  → NOT FOUND
+          │   └─ Try: ~/.claude/settings.local.json             → MAY NOT HAVE IT
+          └─ claude --print "call ralph_hero__create_issue..."
+              └─ Claude Code launches MCP server
+                  ├─ Loads env from current project's settings.local.json
+                  │   (ralph-engine's, not ralph-hero's)
+                  └─ resolveEnv("RALPH_GH_OWNER") → undefined
+                      └─ resolveConfig() → ERROR: "owner is required"
+```
+
+### Two Independent Failure Points
+
+1. **Shell-side** (`read_settings_env`): Searches repo-local then global settings. Works if global settings have the value.
+2. **MCP-server-side** (via Claude Code `--print`): Depends on which project Claude Code resolves. The MCP server only sees env vars from the active project's `settings.local.json`.
+
+Even if the shell-side resolves the value, the MCP-server-side may still fail because Claude Code scopes env injection to the current project directory.
+
+## Historical Context (from thoughts/)
+
+- **GH-0588**: Removed the `.mcp.json` env block, consolidating all config into `settings.local.json`. This made the problem more acute — there's no env fallback in the MCP config itself.
+- **GH-0634**: Added `settings.local.json` fallback to the doctor command, establishing the repo-local → global search pattern now used by `read_settings_env()`.
+- **GH-0684/0685**: Active work on userconfig healthcheck and setup rewrite (Mar 25), which may touch config resolution.
+- **Agent env propagation research** (Mar 24): Documents how env vars flow from settings to agents and MCP servers.
+- **Token management research** (Mar 25): Maps token resolution across all tools, relevant to understanding the full config chain.
+
+## Related Research
+
+- [[2026-03-06-GH-0546-ralph-cli-justfile-architecture]] — CLI justfile architecture
+- [[2026-03-18-justfile-cli-setup-fallbacks]] — Justfile CLI setup fallbacks
+- [[2026-03-24-agent-env-propagation-token-scope]] — Agent env propagation
+- [[2026-03-25-github-token-management-across-tools]] — Token management cross-tool
+- [[2026-03-25-userconfig-manifest-schema-validation]] — Userconfig manifest validation
+- [[2026-02-21-group-GH-0281-global-ralph-cli]] — Global ralph CLI plan
+
+## Open Questions
+
+1. Should the `ralph` CLI explicitly pass `--owner` / `--project-number` to the `claude --print` invocation when `read_settings_env()` resolves them shell-side, bridging the gap between shell resolution and MCP server resolution?
+2. Should there be a dedicated `~/.ralph/config` or `~/.config/ralph/config.json` that both the shell scripts and the MCP server can read, independent of Claude Code's project scoping?
+3. Does the active GH-0684/0685 userconfig work already address this gap, or is it focused only on the MCP server's internal config validation?

--- a/thoughts/shared/research/2026-03-28-claude-code-auto-mode-for-ralph-hero.md
+++ b/thoughts/shared/research/2026-03-28-claude-code-auto-mode-for-ralph-hero.md
@@ -1,0 +1,171 @@
+---
+title: Claude Code Auto Mode — Replacing --dangerously-skip-permissions in Ralph-Hero
+type: research
+status: complete
+date: 2026-03-28
+tags: [permissions, auto-mode, safety, cli, migration]
+---
+
+# Claude Code Auto Mode for Ralph-Hero
+
+## Context
+
+Anthropic released [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) as a research preview (March 2026). It provides a safer alternative to `--dangerously-skip-permissions` by running a classifier model (Sonnet 4.6) that reviews each action before execution. Ralph-hero currently assumes `--dangerously-skip-permissions` is enabled for all autonomous execution.
+
+## How Auto Mode Works
+
+- A **separate classifier model** (always Sonnet 4.6) reviews each tool call before execution
+- The classifier sees user messages, tool calls, and CLAUDE.md — but **not tool results** (prompt injection resistant)
+- Read-only actions and file edits in the working directory are auto-approved without calling the classifier
+- First matching rule wins: explicit allow/deny rules → built-in auto-approvals → classifier → block with reason
+
+### Default Blocks
+
+- `curl | bash` and scripts from cloned repos
+- Sending sensitive data to external endpoints
+- Production deploys and migrations
+- Mass deletion on cloud storage
+- Granting IAM or repo permissions
+- Force push or pushing directly to `main`
+- Irreversibly destroying pre-session files
+
+### Default Allows
+
+- Local file operations in working directory
+- Installing deps declared in lock files/manifests
+- Reading `.env` and sending credentials to the matching API
+- Read-only HTTP requests
+- Pushing to the current branch or one Claude created
+
+### Fallback Thresholds
+
+- 3 consecutive blocks → session pauses (interactive) or **aborts** (`-p` mode)
+- 20 total blocks in a session → same behavior
+- Thresholds are **not configurable**
+
+## Current Ralph-Hero Permission Usage
+
+### Scripts using `--dangerously-skip-permissions`
+
+| File | Line | Context |
+|------|------|---------|
+| `scripts/cli-dispatch.sh` | 49 | `run_headless()` — all headless skill dispatch |
+| `scripts/ralph-loop.sh` | 79 | Autonomous workflow loop |
+| `scripts/ralph-team-loop.sh` | 54 | Multi-agent team orchestrator |
+
+### Two-level permission system
+
+1. **CLI level**: `--dangerously-skip-permissions` → can Claude execute tools at all?
+2. **Workflow level**: `RALPH_AUTO_APPROVE` env var → should ralph-hero stop for human plan approval?
+
+Auto mode replaces only the first. `RALPH_AUTO_APPROVE` is unaffected.
+
+### Subagent behavior
+
+Ralph-hero subagents declare `permissionMode: bypassPermissions` in frontmatter. In auto mode, **this is ignored** — the classifier evaluates the delegated task before the subagent starts and reviews its action history afterward.
+
+## Auto Mode vs Bypass Permissions
+
+| Aspect | Auto mode | `--dangerously-skip-permissions` |
+|--------|-----------|----------------------------------|
+| Permission prompts | None (unless fallback triggers) | None, ever |
+| Safety checks | Classifier reviews each action | No checks |
+| Token usage | Higher (classifier calls) | Standard |
+| Prompt injection protection | Yes | None |
+| Recommended environment | Any | Isolated containers/VMs only |
+| Plan availability | Team/Enterprise only | All plans |
+
+## Availability (as of 2026-03-28)
+
+| Plan | Auto Mode |
+|------|-----------|
+| Team | Yes (research preview, admin must enable) |
+| Enterprise | Rolling out |
+| API | Rolling out |
+| Max (individual) | Not yet — no timeline |
+| Pro (individual) | Not yet — no timeline |
+
+Requirements: Sonnet 4.6 or Opus 4.6 only. Not available on Haiku, claude-3, or third-party providers (Bedrock, Vertex, Foundry).
+
+## Migration Plan
+
+### 1. Configure `autoMode` environment
+
+In `~/.claude/settings.json` or `.claude/settings.local.json`:
+
+```json
+{
+  "autoMode": {
+    "environment": [
+      "Organization: personal development. Primary use: autonomous GitHub project management",
+      "Source control: github.com and all repos under the configured RALPH_GH_OWNER",
+      "Ralph-hero is an autonomous workflow orchestrator that manages GitHub issues through a pipeline: Backlog -> Research -> Plan -> Implementation -> Review -> Done",
+      "Git worktrees are used for isolated implementation — branches are created, pushed, and PRs opened as part of normal operation",
+      "The MCP server ralph-hero-mcp-server manages GitHub Projects V2 via GraphQL"
+    ],
+    "allow": [
+      "Creating and pushing git branches is allowed: ralph-hero uses worktrees for isolated implementation",
+      "Creating pull requests via gh CLI is allowed: normal end-of-implementation workflow",
+      "Running npm test, npm run build, and npm install is allowed: standard build/test operations",
+      "Writing to thoughts/shared/ directory is allowed: research and plan artifacts are stored here"
+    ]
+  }
+}
+```
+
+### 2. Add narrow permission allow rules
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout *)",
+      "Bash(git branch *)",
+      "Bash(git push *)",
+      "Bash(git worktree *)",
+      "Bash(gh pr create *)",
+      "Bash(gh pr merge *)",
+      "Bash(npm test *)",
+      "Bash(npm run build *)",
+      "Bash(npx vitest *)",
+      "mcp__ralph-hero-mcp-server",
+      "mcp__ralph-knowledge"
+    ]
+  }
+}
+```
+
+### 3. Update scripts
+
+Replace `--dangerously-skip-permissions` with `--permission-mode auto` in all three scripts. For `-p` mode, `--permission-mode auto` directly activates it (no `--enable-auto-mode` needed).
+
+Add fallback for plans without auto mode support:
+
+```bash
+PERMISSION_FLAG="${RALPH_PERMISSION_MODE:---permission-mode auto}"
+# Override: RALPH_PERMISSION_MODE="--dangerously-skip-permissions"
+```
+
+### 4. Validate with built-in tools
+
+```bash
+claude auto-mode defaults   # view built-in classifier rules
+claude auto-mode config     # view effective config (settings + defaults)
+claude auto-mode critique   # AI feedback on custom rules
+```
+
+## Risks
+
+1. **3-block abort in `-p` mode**: If the classifier misunderstands a legitimate ralph-hero action during autonomous runs, 3 consecutive blocks kills the session. Mitigation: thorough `autoMode.allow` rules.
+2. **Broad allow rules get dropped**: Auto mode strips `Bash(*)`, `Bash(python*)`, `Bash(node*)`, and `Agent` allow rules. Narrow rules survive. Ralph-hero's `allowed-tools` in skill frontmatter may need adjustment.
+3. **Token cost**: Every non-trivial action goes through classifier, increasing cost for long autonomous runs.
+4. **Plan availability**: Currently Team/Enterprise only. Individual Max/Pro has no timeline.
+
+## Recommendation
+
+Auto mode is a good fit for ralph-hero because:
+- Ralph-hero's core operations (git branches, PRs, file writes, MCP calls) align with what the classifier auto-allows
+- It adds prompt injection protection — valuable since ralph-hero reads untrusted content from GitHub issues
+- The `autoMode.environment` config can teach the classifier about ralph-hero's legitimate workflow
+
+**Blocker**: Not available on individual Max plan yet. Keep `--dangerously-skip-permissions` as default with auto mode as opt-in via `RALPH_PERMISSION_MODE` env var until availability expands.

--- a/thoughts/shared/research/2026-04-01-GH-0674-agent-per-phase-still-needed.md
+++ b/thoughts/shared/research/2026-04-01-GH-0674-agent-per-phase-still-needed.md
@@ -1,0 +1,165 @@
+---
+date: 2026-04-01
+github_issue: 674
+github_url: https://github.com/cdubiel08/ralph-hero/issues/674
+topic: "Is the agent-per-phase architecture (GH-674) still needed?"
+tags: [research, codebase, agents, skills, hooks, architecture, platform-constraints]
+status: complete
+type: research
+git_commit: 82c6a48
+---
+
+# Research: Is the Agent-Per-Phase Architecture (GH-674) Still Needed?
+
+## Prior Work
+
+- builds_on:: [[2026-03-24-agent-env-propagation-token-scope]]
+- builds_on:: [[2026-03-24-GH-0674-agent-per-phase-architecture]]
+
+## Research Question
+
+Re-examine whether the three root causes identified in GH-674 (March 24, 2026) still exist in the current codebase and whether Claude Code platform changes have resolved any of them.
+
+## Summary
+
+**Yes, GH-674 is still needed.** All three root causes remain active. No Claude Code platform changes have resolved them. However, partial implementation progress exists — Phase 1 (hook infrastructure) is ~50% complete with `get_agent_type()` and the `skill-precondition.sh` fallback already landed on main.
+
+| Root Cause | Status | Platform Fix? |
+|------------|--------|---------------|
+| Sub-agents cannot spawn sub-agents | **Still broken** | No — documented as intentional policy |
+| `$VAR` references unexpandable by LLMs | **Still broken** | No — only `${CLAUDE_SKILL_DIR}` added |
+| Plugin sub-agent hooks silently ignored | **Still broken** | No — now explicitly documented as security policy |
+
+## Detailed Findings
+
+### Root Cause 1: Nested Sub-Agent Prohibition — Still Active
+
+The wrapper-agent dispatch chain remains unchanged:
+
+```
+hero → Agent("ralph-analyst") → Skill("ralph-research")
+                                     └── context: fork → SILENTLY FAILS
+                                     └── model: opus → IGNORED (runs on sonnet)
+```
+
+**Codebase state:**
+- All three wrapper agents still exist: `ralph-analyst.md`, `ralph-builder.md`, `ralph-integrator.md`
+- No per-phase agents (research-agent, plan-agent, impl-agent, etc.) have been created
+- 18 skills declare `context: fork` in frontmatter — all silently fail when called from a sub-agent
+- Hero dispatch at `hero/SKILL.md:246-358` still routes through wrapper agents exclusively
+
+**Platform state:**
+- Official docs still state: "Subagents cannot spawn other subagents"
+- [Issue #16803](https://github.com/anthropics/claude-code/issues/16803) (`context: fork` fails inconsistently) remains OPEN
+- A January 2026 comment confirms: works for project-level skills, still broken for plugin-scoped skills
+- No changelog entries indicate any change to this restriction
+
+### Root Cause 2: Unexpandable Env Var References — Still Active
+
+Skills still instruct LLMs to pass literal `$RALPH_GH_OWNER` / `$RALPH_GH_REPO` as MCP tool parameters.
+
+**Codebase state:**
+- **85 occurrences** of `$RALPH_GH_OWNER` across 17 skill files
+- **82 occurrences** of `$RALPH_GH_REPO` across the same files
+- **Zero** skills use backtick preprocessing (`` !`echo $RALPH_GH_OWNER` ``)
+- **Zero** skills have a `## Configuration` block with resolved values
+- Highest concentration: `ralph-review` (12 each), `ralph-impl` (9 each), `ralph-plan` (8 each)
+
+**Platform state:**
+- Only new substitution variable since March: `${CLAUDE_SKILL_DIR}` (v2.1.69)
+- General `$VAR` expansion still not supported in skill markdown
+- `` !`command` `` backtick preprocessing remains the only sanctioned escape hatch
+- The MCP server's `resolveConfig()` correctly defaults when params are omitted — the skill prompts' insistence on explicit params creates the failure
+
+### Root Cause 3: Plugin Sub-Agent Hooks Ignored — Still Active
+
+Plugin agents cannot have `hooks` frontmatter. The `RALPH_COMMAND` env var (needed by `skill-precondition.sh`) is never set in sub-agent contexts.
+
+**Codebase state — partial progress:**
+- `hook-utils.sh:35-37` — `get_agent_type()` function **exists** (Phase 1 deliverable)
+- `skill-precondition.sh:25-31` — agent_type fallback **exists** (Phase 1 deliverable): when `RALPH_COMMAND` is empty but `agent_type` is present in hook input, it allows
+- `agent-phase-gate.sh` — **does not exist** (Phase 1 deliverable, not yet created)
+- `hooks.json` — **no** agent_type-aware hooks registered (Phase 1 deliverable, not yet done)
+- `set-skill-env.sh:13-16` — still guards on `CLAUDE_ENV_FILE`, silently no-ops when unavailable
+
+**Platform state:**
+- Official docs now explicitly document the restriction: "For security reasons, plugin subagents do not support the `hooks`, `mcpServers`, or `permissionMode` frontmatter fields"
+- [Issue #17688](https://github.com/anthropics/claude-code/issues/17688) (skill-scoped hooks not triggered in plugins) remains OPEN
+- This is now documented policy, not a bug — unlikely to change
+
+## Implementation Progress Assessment
+
+### Phase 1: Hook Infrastructure — ~50% Complete
+
+| Deliverable | Status |
+|-------------|--------|
+| `get_agent_type()` in hook-utils.sh | Done |
+| `skill-precondition.sh` agent_type fallback | Done |
+| `agent-phase-gate.sh` dispatch script | Not started |
+| hooks.json agent_type-aware entries | Not started |
+
+### Phases 2–7: Not Started
+
+No backtick preprocessing in skills, no per-phase agents, no hero dispatch changes, no wrapper agent removal, no docs updates, no integration testing.
+
+## Dispatch Inconsistency Noted
+
+The skill-vs-agent-dispatch fragment (`shared/fragments/skill-vs-agent-dispatch.md:9-11`) assigns `ralph-merge` to `ralph-builder`, but `ralph-integrator.md` also lists `ralph-merge` as one of its skills. The hero SKILL.md does not dispatch `ralph-integrator` at all — it only appears in team mode via `TeamCreate`.
+
+## Architecture Documentation
+
+### Current Agent Inventory (11 files in `plugin/ralph-hero/agents/`)
+
+| Agent | Purpose | Model |
+|-------|---------|-------|
+| ralph-analyst | Routes to triage/split/research/plan skills | sonnet |
+| ralph-builder | Routes to review/impl skills | sonnet |
+| ralph-integrator | Routes to val/pr/merge skills | haiku |
+| codebase-analyzer | Analyze code with file:line refs | (research helper) |
+| codebase-locator | Find files/components | (research helper) |
+| codebase-pattern-finder | Find usage patterns | (research helper) |
+| github-analyzer | Analyze GitHub findings | (research helper) |
+| github-lister | Search GitHub repos/issues | (research helper) |
+| thoughts-analyzer | Analyze research docs | (research helper) |
+| thoughts-locator | Find docs in thoughts/ | (research helper) |
+| web-search-researcher | Web research | (research helper) |
+
+### Active Hero Dispatch Targets
+
+| Line | Phase | Dispatch |
+|------|-------|----------|
+| 246 | SPLIT | `Agent("ralph-hero:ralph-analyst", "Run /ralph-hero:ralph-split NNN")` |
+| 309 | RESEARCH | `Agent("ralph-hero:ralph-analyst", "Run /ralph-hero:ralph-research NNN")` |
+| 318-332 | PLAN | `Agent("ralph-hero:ralph-analyst", ...)` — 4 variants |
+| 340 | REVIEW | `Agent("ralph-hero:ralph-builder", "Run /ralph-hero:ralph-review NNN ...")` |
+| 354-358 | IMPLEMENT | `Agent("ralph-hero:ralph-builder", "Run /ralph-hero:ralph-impl NNN ...")` |
+
+## Code References
+
+- `plugin/ralph-hero/agents/ralph-analyst.md` — Wrapper agent, still active
+- `plugin/ralph-hero/agents/ralph-builder.md` — Wrapper agent, still active
+- `plugin/ralph-hero/agents/ralph-integrator.md` — Wrapper agent, team-only
+- `plugin/ralph-hero/skills/hero/SKILL.md:246-358` — Hero dispatch, all via wrapper agents
+- `plugin/ralph-hero/hooks/scripts/hook-utils.sh:35-37` — `get_agent_type()` exists
+- `plugin/ralph-hero/hooks/scripts/skill-precondition.sh:25-31` — agent_type fallback exists
+- `plugin/ralph-hero/hooks/hooks.json` — No agent_type-aware entries
+- `plugin/ralph-hero/hooks/scripts/set-skill-env.sh:13-16` — CLAUDE_ENV_FILE guard unchanged
+- `plugin/ralph-hero/skills/shared/fragments/skill-vs-agent-dispatch.md:9-11` — Routing table (inconsistent on ralph-merge)
+
+## Related Research
+
+- [[2026-03-24-agent-env-propagation-token-scope]] — Original root cause investigation
+- [[2026-03-24-GH-0674-agent-per-phase-architecture]] — Implementation plan (draft status)
+
+## External References
+
+- [Claude Code Sub-agents Docs](https://code.claude.com/docs/en/sub-agents) — No sub-agent nesting, plugin hooks restriction
+- [Issue #16803](https://github.com/anthropics/claude-code/issues/16803) — `context: fork` fails for plugin skills (OPEN)
+- [Issue #17688](https://github.com/anthropics/claude-code/issues/17688) — Plugin skill-scoped hooks not triggered (OPEN)
+- [Claude Code CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) — March/April 2026 entries
+
+## Open Questions
+
+1. **Should Phase 1 be completed before moving to Phase 2?** The plan says Phases 1 and 2 can run in parallel, but Phase 1 is half-done — finishing it first might simplify validation.
+2. **Is the L estimate still accurate?** With Phase 1 partially complete, the remaining work might be closer to M.
+3. **Should the plan be split into sub-issues now?** The dashboard flagged #674 as oversized (L in Ready for Plan).

--- a/thoughts/shared/research/2026-04-01-skill-mcp-tool-name-mismatch.md
+++ b/thoughts/shared/research/2026-04-01-skill-mcp-tool-name-mismatch.md
@@ -1,0 +1,153 @@
+---
+date: 2026-04-01
+github_issue: 714
+github_url: https://github.com/cdubiel08/ralph-hero/issues/714
+topic: "Skill SKILL.md files reference MCP tools by short names that ToolSearch cannot resolve"
+tags: [research, skills, mcp, tool-names, toolsearch, bug]
+status: complete
+type: research
+git_commit: 77b675ae380ea1524d8273d9eb858067bbf09317
+---
+
+# Research: Skill MCP Tool Name Mismatch Causes ToolSearch Failures
+
+## Prior Work
+
+None found.
+
+## Research Question
+
+When `/ralph-hero:plan` is invoked (ingesting from a plan file), it fails to call MCP tools. Claude uses ToolSearch to resolve the deferred tools but gets no hits because the tool name literals in SKILL.md don't match the actual deferred tool names. What is the mismatch, and how widespread is it?
+
+## Summary
+
+Every ralph-hero skill that references MCP tools uses **short-form** names (e.g., `ralph_hero__get_issue`) in both the `allowed-tools` frontmatter and inline body text. However, the actual deferred tool names visible to ToolSearch use the **fully-qualified** form: `mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue`. When Claude reads the skill body and tries to call a tool by its short name, ToolSearch cannot find it because the deferred tool list only contains long-form names.
+
+## The Name Construction
+
+Claude Code constructs deferred MCP tool names using this formula:
+
+```
+mcp__plugin_{plugin-name}_{server-key}__{registered-tool-name}
+```
+
+For ralph-hero tools:
+- Plugin name: `ralph-hero` (from `plugin.json`)
+- Server key: `ralph-github` (from `.mcp.json`)
+- Registered name: `ralph_hero__get_issue` (from `server.tool()` in MCP server)
+- **Result**: `mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue`
+
+For ralph-knowledge tools:
+- Plugin name: `ralph-knowledge`
+- Server key: `ralph-knowledge`
+- Registered name: `knowledge_search`
+- **Result**: `mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search`
+
+## Detailed Findings
+
+### The Failure Scenario
+
+1. Skill is invoked, its SKILL.md content is injected into the conversation
+2. `allowed-tools` gates which tools the skill can use (permission check only -- does not load deferred tools)
+3. Claude reads the skill body and sees instructions like `ralph_hero__get_issue(number=NNN)`
+4. Claude tries to call this tool, but it's deferred (not yet loaded into the conversation)
+5. Claude uses ToolSearch to resolve it, searching for `ralph_hero__get_issue`
+6. ToolSearch looks at the deferred tool list which contains `mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue`
+7. **No match** -- the short name doesn't resolve to the long-form deferred name
+8. Claude concludes the tool doesn't exist and skips the MCP call entirely
+
+### Affected Skills (ralph-hero tools referenced by short name)
+
+Every ralph-hero skill that calls MCP tools is affected. The `allowed-tools` frontmatter and inline body references all use the short form `ralph_hero__*`:
+
+| Skill | Tools Referenced (short form) |
+|-------|-------------------------------|
+| `plan` | `ralph_hero__get_issue`, `create_comment`, `save_issue`, `create_issue`, `list_issues` |
+| `hero` | 13 ralph-hero tools (all short form) |
+| `team` | `get_issue`, `pipeline_dashboard`, `detect_stream_positions`, `pick_actionable_issue`, `create_issue` |
+| `impl` | `get_issue`, `list_issues`, `save_issue`, `create_comment`, `list_sub_issues` |
+| `ralph-impl` | same as `impl` |
+| `ralph-plan` | `get_issue`, `list_issues`, `save_issue`, `create_comment`, `sync_plan_graph` |
+| `ralph-plan-epic` | 8 ralph-hero tools (short form) |
+| `ralph-triage` | 8 ralph-hero tools |
+| `ralph-split` | 8 ralph-hero tools |
+| `ralph-research` | 6 ralph-hero tools |
+| `ralph-review` | 4 ralph-hero tools |
+| `ralph-merge` | 6 ralph-hero tools |
+| `ralph-pr` | 5 ralph-hero tools |
+| `ralph-val` | 2 ralph-hero tools |
+| `ralph-hygiene` | 3 ralph-hero tools |
+| `form` | 6 ralph-hero tools |
+| `research` | 3 ralph-hero tools |
+| `iterate` | 3 ralph-hero tools |
+| `bridge-artifact` | 2 ralph-hero tools |
+| `hello` | `pipeline_dashboard` |
+| `status` | `pipeline_dashboard` |
+| `report` | `pipeline_dashboard`, `create_status_update` |
+| `setup` | `health_check`, `get_project`, `setup_project` |
+| `setup-repos` | 5 ralph-hero tools |
+| `record-demo` | 2 ralph-hero tools |
+| `prove-claim` | 0 ralph-hero tools (knowledge only) |
+
+**26 skills** reference ralph-hero MCP tools by short name.
+
+### Skills That Already Use Correct Long-Form Names
+
+Three skills reference **ralph-knowledge** tools using the correct fully-qualified form in `allowed-tools`:
+
+| Skill | Knowledge Tools (long form in frontmatter) |
+|-------|---------------------------------------------|
+| `prove-claim` | 7 knowledge tools, all `mcp__plugin_ralph-knowledge_ralph-knowledge__*` |
+| `hero` | `mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search`, `knowledge_traverse` |
+| `ralph-plan-epic` | `mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search` |
+
+These work correctly because they match the deferred tool name format.
+
+### Inconsistency in Knowledge Tool References
+
+Even within skills that use long-form names in `allowed-tools` for knowledge tools, the **inline body** text often uses bare names:
+- `knowledge_search(query="...")` -- bare, no prefix
+- `knowledge_traverse(...)` -- bare, no prefix
+
+This means even knowledge tools may fail ToolSearch when referenced inline.
+
+Skills that reference knowledge tools as bare names in body text only:
+`form`, `ralph-impl`, `ralph-plan`, `ralph-review`, `ralph-triage`, `research`, `ralph-postmortem`, `ralph-plan-epic`
+
+### The `ralph-postmortem` Special Case
+
+`ralph-postmortem` lists `knowledge_record_outcome` as a **bare name** in `allowed-tools` -- neither short form (`ralph_hero__` prefix) nor long form (`mcp__plugin_*` prefix). This is a third naming variant.
+
+## Code References
+
+- MCP server tool registration: `plugin/ralph-hero/mcp-server/src/index.ts:133` (health_check), `src/tools/issue-tools.ts:61` (list_issues), etc.
+- Plugin name: `plugin/ralph-hero/.claude-plugin/plugin.json:2` -- `"name": "ralph-hero"`
+- Server key: `plugin/ralph-hero/.mcp.json:3` -- `"ralph-github": { ... }`
+- Knowledge server key: `plugin/ralph-knowledge/.mcp.json:3` -- `"ralph-knowledge": { ... }`
+- Skill permissions spec: `specs/skill-permissions.md:36` -- documents `ralph_hero__*` pattern
+
+## Architecture Documentation
+
+### Three Naming Layers
+
+| Layer | Name Format | Example |
+|-------|------------|---------|
+| MCP server registration | `ralph_hero__get_issue` | `server.tool("ralph_hero__get_issue", ...)` |
+| Skill `allowed-tools` | `ralph_hero__get_issue` (short) | Only a permission gate |
+| Deferred tool list (ToolSearch) | `mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue` | What ToolSearch indexes |
+
+The gap is between layers 2 and 3. Skills use layer-1 names, but ToolSearch only knows layer-3 names.
+
+### Agent Definitions Already Use Long Form
+
+Agent definitions in `plugin/ralph-hero/agents/` correctly use fully-qualified tool names:
+- `agents/ralph-analyst.md` line 3: `mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue`, etc.
+- `agents/ralph-builder.md` line 3: same pattern
+
+This confirms the long-form names are the correct ones for tool resolution.
+
+## Open Questions
+
+1. **Does `allowed-tools` ever trigger tool loading?** If it's purely a permission gate (likely), then even fixing frontmatter won't help -- the inline body references also need updating. If `allowed-tools` does trigger loading, then updating frontmatter to long-form names would be sufficient.
+2. **ToolSearch query strategy**: Does Claude use `select:ralph_hero__get_issue` (exact match, guaranteed fail) or keyword search like `"ralph_hero get_issue"` (might partially match)? The exact ToolSearch behavior determines whether this is a total failure or intermittent.
+3. **Why do some invocations succeed?** If tools were loaded earlier in the session (e.g., by a prior skill or agent call), they remain available. The bug only manifests when the tools are still deferred at the time the skill tries to use them.

--- a/thoughts/shared/research/2026-04-03-knowledge-implementation-comparison-obra-vs-ralph.md
+++ b/thoughts/shared/research/2026-04-03-knowledge-implementation-comparison-obra-vs-ralph.md
@@ -1,0 +1,167 @@
+---
+date: 2026-04-03
+topic: "obra/knowledge-graph vs ralph-knowledge: implementation comparison after convergence"
+tags: [research, knowledge-graph, ralph-knowledge, graphology, semantic-search, obra, comparison]
+status: complete
+type: research
+git_commit: 22a88633ef60046ddfc77c3d54fb6a70c3189acc
+---
+
+# Research: obra/knowledge-graph vs ralph-knowledge — Post-Convergence Comparison
+
+## Prior Work
+
+- builds_on:: [[2026-03-24-knowledge-graph-plugin-comparison]]
+- builds_on:: [[2026-03-24-GH-0670-graphology-graph-builder]]
+- builds_on:: [[2026-03-24-GH-0671-knowledge-communities-louvain]]
+- builds_on:: [[2026-03-24-GH-0672-centrality-tools]]
+- builds_on:: [[2026-03-24-GH-0673-knowledge-paths-and-common-tools]]
+- builds_on:: [[2026-03-24-GH-0664-capture-all-wiki-links-as-edges]]
+- builds_on:: [[2026-03-24-GH-0667-knowledge-brief-full-mode]]
+- builds_on:: [[2026-03-24-GH-0668-prove-claim-investigative-skill]]
+
+## Research Question
+
+The original comparison (March 24) identified 7 gaps in ralph-knowledge relative to obra/knowledge-graph. A burst of implementation followed. What is the current parity status? What still diverges, and what has each system done that the other hasn't?
+
+## Summary
+
+Since the March 24 comparison, ralph-knowledge has implemented **6 of the 7 identified gaps**: graphology integration, untyped edges with context, incremental indexing, stub nodes, brief mode on search/traverse, and the prove-claim skill. The one remaining gap is **write tools** (kg_create_node, kg_annotate_node, kg_add_link). Meanwhile, ralph-knowledge retains 6 structural advantages that obra's implementation does not have: hybrid RRF search fusion, typed semantic relationships, superseded document lifecycle, outcome ledger, document type taxonomy, and tag-filtered search. The two implementations have converged significantly but serve fundamentally different use cases — obra indexes a personal Obsidian vault, ralph-knowledge indexes a project-management document corpus with GitHub integration.
+
+---
+
+## Gap Closure Scorecard
+
+| Original Gap (March 24) | Status | Implementation |
+|---|---|---|
+| Graph algorithms (Louvain, PageRank, betweenness, DFS, common) | **Closed** | `graph-tools.ts`, `graph-builder.ts` — 5 tools |
+| Capture all wiki links as untyped edges | **Closed** | `parser.ts:120-121` — `extractUntypedWikilinks()` with paragraph context |
+| Edge context preservation | **Closed** | `relationships.context` column, schema migration in `db.ts:169-189` |
+| Incremental indexing (mtime) | **Closed** | `sync` table in `db.ts:153-157`, mtime comparison in `reindex.ts:57` |
+| Stub nodes for unresolved references | **Closed** | `db.upsertStubDocument()` called per-edge and in global pass (`reindex.ts:102-145`) |
+| Brief/full mode for search results | **Closed** | `brief` param on `knowledge_search` and `knowledge_traverse` (`index.ts:42,79`) |
+| Write tools (create/annotate/link) | **Open** | obra has `kg_create_node`, `kg_annotate_node`, `kg_add_link`; ralph-knowledge is read-only |
+
+---
+
+## Detailed Feature Comparison
+
+### Shared Foundation (identical)
+
+Both implementations share:
+- **SQLite** via `better-sqlite3`
+- **sqlite-vec** for vector storage (384-dim float arrays)
+- **FTS5** for full-text search
+- **`Xenova/all-MiniLM-L6-v2`** via `@huggingface/transformers` for local embeddings
+- **graphology** for in-memory graph algorithms
+- **Incremental indexing** with mtime-based sync tables
+- **Stub nodes** for unresolved wikilink targets
+
+### Where ralph-knowledge is ahead
+
+**1. Hybrid search with Reciprocal Rank Fusion**
+
+ralph-knowledge runs FTS5 and vector search in parallel, fuses via RRF (K=60), and returns a single ranked list (`hybrid-search.ts`). obra's `kg_search` requires the caller to choose `fulltext: true` or semantic — one mode per call, no fusion.
+
+**2. Typed semantic relationships**
+
+ralph-knowledge's `relationships` table has a `type` column with CHECK constraint: `builds_on`, `tensions`, `superseded_by`, `post_mortem`, `untyped`. This enables typed traversal ("what does this document build on?"). obra stores all edges as untyped rows in a flat `edges` table — context text is the only qualifier.
+
+**3. Superseded document lifecycle**
+
+`knowledge_search` defaults to filtering out documents with `superseded_by` relationships, preventing stale research from appearing. obra has no document lifecycle concept.
+
+**4. Outcome ledger**
+
+`outcome_events` table records pipeline events (triage verdicts, phase completions, drift counts) tied to GitHub issue numbers. `knowledge_search` enriches results with outcome summaries. Two MCP tools: `knowledge_record_outcome`, `knowledge_query_outcomes`. obra has nothing equivalent.
+
+**5. Document type taxonomy**
+
+Parser infers types from path segments (`/research/`, `/plans/`, `/ideas/`, `/reviews/`, `/reports/`). Search accepts `type` filter. obra treats all vault content uniformly.
+
+**6. Tag-filtered search**
+
+`knowledge_search` accepts a `tags` array for filtering. obra extracts `#hashtags` into frontmatter but doesn't expose tag-filtered search via MCP.
+
+### Where obra is ahead
+
+**1. Write tools**
+
+obra has 3 write tools (`kg_create_node`, `kg_annotate_node`, `kg_add_link`) backed by a `VaultWriter` class. These atomically create/modify markdown files AND update the index in one operation, ensuring graph-filesystem consistency. ralph-knowledge is strictly read-only — document creation happens through skills writing files directly, with a manual reindex to pick up changes.
+
+**2. Fuzzy node resolution**
+
+obra implements a 5-tier name matching cascade: exact ID → exact title → case-insensitive title → alias → substring (`resolve.ts`). All MCP tools use this resolver. ralph-knowledge requires exact document IDs.
+
+**3. Subgraph extraction tool**
+
+obra's `kg_subgraph` extracts an N-hop neighborhood as a self-contained graph (nodes + edges). ralph-knowledge has `knowledge_traverse` for chain walking and `knowledge_paths` for path finding, but no tool that returns a subgraph as a structural unit.
+
+**4. Community persistence**
+
+obra stores detected communities in a `communities` table with labels and summaries. ralph-knowledge computes communities on-the-fly with no persistence — every `knowledge_communities` call rebuilds the graph and runs Louvain from scratch.
+
+**5. Separate community detail tool**
+
+obra has both `kg_communities` (list all) and `kg_community` (get one by ID/label). ralph-knowledge has only `knowledge_communities` which returns all communities in one response (the 318K character output we observed is evidence of this scaling issue).
+
+### Differences in implementation approach
+
+| Dimension | obra | ralph-knowledge |
+|-----------|------|-----------------|
+| **Edge storage** | Flat `edges` table, no type column, autoincrement PK | Single `relationships` table with type CHECK constraint, composite PK `(source, target, type)` |
+| **Edge context** | Always stored (default `''`) | Stored for untyped edges, NULL for typed |
+| **Embedding text** | `title + tags + first paragraph`, no explicit truncation | `title + content`, truncated to 500 chars |
+| **Embedding quantization** | `dtype: 'q8'` (8-bit, 22MB) | Default precision (no quantization specified) |
+| **FTS rebuild** | Per-document insert/delete via FTS content sync | Full FTS rebuild on every reindex (`reindex.ts:129`) |
+| **Graph construction** | Persistent communities table | On-demand graph construction from relationships table |
+| **Node filtering** | All nodes including stubs | Stubs excluded from graph and vector search |
+| **PageRank isolation** | Filters isolates before computation | Runs PageRank on all nodes, then zeroes isolate scores post-hoc |
+| **Louvain determinism** | Not specified in source | Fixed RNG `() => 0.5` for deterministic results |
+| **CJS interop** | Not addressed in available source | Explicit CJS interop via `createRequire` for graphology-metrics subpath modules |
+| **MCP tool count** | 14 tools | 9 tools (search, traverse, record/query outcomes, communities, central, bridges, paths, common) |
+| **Skills** | 1 (`prove-claim`) | 3 setup skills + `prove-claim` in ralph-hero plugin |
+| **CLI** | 10 CLI commands via commander | No CLI (MCP-only) |
+
+---
+
+## Graph Statistics (live, as of 2026-04-03)
+
+ralph-knowledge graph: **1,026 nodes / 499 edges**
+
+Top bridge documents by betweenness centrality:
+1. `2026-03-19-stripe-minions-agentic-infrastructure` (0.0062)
+2. `2026-03-25-eight-pillar-product-readiness-audit` (0.0044)
+3. `2026-03-21-GH-0150-deployment-architecture-state` (0.0024)
+
+obra's graph size is ~3,300 nodes (full Obsidian vault) — no public statistics on edge count.
+
+---
+
+## Code References
+
+- Graph builder: `plugin/ralph-knowledge/src/graph-builder.ts:27-68`
+- Graph tools (5 algorithms): `plugin/ralph-knowledge/src/graph-tools.ts:176-649`
+- Relationship schema + migration: `plugin/ralph-knowledge/src/db.ts:120-189`
+- Incremental indexing: `plugin/ralph-knowledge/src/reindex.ts:32-126`
+- Stub creation: `plugin/ralph-knowledge/src/reindex.ts:102-145`
+- Untyped edge extraction: `plugin/ralph-knowledge/src/parser.ts:62-90`
+- Hybrid RRF search: `plugin/ralph-knowledge/src/hybrid-search.ts:8-101`
+- Outcome ledger tools: `plugin/ralph-knowledge/src/index.ts:94-170`
+
+## External References
+
+- [obra/knowledge-graph source](https://github.com/obra/knowledge-graph)
+- [obra blog post](https://blog.fsck.com/releases/2026/03/20/knowledge-graph/)
+- [graphology library](https://graphology.github.io/)
+
+## Historical Context (from thoughts/)
+
+20 related documents exist in `thoughts/shared/`. The March 24 original comparison (GH-663) drove a wave of 7+ implementation tickets (GH-664 through GH-673) that closed most gaps within a week. The `prove-claim` skill was implemented in the ralph-hero plugin layer rather than in ralph-knowledge itself, following the existing pattern where skills compose MCP tools.
+
+## Open Questions
+
+1. Should ralph-knowledge add write tools, or is the current pattern (skills write files, reindex picks them up) sufficient?
+2. Should `knowledge_communities` persist results to avoid the 318K response problem, or should a `knowledge_community` (singular) detail tool be added to paginate?
+3. Is fuzzy node resolution worth implementing, or do skills already handle name resolution before calling knowledge tools?
+4. Should FTS rebuild be made incremental (per-document content sync) to match the rest of the incremental indexing pipeline?

--- a/thoughts/shared/research/2026-04-04-knowledge-aware-research-skills.md
+++ b/thoughts/shared/research/2026-04-04-knowledge-aware-research-skills.md
@@ -1,0 +1,325 @@
+---
+date: 2026-04-04
+topic: "Improving research skills with ralph-knowledge MCP tools"
+tags: [ralph-knowledge, research-skill, knowledge-graph, skill-quality, prove-claim]
+status: complete
+type: research
+git_commit: 22a88633ef60046ddfc77c3d54fb6a70c3189acc
+github_issue: 725
+github_url: https://github.com/cdubiel08/ralph-hero/issues/725
+---
+
+# Research: Making Research Skills Knowledge-Aware
+
+## Prior Work
+
+- builds_on:: [[2026-04-03-knowledge-implementation-comparison-obra-vs-ralph]]
+- builds_on:: [[2026-04-03-GH-0723-knowledge-quality-improvements]]
+- builds_on:: [[2026-03-24-GH-0668-prove-claim-investigative-skill]]
+- builds_on:: [[2026-03-09-GH-0551-autonomous-skills-knowledge-metadata]]
+- builds_on:: [[2026-03-09-GH-0552-interactive-skills-knowledge-metadata]]
+- builds_on:: [[2026-02-18-GH-0060-research-skill-missing-agents]]
+
+## Research Question
+
+ralph-knowledge now exposes 9 MCP tools (search, traverse, record/query outcomes, communities, central, bridges, paths, common) with a planned 10th (subgraph) and 11th (community singular) in GH-723. Neither research skill uses any of these tools directly, and the sub-agents they dispatch (thoughts-locator, thoughts-analyzer) only use 2 of 9. How can both `research` (interactive) and `ralph-research` (autonomous) skills become more intelligent consumers of the knowledge graph?
+
+## Summary
+
+The research skills have a **knowledge gap**: they produce documents that feed the knowledge graph but don't consume it during their own work. Meanwhile, `prove-claim` demonstrates sophisticated 7-tool graph usage with evidence weighting, degradation patterns, and anti-pattern guidance. The opportunity is to port prove-claim's patterns into the research workflow at three levels: (1) direct tool access in the skills themselves, (2) richer tool access in sub-agents, and (3) outcome-informed research using the pipeline ledger. The skill-creator evaluation framework suggests specific dimensions for measuring improvement: assertion-based pass rates on prior-work completeness, evidence quality scoring via blind comparison, and trigger evaluation for knowledge tool selection.
+
+---
+
+## Detailed Findings
+
+### Current Knowledge Tool Usage Map
+
+| Component | knowledge_search | knowledge_traverse | communities | central | bridges | paths | common | query_outcomes | record_outcome |
+|---|---|---|---|---|---|---|---|---|---|
+| `research` (interactive skill) | - | - | - | - | - | - | - | - | - |
+| `ralph-research` (autonomous skill) | - | - | - | - | - | - | - | - | - |
+| `research-agent` | - | - | - | - | - | - | - | - | - |
+| `thoughts-locator` | yes | yes | - | - | - | - | - | - | - |
+| `thoughts-analyzer` | yes | yes | - | - | - | - | - | - | - |
+| `prove-claim` | yes | yes | yes | yes | yes | yes | yes | - | - |
+| `ralph-postmortem` | - | - | - | - | - | - | - | - | yes |
+| `hero` | yes | yes | - | - | - | - | - | - | - |
+| `ralph-plan-epic` | yes | - | - | - | - | - | - | - | - |
+
+Neither research skill has any knowledge MCP tools in its `allowed-tools` frontmatter. All knowledge access is indirect, through `thoughts-locator` and `thoughts-analyzer` sub-agents, which themselves only use search + traverse.
+
+### The prove-claim Blueprint
+
+prove-claim ([`plugin/ralph-hero/skills/prove-claim/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-hero/skills/prove-claim/SKILL.md)) is the most sophisticated knowledge graph consumer. Its patterns that are directly portable to research:
+
+**1. Multi-entity search fanout** (Step 2): Decomposes a claim into 2-5 entities, searches each separately, cross-products the resulting document IDs for connection probing. Research could decompose a research question into topic entities the same way.
+
+**2. Layered connection probing** (Step 3): Three complementary graph dimensions per document pair:
+- `knowledge_paths` — any connecting route (structural)
+- `knowledge_traverse` — typed semantic edges (semantic)
+- `knowledge_common` — shared neighbor documents (contextual)
+
+**3. Community scoping into centrality**: Uses `knowledge_communities` output to scope `knowledge_central` to a specific community ID, making PageRank locally meaningful rather than diluted across the whole graph.
+
+**4. Betweenness as negative filter**: `knowledge_bridges` scores identify hub documents — paths through high-betweenness nodes are flagged as weak evidence.
+
+**5. Two-pass reading**: Brief discovery (`knowledge_search` with `brief: true`) followed by `Read` only on selected documents. Saves context window.
+
+**6. Evidence weighting by document type**: research > review > plan > idea. Directly influences confidence scoring.
+
+**7. Graceful degradation**: Three named fallback modes for tool unavailability, parameter rejection, and empty results.
+
+**8. Anti-patterns**: Five explicit warnings (community co-membership ≠ evidence, hub paths are weak, plans ≠ reality, path existence ≠ evidence, paraphrase ≠ evidence).
+
+### Outcome Ledger — An Untapped Resource
+
+The `outcome_events` table ([`db.ts:130-151`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-knowledge/src/db.ts#L130-L151)) records pipeline events with columns: `event_type`, `issue_number`, `component_area`, `estimate`, `verdict`, `drift_count`, `model`, `agent_type`, `iteration_count`. The `knowledge_query_outcomes` tool supports filtering and aggregation.
+
+No research skill currently queries this data. For research that touches a specific component area, outcomes could reveal:
+- Historical pass/fail rates for the component
+- Average drift count (scope creep indicator)
+- Which estimates proved accurate vs. inaccurate
+- Which agent types and models performed best
+
+The `knowledge_search` tool already enriches results with `outcomes_summary` when a document has a linked `github_issue` ([`index.ts:53-61`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-knowledge/src/index.ts#L53-L61)), so research documents about issues with prior pipeline history already surface this data — if the skill were calling `knowledge_search` directly.
+
+### Upcoming Tools (GH-723) Relevant to Research
+
+The [GH-723 quality improvements plan](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/thoughts/shared/plans/2026-04-03-GH-0723-knowledge-quality-improvements.md) introduces two tools particularly useful for research:
+
+1. **`knowledge_subgraph`** (Phase 2): Returns N-hop neighborhood as `{ nodes[], edges[] }` with edge context. This is exactly what a research skill needs to understand the document landscape around a topic — one call replaces multiple traverse + paths calls.
+
+2. **`knowledge_community`** (singular, Phase 1): Fetch one community's full details by ID. Enables the community → centrality scoping pattern without the 318K response problem.
+
+### Skill-Creator Evaluation Framework
+
+The skill-creator plugin provides a structured evaluation approach. Applied to research skill improvement:
+
+**Assertion dimensions** (what to test):
+- Does the research skill find relevant prior research documents? (knowledge_search hit rate)
+- Does the Files Affected section match actual file analysis? (codebase-locator agreement)
+- Does the Prior Work section include all relevant `builds_on` links? (graph completeness)
+- Does the skill use outcome data when available? (outcome enrichment)
+
+**Improvement categories** (from skill-creator `agents/analyzer.md`):
+- `instructions` — add guidance on when to use knowledge tools vs grep-based fallback
+- `tools` — add knowledge MCP tools to allowed-tools
+- `examples` — add example search/traverse sequences for common research patterns
+- `error_handling` — add degradation paths for unavailable knowledge tools
+- `structure` — add a "Knowledge Graph Context" step before sub-agent dispatch
+
+**Benchmark metrics** to track:
+- Prior-work completeness (% of relevant documents found by research vs. manual audit)
+- Research time (does knowledge-aware research finish faster by avoiding redundant sub-agent work?)
+- Token consumption (does brief-first pattern reduce context usage?)
+
+---
+
+## Improvement Opportunities
+
+### Opportunity 1: Add Knowledge Tools to Skill Allowed-Tools
+
+**Both research skills** need `knowledge_search`, `knowledge_traverse`, and `knowledge_query_outcomes` in their `allowed-tools` frontmatter. This enables the main research context to:
+- Query prior research before spawning sub-agents (avoid duplicate work)
+- Check outcome history for the component area being researched
+- Verify sub-agent findings against the knowledge graph during synthesis
+
+**Files:**
+- `plugin/ralph-hero/skills/research/SKILL.md` — add to `allowed-tools` list (line 16-18)
+- `plugin/ralph-hero/skills/ralph-research/SKILL.md` — add to `allowed-tools` list (line 30-45)
+- `plugin/ralph-hero/agents/research-agent.md` — add to `tools` list (line 6)
+
+### Opportunity 2: Knowledge-First Prior Art Discovery Step
+
+Add a new step before sub-agent dispatch (between current Step 2 and Step 3 in both skills):
+
+```
+### Step 2.5: Knowledge Graph Prior Art Discovery
+
+Before spawning sub-agents, query the knowledge graph directly:
+
+1. Search for prior research: knowledge_search(query="[research topic]", type="research", brief=true)
+2. Search for existing plans: knowledge_search(query="[research topic]", type="plan", brief=true)
+3. If the issue has a component area, query outcomes:
+   knowledge_query_outcomes(component_area="[area]", aggregate=true)
+
+Use the results to:
+- Skip sub-agent dispatch for topics already well-documented
+- Target sub-agents at gaps not covered by existing research
+- Include outcome history in the research document
+```
+
+This adapts prove-claim's multi-entity search fanout pattern for the research context.
+
+### Opportunity 3: Enhance Sub-Agent Knowledge Tool Access
+
+**thoughts-locator** currently has `knowledge_search` + `knowledge_traverse`. Add:
+- `knowledge_communities` — find document clusters on the topic
+- `knowledge_central` — find the most-cited documents in a cluster
+- `knowledge_bridges` — find cross-cutting documents
+
+**thoughts-analyzer** currently has `knowledge_search` + `knowledge_traverse`. Add:
+- `knowledge_paths` — trace how documents relate to each other
+- `knowledge_common` — find shared context between two documents
+- `knowledge_query_outcomes` — check if prior research conclusions were validated
+
+**Files:**
+- `plugin/ralph-hero/agents/thoughts-locator.md` — add to `tools` (line 4)
+- `plugin/ralph-hero/agents/thoughts-analyzer.md` — add to `tools` (line 4)
+
+### Opportunity 4: Evidence Weighting for Prior Work
+
+Adapt prove-claim's evidence weighting to the Prior Work section. When citing prior work, qualify by document type:
+
+```markdown
+## Prior Work
+
+- builds_on:: [[prior-research-doc]] (research — primary evidence)
+- builds_on:: [[prior-plan-doc]] (plan — describes intent, may not reflect outcome)
+- tensions:: [[conflicting-idea-doc]] (idea — unvetted, but flags a considered alternative)
+```
+
+This helps planners who read the research document understand the reliability of cited prior work.
+
+### Opportunity 5: Outcome-Informed Research Section
+
+Add a new document section to the research template:
+
+```markdown
+## Pipeline History
+
+Based on outcome_events for component area `src/tools/`:
+- 12 total events, 8 passed, 2 failed, 2 needs_iteration
+- Average drift count: 1.5 files
+- Estimate accuracy: S issues took avg 45min, M issues took avg 2.5h
+- Most common blocker: type errors in adjacent modules
+```
+
+This section would be populated by `knowledge_query_outcomes` with `aggregate: true` and the issue's component area as filter.
+
+### Opportunity 6: Graceful Degradation Guidance
+
+Neither research skill has fallback guidance for when knowledge tools are unavailable. Add a degradation section modeled on prove-claim's pattern:
+
+```
+## Knowledge Tool Degradation
+
+If knowledge tools are unavailable (MCP server not running, tools not in allowlist):
+- Fall back to thoughts-locator sub-agent (always works, uses grep/glob)
+- Note in research document: "Knowledge graph unavailable — prior work discovery via file scan only"
+- Skip outcome history section
+
+If knowledge_search returns zero results:
+- Try broader search terms (remove specific qualifiers)
+- Fall back to grep-based search in thoughts/ directory
+- Do not skip sub-agent dispatch — knowledge graph may be stale
+```
+
+### Opportunity 7: Brief-First Pattern for Sub-Agent Dispatch
+
+Adopt prove-claim's two-pass approach:
+
+1. Main research context does `knowledge_search(brief=true)` to get a quick topic landscape
+2. Based on brief results, dispatch targeted sub-agents only for areas that need deep investigation
+3. Sub-agents do full reads on specific documents
+
+This avoids the current pattern where sub-agents redundantly scan the full thoughts directory.
+
+### Opportunity 8: Knowledge Subgraph Integration (post-GH-723)
+
+Once `knowledge_subgraph` ships (GH-723 Phase 2), research skills should use it as their primary prior-art tool. One call to `knowledge_subgraph(root="[relevant-doc-id]", depth=2)` returns the full document neighborhood with edges and context, replacing multiple traverse + paths calls.
+
+### Opportunity 9: Record Research Outcomes
+
+`knowledge_record_outcome` is only used by `ralph-postmortem`. Research skills should record events too:
+
+```
+knowledge_record_outcome(
+  event_type="research_completed",
+  issue_number=NNN,
+  component_area="src/tools/",
+  verdict="complete",
+  duration_ms=elapsed,
+  model="sonnet",
+  agent_type="analyst"
+)
+```
+
+This builds the outcome ledger that future research can query (Opportunity 5), creating a feedback loop.
+
+### Opportunity 10: Skill-Creator Evaluation Suite
+
+Create evals for the research skill using skill-creator's framework:
+
+**Eval 1: Prior-work completeness**
+- Prompt: "Research the caching system in ralph-hero"
+- Assertions: Finds `cache.ts`, finds prior research docs about caching, Prior Work section has `builds_on` links
+
+**Eval 2: Outcome integration**
+- Prompt: "Research issue #651 (lock state enforcement)"
+- Assertions: Includes pipeline history section, references prior implementation attempts
+
+**Eval 3: Degradation handling**
+- Prompt: Run with knowledge tools removed from allowlist
+- Assertions: Still produces complete research, notes knowledge unavailability
+
+---
+
+## Code References
+
+- Interactive research skill: [`plugin/ralph-hero/skills/research/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-hero/skills/research/SKILL.md)
+- Autonomous research skill: [`plugin/ralph-hero/skills/ralph-research/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-hero/skills/ralph-research/SKILL.md)
+- Research agent: [`plugin/ralph-hero/agents/research-agent.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-hero/agents/research-agent.md)
+- Prove-claim skill: [`plugin/ralph-hero/skills/prove-claim/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-hero/skills/prove-claim/SKILL.md)
+- thoughts-locator agent: [`plugin/ralph-hero/agents/thoughts-locator.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-hero/agents/thoughts-locator.md)
+- thoughts-analyzer agent: [`plugin/ralph-hero/agents/thoughts-analyzer.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-hero/agents/thoughts-analyzer.md)
+- Knowledge MCP server: [`plugin/ralph-knowledge/src/index.ts`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-knowledge/src/index.ts)
+- Graph tools: [`plugin/ralph-knowledge/src/graph-tools.ts`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-knowledge/src/graph-tools.ts)
+- Outcome events schema: [`plugin/ralph-knowledge/src/db.ts:130-151`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/plugin/ralph-knowledge/src/db.ts#L130-L151)
+- GH-723 quality plan: [`thoughts/shared/plans/2026-04-03-GH-0723-knowledge-quality-improvements.md`](https://github.com/cdubiel08/ralph-hero/blob/22a88633ef60046ddfc77c3d54fb6a70c3189acc/thoughts/shared/plans/2026-04-03-GH-0723-knowledge-quality-improvements.md)
+
+## Architecture Documentation
+
+### Current Research → Knowledge Flow (One-Way)
+
+```
+Research skill → writes document → reindex → knowledge DB
+                                                ↑ (no feedback loop)
+Research skill → spawns thoughts-locator → knowledge_search + knowledge_traverse
+Research skill → spawns thoughts-analyzer → knowledge_search + knowledge_traverse
+```
+
+### Proposed Research ↔ Knowledge Flow (Bidirectional)
+
+```
+Research skill → knowledge_search (prior art discovery)
+             → knowledge_query_outcomes (pipeline history)
+             → spawns targeted sub-agents (gap-filling only)
+             → synthesis with knowledge verification
+             → writes document → reindex → knowledge DB
+             → knowledge_record_outcome (feedback loop)
+```
+
+## Historical Context (from thoughts/)
+
+39 related documents exist in `thoughts/shared/`. Key lineage:
+- March 2026: obra/knowledge-graph comparison drove a wave of 7+ implementation tickets (GH-664–673)
+- March 9: Knowledge metadata alignment (GH-549–555) added type inference and frontmatter conventions
+- March 24: Graph tools (communities, central, bridges, paths, common) shipped
+- March 24: prove-claim skill implemented as the first sophisticated knowledge consumer
+- April 3: obra comparison refresh identified 4 remaining quality gaps (GH-723)
+- The research skills themselves have been improved before (GH-060 fixed missing agents, GH-564 added research-to-issue workflow) but never gained knowledge tool access
+
+## Related Research
+
+- [`thoughts/shared/research/2026-04-03-knowledge-implementation-comparison-obra-vs-ralph.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-04-03-knowledge-implementation-comparison-obra-vs-ralph.md) — Latest obra comparison
+- [`thoughts/shared/research/2026-03-24-knowledge-graph-plugin-comparison.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-03-24-knowledge-graph-plugin-comparison.md) — Original obra comparison
+- [`thoughts/shared/research/2026-03-24-GH-0668-prove-claim-investigative-skill.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-03-24-GH-0668-prove-claim-investigative-skill.md) — prove-claim design research
+- [`thoughts/shared/research/2026-02-18-GH-0060-research-skill-missing-agents.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-02-18-GH-0060-research-skill-missing-agents.md) — Prior research skill fix
+
+## Open Questions
+
+1. Should knowledge tools be added directly to the research skills, or should a new dedicated sub-agent (e.g., `knowledge-researcher`) encapsulate knowledge graph queries? Adding tools directly is simpler but increases the skill's tool surface.
+2. Should outcome recording happen automatically at the end of ralph-research (autonomous), or should it be opt-in? Automatic recording builds the ledger faster but adds a dependency on the knowledge MCP server being available.
+3. How should the research skills handle the transition period before GH-723 ships? Should they be written against the current 9-tool surface and updated later, or designed with `knowledge_subgraph` in mind from the start?
+4. What's the right balance between direct knowledge tool usage in the main context vs. delegation to sub-agents? More direct usage saves sub-agent overhead but consumes main context window.

--- a/thoughts/shared/research/2026-04-05-hero-pipeline-handoff-ux-inventory.md
+++ b/thoughts/shared/research/2026-04-05-hero-pipeline-handoff-ux-inventory.md
@@ -1,0 +1,444 @@
+---
+date: 2026-04-05
+last_updated: 2026-04-05
+last_updated_note: "Incorporated user feedback on all six findings — corrected allowed-tools semantics, deepened mode-specific analysis for every handoff"
+github_issue: 745
+github_url: https://github.com/cdubiel08/ralph-hero/issues/745
+topic: "Hero pipeline handoff points and closing UX inventory"
+tags: [hero, pipeline, handoffs, ux, ask-user-question, skills, agents]
+status: complete
+type: research
+---
+
+# Research: Hero Pipeline Handoff Points and Closing UX Inventory
+
+## Prior Work
+
+- builds_on:: [[2026-03-24-GH-0674-agent-per-phase-architecture]]
+
+## Research Question
+
+Inventory every handoff point between the ralph primitives in the ralph-hero:hero chain and examine the closing interactive user experience of each skill. Determine if room for improvement exists — especially around AskUserQuestion usage, option phrasing, and flow continuity between pipeline phases.
+
+## Summary
+
+The hero pipeline chains 8 skill primitives: **split → research → plan → review → impl → pr → finish (val + merge + CI)**. Each skill has both an **autonomous** variant (dispatched by hero via `Skill()`) and an **interactive** variant (invoked directly by users). The closing UX must behave differently depending on **who invoked the skill**:
+
+| Invocation context | User present? | Closing UX should... |
+|--------------------|:---:|---|
+| User invokes interactive skill directly (`/plan`, `/research`, `/impl`) | Yes | Use AskUserQuestion pickers, offer next steps |
+| Hero orchestrator dispatches autonomous skill (`Skill("ralph-plan", ...)`) | No | Return clean status + artifact paths, no prompts |
+| Autonomous loop invokes skill (future: ralph-loop) | No | Return clean status, use "STOP: [reason]" for human-needed situations |
+
+This document inventories every handoff and analyzes the closing experience through all three lenses.
+
+## Correction: `allowed-tools` Semantics
+
+`allowed-tools` in skill frontmatter is a **whitelist to skip permission prompts**, not a hard block on tool access. A tool not listed can still be used but will trigger a permission prompt to the user. This means:
+
+- AskUserQuestion will still *work* in skills that don't list it — but the user gets an extra confirmation dialog, which is friction
+- For interactive skills that should use AskUserQuestion, it should be in `allowed-tools` for a smooth experience
+- For autonomous skills, it doesn't matter (no user to prompt)
+
+The same applies to agent `tools:` frontmatter — it's a hard allowlist in agent context, not just a skip-prompt list. So agents without AskUserQuestion in `tools:` genuinely cannot use it.
+
+## AskUserQuestion Availability Matrix
+
+### Skills (`allowed-tools:` — skip-prompt whitelist)
+
+| Skill | In allowed-tools | Should be? | Notes |
+|-------|:---:|:---:|-------|
+| hero | Yes | Yes | Orchestrator needs it for human gate |
+| plan (interactive) | **No** | **Yes** | Closing UX uses numbered lists instead of picker |
+| research (interactive) | **No** | **Yes** | Should offer structured choices at closing |
+| impl (interactive) | **No** | **Yes** | Should offer structured next-step choices |
+| iterate | **No** | Maybe | Simpler flow, may not need structured picker |
+| ralph-plan (autonomous) | **No** | No | No user present |
+| ralph-research (autonomous) | **No** | No | No user present |
+| ralph-impl (autonomous) | **No** | No | No user present |
+| ralph-review | **No** | **Yes** | INTERACTIVE mode prose calls AskUserQuestion — needs it for skip-prompt |
+| ralph-split | **No** | No | Autonomous only |
+| ralph-triage | **No** | No | Autonomous only |
+| ralph-pr | **No** | No | Autonomous only |
+| ralph-merge | Yes | Yes | Code review gate uses it correctly |
+| ralph-val | **No** | No | Autonomous only, read-only |
+| finish | Yes | Yes | Delegates to ralph-merge which needs it |
+
+### Agents (`tools:` — hard allowlist)
+
+| Agent | Has AskUserQuestion | Should have? | Notes |
+|-------|:---:|:---:|-------|
+| finish-agent | **Yes** | Yes | Only agent with it — correct |
+| merge-agent | **No** | **Yes** | Skill prose uses it for code review gate; fails as agent |
+| review-agent | **No** | Conditional | Only needed if INTERACTIVE mode is passed through to agent |
+| All others | **No** | No | Autonomous agents, no user present |
+
+## Detailed Handoff Inventory
+
+Each handoff is analyzed across three invocation modes:
+- **:hero** — hero orchestrator dispatching via `Skill()`
+- **Interactive** — user invoking the interactive variant directly
+- **Autonomous standalone** — skill invoked programmatically with no user
+
+---
+
+### 1. Entry → Split (if M/L/XL)
+
+**Trigger**: `get_issue(includePipeline=true)` returns `phase: SPLIT`
+
+**:hero dispatch**: `Skill("ralph-hero:ralph-split", args="NNN")`
+
+**Split closing UX** (ralph-split SKILL.md Step 11):
+```
+Split complete for #NNN: [Original Title]
+...
+Next: Run /ralph-research or /ralph-plan on sub-issues as appropriate.
+```
+
+**Handoff**: Hero re-detects pipeline position after split, rebuilds task list.
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero | "Next: Run /ralph-research..." printed | Clean status only — hero ignores the suggestion and re-detects. Remove "Next:" line. |
+| Interactive | N/A (split is not user-invocable) | N/A |
+| Autonomous | Same as hero | Clean status only |
+
+---
+
+### 2. Entry → Research (parallel)
+
+**Trigger**: Issues in "Research Needed"
+
+**:hero dispatch**: `Skill("ralph-hero:ralph-research", args="NNN")` — one per issue, parallel
+
+**Research closing UX** (ralph-research SKILL.md Step 10):
+```
+Research complete for #NNN: [Title]
+Findings: thoughts/shared/research/[filename].md
+Status: Ready for Plan
+[If all done]: Group ready for planning. Run /ralph-plan.
+```
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero | "Run /ralph-plan" suggestion printed | Clean status + artifact path only. Hero resolves next task via TaskList dependency chain. |
+| Interactive (research skill) | Writes doc, then suggests `/ralph-hero:form` | Should ask user for feedback on findings BEFORE writing the doc, or write then ask "Does this look right?" and update. See [Research Skill UX Issue](#research-skill-meta-ux-issue). |
+| Autonomous | "Run /ralph-plan" printed | Clean status only |
+
+---
+
+### 3. Research → Plan
+
+**Trigger**: All research tasks complete, plan task unblocks
+
+**:hero dispatch**: `Skill("ralph-hero:ralph-plan", args="NNN --research-doc ...")`
+
+**Autonomous plan closing UX** (ralph-plan SKILL.md Step 10):
+```
+Plan complete for [N] issue(s):
+Plan: thoughts/shared/plans/[filename].md
+Phases: 1. #XX [Title] (XS), 2. #YY [Title] (S), ...
+All issues: Plan in Review
+Ready for human review.
+```
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero | "Ready for human review" — clean | Clean. Hero reads plan task result and unblocks review/gate. Good as-is. |
+| Autonomous | Same | Clean status + artifact path only |
+
+**Interactive plan closing UX** (plan SKILL.md Step 6) — **deep analysis**:
+
+The interactive plan skill's Step 6 has TWO decision points presented as numbered lists:
+
+**Decision 1 — GitHub linking:**
+```
+Would you like to link this plan to a GitHub issue?
+1. Link to existing issue (provide issue number like #123)
+2. Create new issue from this plan
+3. Skip GitHub integration
+```
+
+**Decision 2 — State advancement (after linking):**
+```
+Would you like to advance #NNN?
+1. Move to "Plan in Review" (for later autonomous review via /ralph-review)
+2. Move to "In Progress" (you've reviewed the plan interactively — ready for implementation)
+3. Skip state transition
+```
+
+**Mode-specific analysis:**
+
+| Condition | Current behavior | Desired behavior |
+|-----------|-----------------|------------------|
+| User ran `/plan` interactively, default mode | Two numbered-list prompts | Use AskUserQuestion picker. Rephrase options (see below). |
+| User ran `/plan` interactively with `RALPH_REVIEW_MODE=auto` | Same two prompts | After linking, should NOT prompt for advancement — automatically move to "Plan in Review" so ralph-review picks it up. Say "Plan linked and moved to Plan in Review. Ralph will review it automatically." and offer: "Would you like Ralph to review now, or leave it for the next session?" |
+| ralph-plan invoked by hero | N/A (hero uses ralph-plan, not plan) | N/A — there is no user |
+| ralph-plan invoked autonomously | Prints "Ready for human review" | Clean status only — correct |
+
+**Proposed AskUserQuestion for interactive plan closing:**
+
+Decision 2 options should be rephrased to be user-facing, not system-internal:
+
+| Current option | Problem | Proposed option |
+|---------------|---------|-----------------|
+| `1. Move to "Plan in Review" (for later autonomous review via /ralph-review)` | System jargon — user doesn't know what "Plan in Review" means or what ralph-review is | `{"label": "Queue for review", "description": "Ralph will review this plan in a later session before implementation begins"}` |
+| `2. Move to "In Progress" (you've reviewed the plan interactively — ready for implementation)` | Reasonable but could be tighter | `{"label": "Start implementation", "description": "You've reviewed the plan — move straight to implementation with /impl"}` |
+| `3. Skip state transition` | Vague, sounds indifferent | `{"label": "Leave as-is", "description": "Keep the plan in draft — decide later what to do with it"}` |
+
+And when `RALPH_REVIEW_MODE=auto`, replace the whole Decision 2 with:
+
+```
+{"label": "Review now", "description": "Run Ralph's automated plan review immediately"}
+{"label": "Queue for review", "description": "Ralph will pick this up for review in the next session"}
+```
+
+---
+
+### 4. Plan → Review (conditional)
+
+**Trigger**: Plan task complete in hero pipeline.
+
+Three paths based on `RALPH_REVIEW_MODE`:
+
+#### 4a. `RALPH_REVIEW_MODE=auto` — Autonomous review
+
+**:hero dispatch**: `Skill("ralph-hero:ralph-review", args="NNN --plan-doc ...")`
+
+**Review closing UX — APPROVED** (ralph-review SKILL.md Step 7):
+```
+Review complete for GH-NNN: [Title]
+Mode: AUTO, Result: APPROVED
+Status: In Progress
+Ready for implementation. Run /ralph-impl NNN
+```
+
+**Review closing UX — NEEDS_ITERATION**:
+```
+Review complete for GH-NNN: [Title]
+Mode: AUTO, Result: NEEDS ITERATION
+Issues: [list]
+Status: Ready for Plan
+Run /ralph-plan NNN to address critique and update plan.
+```
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero | "Run /ralph-impl" or "Run /ralph-plan" suggestions | Clean verdict + artifact path only. Hero resolves routing. |
+| Autonomous | Same | Clean verdict only |
+
+#### 4b. `RALPH_REVIEW_MODE=interactive` — Human reviews inline
+
+**ralph-review INTERACTIVE mode** (Step 4A) uses `AskUserQuestion()` with a well-structured picker:
+
+```
+AskUserQuestion(questions=[{
+  "question": "How does the implementation plan for #NNN look?",
+  "options": [
+    {"label": "Approve", "description": "Plan is complete and ready for implementation"},
+    {"label": "Minor Changes", ...},
+    {"label": "Major Changes", ...},
+    {"label": "Reject", ...},
+    {"label": "Open in editor", ...}
+  ]
+}])
+```
+
+| Issue | Detail |
+|-------|--------|
+| Prose trigger strength | The skill prose includes the full AskUserQuestion call with proper structure. The trigger is clear. |
+| allowed-tools gap | AskUserQuestion is NOT in ralph-review's `allowed-tools` — will trigger a permission prompt, adding friction. Should be added. |
+| review-agent tools gap | review-agent does NOT have AskUserQuestion in `tools:` — if spawned as an agent (team mode), the tool call will be denied entirely. Should be added if INTERACTIVE mode is expected to work through agents. |
+| Quality of options | Good — "Approve", "Minor Changes", "Major Changes", "Reject", "Open in editor" are clear verb+target labels following the AskUserQuestion convention. |
+
+#### 4c. `RALPH_REVIEW_MODE=skip` (default) — Human gate
+
+**Hero's HUMAN GATE closing UX** (hero SKILL.md "HUMAN GATE tasks"):
+```
+Report planned groups with plan URLs. All issues are in "Plan in Review".
+Instruct user to: (1) Review plans in GitHub, (2) Move to "In Progress", (3) Re-run /ralph-hero [ROOT-NUMBER].
+Then STOP.
+```
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero (interactive session) | Procedural instructions to go to GitHub + re-invoke | **Use AskUserQuestion** — hero HAS it in allowed-tools. Offer: `{"label": "Approve plan", "description": "Move to In Progress and begin implementation"}`, `{"label": "Open plan in editor", ...}`, `{"label": "Stop here", "description": "Review the plan in GitHub and re-run /hero later"}` |
+| :hero (autonomous/loop context) | Same procedural instructions | Print a clear **STOP message** explaining WHY: `HUMAN GATE: Plan requires human approval before implementation. Plan URL: [url]. Issue: #NNN. Re-run /ralph-hero NNN after approving.` This gives the calling client a structured stop reason. |
+
+---
+
+### 5. Review → Implement (sequential)
+
+**Trigger**: Review approved (or human gate cleared). Impl tasks unblock per dependency chain.
+
+**:hero dispatch**: `Skill("ralph-hero:ralph-impl", args="NNN --plan-doc ...")`
+
+**Impl closing UX — mid-phase** (ralph-impl SKILL.md Step 9):
+```
+Phase [N]/[M] complete. Next: Phase [N+1]. Run /ralph-impl NNN to continue.
+```
+
+**Impl closing UX — final phase** (ralph-impl SKILL.md Step 14):
+```
+Implementation complete.
+PR: [GitHub PR URL]
+[List all issues with titles and "In Review" status]
+Worktree preserved at: $GIT_ROOT/worktrees/[WORKTREE_ID]
+```
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero | Mid-phase: "Run /ralph-impl" suggestion. Final: PR URL + worktree path. | Mid-phase: clean phase status only. Final: clean status + worktree path. **Remove PR creation from ralph-impl** — see below. |
+| Interactive (/impl) | Mid-phase: pause for manual verification (correct). Final: PR created + "iterate with /ralph-hero:iterate" suggestion. | Mid-phase: correct. Final: should use AskUserQuestion: `{"label": "Run finish", "description": "Validate, merge, and watch CI"}`, `{"label": "Create PR only", ...}`, `{"label": "Done for now", ...}` |
+| Autonomous | Same as hero | Clean status only |
+
+**Critical: Remove PR creation from ralph-impl.** ralph-impl's Step 10 creates a PR when all phases complete. This is problematic because:
+- ralph-impl may be invoked in parallel (multiple issues in a group each executing their phases)
+- Creating multiple PRs from parallel impl invocations is undesirable
+- The orchestrator (hero) has better sightlines on when the full group is ready for a single PR
+- Hero already has a dedicated ralph-pr stage for this purpose
+
+**Resolution**: Remove Steps 10-12 (PR creation, PR gate, GitHub issue update) from ralph-impl. ralph-impl should STOP after committing the final phase and reporting status. PR creation is the caller's responsibility — hero dispatches ralph-pr, interactive /impl can offer it via AskUserQuestion.
+
+---
+
+### 6. Implement → PR
+
+**Trigger**: Last impl task complete, PR task unblocks in hero pipeline.
+
+**:hero dispatch**: `Skill("ralph-hero:ralph-pr", args="NNN")`
+
+**PR closing UX** (ralph-pr SKILL.md Step 8):
+```
+PR CREATED
+Issue: #NNN
+PR: https://github.com/owner/repo/pull/NNN
+State: In Review
+```
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero | Clean terse output with PR URL | Good as-is — hero consumes the PR URL and passes it to finish. |
+| Interactive | N/A (ralph-pr is not user-invocable) | N/A |
+| Autonomous | Same | Good as-is |
+
+With ralph-impl's PR creation removed, there is no longer an overlap. ralph-pr is the sole PR creator. Clean separation.
+
+---
+
+### 7. PR → Finish (validate → merge → CI watch)
+
+**Trigger**: PR task complete, finish task unblocks.
+
+**:hero dispatch**: `Skill("ralph-hero:finish", args="NNN")`
+
+Finish chains internally: `ralph-val → ralph-merge → CI watch`
+
+**Finish closing UX** (finish SKILL.md Step 6):
+```
+FINISHED
+Issue: #NNN
+PR: https://github.com/OWNER/REPO/pull/PR_NUMBER
+Validation: PASS
+Merge: Done
+CI: [PASS / FAIL / PENDING (timeout) / SKIPPED (no runs)]
+```
+
+**ralph-merge code review gate** (ralph-merge SKILL.md Step 4):
+Uses AskUserQuestion correctly to ask about code review before merge. Options:
+- "Run code review" — invokes `/code-review:code-review`
+- "Merge without review" — proceeds to merge
+
+| Mode | Current behavior | Desired behavior |
+|------|-----------------|------------------|
+| :hero (interactive) | AskUserQuestion picker for code review gate — works correctly | Good as-is. Best interactive UX in the pipeline. |
+| :hero (autonomous/loop) | Same AskUserQuestion | Should detect autonomous context and either auto-select based on env var (e.g., `RALPH_AUTO_MERGE=true`) or emit a STOP message: `HUMAN GATE: PR ready for merge but requires human decision on code review.` |
+| Interactive (/finish) | Same | Good as-is |
+
+**merge-agent gap**: merge-agent lacks AskUserQuestion in `tools:` — when ralph-merge is dispatched via agent (team mode), the code review gate prompt fails silently. Should be added.
+
+---
+
+## Research Skill Meta-UX Issue {#research-skill-meta-ux-issue}
+
+The interactive `research` skill (SKILL.md) writes the research document first, then presents findings and asks if the user has follow-up questions. This ordering means the user's first feedback gets appended as "Follow-up Research" rather than incorporated into the primary document.
+
+**Current flow**: Research → Write doc → Present findings → Ask for follow-ups → Append to doc
+
+**Proposed flow (interactive only)**:
+1. Research → Present findings summary
+2. Ask: "Does this capture your question accurately? Any corrections or areas to go deeper?"
+3. If user provides feedback: incorporate before writing, or update the written doc
+4. Write/update the doc with corrections incorporated
+5. Offer next steps (link to issue, create issue via `/form`)
+
+The autonomous `ralph-research` correctly skips user feedback (no user present). This change only applies to the interactive `research` skill.
+
+This is itself a handoff UX issue: the document is the artifact, and the user should have a chance to shape it before it's finalized.
+
+---
+
+## Cross-Cutting Themes
+
+### 1. Mode-aware closing UX
+
+Every skill that can be invoked in multiple contexts (hero, interactive, autonomous) needs mode-aware closing behavior. Currently, all skills have a single closing template that tries to serve all three contexts and serves none perfectly.
+
+**Pattern to adopt**: Check whether a user is present (AskUserQuestion availability or an env var like `RALPH_INTERACTIVE=true`) and branch:
+- User present → AskUserQuestion picker with clear next-step options
+- No user, hero context → clean status + artifact path for hero to consume
+- No user, autonomous stop → structured STOP message with reason
+
+### 2. AskUserQuestion should be in all interactive skill `allowed-tools`
+
+Interactive skills (plan, research, impl, iterate, ralph-review) should include AskUserQuestion in `allowed-tools` to skip the permission prompt. This is the minimum change to enable structured pickers everywhere.
+
+### 3. "Next:" suggestions should be context-dependent
+
+When hero invokes an autonomous skill, "Next: Run /ralph-foo" is noise — hero determines routing via its task dependency graph. These suggestions should only appear when a user invoked the skill directly and needs guidance on what to do next.
+
+### 4. PR creation belongs to the caller, not ralph-impl
+
+ralph-impl should be pure implementation: execute phases, commit, push. PR creation should be removed from ralph-impl because:
+- impl may run in parallel across a group
+- The orchestrator has better sightlines on when all impl work is done
+- Hero already has a dedicated ralph-pr stage
+- Interactive /impl can offer PR creation via AskUserQuestion at closing
+
+### 5. Human gates should be structured, not procedural
+
+When a pipeline hits a human-needed point:
+- Interactive sessions: use AskUserQuestion inline
+- Autonomous sessions: emit a machine-parseable STOP with reason and required action, not prose instructions
+
+### 6. Research skill should gather feedback before finalizing
+
+The interactive research skill should present findings and invite corrections before writing the final document. The autonomous ralph-research correctly skips this. This applies to the research skill's closing UX and also serves as a general pattern: interactive skills should checkpoint with the user before producing artifacts.
+
+## Code References
+
+All paths relative to `plugin/ralph-hero/` in the marketplace install at `~/.claude/plugins/marketplaces/ralph-hero/plugin/ralph-hero/`.
+
+| Component | Path | Relevant section |
+|-----------|------|-----------------|
+| Hero orchestrator | `skills/hero/SKILL.md` | Full pipeline, HUMAN GATE at line ~355 |
+| Plan (interactive) | `skills/plan/SKILL.md` | Step 6 closing UX at lines 394-453 |
+| Plan (autonomous) | `skills/ralph-plan/SKILL.md` | Steps 7-10 closing at lines 490-567 |
+| Research (interactive) | `skills/research/SKILL.md` | Steps 8-9 closing at lines 248-297 |
+| Research (autonomous) | `skills/ralph-research/SKILL.md` | Steps 8-10 closing at lines 338-369 |
+| Impl (interactive) | `skills/impl/SKILL.md` | Step 5 closing at lines 171-244 |
+| Impl (autonomous) | `skills/ralph-impl/SKILL.md` | Steps 9-14 closing at lines 383-477 |
+| Review | `skills/ralph-review/SKILL.md` | Step 4A INTERACTIVE at lines 130-203 |
+| Merge | `skills/ralph-merge/SKILL.md` | Step 4 code review gate at lines 88-153 |
+| Finish | `skills/finish/SKILL.md` | Steps 3-6 chain at lines 97-176 |
+| Iterate | `skills/iterate/SKILL.md` | Step 6 closing at lines 229-257 |
+| AskUserQuestion convention | `skills/shared/fragments/ask-user-question.md` | Label/description rules |
+| finish-agent (has AskUserQuestion) | `agents/finish-agent.md` | tools line |
+| merge-agent (missing AskUserQuestion) | `agents/merge-agent.md` | tools line |
+| review-agent (missing AskUserQuestion) | `agents/review-agent.md` | tools line |
+
+## Open Questions
+
+1. Should `RALPH_INTERACTIVE` env var be formalized as the mode detection mechanism, or should skills detect mode by checking if AskUserQuestion is available?
+2. For the HUMAN GATE in autonomous mode, should the STOP message follow a structured format (JSON, YAML) for machine parsing by future orchestrators like ralph-loop?
+3. Should iterate also get mode-aware closing UX, or is it simple enough to keep as free-text?

--- a/thoughts/shared/reviews/2026-04-05-GH-0743-critique.md
+++ b/thoughts/shared/reviews/2026-04-05-GH-0743-critique.md
@@ -1,0 +1,109 @@
+---
+date: 2026-04-05
+github_issue: 743
+github_url: https://github.com/cdubiel08/ralph-hero/issues/743
+plan_document: thoughts/shared/plans/2026-04-05-GH-0743-finish-skill.md
+status: approved
+type: review
+tags: [plan-review, finish, orchestration, integrator]
+---
+
+# Critique: GH-743 Add :finish Skill
+
+## Summary
+
+Well-structured plan for an orchestrator skill that chains validate, code-review, fix-loop, merge, and CI watch into a single post-PR pipeline. All three phases are fully specified with accurate codebase references. Two medium-severity issues need attention but are not blocking: fragile PR comment parsing and a redundant code-review gate in ralph-merge when dispatched from finish.
+
+## Completeness: 5/5
+
+All three phases are fully specified:
+
+- **Phase 1 (skill creation)**: 8-step flow covering parse, fetch, validate, code-review, fix-loop, merge, CI watch, and final report. Error paths for each step are documented (validation fail stops, merge blocked stops, CI timeout reports pending).
+- **Phase 2 (hero wiring)**: 5 changes enumerated across the hero SKILL.md -- state machine diagram, all 4 task graph variants, execution loop dispatch, integrator complete section, and allowed-tools verification.
+- **Phase 3 (agent definition)**: Agent frontmatter with model, tools, and skill preload. Differences from other integrator agents are justified (sonnet for code comprehension, Write/Edit/Agent for fix loop).
+
+Edge cases are addressed: code-review plugin absent (skip to merge), no worktree (ralph-val handles), PR already merged (ralph-merge handles), CI timeout (report pending, not fail). The fix-loop classification criteria (auto-fixable vs. escalate) are exhaustive with clear boundaries.
+
+## Feasibility: 4/5
+
+### Verified claims (all correct):
+
+**(a) Task graph templates end at "Create PR"** -- Confirmed. All 4 non-SPLIT variants in `plugin/ralph-hero/skills/hero/SKILL.md:169,178,185,191` terminate with `Create PR GH-[PRIMARY] -> blockedBy: [last impl task]`. SPLIT rebuilds the task list after re-detection so does not need explicit Finish wiring.
+
+**(b) merge-state-gate.sh exists and allows "Done,Human Needed"** -- Confirmed. `plugin/ralph-hero/hooks/scripts/merge-state-gate.sh:20` reads `RALPH_VALID_OUTPUT_STATES` with default `"Done,Human Needed"`. The finish skill's SessionStart sets the same value, so the gate will pass identically.
+
+**(c) set-skill-env.sh accepts KEY=VALUE args** -- Confirmed. `plugin/ralph-hero/hooks/scripts/set-skill-env.sh:18-22` iterates over positional args, splits on `=`, and writes `export KEY=VALUE` to `$CLAUDE_ENV_FILE`.
+
+**(d) ralph-val outputs VALIDATION PASS/FAIL** -- Partially confirmed. The early-exit paths at `ralph-val/SKILL.md:66,80` output `VALIDATION FAIL` as the first line. The normal verdict at line 158 outputs `VALIDATION [PASS/FAIL]` as a template. The plan's description of parsing `VALIDATION PASS` and `VALIDATION FAIL` is accurate in practice -- the skill will emit one or the other.
+
+**(e) ralph-merge accepts --pr-url flag** -- Confirmed. `ralph-merge/SKILL.md:4` declares `argument-hint: <issue-number> [--pr-url url]` and Step 1 at line 45-49 shows parsing.
+
+**(f) code-review:code-review exists at described path** -- Confirmed at `~/.claude/plugins/marketplaces/claude-plugins-official/plugins/code-review/commands/code-review.md`.
+
+**(g) gh pr view supports --json mergeCommit** -- Confirmed via `gh pr view --help` output listing `mergeCommit` in JSON fields.
+
+**(h) Allowed-tools completeness** -- The finish skill's allowed-tools list is sufficient for its direct operations. It does NOT need `list_dependencies` or other tools that ralph-merge uses, because ralph-merge runs as `context: fork` with its own allowed-tools list (`plugin/ralph-hero/skills/ralph-merge/SKILL.md:17-28`). Each forked sub-skill brings its own tool allowlist. However, the finish skill is missing the `Task` tool that ralph-val has in its allowlist (line 21). This is minor since finish does not need task tracking.
+
+### Issue found:
+
+**ralph-merge's code-review gate is redundant when dispatched from finish.** ralph-merge Step 4 (`ralph-merge/SKILL.md:81-153`) presents an interactive AskUserQuestion asking whether to run code review before merging. When finish dispatches ralph-merge, code review has already been completed (or skipped). ralph-merge will check `reviewDecision` via `gh pr view`, and since code-review:code-review posts a PR comment (not a formal GitHub review), `reviewDecision` will still be null. This means ralph-merge will re-prompt the user about code review -- defeating the purpose of finish having already handled it.
+
+This is not blocking because: (1) the plan explicitly states it will NOT change ralph-merge internals, and (2) the user can select "Merge without review" at the prompt. But it creates a poor UX in the automated pipeline. A recommendation is provided below.
+
+## Clarity: 4/5
+
+- Success criteria are specific and testable for all three phases, with both automated and manual verification checklists.
+- The fix-loop classification is well-defined with explicit "all must be true" for auto-fixable and "any one triggers" for escalate. The operational/cloud infrastructure exclusion is a good catch.
+- CI watch polling strategy is clear: 30-second intervals, 10-minute timeout, three outcomes (pass/fail/pending).
+
+One clarity gap: the plan does not specify what happens if the fix agent's `git push` fails (e.g., due to branch protection requiring PR reviews). The worktree pushes directly to the feature branch, which should work since it is the PR head, but this assumption is unstated.
+
+## Scope: 5/5
+
+- "What we're NOT doing" is precise: no CD monitoring, no GitHub review API, no new MCP tools, no changes to existing skill internals.
+- Phase 2 covers all 4 task graph variants (RESEARCH, PLAN, REVIEW/HUMAN_GATE, IMPLEMENT). SPLIT is excluded correctly since it rebuilds the task list.
+- Phase 3 agent definition is consistent with the repository's agent pattern (compare `val-agent.md`, `merge-agent.md`, `pr-agent.md`). The model upgrade to sonnet (vs. haiku for other integrators) is justified by the fix loop's code comprehension needs. The tools list correctly adds Write, Edit, Agent, Skill beyond what merge-agent and val-agent have.
+
+## Potential Issues
+
+### 1. PR comment parsing fragility -- MEDIUM severity
+
+The plan parses code-review output by fetching `gh pr view PR_NUMBER --json comments --jq '.comments[-1].body'` and looking for "Found N issues:". This grabs the **last** PR comment. If any other actor posts a comment between code-review completing and finish parsing (GitHub Actions bot, a human, CI status checks that post comments), the parse will read the wrong comment.
+
+**Mitigation**: Instead of `.comments[-1]`, search for the most recent comment containing the `### Code review` header and the `Generated with [Claude Code]` footer. The code-review plugin uses a deterministic format (`code-review.md:54-73`) that can be matched reliably with:
+```bash
+gh pr view PR_NUMBER --json comments --jq '[.comments[] | select(.body | contains("### Code review"))] | last | .body'
+```
+
+### 2. ralph-merge re-prompts for code review -- MEDIUM severity
+
+As detailed in the Feasibility section, ralph-merge's Step 4 code-review gate will fire even when finish has already handled code review. Since `code-review:code-review` posts a comment (not a formal GitHub review), `reviewDecision` stays null, triggering ralph-merge's AskUserQuestion. In an automated hero pipeline, this creates an unnecessary human interaction point.
+
+**Mitigation options** (choose one during implementation):
+- Pass a flag like `--skip-review` to ralph-merge (requires modifying ralph-merge, which the plan explicitly avoids)
+- Accept the UX friction as a v1 limitation and document it
+- Have finish post a PR review approval via `gh pr review --approve` before dispatching ralph-merge (lightweight workaround that does not change ralph-merge internals)
+
+### 3. Hook nesting is safe -- NON-ISSUE (verified)
+
+The plan's finish skill and ralph-merge both declare `merge-state-gate.sh` as a PreToolUse hook. Since both skills use `context: fork`, each fork gets its own hook environment. ralph-merge's hooks fire in ralph-merge's fork context with ralph-merge's `RALPH_VALID_OUTPUT_STATES`. Finish's hooks fire in finish's fork context. There is no hook collision because finish itself never calls `save_issue` or `advance_issue` directly for state transitions -- it delegates to ralph-merge for that.
+
+### 4. Context window is safe -- NON-ISSUE (verified)
+
+The concern about context exhaustion from inline Skill() dispatch is unfounded. Finish uses `context: fork`, and all sub-skills (ralph-val, ralph-merge) also use `context: fork`. Each gets its own context window. The fix-loop Agent() also spawns with its own context. Only the orchestration logic (argument parsing, output checking, CI polling) lives in finish's context window, which is lightweight.
+
+## Verdict: APPROVED
+
+The plan is technically sound, well-scoped, and all codebase references are verified accurate. The two medium-severity issues (comment parsing fragility and ralph-merge's redundant code-review gate) are real but non-blocking -- both have clear mitigations that can be applied during implementation without changing the plan's structure.
+
+## Recommendations
+
+1. **Harden PR comment parsing** (Phase 1, Step 4): Replace `.comments[-1].body` with a filtered query that selects the most recent comment containing `### Code review`. This eliminates the race condition with other PR commenters.
+
+2. **Address ralph-merge's code-review re-prompt** (Phase 1, Step 6): Before dispatching ralph-merge, post a lightweight PR approval via `gh pr review PR_NUMBER --approve --body "Approved by finish pipeline after code review"`. This sets `reviewDecision` to `APPROVED`, causing ralph-merge to skip its Step 4 gate entirely. This approach changes no skill internals and only adds one bash command to finish.
+
+3. **Document git push assumption in fix loop** (Phase 1, Step 5): Add a note that the fix agent's `git push` assumes the feature branch does not have branch protection rules requiring PR review approvals before push. If the repo uses such protections, the fix loop should be documented as unsupported.
+
+4. **Consider adding `--skip-review` to ralph-merge in a follow-up issue** rather than the `gh pr review --approve` workaround. This would be a cleaner long-term solution for any orchestrator that pre-handles code review before dispatching merge.
+
+5. **Add the SPLIT variant explicitly to Phase 2** as a no-op note: "SPLIT rebuilds the task list after re-detection, so Finish is picked up automatically when the pipeline reaches RESEARCH or later." This prevents a future reader from wondering if SPLIT was overlooked.

--- a/thoughts/shared/specs/2026-03-27-GH-0694-cli-env-scope-parity-design.md
+++ b/thoughts/shared/specs/2026-03-27-GH-0694-cli-env-scope-parity-design.md
@@ -1,0 +1,116 @@
+---
+date: 2026-03-27
+status: approved
+type: spec
+github_issue: 694
+github_url: https://github.com/cdubiel08/ralph-hero/issues/694
+tags: [spec, cli, env-resolution, setup, scope-detection, settings]
+---
+
+# Design: CLI Environment Resolution Scope Parity
+
+## Prior Work
+
+- builds_on:: [[2026-03-26-GH-0694-ralph-cli-env-resolution-outside-repo]]
+- builds_on:: [[2026-03-06-GH-0546-ralph-cli-justfile-architecture]]
+- builds_on:: [[2026-03-25-GH-0684-userconfig-healthcheck-setup-rewrite]]
+
+## Problem
+
+The `ralph` CLI fails with `"owner is required (set RALPH_GH_OWNER env var or pass explicitly)"` when run outside the ralph-hero repo. Root cause: env vars are stored in project-scoped `settings.local.json`, which is invisible to other directories.
+
+## Design Principle
+
+Use Claude Code's native settings hierarchy — no parallel config system (`~/.ralph/config`, etc.):
+
+| Install scope | Config file for env vars | Implication |
+|---|---|---|
+| User (`"scope": "user"`) | `~/.claude/settings.json` | Works wherever Claude runs |
+| Project (`"scope": "project"`) | `<project>/.claude/settings.local.json` | Only works from that project root |
+
+The authoritative scope signal is the `"scope"` field in `~/.claude/plugins/installed_plugins.json`.
+
+## Approach
+
+**Scope Detection + Correct Config Placement** (Approach A from brainstorming). One source of truth per install scope, no dual-write drift, no parallel resolution logic.
+
+## Design Sections
+
+### 1. Scope Detection
+
+Read `~/.claude/plugins/installed_plugins.json`, find the `ralph-hero@ralph-hero` entry, check `"scope"`:
+
+```json
+"ralph-hero@ralph-hero": [
+  {
+    "scope": "user",
+    "installPath": "/Users/dubiel/.claude/plugins/cache/ralph-hero/ralph-hero/2.5.50",
+    ...
+  }
+]
+```
+
+- `"user"` → target `~/.claude/settings.json`
+- `"project"` → target `<project>/.claude/settings.local.json`
+
+Used by: setup skill (write), doctor (diagnostic), `read_settings_env()` (read).
+
+### 2. Setup Skill Changes
+
+The setup skill currently always writes to `<project>/.claude/settings.local.json`. Changes:
+
+1. **Detect scope** from `installed_plugins.json`
+2. **Write non-sensitive env vars** (`RALPH_GH_OWNER`, `RALPH_GH_PROJECT_NUMBER`, optionally `RALPH_GH_REPO`) to the scope-appropriate file
+3. **Token handling** stays as-is (manual `settings.local.json` for the token specifically). This design is independent of GH-684 `userConfig` work — when that lands, it changes only the token delivery path, not the non-sensitive env var placement. Setup communicates where the token needs to go based on scope
+4. **Warn on scope mismatch**: If user-scoped install but env vars only in a project-local file, surface as diagnostic
+
+### 3. Doctor / `read_settings_env()` Parity
+
+Current search: repo-local `settings.local.json` → global `settings.local.json`. Updated search order:
+
+1. Shell environment (already checked)
+2. `<repo>/.claude/settings.local.json` (project-scoped user secrets)
+3. `<repo>/.claude/settings.json` (project-scoped committed config)
+4. `~/.claude/settings.json` (user-scoped config)
+
+Additional changes:
+- **Source labeling**: Extend doctor labels to distinguish `settings.json` vs `settings.local.json`, repo vs global
+- **Scope-aware diagnostics**: If scope is `"user"` but vars only found in project-local file, warn that CLI won't work outside that project
+
+### 4. CLI Dispatch Env Bridging
+
+Two subprocess paths in `cli-dispatch.sh`:
+
+| Path | How env arrives | Fix needed? |
+|---|---|---|
+| `run_headless` (`claude -p`) | Claude Code resolves settings | No — if settings are in the right file per scope |
+| `run_quick` (`mcp call` via mcptools) | Direct subprocess, no Claude Code | **Yes** — must bridge env explicitly |
+
+Fix for `run_quick`:
+- **Extract `read_settings_env()`** from the justfile's `doctor` recipe into a shared shell function in `scripts/`
+- Before `mcp call`, resolve and export `RALPH_GH_OWNER`, `RALPH_GH_PROJECT_NUMBER`, `RALPH_GH_REPO` if not already in environment
+- Makes quick path (`ralph status -q`, `ralph issue -q`) work from any directory
+
+`run_headless` / `run_interactive`: No code change, but verify via manual test that Claude Code reads `~/.claude/settings.json` `"env"` for user-scoped plugins.
+
+### 5. Audit Checklist
+
+| Component | Status | Action |
+|---|---|---|
+| Setup skill | Change | Write to scope-appropriate config file |
+| Doctor | Change | Search full hierarchy, scope-aware diagnostics |
+| `read_settings_env()` | Change | Extract to shared function, add `settings.json` paths |
+| `run_quick` | Change | Bridge env before `mcp call` |
+| `run_headless` / `run_interactive` | Verify | Manual test: Claude Code reads `~/.claude/settings.json` for user-scoped |
+| MCP server `resolveEnv()` | No change | Reads `process.env`, correct regardless of source |
+| `ralph-cli.sh` | No change | Hardcoded to user cache path — consistent with user-scope only |
+| `setup-cli` skill | No change | Document: only supports user-scoped installs |
+| Error messages (`helpers.ts:556`) | Change | Update to mention scope-appropriate config file location |
+
+## What We're NOT Doing
+
+- Creating a `~/.ralph/config` or any parallel config system
+- Changing the MCP server's `resolveEnv()` or env var names
+- Changing the token resolution chain
+- Supporting `settings.local.json` at `~/.claude/` (not a real Claude Code pattern)
+- Changing `ralph-cli.sh` to support project-scoped installs (no global CLI for project-scope — that's consistent)


### PR DESCRIPTION
## Summary

Fix for /ralph-hero:finish hanging at "Initializing…" with no error feedback. The finish skill is an orchestrator (dispatches val-agent, ralph-merge, impl-agent) and should use `context: inline` like the hero orchestrator.

## Changes

1. **finish/SKILL.md**: Change `context: fork` → `context: inline`, remove `model: sonnet` override (inline skills inherit the caller's model)
2. **prune-merged-worktrees.sh**: Add `timeout 10` to git fetch to prevent hangs on network issues
3. **skill-vs-agent-dispatch.md**: Add finish-agent to the canonical dispatch table

## Verification

- finish skill now loads instantly without hanging at initialization
- finish-agent agent dispatch still works (agents always fork regardless of skill context)
- hero dispatching finish via Skill() still works (inline → inline)

Closes #758