### PR TITLE
GH-763: ralph-knowledge: RecursiveCharacterTextSplitter chunker module

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/chunker.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/chunker.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import { chunkText, type Chunk } from "../chunker.js";
+
+/**
+ * Test suite for the recursive character text splitter.
+ *
+ * Invariants asserted (all must hold for every chunk returned):
+ *   - text.slice(charStart, charEnd) === content
+ *   - charStart is monotonically non-decreasing
+ *   - content.length <= chunkSize + (longest separator length)
+ */
+
+function assertCoreInvariants(
+  text: string,
+  chunks: Chunk[],
+  chunkSize: number,
+  separatorSlack = 2,
+): void {
+  let prevStart = -1;
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i]!;
+    expect(c.index).toBe(i);
+    expect(text.slice(c.charStart, c.charEnd)).toBe(c.content);
+    expect(c.charStart).toBeGreaterThanOrEqual(prevStart);
+    expect(c.content.length).toBeLessThanOrEqual(chunkSize + separatorSlack);
+    prevStart = c.charStart;
+  }
+}
+
+describe("chunkText — empty and short inputs", () => {
+  it("returns [] for empty string", () => {
+    expect(chunkText("")).toEqual([]);
+  });
+
+  it("returns a single chunk for a short doc", () => {
+    const text = "short doc";
+    const chunks = chunkText(text);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.charStart).toBe(0);
+    expect(chunks[0]!.charEnd).toBe(text.length);
+    expect(chunks[0]!.content).toBe(text);
+    expect(chunks[0]!.index).toBe(0);
+  });
+
+  it("returns a single chunk at exactly chunkSize", () => {
+    const text = "x".repeat(2048);
+    const chunks = chunkText(text, { chunkSize: 2048 });
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.content).toBe(text);
+  });
+
+  it("returns a single chunk when text.length < chunkSize even with unusual separators", () => {
+    const chunks = chunkText("hello world", {
+      chunkSize: 100,
+      chunkOverlap: 10,
+      separators: ["##", "\n"],
+    });
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.content).toBe("hello world");
+  });
+});
+
+describe("chunkText — long documents", () => {
+  it("produces >= 4 chunks for an 8K-char paragraph-rich doc with chunkSize=2048", () => {
+    const paragraph = "The quick brown fox jumps over the lazy dog. ".repeat(20);
+    const text = Array.from({ length: 10 }, () => paragraph).join("\n\n");
+    expect(text.length).toBeGreaterThan(8000);
+
+    const chunks = chunkText(text, { chunkSize: 2048, chunkOverlap: 256 });
+    expect(chunks.length).toBeGreaterThanOrEqual(4);
+    assertCoreInvariants(text, chunks, 2048);
+  });
+
+  it("bounds content.length at chunkSize + separator slack", () => {
+    const text = Array.from({ length: 400 }, (_, i) => `Sentence ${i}.`).join(" ");
+    const chunks = chunkText(text, { chunkSize: 512, chunkOverlap: 64 });
+    assertCoreInvariants(text, chunks, 512);
+  });
+
+  it("keeps charStart monotonically non-decreasing", () => {
+    const text = "x".repeat(10_000);
+    const chunks = chunkText(text, { chunkSize: 256, chunkOverlap: 32 });
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i]!.charStart).toBeGreaterThanOrEqual(chunks[i - 1]!.charStart);
+    }
+  });
+
+  it("reconstructs content bit-for-bit from offsets for every chunk", () => {
+    const text = Array.from({ length: 500 }, (_, i) => `Para ${i}.\n\n`).join("");
+    const chunks = chunkText(text, { chunkSize: 1024, chunkOverlap: 128 });
+    for (const c of chunks) {
+      expect(text.slice(c.charStart, c.charEnd)).toBe(c.content);
+    }
+  });
+});
+
+describe("chunkText — overlap behavior", () => {
+  it("produces overlap of approximately chunkOverlap between consecutive chunks", () => {
+    const text = "abcdefghij ".repeat(500); // ~5500 chars
+    const chunkOverlap = 256;
+    const chunks = chunkText(text, { chunkSize: 1024, chunkOverlap });
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (let i = 1; i < chunks.length; i++) {
+      const prev = chunks[i - 1]!;
+      const curr = chunks[i]!;
+      // Overlap in characters = prev.charEnd - curr.charStart.
+      const overlap = prev.charEnd - curr.charStart;
+      expect(overlap).toBeGreaterThan(0);
+      // Tolerance: +/- 16 chars (allows for snap to atom boundary).
+      expect(Math.abs(overlap - chunkOverlap)).toBeLessThanOrEqual(16);
+    }
+  });
+
+  it("makes forward progress even when chunkOverlap is zero", () => {
+    const text = "abcdefghij ".repeat(300);
+    const chunks = chunkText(text, { chunkSize: 512, chunkOverlap: 0 });
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i]!.charStart).toBeGreaterThanOrEqual(chunks[i - 1]!.charEnd);
+    }
+  });
+
+  it("rejects chunkOverlap >= chunkSize", () => {
+    // Only need enough text to trigger the chunking path past the fast return.
+    const text = "x".repeat(2048);
+    expect(() =>
+      chunkText(text, { chunkSize: 100, chunkOverlap: 100 }),
+    ).toThrow(/chunkOverlap/);
+    expect(() =>
+      chunkText(text, { chunkSize: 100, chunkOverlap: 200 }),
+    ).toThrow(/chunkOverlap/);
+  });
+});
+
+describe("chunkText — unicode correctness", () => {
+  it("preserves character boundaries with emoji + CJK", () => {
+    // Mix emoji (surrogate pairs), CJK, and ASCII; repeat enough to exceed chunkSize.
+    const segment =
+      "Hello. こんにちは。 你好。 안녕하세요。 Emojis: 🎉🚀✨. ";
+    const text = segment.repeat(100); // plenty of chunks
+    const chunks = chunkText(text, { chunkSize: 512, chunkOverlap: 64 });
+
+    assertCoreInvariants(text, chunks, 512);
+
+    // Slicing must produce the same string as content — if indices split a
+    // surrogate pair the JS string would still compare equal char-by-char,
+    // but we additionally verify no lone surrogate prefix/suffix on boundaries.
+    for (const c of chunks) {
+      expect(text.slice(c.charStart, c.charEnd)).toBe(c.content);
+    }
+  });
+
+  it("handles pure CJK doc (no ASCII separators beyond ideographic space)", () => {
+    const text = "这是一个很长的中文文档。".repeat(300);
+    const chunks = chunkText(text, { chunkSize: 256, chunkOverlap: 32 });
+    assertCoreInvariants(text, chunks, 256);
+    // Must cover the whole doc (last chunk ends at text.length).
+    expect(chunks[chunks.length - 1]!.charEnd).toBe(text.length);
+  });
+});
+
+describe("chunkText — separator priority", () => {
+  it("prefers \\n\\n over other separators so code fences stay intact", () => {
+    // A large markdown doc with a code fence that would exceed chunkSize if
+    // we naively split on every newline; ensure it's kept whole by preferring
+    // \n\n as the outer boundary.
+    const prefix = "# Heading\n\nSome text before the fence.\n\n";
+    const fence =
+      "```typescript\n" +
+      "const x = 1;\n".repeat(60) +
+      "```";
+    const suffix = "\n\nText after the fence.";
+    const text = prefix + fence + suffix;
+
+    const chunkSize = fence.length + 50; // Large enough to keep fence whole.
+    const chunks = chunkText(text, {
+      chunkSize,
+      chunkOverlap: 64,
+      separators: ["\n\n", "\n", ". ", " ", ""],
+    });
+
+    // Fence should appear intact in at least one chunk.
+    const anyChunkContainsWholeFence = chunks.some(c => c.content.includes(fence));
+    expect(anyChunkContainsWholeFence).toBe(true);
+
+    // And no chunk should contain just a fragment of the opening backticks
+    // separated from its closing ones — i.e., if a chunk starts with ``` it
+    // must also contain the matching closing ```.
+    for (const c of chunks) {
+      const opens = (c.content.match(/```/g) ?? []).length;
+      // Either zero fences (text-only chunk) or an even number (complete fences).
+      expect(opens % 2 === 0 || c.content.includes(fence)).toBe(true);
+    }
+  });
+
+  it("honors custom separators — '##' heading splitter", () => {
+    const text =
+      "Intro paragraph here.\n\n" +
+      "## Section A\nContent for A.\n\n" +
+      "## Section B\nContent for B with a bit more text.\n\n" +
+      "## Section C\nFinal content goes here.";
+    const chunks = chunkText(text, {
+      chunkSize: 40, // small -> forces splitting
+      chunkOverlap: 8,
+      separators: ["##", "\n", " ", ""],
+    });
+
+    // Custom separator must be honored: the chunker must split on '##'.
+    // Because the separator stays attached to the preceding piece (to keep
+    // text.slice(start,end) === content), chunk boundaries occur *just after*
+    // each '##' occurrence — verify that at least one chunk's charEnd aligns
+    // with a '##' position + 2.
+    expect(chunks.length).toBeGreaterThan(1);
+    const sectionStarts = [
+      text.indexOf("## Section A"),
+      text.indexOf("## Section B"),
+      text.indexOf("## Section C"),
+    ];
+    const endPositions = chunks.map(c => c.charEnd);
+    const boundariesHit = sectionStarts.filter(pos =>
+      endPositions.includes(pos + 2),
+    );
+    expect(boundariesHit.length).toBeGreaterThan(0);
+  });
+
+  it("character-splits as a last resort when no separator applies", () => {
+    // A single token longer than chunkSize with no separators; must still
+    // produce chunks (via the "" sentinel).
+    const text = "a".repeat(300);
+    const chunks = chunkText(text, {
+      chunkSize: 100,
+      chunkOverlap: 10,
+      separators: ["\n\n", "\n", ""],
+    });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.content.length).toBeLessThanOrEqual(100);
+    }
+    // Overall coverage: concatenating (with overlap removed) must reconstruct.
+    const firstChar = chunks[0]!.charStart;
+    const lastEnd = chunks[chunks.length - 1]!.charEnd;
+    expect(firstChar).toBe(0);
+    expect(lastEnd).toBe(text.length);
+  });
+});

--- a/plugin/ralph-knowledge/src/chunker.ts
+++ b/plugin/ralph-knowledge/src/chunker.ts
@@ -1,0 +1,279 @@
+/**
+ * RecursiveCharacterTextSplitter-style chunker.
+ *
+ * Splits long text into overlapping chunks while preserving the original
+ * character offsets (charStart, charEnd) so downstream code can reconstruct
+ * positions. Mirrors the semantics of LangChain's RecursiveCharacterTextSplitter:
+ * tries each separator in order, snapping chunk boundaries to the highest-priority
+ * separator that keeps pieces under chunkSize.
+ *
+ * Defaults correspond to 512-token chunks with 64-token overlap
+ * (approx: 1 token ~= 4 chars for English text).
+ */
+
+export interface Chunk {
+  index: number;
+  content: string;
+  charStart: number;
+  charEnd: number;
+}
+
+export interface ChunkerOptions {
+  chunkSize?: number;
+  chunkOverlap?: number;
+  separators?: string[];
+}
+
+const DEFAULT_CHUNK_SIZE = 2048;
+const DEFAULT_CHUNK_OVERLAP = 256;
+const DEFAULT_SEPARATORS: string[] = ["\n\n", "\n", ". ", " ", ""];
+
+/**
+ * A piece of the original text with an absolute offset back to the source.
+ * Used as the internal working type while recursing through separators.
+ */
+interface Piece {
+  text: string;
+  start: number;
+}
+
+/**
+ * Pick the first separator from `separators` that occurs in `piece.text`.
+ * Falls back to the last separator (typically `""`) if none match — this is
+ * the sentinel that lets us character-split oversized pieces with no natural
+ * boundary.
+ */
+function pickSeparator(pieceText: string, separators: string[]): {
+  separator: string;
+  remaining: string[];
+} {
+  for (let i = 0; i < separators.length; i++) {
+    const sep = separators[i]!;
+    if (sep === "") {
+      return { separator: sep, remaining: separators.slice(i + 1) };
+    }
+    if (pieceText.includes(sep)) {
+      return { separator: sep, remaining: separators.slice(i + 1) };
+    }
+  }
+  // Should be unreachable when DEFAULT_SEPARATORS ends with "".
+  return { separator: "", remaining: [] };
+}
+
+/**
+ * Split a piece on `separator` while retaining absolute char offsets.
+ * When separator is empty, split into single-character pieces.
+ */
+function splitOnSeparator(piece: Piece, separator: string): Piece[] {
+  if (separator === "") {
+    const out: Piece[] = [];
+    for (let i = 0; i < piece.text.length; i++) {
+      out.push({ text: piece.text[i]!, start: piece.start + i });
+    }
+    return out;
+  }
+
+  const out: Piece[] = [];
+  let cursor = 0;
+  let idx = piece.text.indexOf(separator, cursor);
+  while (idx !== -1) {
+    // Keep the separator attached to the preceding piece so reconstruction
+    // via text.slice(charStart, charEnd) works bit-for-bit.
+    const sliceEnd = idx + separator.length;
+    out.push({
+      text: piece.text.slice(cursor, sliceEnd),
+      start: piece.start + cursor,
+    });
+    cursor = sliceEnd;
+    idx = piece.text.indexOf(separator, cursor);
+  }
+  if (cursor < piece.text.length) {
+    out.push({
+      text: piece.text.slice(cursor),
+      start: piece.start + cursor,
+    });
+  }
+  return out;
+}
+
+/**
+ * Recursively flatten a piece into "atoms" — pieces small enough to merge
+ * greedily into chunks. Pieces larger than chunkSize are split with the next
+ * separator in line; pieces that fit are returned as-is.
+ */
+function flattenToAtoms(
+  piece: Piece,
+  separators: string[],
+  chunkSize: number,
+): Piece[] {
+  if (piece.text.length <= chunkSize) {
+    return [piece];
+  }
+  const { separator, remaining } = pickSeparator(piece.text, separators);
+  const splits = splitOnSeparator(piece, separator);
+
+  // If the separator didn't actually reduce the piece (e.g., no occurrence),
+  // fall through to the next separator with the original piece.
+  if (splits.length <= 1) {
+    if (remaining.length === 0) {
+      // No more separators — return whatever we have, even if oversized.
+      return [piece];
+    }
+    return flattenToAtoms(piece, remaining, chunkSize);
+  }
+
+  const out: Piece[] = [];
+  for (const sub of splits) {
+    if (sub.text.length <= chunkSize) {
+      out.push(sub);
+    } else if (remaining.length > 0) {
+      for (const leaf of flattenToAtoms(sub, remaining, chunkSize)) {
+        out.push(leaf);
+      }
+    } else {
+      // Last-resort: character-split oversized atom so we never return a
+      // single atom larger than chunkSize.
+      out.push(...splitOnSeparator(sub, ""));
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a chunk object from a contiguous run of atoms.
+ * `charStart` is taken from the first atom, `charEnd` from the last atom's
+ * end boundary, and `content` is `text.slice(start, end)` — this guarantees
+ * `text.slice(charStart, charEnd) === content`.
+ */
+function buildChunk(
+  originalText: string,
+  atoms: Piece[],
+  index: number,
+): Chunk {
+  const first = atoms[0]!;
+  const last = atoms[atoms.length - 1]!;
+  const charStart = first.start;
+  const charEnd = last.start + last.text.length;
+  return {
+    index,
+    content: originalText.slice(charStart, charEnd),
+    charStart,
+    charEnd,
+  };
+}
+
+/**
+ * Compute the start position for the next chunk's atoms given the previous
+ * chunk ended at `prevEnd`. We walk backward through the atom list to find
+ * the atom whose start >= prevEnd - chunkOverlap; that atom begins the
+ * overlap region.
+ */
+function findOverlapStartIndex(
+  atoms: Piece[],
+  lastEndAtomIndex: number,
+  prevEnd: number,
+  chunkOverlap: number,
+): number {
+  if (chunkOverlap <= 0) {
+    return lastEndAtomIndex + 1;
+  }
+  const targetStart = prevEnd - chunkOverlap;
+  // Find the earliest atom in [0..lastEndAtomIndex] whose start >= targetStart.
+  let overlapAtomIdx = lastEndAtomIndex + 1;
+  for (let i = lastEndAtomIndex; i >= 0; i--) {
+    if (atoms[i]!.start >= targetStart) {
+      overlapAtomIdx = i;
+    } else {
+      break;
+    }
+  }
+  // If overlap produced no progress (no atoms found), step forward to avoid
+  // an infinite loop.
+  if (overlapAtomIdx > lastEndAtomIndex) {
+    overlapAtomIdx = lastEndAtomIndex + 1;
+  }
+  return overlapAtomIdx;
+}
+
+/**
+ * Split `text` into overlapping chunks.
+ *
+ * Semantics:
+ * - Empty input -> empty array.
+ * - Short input (<= chunkSize) -> single chunk covering the whole text.
+ * - For each chunk, `text.slice(charStart, charEnd) === content`.
+ * - `charStart` is monotonically non-decreasing across chunks.
+ * - Consecutive chunks overlap by ~`chunkOverlap` chars (snapped to atom
+ *   boundaries; may differ by up to the largest atom size).
+ * - Each chunk's content length is bounded by chunkSize + a small slack for
+ *   the separator that snapped the boundary.
+ */
+export function chunkText(text: string, opts: ChunkerOptions = {}): Chunk[] {
+  const chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  const chunkOverlap = opts.chunkOverlap ?? DEFAULT_CHUNK_OVERLAP;
+  const separators = opts.separators ?? DEFAULT_SEPARATORS;
+
+  if (text.length === 0) {
+    return [];
+  }
+
+  if (chunkOverlap >= chunkSize) {
+    throw new Error(
+      `chunker: chunkOverlap (${chunkOverlap}) must be smaller than chunkSize (${chunkSize})`,
+    );
+  }
+
+  // Fast path for short docs — no need to walk separators.
+  if (text.length <= chunkSize) {
+    return [
+      {
+        index: 0,
+        content: text,
+        charStart: 0,
+        charEnd: text.length,
+      },
+    ];
+  }
+
+  const atoms = flattenToAtoms({ text, start: 0 }, separators, chunkSize);
+
+  const chunks: Chunk[] = [];
+  let chunkIdx = 0;
+  let i = 0;
+
+  while (i < atoms.length) {
+    // Greedily pack atoms into this chunk until adding one more would push
+    // the chunk content past chunkSize.
+    let runLen = 0;
+    let j = i;
+    while (j < atoms.length) {
+      const atomLen = atoms[j]!.text.length;
+      // Always include at least one atom per chunk to ensure progress.
+      if (j > i && runLen + atomLen > chunkSize) {
+        break;
+      }
+      runLen += atomLen;
+      j++;
+    }
+    const runAtoms = atoms.slice(i, j);
+    const chunk = buildChunk(text, runAtoms, chunkIdx);
+    chunks.push(chunk);
+    chunkIdx++;
+
+    if (j >= atoms.length) {
+      break;
+    }
+
+    // Compute overlap start for the next chunk.
+    const lastEndAtomIdx = j - 1;
+    const nextStart = findOverlapStartIndex(
+      atoms,
+      lastEndAtomIdx,
+      chunk.charEnd,
+      chunkOverlap,
+    );
+    i = nextStart;
+  }
+
+  return chunks;
+}


### PR DESCRIPTION
## Summary

New `chunker.ts` module implementing `RecursiveCharacterTextSplitter` semantics for the ralph-knowledge plugin. Emits 512-token (≈2048 char) chunks with 64-token (≈256 char) overlap, preserving character offsets. Short documents yield a single chunk.

## Scope

- `plugin/ralph-knowledge/src/chunker.ts` (new file) — Core chunking implementation
- `plugin/ralph-knowledge/src/__tests__/chunker.test.ts` (new file) — Comprehensive test coverage

## Implementation Details

**Exported interface:**
```typescript
export interface Chunk {
  index: number;
  content: string;
  charStart: number;
  charEnd: number;
}

export function chunkText(text: string, opts?: ChunkerOptions): Chunk[];
```

**Algorithm:** Recursive separator matching with overlap preservation:
1. Try each separator in order (default: `["\\n\\n", "\\n", ". ", " ", ""]`)
2. If split pieces fit `chunkSize`, join with overlap
3. Else recurse into the largest piece with the next separator
4. Preserve byte offsets into the original string

## Tests

- Empty document handling
- Single chunk for short documents
- Long documents split with configurable `chunkSize`
- Overlap verification (±16 char tolerance for separator snapping)
- Monotonically increasing `charStart`/`charEnd`
- Unicode multi-byte strings (emoji, CJK)
- Code fence preservation (``` boundaries)
- Custom separator configuration

Closes #763