### PR TITLE
GH-768: ralph-knowledge: .ralphignore + knowledge.config.json + scanner wiring

### DIFF
--- a/plugin/ralph-knowledge/README.md
+++ b/plugin/ralph-knowledge/README.md
@@ -1,0 +1,109 @@
+# ralph-knowledge
+
+Semantic search over a personal knowledge corpus (`thoughts/` plus any other
+markdown roots). Uses SQLite + `sqlite-vec` for local embeddings and exposes
+a stdio MCP server to Claude Code.
+
+## Quick start
+
+```bash
+cd plugin/ralph-knowledge
+npm install
+npm run build
+npm run reindex                     # index default root (../../thoughts)
+npm run reindex -- /path/to/roots   # CLI override, see "Configuration"
+```
+
+A SQLite file is written to `~/.ralph-hero/knowledge.db` by default.
+
+## Configuration
+
+ralph-knowledge reads configuration from four sources. Each source can be
+missing; later sources fill in only what earlier sources did not provide. The
+precedence for **roots** (directories to index), from highest to lowest, is:
+
+1. CLI positional arguments (`npm run reindex -- /a /b /c`)
+2. `RALPH_KNOWLEDGE_DIRS` environment variable (comma-separated)
+3. `roots[]` in `~/.ralph/knowledge.config.json`
+4. Fallback: `../../thoughts` (relative to the current working directory)
+
+`dbPath` precedence is independent:
+
+1. CLI positional argument ending in `.db`
+2. `RALPH_KNOWLEDGE_DB` environment variable
+3. `dbPath` in `~/.ralph/knowledge.config.json`
+4. Default: `~/.ralph-hero/knowledge.db`
+
+### `~/.ralph/knowledge.config.json`
+
+Create this file to persist multi-root setups and global ignore patterns.
+The path can be overridden via the `RALPH_KNOWLEDGE_CONFIG` env var.
+
+```json
+{
+  "roots": [
+    "~/projects/ralph-hero/thoughts",
+    "~/projects/landcrawler-ai/thoughts",
+    "~/notes"
+  ],
+  "ignorePatterns": [
+    "**/drafts/**",
+    "**/worktrees/**",
+    "*.bak"
+  ],
+  "dbPath": "~/.ralph-hero/knowledge.db"
+}
+```
+
+All fields are optional. Tilde (`~`) prefixes in `roots[]` and `dbPath` are
+expanded to the user's home directory at load time. Malformed JSON, non-object
+top levels, and non-string entries are ignored with a warning.
+
+On startup, ralph-knowledge logs which source provided the roots, e.g.:
+
+```
+Using roots from: config
+```
+
+## Ignoring files
+
+Per-root `.ralphignore` files use full gitignore syntax and are layered on
+top of the config's `ignorePatterns` and the following default globals (always
+applied):
+
+- `.claude/`
+- `node_modules/`
+- `dist/`
+- `.git/`
+- `*.log`
+
+Example `.ralphignore` at the top of a root directory:
+
+```gitignore
+# Skip a whole subtree
+.claude/worktrees/**
+
+# Skip drafts but keep the index
+drafts/**
+!drafts/INDEX.md
+
+# Skip anything ending in .bak
+*.bak
+```
+
+Patterns behave exactly like `.gitignore`:
+
+- `**/name/**` matches `name/` at any depth.
+- A leading `!` negates an earlier match, re-including a path.
+- A trailing `/` makes the pattern directory-only.
+
+Directories whose names start with `.` or `_` are also always skipped, as a
+fast-path before any matcher is consulted.
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `RALPH_KNOWLEDGE_CONFIG` | Override path to `knowledge.config.json` (tilde expanded). |
+| `RALPH_KNOWLEDGE_DIRS` | Comma-separated list of roots. Beats config, loses to CLI. |
+| `RALPH_KNOWLEDGE_DB` | Override SQLite path. Beats `config.dbPath`, loses to a CLI `.db` positional. |

--- a/plugin/ralph-knowledge/package-lock.json
+++ b/plugin/ralph-knowledge/package-lock.json
@@ -20,6 +20,7 @@
         "graphology-simple-path": "^0.2.0",
         "graphology-traversal": "^0.3.1",
         "graphology-types": "^0.24.8",
+        "ignore": "^5.3.2",
         "sqlite-vec": "^0.1.7-alpha.10",
         "yaml": "^2.7.0",
         "zod": "^3.25.0"
@@ -2749,6 +2750,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",

--- a/plugin/ralph-knowledge/package.json
+++ b/plugin/ralph-knowledge/package.json
@@ -31,6 +31,7 @@
     "graphology-simple-path": "^0.2.0",
     "graphology-traversal": "^0.3.1",
     "graphology-types": "^0.24.8",
+    "ignore": "^5.3.2",
     "sqlite-vec": "^0.1.7-alpha.10",
     "yaml": "^2.7.0",
     "zod": "^3.25.0"

--- a/plugin/ralph-knowledge/src/__tests__/config.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/config.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import { loadConfig, expandHome, resolveConfigPath } from "../config.js";
+
+describe("expandHome", () => {
+  it("returns input unchanged when it does not start with ~", () => {
+    expect(expandHome("/absolute/path")).toBe("/absolute/path");
+    expect(expandHome("relative/path")).toBe("relative/path");
+    expect(expandHome("")).toBe("");
+  });
+
+  it("expands a lone ~", () => {
+    expect(expandHome("~")).toBe(homedir());
+  });
+
+  it("expands ~/ prefix to homedir/rest", () => {
+    expect(expandHome("~/thoughts")).toBe(join(homedir(), "thoughts"));
+    expect(expandHome("~/foo/bar")).toBe(join(homedir(), "foo/bar"));
+  });
+});
+
+describe("loadConfig", () => {
+  let originalEnv: string | undefined;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    originalEnv = process.env.RALPH_KNOWLEDGE_CONFIG;
+    tmpDir = mkdtempSync(join(tmpdir(), "ralph-config-"));
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.RALPH_KNOWLEDGE_CONFIG;
+    } else {
+      process.env.RALPH_KNOWLEDGE_CONFIG = originalEnv;
+    }
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns {} when the config file is missing", () => {
+    // Point env var at a nonexistent path so we don't read the real ~/.ralph file.
+    process.env.RALPH_KNOWLEDGE_CONFIG = join(tmpDir, "nope.json");
+    expect(loadConfig()).toEqual({});
+  });
+
+  it("returns {} and warns on malformed JSON", () => {
+    const configPath = join(tmpDir, "broken.json");
+    writeFileSync(configPath, "{ not: valid json");
+    process.env.RALPH_KNOWLEDGE_CONFIG = configPath;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = loadConfig();
+    expect(result).toEqual({});
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0][0] as string;
+    expect(msg).toContain("Malformed JSON");
+    warn.mockRestore();
+  });
+
+  it("returns {} and warns when top-level is not an object", () => {
+    const configPath = join(tmpDir, "array.json");
+    writeFileSync(configPath, JSON.stringify(["not", "an", "object"]));
+    process.env.RALPH_KNOWLEDGE_CONFIG = configPath;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(loadConfig()).toEqual({});
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("expands ~ prefixes in roots[] to absolute paths", () => {
+    const configPath = join(tmpDir, "tilde.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ roots: ["~/thoughts", "/absolute/dir"] }),
+    );
+    process.env.RALPH_KNOWLEDGE_CONFIG = configPath;
+    const cfg = loadConfig();
+    expect(cfg.roots).toEqual([
+      join(homedir(), "thoughts"),
+      "/absolute/dir",
+    ]);
+  });
+
+  it("expands ~ in dbPath", () => {
+    const configPath = join(tmpDir, "db.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ dbPath: "~/.ralph-hero/knowledge.db" }),
+    );
+    process.env.RALPH_KNOWLEDGE_CONFIG = configPath;
+    const cfg = loadConfig();
+    expect(cfg.dbPath).toBe(join(homedir(), ".ralph-hero/knowledge.db"));
+  });
+
+  it("loads ignorePatterns as provided (no expansion)", () => {
+    const configPath = join(tmpDir, "ignore.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ ignorePatterns: ["**/drafts/**", "*.bak"] }),
+    );
+    process.env.RALPH_KNOWLEDGE_CONFIG = configPath;
+    const cfg = loadConfig();
+    expect(cfg.ignorePatterns).toEqual(["**/drafts/**", "*.bak"]);
+  });
+
+  it("honors RALPH_KNOWLEDGE_CONFIG env var override", () => {
+    const configPath = join(tmpDir, "override.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ roots: ["/x"], ignorePatterns: ["y/**"], dbPath: "/z.db" }),
+    );
+    process.env.RALPH_KNOWLEDGE_CONFIG = configPath;
+    const cfg = loadConfig();
+    expect(cfg).toEqual({
+      roots: ["/x"],
+      ignorePatterns: ["y/**"],
+      dbPath: "/z.db",
+    });
+  });
+
+  it("drops non-string roots and ignorePatterns entries", () => {
+    const configPath = join(tmpDir, "mixed.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        roots: ["/a", 42, null, "/b"],
+        ignorePatterns: ["good", 7, "more"],
+      }),
+    );
+    process.env.RALPH_KNOWLEDGE_CONFIG = configPath;
+    const cfg = loadConfig();
+    expect(cfg.roots).toEqual(["/a", "/b"]);
+    expect(cfg.ignorePatterns).toEqual(["good", "more"]);
+  });
+});
+
+describe("resolveConfigPath", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.RALPH_KNOWLEDGE_CONFIG;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.RALPH_KNOWLEDGE_CONFIG;
+    } else {
+      process.env.RALPH_KNOWLEDGE_CONFIG = originalEnv;
+    }
+  });
+
+  it("defaults to ~/.ralph/knowledge.config.json when env var is unset", () => {
+    delete process.env.RALPH_KNOWLEDGE_CONFIG;
+    expect(resolveConfigPath()).toBe(
+      join(homedir(), ".ralph", "knowledge.config.json"),
+    );
+  });
+
+  it("expands ~ prefix in RALPH_KNOWLEDGE_CONFIG", () => {
+    process.env.RALPH_KNOWLEDGE_CONFIG = "~/custom/knowledge.json";
+    expect(resolveConfigPath()).toBe(
+      join(homedir(), "custom/knowledge.json"),
+    );
+  });
+
+  it("uses RALPH_KNOWLEDGE_CONFIG absolute path verbatim", () => {
+    process.env.RALPH_KNOWLEDGE_CONFIG = "/etc/ralph/knowledge.json";
+    expect(resolveConfigPath()).toBe("/etc/ralph/knowledge.json");
+  });
+});

--- a/plugin/ralph-knowledge/src/__tests__/file-scanner.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/file-scanner.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { findMarkdownFiles } from "../file-scanner.js";
+import { loadIgnoreForRoot } from "../ignore.js";
+
+describe("findMarkdownFiles with IgnoreMatcher", () => {
+  it("excludes files matched by a .ralphignore entry", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fs-ignore-"));
+    writeFileSync(join(dir, "a.md"), "# A");
+    writeFileSync(join(dir, "b.md"), "# B");
+    writeFileSync(join(dir, "c.md"), "# C");
+    writeFileSync(join(dir, ".ralphignore"), "b.md\n");
+
+    const matcher = loadIgnoreForRoot(dir);
+    const files = findMarkdownFiles(dir, matcher);
+    expect(files).toHaveLength(2);
+    expect(files.some(f => f.endsWith("a.md"))).toBe(true);
+    expect(files.some(f => f.endsWith("c.md"))).toBe(true);
+    expect(files.some(f => f.endsWith("b.md"))).toBe(false);
+  });
+
+  it("skips a whole subdirectory covered by subdir/** pattern", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fs-ignore-"));
+    writeFileSync(join(dir, "keep.md"), "# keep");
+    mkdirSync(join(dir, "subdir"));
+    writeFileSync(join(dir, "subdir", "skip.md"), "# skip");
+    writeFileSync(join(dir, "subdir", "also-skip.md"), "# skip2");
+    writeFileSync(join(dir, ".ralphignore"), "subdir/**\n");
+
+    const matcher = loadIgnoreForRoot(dir);
+    const files = findMarkdownFiles(dir, matcher);
+    expect(files).toHaveLength(1);
+    expect(files[0].endsWith("keep.md")).toBe(true);
+  });
+
+  it("honors caller-supplied global patterns via loadIgnoreForRoot", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fs-ignore-"));
+    writeFileSync(join(dir, "readme.md"), "# r");
+    mkdirSync(join(dir, "drafts"));
+    writeFileSync(join(dir, "drafts", "wip.md"), "# wip");
+
+    const matcher = loadIgnoreForRoot(dir, ["drafts/**"]);
+    const files = findMarkdownFiles(dir, matcher);
+    expect(files).toHaveLength(1);
+    expect(files[0].endsWith("readme.md")).toBe(true);
+  });
+
+  it("preserves back-compat when called without a matcher", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fs-ignore-"));
+    writeFileSync(join(dir, "a.md"), "# A");
+    writeFileSync(join(dir, "b.md"), "# B");
+    mkdirSync(join(dir, "nested"));
+    writeFileSync(join(dir, "nested", "c.md"), "# C");
+
+    const files = findMarkdownFiles(dir);
+    expect(files).toHaveLength(3);
+    expect(files.every(f => f.endsWith(".md"))).toBe(true);
+  });
+
+  it("still skips dot- and underscore-prefixed directories even without a matcher", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fs-ignore-"));
+    writeFileSync(join(dir, "top.md"), "# top");
+    mkdirSync(join(dir, ".hidden"));
+    writeFileSync(join(dir, ".hidden", "hidden.md"), "# h");
+    mkdirSync(join(dir, "_private"));
+    writeFileSync(join(dir, "_private", "private.md"), "# p");
+
+    const files = findMarkdownFiles(dir);
+    expect(files).toHaveLength(1);
+    expect(files[0].endsWith("top.md")).toBe(true);
+  });
+
+  it("applies default ignore globals (node_modules/, dist/) via loadIgnoreForRoot", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fs-ignore-"));
+    writeFileSync(join(dir, "root.md"), "# root");
+    mkdirSync(join(dir, "node_modules"));
+    writeFileSync(join(dir, "node_modules", "pkg.md"), "# pkg");
+    mkdirSync(join(dir, "dist"));
+    writeFileSync(join(dir, "dist", "out.md"), "# out");
+
+    const matcher = loadIgnoreForRoot(dir);
+    const files = findMarkdownFiles(dir, matcher);
+    expect(files).toHaveLength(1);
+    expect(files[0].endsWith("root.md")).toBe(true);
+  });
+});

--- a/plugin/ralph-knowledge/src/__tests__/ignore.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/ignore.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadIgnoreForRoot, DEFAULT_IGNORE_PATTERNS } from "../ignore.js";
+
+describe("loadIgnoreForRoot", () => {
+  it("applies default globals when no .ralphignore and no caller globals are provided", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    const matcher = loadIgnoreForRoot(dir);
+    expect(matcher.isIgnored("node_modules/foo.js")).toBe(true);
+    expect(matcher.isIgnored(".claude/settings.json")).toBe(true);
+    expect(matcher.isIgnored("dist/index.js")).toBe(true);
+    expect(matcher.isIgnored("debug.log")).toBe(true);
+    expect(matcher.isIgnored("thoughts/research/doc.md")).toBe(false);
+  });
+
+  it("honors glob pattern **/node_modules/** against nested paths", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    writeFileSync(join(dir, ".ralphignore"), "**/node_modules/**\n");
+    const matcher = loadIgnoreForRoot(dir);
+    expect(matcher.isIgnored("foo/node_modules/bar.js")).toBe(true);
+  });
+
+  it("honors negation that overrides an earlier *.md pattern", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    writeFileSync(join(dir, ".ralphignore"), "*.md\n!keep-me.md\n");
+    const matcher = loadIgnoreForRoot(dir);
+    expect(matcher.isIgnored("foo.md")).toBe(true);
+    expect(matcher.isIgnored("keep-me.md")).toBe(false);
+  });
+
+  it("treats directory-only patterns as directories", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    writeFileSync(join(dir, ".ralphignore"), "dist/\n");
+    const matcher = loadIgnoreForRoot(dir);
+    // `dist/file.js` matches the directory pattern
+    expect(matcher.isIgnored("dist/file.js")).toBe(true);
+    // A file literally named `dist` should NOT be matched by the directory-only pattern
+    expect(matcher.isIgnored("dist")).toBe(false);
+  });
+
+  it("honors caller-provided globals when .ralphignore is absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    const matcher = loadIgnoreForRoot(dir, ["custom/**"]);
+    expect(matcher.isIgnored("custom/inside.md")).toBe(true);
+    expect(matcher.isIgnored("other/inside.md")).toBe(false);
+  });
+
+  it("does not throw when the .ralphignore file is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    expect(() => loadIgnoreForRoot(dir)).not.toThrow();
+    const matcher = loadIgnoreForRoot(dir);
+    // Baseline defaults still apply
+    expect(matcher.isIgnored("node_modules/x.js")).toBe(true);
+  });
+
+  it("combines default globals, caller globals, and .ralphignore file together", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    writeFileSync(join(dir, ".ralphignore"), "local/**\n");
+    const matcher = loadIgnoreForRoot(dir, ["global/**"]);
+    // From defaults
+    expect(matcher.isIgnored("node_modules/y.js")).toBe(true);
+    // From caller globals
+    expect(matcher.isIgnored("global/a.md")).toBe(true);
+    // From per-root file
+    expect(matcher.isIgnored("local/b.md")).toBe(true);
+    // Unmatched
+    expect(matcher.isIgnored("thoughts/keep.md")).toBe(false);
+  });
+
+  it("returns false for empty or root-level relative paths", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-ignore-"));
+    const matcher = loadIgnoreForRoot(dir);
+    expect(matcher.isIgnored("")).toBe(false);
+    expect(matcher.isIgnored("/")).toBe(false);
+  });
+
+  it("exports the documented default patterns", () => {
+    expect(DEFAULT_IGNORE_PATTERNS).toContain(".claude/");
+    expect(DEFAULT_IGNORE_PATTERNS).toContain("node_modules/");
+    expect(DEFAULT_IGNORE_PATTERNS).toContain("dist/");
+    expect(DEFAULT_IGNORE_PATTERNS).toContain(".git/");
+    expect(DEFAULT_IGNORE_PATTERNS).toContain("*.log");
+  });
+});

--- a/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, unlinkSync, utimesSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -15,7 +15,7 @@ vi.mock("../embedder.js", () => ({
 }));
 
 import { embed } from "../embedder.js";
-import { reindex } from "../reindex.js";
+import { reindex, resolveDirs } from "../reindex.js";
 import { KnowledgeDB } from "../db.js";
 
 const mockedEmbed = vi.mocked(embed);
@@ -352,5 +352,151 @@ describe("incremental reindex", () => {
     const results = fts1.search("Fresh");
     expect(results.some(r => r.id === "fresh-doc")).toBe(true);
     db1.close();
+  });
+
+  it("scenario 13: reindex honors .ralphignore for file discovery", async () => {
+    writeFileSync(join(dir, "kept.md"), makeDoc("Kept"));
+    writeFileSync(join(dir, "skipped.md"), makeDoc("Skipped"));
+    writeFileSync(join(dir, ".ralphignore"), "skipped.md\n");
+
+    await reindex([dir], dbPath);
+    expect(mockedEmbed).toHaveBeenCalledTimes(1);
+
+    const db = new KnowledgeDB(dbPath);
+    expect(db.getDocument("kept")).toBeTruthy();
+    expect(db.getDocument("skipped")).toBeUndefined();
+    db.close();
+  });
+
+  it("scenario 14: reindex honors caller-supplied ignorePatterns arg", async () => {
+    writeFileSync(join(dir, "kept.md"), makeDoc("Kept"));
+    mkdirSync(join(dir, "drafts"));
+    writeFileSync(join(dir, "drafts", "wip.md"), makeDoc("WIP"));
+
+    await reindex([dir], dbPath, false, ["drafts/**"]);
+    // Only kept.md should have been embedded.
+    expect(mockedEmbed).toHaveBeenCalledTimes(1);
+
+    const db = new KnowledgeDB(dbPath);
+    expect(db.getDocument("kept")).toBeTruthy();
+    expect(db.getDocument("wip")).toBeUndefined();
+    db.close();
+  });
+});
+
+describe("resolveDirs precedence", () => {
+  const ORIGINAL_ARGV = process.argv;
+  const ORIGINAL_ENV = {
+    RALPH_KNOWLEDGE_DIRS: process.env.RALPH_KNOWLEDGE_DIRS,
+    RALPH_KNOWLEDGE_DB: process.env.RALPH_KNOWLEDGE_DB,
+    RALPH_KNOWLEDGE_CONFIG: process.env.RALPH_KNOWLEDGE_CONFIG,
+  };
+  let tmpHome: string;
+  let configDir: string;
+
+  beforeEach(() => {
+    process.argv = ["node", "reindex.js"];
+    delete process.env.RALPH_KNOWLEDGE_DIRS;
+    delete process.env.RALPH_KNOWLEDGE_DB;
+    configDir = mkdtempSync(join(tmpdir(), "resolve-dirs-"));
+    tmpHome = configDir;
+    process.env.RALPH_KNOWLEDGE_CONFIG = join(configDir, "knowledge.config.json");
+  });
+
+  afterEach(() => {
+    process.argv = ORIGINAL_ARGV;
+    for (const key of Object.keys(ORIGINAL_ENV) as (keyof typeof ORIGINAL_ENV)[]) {
+      const orig = ORIGINAL_ENV[key];
+      if (orig === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = orig;
+      }
+    }
+  });
+
+  it("CLI positional args beat env var even when both are set", () => {
+    writeFileSync(
+      process.env.RALPH_KNOWLEDGE_CONFIG!,
+      JSON.stringify({ roots: ["/from/config"] }),
+    );
+    process.argv = ["node", "reindex.js", "/from/cli"];
+    process.env.RALPH_KNOWLEDGE_DIRS = "/from/env";
+    const r = resolveDirs();
+    expect(r.source).toBe("cli");
+    expect(r.dirs).toEqual(["/from/cli"]);
+  });
+
+  it("env var beats config file roots when CLI is empty", () => {
+    writeFileSync(
+      process.env.RALPH_KNOWLEDGE_CONFIG!,
+      JSON.stringify({ roots: ["/from/config"] }),
+    );
+    process.env.RALPH_KNOWLEDGE_DIRS = "/from/env-a,/from/env-b";
+    const r = resolveDirs();
+    expect(r.source).toBe("env");
+    expect(r.dirs).toEqual(["/from/env-a", "/from/env-b"]);
+  });
+
+  it("config file roots beat fallback when CLI and env are absent", () => {
+    writeFileSync(
+      process.env.RALPH_KNOWLEDGE_CONFIG!,
+      JSON.stringify({ roots: ["/from/config-a", "/from/config-b"] }),
+    );
+    const r = resolveDirs();
+    expect(r.source).toBe("config");
+    expect(r.dirs).toEqual(["/from/config-a", "/from/config-b"]);
+  });
+
+  it("falls back to ../../thoughts when no source is configured", () => {
+    // Point env var at a nonexistent config path so loadConfig returns {}.
+    process.env.RALPH_KNOWLEDGE_CONFIG = join(configDir, "missing.json");
+    const r = resolveDirs();
+    expect(r.source).toBe("fallback");
+    expect(r.dirs).toEqual(["../../thoughts"]);
+  });
+
+  it("dbPath precedence: CLI arg > env var > config > default", () => {
+    writeFileSync(
+      process.env.RALPH_KNOWLEDGE_CONFIG!,
+      JSON.stringify({ roots: ["/x"], dbPath: "/from/config.db" }),
+    );
+    // CLI wins
+    process.argv = ["node", "reindex.js", "/cli/root", "/cli/override.db"];
+    process.env.RALPH_KNOWLEDGE_DB = "/from/env.db";
+    expect(resolveDirs().dbPath).toBe("/cli/override.db");
+
+    // Env wins over config when CLI is absent
+    process.argv = ["node", "reindex.js"];
+    process.env.RALPH_KNOWLEDGE_DIRS = "/env/root";
+    process.env.RALPH_KNOWLEDGE_DB = "/from/env.db";
+    expect(resolveDirs().dbPath).toBe("/from/env.db");
+
+    // Config wins when neither CLI nor env set dbPath
+    delete process.env.RALPH_KNOWLEDGE_DB;
+    expect(resolveDirs().dbPath).toBe("/from/config.db");
+  });
+
+  it("forwards config.ignorePatterns on the returned config object", () => {
+    writeFileSync(
+      process.env.RALPH_KNOWLEDGE_CONFIG!,
+      JSON.stringify({
+        roots: ["/r1"],
+        ignorePatterns: ["draft/**", "*.bak"],
+      }),
+    );
+    const r = resolveDirs();
+    expect(r.config.ignorePatterns).toEqual(["draft/**", "*.bak"]);
+  });
+
+  it("treats an empty RALPH_KNOWLEDGE_DIRS as unset and falls through", () => {
+    writeFileSync(
+      process.env.RALPH_KNOWLEDGE_CONFIG!,
+      JSON.stringify({ roots: ["/from/config"] }),
+    );
+    process.env.RALPH_KNOWLEDGE_DIRS = "  ,  ";
+    const r = resolveDirs();
+    expect(r.source).toBe("config");
+    expect(r.dirs).toEqual(["/from/config"]);
   });
 });

--- a/plugin/ralph-knowledge/src/config.ts
+++ b/plugin/ralph-knowledge/src/config.ts
@@ -1,0 +1,105 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Shape of the optional `~/.ralph/knowledge.config.json` file.
+ *
+ * All fields are optional. Unknown fields are preserved at parse time but are
+ * not surfaced through this interface — callers should treat the file as
+ * forward-compatible.
+ */
+export interface KnowledgeConfig {
+  /** Absolute or `~`-prefixed directories to index. */
+  roots?: string[];
+  /** Extra gitignore-syntax patterns layered on top of per-root `.ralphignore`. */
+  ignorePatterns?: string[];
+  /** Override for the SQLite database path. */
+  dbPath?: string;
+}
+
+/**
+ * Expand a leading `~` or `~/` segment in a path to the user's home directory.
+ * Paths that do not begin with `~` are returned unchanged.
+ */
+export function expandHome(p: string): string {
+  if (!p) return p;
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return join(homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Resolve the knowledge config file path. Precedence:
+ *   1. `process.env.RALPH_KNOWLEDGE_CONFIG`
+ *   2. `~/.ralph/knowledge.config.json`
+ */
+export function resolveConfigPath(): string {
+  const envPath = process.env.RALPH_KNOWLEDGE_CONFIG;
+  if (envPath && envPath.trim().length > 0) {
+    return expandHome(envPath);
+  }
+  return join(homedir(), ".ralph", "knowledge.config.json");
+}
+
+/**
+ * Load the optional `knowledge.config.json` file. Returns an empty object when
+ * the file is missing or malformed. Tilde-prefixed paths inside `roots` and
+ * `dbPath` are expanded eagerly so callers receive absolute paths.
+ */
+export function loadConfig(): KnowledgeConfig {
+  const configPath = resolveConfigPath();
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch (e) {
+    console.warn(
+      `Failed to read knowledge config at ${configPath}: ${(e as Error).message}`,
+    );
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    console.warn(
+      `Malformed JSON in knowledge config at ${configPath}: ${(e as Error).message}`,
+    );
+    return {};
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    console.warn(
+      `Knowledge config at ${configPath} is not a JSON object; ignoring.`,
+    );
+    return {};
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const out: KnowledgeConfig = {};
+
+  if (Array.isArray(obj.roots)) {
+    out.roots = obj.roots
+      .filter((r): r is string => typeof r === "string" && r.length > 0)
+      .map(expandHome);
+  }
+
+  if (Array.isArray(obj.ignorePatterns)) {
+    out.ignorePatterns = obj.ignorePatterns.filter(
+      (p): p is string => typeof p === "string" && p.length > 0,
+    );
+  }
+
+  if (typeof obj.dbPath === "string" && obj.dbPath.length > 0) {
+    out.dbPath = expandHome(obj.dbPath);
+  }
+
+  return out;
+}

--- a/plugin/ralph-knowledge/src/file-scanner.ts
+++ b/plugin/ralph-knowledge/src/file-scanner.ts
@@ -1,14 +1,39 @@
 import { readdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
+import type { IgnoreMatcher } from "./ignore.js";
 
-export function findMarkdownFiles(dir: string): string[] {
+/**
+ * Recursively find all `.md` files under `dir`.
+ *
+ * Directory names beginning with `.` or `_` and file names beginning with `_`
+ * are always skipped (fast-path). When an {@link IgnoreMatcher} is supplied,
+ * each remaining path is additionally tested against it via its root-relative
+ * form; matches are skipped.
+ *
+ * @param dir root directory to walk
+ * @param matcher optional matcher built via `loadIgnoreForRoot(dir, …)`
+ */
+export function findMarkdownFiles(dir: string, matcher?: IgnoreMatcher): string[] {
   const results: string[] = [];
   function walk(d: string) {
     for (const entry of readdirSync(d, { withFileTypes: true })) {
       const fullPath = join(d, entry.name);
-      if (entry.isDirectory() && !entry.name.startsWith(".") && !entry.name.startsWith("_")) {
+      if (entry.isDirectory()) {
+        // Fast-path: hidden/underscored directories are always skipped.
+        if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+        if (matcher) {
+          // Test both bare and trailing-slash forms so gitignore-style
+          // directory-only patterns (e.g., `dist/`) match even when the
+          // directory itself has not yet been descended.
+          const rel = relative(dir, fullPath);
+          if (matcher.isIgnored(rel) || matcher.isIgnored(`${rel}/`)) continue;
+        }
         walk(fullPath);
       } else if (entry.isFile() && entry.name.endsWith(".md") && !entry.name.startsWith("_")) {
+        if (matcher) {
+          const rel = relative(dir, fullPath);
+          if (matcher.isIgnored(rel)) continue;
+        }
         results.push(fullPath);
       }
     }

--- a/plugin/ralph-knowledge/src/ignore.ts
+++ b/plugin/ralph-knowledge/src/ignore.ts
@@ -1,0 +1,82 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import ignorePkg, { type Ignore } from "ignore";
+
+// The `ignore` CJS module exposes the factory via `module.exports = factory`
+// with `factory.default = factory` attached. Under `NodeNext` + ESM, depending
+// on the interop mode, the default import can resolve to either the factory
+// itself or the whole namespace. Probe and pick the callable form.
+const ignore: (options?: { ignorecase?: boolean }) => Ignore = (
+  typeof (ignorePkg as unknown) === "function"
+    ? (ignorePkg as unknown as (options?: { ignorecase?: boolean }) => Ignore)
+    : ((ignorePkg as unknown as { default: (options?: { ignorecase?: boolean }) => Ignore }).default)
+);
+
+/**
+ * Default ignore patterns applied to every root even when no `.ralphignore`
+ * file or caller-supplied globals are provided. These target directories and
+ * files that should virtually never be indexed.
+ */
+export const DEFAULT_IGNORE_PATTERNS: string[] = [
+  ".claude/",
+  "node_modules/",
+  "dist/",
+  ".git/",
+  "*.log",
+];
+
+/**
+ * Opaque matcher returned by {@link loadIgnoreForRoot}. Given a path relative
+ * to the root used to construct the matcher, {@link isIgnored} reports whether
+ * the path should be skipped by the scanner.
+ */
+export interface IgnoreMatcher {
+  isIgnored(relativePath: string): boolean;
+}
+
+/**
+ * Build an {@link IgnoreMatcher} for a given root directory. The matcher
+ * combines (in order):
+ *   1. {@link DEFAULT_IGNORE_PATTERNS} — always applied.
+ *   2. `globalPatterns` — caller-supplied patterns (typically from
+ *      `knowledge.config.json`'s `ignorePatterns`).
+ *   3. Contents of `<rootDir>/.ralphignore`, if present.
+ *
+ * All patterns follow gitignore syntax via the `ignore` package.
+ *
+ * @param rootDir absolute path of the root being scanned
+ * @param globalPatterns optional extra patterns applied before the per-root
+ *   `.ralphignore` file
+ */
+export function loadIgnoreForRoot(
+  rootDir: string,
+  globalPatterns?: string[],
+): IgnoreMatcher {
+  const ign: Ignore = ignore();
+  ign.add(DEFAULT_IGNORE_PATTERNS);
+  if (globalPatterns && globalPatterns.length > 0) {
+    ign.add(globalPatterns);
+  }
+
+  const ralphIgnorePath = join(rootDir, ".ralphignore");
+  if (existsSync(ralphIgnorePath)) {
+    try {
+      const contents = readFileSync(ralphIgnorePath, "utf-8");
+      ign.add(contents);
+    } catch (e) {
+      console.warn(
+        `Failed to read .ralphignore at ${ralphIgnorePath}: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  return {
+    isIgnored(relativePath: string): boolean {
+      if (!relativePath) return false;
+      // `ignore` package requires forward-slash paths with no leading slash.
+      const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+      if (!normalized) return false;
+      return ign.ignores(normalized);
+    },
+  };
+}

--- a/plugin/ralph-knowledge/src/reindex.ts
+++ b/plugin/ralph-knowledge/src/reindex.ts
@@ -8,8 +8,15 @@ import { embed, prepareTextForEmbedding } from "./embedder.js";
 import { parseDocument, type ParsedDocument } from "./parser.js";
 import { findMarkdownFiles } from "./file-scanner.js";
 import { generateIndexes } from "./generate-indexes.js";
+import { loadConfig, type KnowledgeConfig } from "./config.js";
+import { loadIgnoreForRoot } from "./ignore.js";
 
-export async function reindex(dirs: string[], dbPath: string, generate: boolean = false): Promise<void> {
+export async function reindex(
+  dirs: string[],
+  dbPath: string,
+  generate: boolean = false,
+  ignorePatterns?: string[],
+): Promise<void> {
   console.log(`Indexing ${dirs.join(", ")} -> ${dbPath}`);
 
   const db = new KnowledgeDB(dbPath);
@@ -32,7 +39,8 @@ export async function reindex(dirs: string[], dbPath: string, generate: boolean 
   // Phase 1: Discover files on disk
   const filesOnDisk: string[] = [];
   for (const dir of dirs) {
-    const found = findMarkdownFiles(dir);
+    const matcher = loadIgnoreForRoot(dir, ignorePatterns);
+    const found = findMarkdownFiles(dir, matcher);
     console.log(`  ${dir}: ${found.length} files`);
     filesOnDisk.push(...found);
   }
@@ -182,31 +190,94 @@ export async function reindex(dirs: string[], dbPath: string, generate: boolean 
 
 const DEFAULT_DB_PATH = join(homedir(), ".ralph-hero", "knowledge.db");
 
-export function resolveDirs(): { dirs: string[]; dbPath: string; generate: boolean } {
+export type ResolvedDirsSource = "cli" | "env" | "config" | "fallback";
+
+export interface ResolvedDirs {
+  dirs: string[];
+  dbPath: string;
+  generate: boolean;
+  source: ResolvedDirsSource;
+  config: KnowledgeConfig;
+}
+
+/**
+ * Resolve the set of roots, database path, and generate flag for a reindex
+ * run. Precedence (highest to lowest):
+ *   1. CLI positional args
+ *   2. `RALPH_KNOWLEDGE_DIRS` environment variable
+ *   3. `config.roots` from `~/.ralph/knowledge.config.json`
+ *   4. `"../../thoughts"` fallback
+ *
+ * `dbPath` precedence is independent: CLI `.db` positional > `RALPH_KNOWLEDGE_DB`
+ * env var > `config.dbPath` > {@link DEFAULT_DB_PATH}.
+ *
+ * The returned `config` is forwarded to the caller so `ignorePatterns` can be
+ * threaded into {@link reindex}.
+ */
+export function resolveDirs(): ResolvedDirs {
   const cliArgs = process.argv.slice(2);
   const noGenerate = cliArgs.includes("--no-generate");
   const positional = cliArgs.filter(a => !a.startsWith("--"));
   const cliDb = positional.find(a => a.endsWith(".db"));
   const cliDirs = positional.filter(a => !a.endsWith(".db"));
 
+  const config = loadConfig();
+
+  const resolveDbPath = (): string =>
+    cliDb ??
+    process.env.RALPH_KNOWLEDGE_DB ??
+    config.dbPath ??
+    DEFAULT_DB_PATH;
+
   if (cliDirs.length > 0) {
-    return { dirs: cliDirs, dbPath: cliDb ?? DEFAULT_DB_PATH, generate: !noGenerate };
+    console.log("Using roots from: CLI");
+    return {
+      dirs: cliDirs,
+      dbPath: resolveDbPath(),
+      generate: !noGenerate,
+      source: "cli",
+      config,
+    };
   }
 
   const envDirs = process.env.RALPH_KNOWLEDGE_DIRS;
   if (envDirs) {
+    const parsed = envDirs.split(",").map(d => d.trim()).filter(Boolean);
+    if (parsed.length > 0) {
+      console.log("Using roots from: env");
+      return {
+        dirs: parsed,
+        dbPath: resolveDbPath(),
+        generate: !noGenerate,
+        source: "env",
+        config,
+      };
+    }
+  }
+
+  if (config.roots && config.roots.length > 0) {
+    console.log("Using roots from: config");
     return {
-      dirs: envDirs.split(",").map(d => d.trim()).filter(Boolean),
-      dbPath: cliDb ?? process.env.RALPH_KNOWLEDGE_DB ?? DEFAULT_DB_PATH,
+      dirs: config.roots,
+      dbPath: resolveDbPath(),
       generate: !noGenerate,
+      source: "config",
+      config,
     };
   }
 
-  return { dirs: ["../../thoughts"], dbPath: cliDb ?? DEFAULT_DB_PATH, generate: !noGenerate };
+  console.log("Using roots from: fallback");
+  return {
+    dirs: ["../../thoughts"],
+    dbPath: resolveDbPath(),
+    generate: !noGenerate,
+    source: "fallback",
+    config,
+  };
 }
 
 const isMain = process.argv[1]?.endsWith("reindex.js");
 if (isMain) {
-  const { dirs, dbPath, generate } = resolveDirs();
-  reindex(dirs, dbPath, generate).catch(console.error);
+  const { dirs, dbPath, generate, config } = resolveDirs();
+  reindex(dirs, dbPath, generate, config.ignorePatterns).catch(console.error);
 }

--- a/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
+++ b/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
@@ -623,9 +623,9 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `dependencies` in `package.json` includes `"ignore": "^5.3.0"` (or latest stable at implementation time)
-  - [ ] `npm install` succeeds; `node_modules/ignore/` exists
-  - [ ] `package-lock.json` updated
+  - [x] `dependencies` in `package.json` includes `"ignore": "^5.3.0"` (or latest stable at implementation time)
+  - [x] `npm install` succeeds; `node_modules/ignore/` exists
+  - [x] `package-lock.json` updated
 
 #### Task 7.2: Create ignore.ts with loadIgnoreForRoot()
 - **files**: `plugin/ralph-knowledge/src/ignore.ts` (create)
@@ -633,11 +633,11 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.1]
 - **acceptance**:
-  - [ ] Exports `interface IgnoreMatcher { isIgnored(relativePath: string): boolean }`
-  - [ ] Exports `function loadIgnoreForRoot(rootDir: string, globalPatterns?: string[]): IgnoreMatcher`
-  - [ ] Implementation: reads `${rootDir}/.ralphignore` via `readFileSync` if present; combines with `globalPatterns`; instantiates `ignore()` instance from the `ignore` package
-  - [ ] Default global patterns (applied even without config): `.claude/`, `node_modules/`, `dist/`, `.git/`, `*.log`
-  - [ ] `isIgnored()` delegates to `ign.ignores(relativePath)` on the ignore instance
+  - [x] Exports `interface IgnoreMatcher { isIgnored(relativePath: string): boolean }`
+  - [x] Exports `function loadIgnoreForRoot(rootDir: string, globalPatterns?: string[]): IgnoreMatcher`
+  - [x] Implementation: reads `${rootDir}/.ralphignore` via `readFileSync` if present; combines with `globalPatterns`; instantiates `ignore()` instance from the `ignore` package
+  - [x] Default global patterns (applied even without config): `.claude/`, `node_modules/`, `dist/`, `.git/`, `*.log`
+  - [x] `isIgnored()` delegates to `ign.ignores(relativePath)` on the ignore instance
 
 #### Task 7.3: Test ignore.ts gitignore semantics
 - **files**: `plugin/ralph-knowledge/src/__tests__/ignore.test.ts` (create)
@@ -645,11 +645,11 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.2]
 - **acceptance**:
-  - [ ] Test: glob pattern `**/node_modules/**` matches `foo/node_modules/bar.js`
-  - [ ] Test: negation `!keep-me.md` overrides earlier `*.md`
-  - [ ] Test: directory-only pattern `dist/` matches `dist/file.js` but not a file named `dist`
-  - [ ] Test: `loadIgnoreForRoot(tmpDir, ["custom/**"])` honors caller-provided globals even when `.ralphignore` is absent
-  - [ ] Test: missing `.ralphignore` file falls back to globals-only behavior (no thrown error)
+  - [x] Test: glob pattern `**/node_modules/**` matches `foo/node_modules/bar.js`
+  - [x] Test: negation `!keep-me.md` overrides earlier `*.md`
+  - [x] Test: directory-only pattern `dist/` matches `dist/file.js` but not a file named `dist`
+  - [x] Test: `loadIgnoreForRoot(tmpDir, ["custom/**"])` honors caller-provided globals even when `.ralphignore` is absent
+  - [x] Test: missing `.ralphignore` file falls back to globals-only behavior (no thrown error)
 
 #### Task 7.4: Create config.ts with loadConfig()
 - **files**: `plugin/ralph-knowledge/src/config.ts` (create)
@@ -657,12 +657,12 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Exports `interface KnowledgeConfig { roots?: string[]; ignorePatterns?: string[]; dbPath?: string }`
-  - [ ] Exports `function loadConfig(): KnowledgeConfig`
-  - [ ] Priority order for config file path: `process.env.RALPH_KNOWLEDGE_CONFIG` env var > `path.join(os.homedir(), ".ralph", "knowledge.config.json")`
-  - [ ] Returns `{}` if no file present (no exception)
-  - [ ] On file read, expands `~` prefixes in `roots[]` and `dbPath` to `os.homedir()` + rest
-  - [ ] Malformed JSON caught; logs one warning; returns `{}`
+  - [x] Exports `interface KnowledgeConfig { roots?: string[]; ignorePatterns?: string[]; dbPath?: string }`
+  - [x] Exports `function loadConfig(): KnowledgeConfig`
+  - [x] Priority order for config file path: `process.env.RALPH_KNOWLEDGE_CONFIG` env var > `path.join(os.homedir(), ".ralph", "knowledge.config.json")`
+  - [x] Returns `{}` if no file present (no exception)
+  - [x] On file read, expands `~` prefixes in `roots[]` and `dbPath` to `os.homedir()` + rest
+  - [x] Malformed JSON caught; logs one warning; returns `{}`
 
 #### Task 7.5: Test config.ts loading paths
 - **files**: `plugin/ralph-knowledge/src/__tests__/config.test.ts` (create)
@@ -670,10 +670,10 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.4]
 - **acceptance**:
-  - [ ] Test: missing config file returns `{}`
-  - [ ] Test: malformed JSON returns `{}` and logs warning (capture console.warn)
-  - [ ] Test: tilde expansion: `{"roots":["~/thoughts"]}` produces absolute path with `os.homedir()` prefix
-  - [ ] Test: `RALPH_KNOWLEDGE_CONFIG` env var override is honored (write fixture to tmp path, set env, call `loadConfig()`)
+  - [x] Test: missing config file returns `{}`
+  - [x] Test: malformed JSON returns `{}` and logs warning (capture console.warn)
+  - [x] Test: tilde expansion: `{"roots":["~/thoughts"]}` produces absolute path with `os.homedir()` prefix
+  - [x] Test: `RALPH_KNOWLEDGE_CONFIG` env var override is honored (write fixture to tmp path, set env, call `loadConfig()`)
 
 #### Task 7.6: Extend findMarkdownFiles to accept IgnoreMatcher
 - **files**: `plugin/ralph-knowledge/src/file-scanner.ts` (modify)
@@ -681,11 +681,11 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.2]
 - **acceptance**:
-  - [ ] Signature updates to `findMarkdownFiles(dir: string, matcher?: IgnoreMatcher): string[]`
-  - [ ] Walker computes `relativeToRoot = relative(dir, fullPath)` for each entry; skips when `matcher?.isIgnored(relativeToRoot)` returns true
-  - [ ] Existing `.`/`_`-prefix skip retained as fast-path before matcher check
-  - [ ] Back-compat: calling without matcher preserves existing behavior
-  - [ ] `import { relative } from "node:path"` added
+  - [x] Signature updates to `findMarkdownFiles(dir: string, matcher?: IgnoreMatcher): string[]`
+  - [x] Walker computes `relativeToRoot = relative(dir, fullPath)` for each entry; skips when `matcher?.isIgnored(relativeToRoot)` returns true
+  - [x] Existing `.`/`_`-prefix skip retained as fast-path before matcher check
+  - [x] Back-compat: calling without matcher preserves existing behavior
+  - [x] `import { relative } from "node:path"` added
 
 #### Task 7.7: Test file-scanner with .ralphignore
 - **files**: `plugin/ralph-knowledge/src/__tests__/file-scanner.test.ts` (modify)
@@ -693,9 +693,9 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.6]
 - **acceptance**:
-  - [ ] Test: tmp directory with 3 `.md` files where one is covered by `.ralphignore` — `findMarkdownFiles(tmpDir, matcher)` returns 2
-  - [ ] Test: directory excluded by pattern `subdir/**` has its children skipped even if they contain `.md`
-  - [ ] Test: calling without matcher returns all `.md` files (back-compat)
+  - [x] Test: tmp directory with 3 `.md` files where one is covered by `.ralphignore` — `findMarkdownFiles(tmpDir, matcher)` returns 2
+  - [x] Test: directory excluded by pattern `subdir/**` has its children skipped even if they contain `.md`
+  - [x] Test: calling without matcher returns all `.md` files (back-compat)
 
 #### Task 7.8: Update resolveDirs() precedence
 - **files**: `plugin/ralph-knowledge/src/reindex.ts` (modify)
@@ -703,11 +703,11 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.4]
 - **acceptance**:
-  - [ ] `resolveDirs()` at [reindex.ts:185-206](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L185-L206) imports `loadConfig` and calls it once
-  - [ ] New precedence order: (1) CLI positional args, (2) `RALPH_KNOWLEDGE_DIRS` env, (3) `config.roots`, (4) `"../../thoughts"` fallback
-  - [ ] `dbPath` precedence: CLI `.db` arg > `process.env.RALPH_KNOWLEDGE_DB` > `config.dbPath` > `DEFAULT_DB_PATH`
-  - [ ] Returns new field `config: KnowledgeConfig` so `reindex()` can forward `ignorePatterns`
-  - [ ] Log line added: `console.log("Using roots from: CLI|env|config|fallback")` indicating the selected source
+  - [x] `resolveDirs()` at [reindex.ts:185-206](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L185-L206) imports `loadConfig` and calls it once
+  - [x] New precedence order: (1) CLI positional args, (2) `RALPH_KNOWLEDGE_DIRS` env, (3) `config.roots`, (4) `"../../thoughts"` fallback
+  - [x] `dbPath` precedence: CLI `.db` arg > `process.env.RALPH_KNOWLEDGE_DB` > `config.dbPath` > `DEFAULT_DB_PATH`
+  - [x] Returns new field `config: KnowledgeConfig` so `reindex()` can forward `ignorePatterns`
+  - [x] Log line added: `console.log("Using roots from: CLI|env|config|fallback")` indicating the selected source
 
 #### Task 7.9: Wire ignore matcher per-root into reindex()
 - **files**: `plugin/ralph-knowledge/src/reindex.ts` (modify)
@@ -715,9 +715,9 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.2, 7.6, 7.8]
 - **acceptance**:
-  - [ ] `reindex()` accepts optional `ignorePatterns` (either via extended signature or from the extended `resolveDirs()` return shape)
-  - [ ] For each root, `matcher = loadIgnoreForRoot(root, ignorePatterns)` built before `findMarkdownFiles(root, matcher)`
-  - [ ] The `main()` branch at [reindex.ts:208-212](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L208-L212) forwards config.ignorePatterns to reindex
+  - [x] `reindex()` accepts optional `ignorePatterns` (either via extended signature or from the extended `resolveDirs()` return shape)
+  - [x] For each root, `matcher = loadIgnoreForRoot(root, ignorePatterns)` built before `findMarkdownFiles(root, matcher)`
+  - [x] The `main()` branch at [reindex.ts:208-212](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L208-L212) forwards config.ignorePatterns to reindex
 
 #### Task 7.10: Update reindex.test.ts precedence cases
 - **files**: `plugin/ralph-knowledge/src/__tests__/reindex.test.ts` (modify)
@@ -725,10 +725,10 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: medium
 - **depends_on**: [7.8]
 - **acceptance**:
-  - [ ] Test: CLI args beat env var even when both set
-  - [ ] Test: env var beats config file roots
-  - [ ] Test: config file roots beat fallback when CLI + env absent
-  - [ ] Test: fallback used when all other sources absent
+  - [x] Test: CLI args beat env var even when both set
+  - [x] Test: env var beats config file roots
+  - [x] Test: config file roots beat fallback when CLI + env absent
+  - [x] Test: fallback used when all other sources absent
 
 #### Task 7.11: Document config + .ralphignore in README
 - **files**: `plugin/ralph-knowledge/README.md` (modify if exists, create if not)
@@ -736,15 +736,15 @@ Add per-root `.ralphignore` (gitignore syntax) + optional `~/.ralph/knowledge.co
 - **complexity**: low
 - **depends_on**: [7.4]
 - **acceptance**:
-  - [ ] Section "Configuration" documents `~/.ralph/knowledge.config.json` path, schema, example with 3 roots + ignore patterns
-  - [ ] Section "Ignoring files" documents `.ralphignore` with gitignore syntax example
+  - [x] Section "Configuration" documents `~/.ralph/knowledge.config.json` path, schema, example with 3 roots + ignore patterns
+  - [x] Section "Ignoring files" documents `.ralphignore` with gitignore syntax example
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` passes
-- [ ] `npm test` — new ignore/config tests + updated file-scanner/reindex tests pass
-- [ ] `npm install` completes with `ignore` dep resolved
+- [x] `npm run build` passes
+- [x] `npm test` — new ignore/config tests + updated file-scanner/reindex tests pass
+- [x] `npm install` completes with `ignore` dep resolved
 
 #### Manual Verification:
 - [ ] Write `~/.ralph/knowledge.config.json` with 3 roots; run `npm run reindex`; log line shows `"Using roots from: config"` and all 3 roots appear in output


### PR DESCRIPTION
## Summary

Adds `.ralphignore` (gitignore syntax per-root), `~/.ralph/knowledge.config.json` (persistent roots + global ignore patterns), and wires both into `resolveDirs` + `file-scanner`. Multi-root via `RALPH_KNOWLEDGE_DIRS` already works; this makes it persistent and filterable.

## Changes

- New `src/ignore.ts` — wrapper around `ignore` npm package; `loadIgnoreForRoot(rootDir, globalPatterns?)` returns `IgnoreMatcher`. Default global patterns: `.claude/`, `node_modules/`, `dist/`, `.git/`, `*.log`
- New `src/config.ts` — `loadConfig()` reads `$RALPH_KNOWLEDGE_CONFIG` or `~/.ralph/knowledge.config.json`; returns `KnowledgeConfig { roots?, ignorePatterns?, dbPath? }`
- Updated `src/reindex.ts` — update `resolveDirs` precedence: CLI args > `RALPH_KNOWLEDGE_DIRS` > config file roots > cwd/thoughts fallback; log which source was selected
- Extended `src/file-scanner.ts` — extend `findMarkdownFiles(dir, matcher?)` to test each path against `matcher.isIgnored(relativeToRoot)` before descending/including; keep `.`/`_` prefix skip as fast-path
- Updated `package.json` — add `ignore` dep
- Updated `README.md` — document config file + `.ralphignore` pattern with example
- Tests: `src/__tests__/ignore.test.ts`, `src/__tests__/config.test.ts`, update `reindex.test.ts` and `file-scanner.test.ts`

Closes #768