### PR TITLE
GH-769: ralph-knowledge MCP tool extensions (memory_tier filter + knowledge_memory_stats)

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/hybrid-search.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/hybrid-search.test.ts
@@ -73,6 +73,34 @@ beforeEach(() => {
   hybrid = new HybridSearch(db, fts, vec, mockEmbedFn);
 });
 
+/**
+ * Ensure the v3 schema extensions (memory_tier column, chunks table) exist.
+ * Phase 1 (GH-762) owns the production migration; tests add them so Phase 8
+ * features can be exercised independently of Phase 1's merge order.
+ */
+function ensureV3Schema(targetDb: KnowledgeDB): void {
+  const rows = targetDb.db
+    .prepare("PRAGMA table_info(documents)")
+    .all() as Array<{ name: string }>;
+  if (!rows.some((r) => r.name === "memory_tier")) {
+    targetDb.db.exec(
+      "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))",
+    );
+  }
+  targetDb.db.exec(
+    `CREATE TABLE IF NOT EXISTS chunks (
+       id TEXT PRIMARY KEY,
+       document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+       chunk_index INTEGER NOT NULL,
+       content TEXT NOT NULL,
+       char_start INTEGER NOT NULL,
+       char_end INTEGER NOT NULL,
+       context_prefix TEXT NOT NULL DEFAULT '',
+       UNIQUE(document_id, chunk_index)
+     )`,
+  );
+}
+
 describe("HybridSearch", () => {
   it("returns results combining FTS and vector scores", async () => {
     const results = await hybrid.search("cache");
@@ -108,5 +136,84 @@ describe("HybridSearch", () => {
     const ids = results.map((r) => r.id);
     expect(ids).toContain("auth-doc");
     expect(ids).not.toContain("cache-doc");
+  });
+});
+
+describe("HybridSearch memory_tier filter", () => {
+  it("filters to reflection when memoryTier='reflection'", async () => {
+    // Rebuild fixture with memory_tier column populated
+    ensureV3Schema(db);
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "cache-doc");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("reflection", "auth-doc");
+    // FTS must be rebuilt to pick up the new column for its JOIN
+    fts.rebuildIndex();
+
+    const results = await hybrid.search("cache OR auth", { memoryTier: "reflection" });
+    const ids = results.map((r) => r.id);
+    expect(ids).toContain("auth-doc");
+    expect(ids).not.toContain("cache-doc");
+  });
+
+  it("returns all tiers when memoryTier='any' (default)", async () => {
+    ensureV3Schema(db);
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("raw", "cache-doc");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("reflection", "auth-doc");
+    fts.rebuildIndex();
+
+    const results = await hybrid.search("cache OR auth", { memoryTier: "any" });
+    const ids = results.map((r) => r.id);
+    expect(ids).toContain("cache-doc");
+    expect(ids).toContain("auth-doc");
+  });
+
+  it("passes silently on v2 DB where memory_tier column is absent", async () => {
+    // Do NOT call ensureV3Schema — simulate v2 schema.
+    const results = await hybrid.search("cache", { memoryTier: "reflection" });
+    // Schema has no tier info; filter treats all docs as 'doc', so reflection
+    // filter drops everything on a v2 DB — no error thrown.
+    expect(Array.isArray(results)).toBe(true);
+  });
+});
+
+describe("HybridSearch chunk metadata enrichment", () => {
+  it("populates bestChunkId + chunk meta when vec returns chunk ids", async () => {
+    ensureV3Schema(db);
+
+    // Seed a chunk row for cache-doc and mirror its id in the vec table
+    db.db
+      .prepare(
+        `INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end, context_prefix)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "cache-doc#c0",
+        "cache-doc",
+        0,
+        "Analysis of cache invalidation patterns...",
+        0,
+        40,
+        "Research: cache-invalidation context.",
+      );
+    // Replace the doc-level vec entry with a chunk-level one.
+    vec.deleteEmbedding("cache-doc");
+    vec.upsertEmbedding("cache-doc#c0", mockEmbedding(1));
+
+    const results = await hybrid.search("cache");
+    const hit = results.find((r) => r.id === "cache-doc");
+    expect(hit).toBeDefined();
+    expect(hit!.bestChunkId).toBe("cache-doc#c0");
+    expect(hit!.chunkIndex).toBe(0);
+    expect(hit!.charStart).toBe(0);
+    expect(hit!.charEnd).toBe(40);
+    expect(hit!.contextPrefix).toBe("Research: cache-invalidation context.");
+  });
+
+  it("does not populate chunk meta when vec returns doc-level ids", async () => {
+    // Fixture as-is: vec stores doc ids, not chunk ids.
+    const results = await hybrid.search("cache");
+    const hit = results.find((r) => r.id === "cache-doc");
+    expect(hit).toBeDefined();
+    expect(hit!.bestChunkId).toBeUndefined();
+    expect(hit!.chunkIndex).toBeUndefined();
   });
 });

--- a/plugin/ralph-knowledge/src/__tests__/index.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/index.test.ts
@@ -1,4 +1,84 @@
 import { describe, it, expect } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { KnowledgeDB } from "../db.js";
+
+/**
+ * Deterministic mock embedding. Avoids the 16MB ONNX model download in tests.
+ */
+function mockEmbed(seed: number): Float32Array {
+  const v = new Float32Array(384);
+  for (let i = 0; i < 384; i++) {
+    v[i] = Math.sin(seed * (i + 1) * 0.1);
+  }
+  let norm = 0;
+  for (let i = 0; i < v.length; i++) norm += v[i] * v[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < v.length; i++) v[i] /= norm;
+  return v;
+}
+
+function hashSeed(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h) % 1000;
+}
+
+const mockEmbedFn = async (text: string) => mockEmbed(hashSeed(text));
+
+/**
+ * Helper to call a registered MCP tool by name (mirrors the pattern in
+ * graph-tools.test.ts). McpServer stores handlers at `_registeredTools`.
+ */
+async function callTool(
+  toolServer: McpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const registeredTools = (toolServer as unknown as Record<string, unknown>)
+    ._registeredTools as Record<
+    string,
+    { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+  >;
+  const tool = registeredTools?.[name];
+  if (!tool) {
+    throw new Error(`Tool "${name}" not registered`);
+  }
+  return tool.handler(args, {}) as Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+/**
+ * Ensure the v3 schema extensions (memory_tier column on documents, chunks
+ * table) exist on the test DB. Phase 1 (GH-762) owns the production schema
+ * migration; here we add them in test fixtures so Phase 8's features can be
+ * exercised independently of Phase 1's merge order.
+ */
+function ensureV3Schema(db: KnowledgeDB): void {
+  const rows = db.db.prepare("PRAGMA table_info(documents)").all() as Array<{ name: string }>;
+  const hasTier = rows.some((r) => r.name === "memory_tier");
+  if (!hasTier) {
+    db.db.exec(
+      "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))",
+    );
+  }
+  db.db.exec(
+    `CREATE TABLE IF NOT EXISTS chunks (
+       id TEXT PRIMARY KEY,
+       document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+       chunk_index INTEGER NOT NULL,
+       content TEXT NOT NULL,
+       char_start INTEGER NOT NULL,
+       char_end INTEGER NOT NULL,
+       context_prefix TEXT NOT NULL DEFAULT '',
+       UNIQUE(document_id, chunk_index)
+     )`,
+  );
+  db.db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id)",
+  );
+}
 
 describe("knowledge-index server", () => {
   it("exports createServer function", async () => {
@@ -10,5 +90,375 @@ describe("knowledge-index server", () => {
     const mod = await import("../index.js");
     const { server } = mod.createServer(":memory:");
     expect(server).toBeTruthy();
+  });
+
+  it("registers knowledge_memory_stats tool alongside search/traverse", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const registered = (server as unknown as Record<string, unknown>)
+      ._registeredTools as Record<string, unknown>;
+    expect(registered).toHaveProperty("knowledge_memory_stats");
+    expect(registered).toHaveProperty("knowledge_search");
+    expect(registered).toHaveProperty("knowledge_traverse");
+  });
+
+  it("knowledge_search tool schema accepts memory_tier + return_chunk_meta", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const registered = (server as unknown as Record<string, unknown>)
+      ._registeredTools as Record<string, { inputSchema?: { parse: (v: unknown) => unknown } }>;
+    const schema = registered.knowledge_search?.inputSchema;
+    expect(schema).toBeDefined();
+    // Valid inputs should pass zod validation without throwing
+    expect(() =>
+      schema!.parse({ query: "hello", memory_tier: "reflection", return_chunk_meta: true }),
+    ).not.toThrow();
+    expect(() => schema!.parse({ query: "hello", memory_tier: "any" })).not.toThrow();
+    // Invalid tier value must be rejected
+    expect(() => schema!.parse({ query: "hello", memory_tier: "garbage" })).toThrow();
+  });
+
+  it("knowledge_traverse schema accepts memory_tier", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const registered = (server as unknown as Record<string, unknown>)
+      ._registeredTools as Record<string, { inputSchema?: { parse: (v: unknown) => unknown } }>;
+    const schema = registered.knowledge_traverse?.inputSchema;
+    expect(schema).toBeDefined();
+    expect(() =>
+      schema!.parse({ from: "doc-1", memory_tier: "reflection" }),
+    ).not.toThrow();
+    expect(() => schema!.parse({ from: "doc-1", memory_tier: "bad" })).toThrow();
+  });
+});
+
+describe("knowledge_search memory_tier + chunk_meta", () => {
+  it("filters to reflection when memory_tier=reflection", async () => {
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", { embedFn: mockEmbedFn });
+
+    ensureV3Schema(db);
+
+    // Seed 3 docs in doc/raw/reflection tiers with distinct content
+    db.upsertDocument({
+      id: "s-doc",
+      path: "s-doc.md",
+      title: "Curated Research",
+      date: "2026-03-01",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "Curated research about chunking retrieval strategies.",
+    });
+    db.upsertDocument({
+      id: "s-raw",
+      path: "s-raw.md",
+      title: "Raw Memory",
+      date: "2026-03-02",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Raw ingested note about chunking retrieval.",
+    });
+    db.upsertDocument({
+      id: "s-reflection",
+      path: "s-reflection.md",
+      title: "Reflection Synthesis",
+      date: "2026-03-03",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Reflection about chunking retrieval patterns.",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "s-doc");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("raw", "s-raw");
+    db.db
+      .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
+      .run("reflection", "s-reflection");
+    fts.rebuildIndex();
+
+    // Ensure vec index exists so the query path runs — empty is fine.
+    vec.createIndex();
+
+    const result = await callTool(server, "knowledge_search", {
+      query: "chunking retrieval",
+      memory_tier: "reflection",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const ids = payload.map((r) => r.id);
+    expect(ids).toContain("s-reflection");
+    expect(ids).not.toContain("s-doc");
+    expect(ids).not.toContain("s-raw");
+  });
+
+  it("returns all tiers when memory_tier='any' (default)", async () => {
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", { embedFn: mockEmbedFn });
+
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "a-doc",
+      path: "a-doc.md",
+      title: "Doc",
+      date: "2026-03-04",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Content about retrieval pipelines.",
+    });
+    db.upsertDocument({
+      id: "a-raw",
+      path: "a-raw.md",
+      title: "Raw",
+      date: "2026-03-04",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Raw content about retrieval pipelines.",
+    });
+    db.upsertDocument({
+      id: "a-reflect",
+      path: "a-reflect.md",
+      title: "Reflect",
+      date: "2026-03-04",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Reflection content about retrieval pipelines.",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "a-doc");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("raw", "a-raw");
+    db.db
+      .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
+      .run("reflection", "a-reflect");
+    fts.rebuildIndex();
+    vec.createIndex();
+
+    const result = await callTool(server, "knowledge_search", {
+      query: "retrieval pipelines",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const ids = payload.map((r) => r.id);
+    expect(ids).toContain("a-doc");
+    expect(ids).toContain("a-raw");
+    expect(ids).toContain("a-reflect");
+  });
+
+  it("populates chunk_index when return_chunk_meta=true", async () => {
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", { embedFn: mockEmbedFn });
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "c-doc",
+      path: "c-doc.md",
+      title: "Chunked Doc",
+      date: "2026-03-05",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "The first portion of a long research document discussing retrieval.",
+    });
+    fts.rebuildIndex();
+
+    // Seed a chunk + a chunk-level vec row
+    db.db
+      .prepare(
+        `INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end, context_prefix)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "c-doc#c0",
+        "c-doc",
+        0,
+        "The first portion of a long research document discussing retrieval.",
+        0,
+        68,
+        "Research context.",
+      );
+
+    vec.createIndex();
+    const queryEmbedding = await mockEmbedFn("retrieval research chunking");
+    vec.upsertEmbedding("c-doc#c0", queryEmbedding);
+
+    const result = await callTool(server, "knowledge_search", {
+      query: "retrieval research chunking",
+      limit: 5,
+      return_chunk_meta: true,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<Record<string, unknown>>;
+    const hit = payload.find((r) => r.id === "c-doc");
+    expect(hit).toBeDefined();
+    expect(hit!.chunk_index).toBe(0);
+    expect(hit!.char_start).toBe(0);
+    expect(hit!.char_end).toBe(68);
+    expect(hit!.context_prefix).toBe("Research context.");
+    expect(hit!.best_chunk_id).toBe("c-doc#c0");
+  });
+
+  it("omits chunk_index when return_chunk_meta is false (default)", async () => {
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", { embedFn: mockEmbedFn });
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "d-doc",
+      path: "d-doc.md",
+      title: "Chunked Doc",
+      date: "2026-03-05",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Chunked document body about retrieval.",
+    });
+    fts.rebuildIndex();
+    db.db
+      .prepare(
+        `INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end, context_prefix)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("d-doc#c0", "d-doc", 0, "Chunked document body about retrieval.", 0, 40, "");
+    vec.createIndex();
+    vec.upsertEmbedding("d-doc#c0", await mockEmbedFn("retrieval document"));
+
+    const result = await callTool(server, "knowledge_search", {
+      query: "retrieval document",
+      limit: 5,
+      // return_chunk_meta omitted (defaults to false)
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<Record<string, unknown>>;
+    const hit = payload.find((r) => r.id === "d-doc");
+    expect(hit).toBeDefined();
+    expect(hit!.chunk_index).toBeUndefined();
+    expect(hit!.best_chunk_id).toBeUndefined();
+  });
+});
+
+describe("knowledge_traverse memory_tier filter", () => {
+  it("drops non-reflection nodes when memory_tier=reflection", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "t-root",
+      path: "t-root.md",
+      title: "Root",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    db.upsertDocument({
+      id: "t-doc-child",
+      path: "c1.md",
+      title: "Doc Child",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    db.upsertDocument({
+      id: "t-reflect-child",
+      path: "c2.md",
+      title: "Reflect Child",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "t-doc-child");
+    db.db
+      .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
+      .run("reflection", "t-reflect-child");
+    db.addRelationship("t-root", "t-doc-child", "builds_on");
+    db.addRelationship("t-root", "t-reflect-child", "builds_on");
+
+    const result = await callTool(server, "knowledge_traverse", {
+      from: "t-root",
+      memory_tier: "reflection",
+    });
+    expect(result.isError).not.toBe(true);
+    const rows = JSON.parse(result.content[0].text) as Array<{ targetId: string }>;
+    const targetIds = rows.map((r) => r.targetId);
+    expect(targetIds).toContain("t-reflect-child");
+    expect(targetIds).not.toContain("t-doc-child");
+  });
+
+  it("returns all tiers when memory_tier='any' (default)", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "any-root",
+      path: "r.md",
+      title: "R",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    db.upsertDocument({
+      id: "any-doc",
+      path: "a.md",
+      title: "A",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    db.upsertDocument({
+      id: "any-raw",
+      path: "b.md",
+      title: "B",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    db.upsertDocument({
+      id: "any-reflect",
+      path: "c.md",
+      title: "C",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "any-doc");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("raw", "any-raw");
+    db.db
+      .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
+      .run("reflection", "any-reflect");
+    db.addRelationship("any-root", "any-doc", "builds_on");
+    db.addRelationship("any-root", "any-raw", "builds_on");
+    db.addRelationship("any-root", "any-reflect", "builds_on");
+
+    const result = await callTool(server, "knowledge_traverse", {
+      from: "any-root",
+    });
+    expect(result.isError).not.toBe(true);
+    const rows = JSON.parse(result.content[0].text) as Array<{ targetId: string }>;
+    const targetIds = rows.map((r) => r.targetId);
+    expect(targetIds).toContain("any-doc");
+    expect(targetIds).toContain("any-raw");
+    expect(targetIds).toContain("any-reflect");
   });
 });

--- a/plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { KnowledgeDB } from "../db.js";
+
+/**
+ * Helper: call the MCP `knowledge_memory_stats` tool directly via the
+ * server's private `_registeredTools` map. Mirrors graph-tools.test.ts.
+ */
+async function callStats(
+  server: McpServer,
+  args: Record<string, unknown> = {},
+): Promise<Record<string, unknown>> {
+  const registered = (server as unknown as Record<string, unknown>)
+    ._registeredTools as Record<
+    string,
+    { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+  >;
+  const tool = registered.knowledge_memory_stats;
+  if (!tool) throw new Error("knowledge_memory_stats not registered");
+  const result = (await tool.handler(args, {})) as {
+    content: Array<{ text: string }>;
+    isError?: boolean;
+  };
+  if (result.isError) {
+    throw new Error(`tool error: ${result.content[0]?.text}`);
+  }
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+/**
+ * Ensure the v3 schema extensions (memory_tier column on documents, chunks
+ * table) exist on the test DB. Phase 1 (GH-762) owns the production schema
+ * migration; test fixtures add them so Phase 8 features can be exercised
+ * independently of Phase 1 merge order.
+ */
+function ensureV3Schema(db: KnowledgeDB): void {
+  const rows = db.db.prepare("PRAGMA table_info(documents)").all() as Array<{ name: string }>;
+  if (!rows.some((r) => r.name === "memory_tier")) {
+    db.db.exec(
+      "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))",
+    );
+  }
+  db.db.exec(
+    `CREATE TABLE IF NOT EXISTS chunks (
+       id TEXT PRIMARY KEY,
+       document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+       chunk_index INTEGER NOT NULL,
+       content TEXT NOT NULL,
+       char_start INTEGER NOT NULL,
+       char_end INTEGER NOT NULL,
+       context_prefix TEXT NOT NULL DEFAULT '',
+       UNIQUE(document_id, chunk_index)
+     )`,
+  );
+}
+
+function seedDoc(
+  db: KnowledgeDB,
+  id: string,
+  tier: "doc" | "raw" | "reflection",
+  date: string | null,
+): void {
+  db.upsertDocument({
+    id,
+    path: `${id}.md`,
+    title: id,
+    date,
+    type: null,
+    status: null,
+    githubIssue: null,
+    content: "",
+  });
+  db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run(tier, id);
+}
+
+function seedChunks(db: KnowledgeDB, docId: string, count: number): void {
+  const stmt = db.db.prepare(
+    `INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end, context_prefix)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  for (let i = 0; i < count; i++) {
+    stmt.run(`${docId}#c${i}`, docId, i, `chunk ${i}`, i * 100, (i + 1) * 100, "");
+  }
+}
+
+describe("knowledge_memory_stats", () => {
+  it("returns tier counts matching the fixture", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    ensureV3Schema(db);
+
+    // 2 doc, 3 raw, 1 reflection
+    seedDoc(db, "d1", "doc", "2026-04-01");
+    seedDoc(db, "d2", "doc", "2026-04-02");
+    seedDoc(db, "r1", "raw", "2026-04-03");
+    seedDoc(db, "r2", "raw", "2026-04-03");
+    seedDoc(db, "r3", "raw", "2026-04-04");
+    seedDoc(db, "f1", "reflection", "2026-04-05");
+
+    const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+    expect(out.total_documents).toBe(6);
+    expect(out.by_tier).toEqual({ doc: 2, raw: 3, reflection: 1 });
+    expect(out.new_since).toEqual({ doc: 2, raw: 3, reflection: 1 });
+  });
+
+  it("computes chunks_per_doc_p50 and _p90 correctly on [1,2,3,4,5]", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    ensureV3Schema(db);
+
+    // Seed 5 docs each with 1,2,3,4,5 chunks respectively
+    const counts = [1, 2, 3, 4, 5];
+    for (let i = 0; i < counts.length; i++) {
+      const id = `chunked-${i}`;
+      seedDoc(db, id, "doc", "2026-04-10");
+      seedChunks(db, id, counts[i]);
+    }
+
+    const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+    // sorted counts: [1,2,3,4,5]. floor(5*0.5)=2 -> 3; floor(5*0.9)=4 -> 5.
+    expect(out.chunks_per_doc_p50).toBe(3);
+    expect(out.chunks_per_doc_p90).toBe(5);
+  });
+
+  it("returns last_reflection_at as null when no reflection docs exist", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    ensureV3Schema(db);
+
+    seedDoc(db, "only-doc", "doc", "2026-04-01");
+
+    const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+    expect(out.last_reflection_at).toBeNull();
+  });
+
+  it("returns ISO timestamp of most recent reflection when present", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    ensureV3Schema(db);
+
+    seedDoc(db, "r-older", "reflection", "2026-03-01");
+    seedDoc(db, "r-newer", "reflection", "2026-04-10");
+
+    const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+    expect(out.last_reflection_at).toBe("2026-04-10");
+  });
+
+  it("counts new_since correctly when filtering by timestamp", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    ensureV3Schema(db);
+
+    seedDoc(db, "old-doc", "doc", "2026-01-01");
+    seedDoc(db, "new-doc", "doc", "2026-05-01");
+    seedDoc(db, "old-raw", "raw", "2026-01-15");
+    seedDoc(db, "new-raw", "raw", "2026-05-02");
+
+    const out = await callStats(server, { since: "2026-04-01T00:00:00Z" });
+    expect(out.total_documents).toBe(4);
+    expect(out.by_tier).toEqual({ doc: 2, raw: 2, reflection: 0 });
+    expect(out.new_since).toEqual({ doc: 1, raw: 1, reflection: 0 });
+  });
+
+  it("defaults `since` to ~24h ago when not provided", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    ensureV3Schema(db);
+    seedDoc(db, "d1", "doc", "2026-04-01");
+
+    const out = await callStats(server);
+    const since = out.since as string;
+    expect(since).toBeTruthy();
+    const sinceMs = Date.parse(since);
+    const nowMs = Date.now();
+    // Allow a wide window to accommodate slow test startup; the spec is 24h.
+    const ageMs = nowMs - sinceMs;
+    expect(ageMs).toBeGreaterThanOrEqual(23.5 * 3600 * 1000);
+    expect(ageMs).toBeLessThanOrEqual(24.5 * 3600 * 1000);
+  });
+
+  it("reports all documents as tier 'doc' on a v2 schema (column absent)", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    // Intentionally do NOT call ensureV3Schema — simulate v2 DB.
+
+    db.upsertDocument({
+      id: "legacy-doc",
+      path: "l.md",
+      title: "Legacy",
+      date: "2026-04-01",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+
+    const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+    expect(out.total_documents).toBe(1);
+    expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0 });
+    expect(out.chunks_per_doc_p50).toBe(0);
+    expect(out.chunks_per_doc_p90).toBe(0);
+    expect(out.last_reflection_at).toBeNull();
+  });
+});

--- a/plugin/ralph-knowledge/src/__tests__/search.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/search.test.ts
@@ -205,6 +205,51 @@ describe("FtsSearch", () => {
     });
   });
 
+  describe("memory_tier filter", () => {
+    it("filters by memory_tier when schema has the column", () => {
+      // Phase 1 (GH-762) owns the production migration; add the column here
+      // so we can exercise the Phase 8 filter independently.
+      db.db.exec(
+        "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))",
+      );
+      db.db
+        .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
+        .run("reflection", "auth-doc");
+      fts.rebuildIndex();
+
+      // auth-doc is "reflection", so search for terms in auth-doc should hit.
+      const reflectionHits = fts.search("authentication", { memoryTier: "reflection" });
+      const ids = reflectionHits.map((r) => r.id);
+      expect(ids).toContain("auth-doc");
+
+      // A "doc" filter should omit the reflection-tagged doc.
+      const docHits = fts.search("authentication", { memoryTier: "doc" });
+      expect(docHits.some((r) => r.id === "auth-doc")).toBe(false);
+    });
+
+    it("ignores memory_tier silently when column is absent (v2 schema)", () => {
+      // beforeEach gives us a v2 schema — column does not exist.
+      const results = fts.search("cache", { memoryTier: "reflection" });
+      // Filter is a no-op on v2; regular FTS results come through.
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it("returns all tiers when memoryTier='any'", () => {
+      db.db.exec(
+        "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))",
+      );
+      db.db
+        .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
+        .run("reflection", "auth-doc");
+      fts.rebuildIndex();
+
+      const authHits = fts.search("authentication", { memoryTier: "any" });
+      expect(authHits.some((r) => r.id === "auth-doc")).toBe(true);
+      const cacheHits = fts.search("cache", { memoryTier: "any" });
+      expect(cacheHits.some((r) => r.id === "cache-doc")).toBe(true);
+    });
+  });
+
   describe("ensureTable", () => {
     it("creates FTS table if it does not exist", () => {
       // Create a fresh DB without FTS table

--- a/plugin/ralph-knowledge/src/db.ts
+++ b/plugin/ralph-knowledge/src/db.ts
@@ -442,6 +442,23 @@ export class KnowledgeDB {
     return row !== undefined;
   }
 
+  /**
+   * Returns the `memory_tier` for the given document id. Returns `undefined`
+   * when the document does not exist OR when the `memory_tier` column is
+   * absent from the schema (pre-v3 databases). Used by MCP `knowledge_*`
+   * tools that need to post-filter result sets by tier.
+   */
+  getMemoryTier(id: string): string | undefined {
+    const columns = this.db
+      .prepare("PRAGMA table_info(documents)")
+      .all() as Array<{ name: string }>;
+    if (!columns.some((c) => c.name === "memory_tier")) return undefined;
+    const row = this.db
+      .prepare("SELECT memory_tier AS memoryTier FROM documents WHERE id = ?")
+      .get(id) as { memoryTier: string } | undefined;
+    return row?.memoryTier;
+  }
+
   deleteDocument(id: string): void {
     this.db.prepare("DELETE FROM documents WHERE id = ?").run(id);
   }

--- a/plugin/ralph-knowledge/src/hybrid-search.ts
+++ b/plugin/ralph-knowledge/src/hybrid-search.ts
@@ -4,6 +4,16 @@ import type { VectorSearch } from "./vector-search.js";
 
 export type EmbedFn = (text: string) => Promise<Float32Array>;
 
+interface ChunkRow {
+  id: string;
+  document_id: string;
+  chunk_index: number;
+  char_start: number;
+  char_end: number;
+  context_prefix: string;
+  content: string;
+}
+
 export class HybridSearch {
   private static readonly RRF_K = 60;
 
@@ -14,23 +24,64 @@ export class HybridSearch {
     private readonly embedFn: EmbedFn,
   ) {}
 
+  /**
+   * Returns true when the `chunks` table exists (schema v3+). When absent we
+   * behave as if all vector ids are doc ids (pre-chunking behavior).
+   */
+  private chunksTableExists(): boolean {
+    const row = this.db.db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='chunks'",
+      )
+      .get();
+    return row !== undefined;
+  }
+
+  /**
+   * Given a vector-search id, return the `document_id` portion. Chunk ids
+   * follow the pattern `{doc_id}#c{index}` per Shared Constraint #6 of the
+   * GH-0761 plan. Legacy non-chunk ids pass through unchanged.
+   */
+  private docIdFromVecId(vecId: string): string {
+    const marker = vecId.lastIndexOf("#c");
+    if (marker === -1) return vecId;
+    const suffix = vecId.slice(marker + 2);
+    if (suffix.length === 0 || !/^\d+$/.test(suffix)) return vecId;
+    return vecId.slice(0, marker);
+  }
+
+  private fetchChunk(chunkId: string): ChunkRow | undefined {
+    if (!this.chunksTableExists()) return undefined;
+    return this.db.db
+      .prepare(
+        `SELECT id, document_id, chunk_index, char_start, char_end, context_prefix, content
+         FROM chunks WHERE id = ?`,
+      )
+      .get(chunkId) as ChunkRow | undefined;
+  }
+
   async search(
     query: string,
     options: SearchOptions = {},
   ): Promise<SearchResult[]> {
-    const { type, tags, includeSuperseded = false, limit = 20 } = options;
+    const { type, tags, includeSuperseded = false, limit = 20, memoryTier } = options;
 
-    // Run FTS and vector search
+    // Run FTS and vector search (FTS already applies memoryTier filter in SQL
+    // when the schema supports it).
     const ftsResults = this.fts.search(query, {
       includeSuperseded: true,
       limit: limit * 2,
+      memoryTier,
     });
 
     const queryEmbedding = await this.embedFn(query);
     const vecResults = this.vec.search(queryEmbedding, limit * 2);
 
-    // Build RRF score map
+    // Build RRF score map, keyed by document_id. When vec ids are chunk ids
+    // like `{doc}#c{n}`, we collapse to the parent doc for scoring but
+    // remember the best-scoring chunk id per doc for later meta enrichment.
     const scores = new Map<string, number>();
+    const bestChunkByDoc = new Map<string, { chunkId: string; rank: number }>();
 
     for (let i = 0; i < ftsResults.length; i++) {
       const id = ftsResults[i].id;
@@ -39,9 +90,16 @@ export class HybridSearch {
     }
 
     for (let i = 0; i < vecResults.length; i++) {
-      const id = vecResults[i].id;
+      const vecId = vecResults[i].id;
+      const docId = this.docIdFromVecId(vecId);
       const rrfScore = 1 / (HybridSearch.RRF_K + i + 1);
-      scores.set(id, (scores.get(id) ?? 0) + rrfScore);
+      scores.set(docId, (scores.get(docId) ?? 0) + rrfScore);
+      if (vecId !== docId) {
+        const existing = bestChunkByDoc.get(docId);
+        if (!existing || i < existing.rank) {
+          bestChunkByDoc.set(docId, { chunkId: vecId, rank: i });
+        }
+      }
     }
 
     // Build a lookup of FTS results by id for quick access
@@ -96,6 +154,31 @@ export class HybridSearch {
         const docTags = this.db.getTags(r.id);
         return docTags.some((t) => tagSet.has(t));
       });
+    }
+
+    // Post-filter: memory_tier for vector-only hits that bypassed the FTS
+    // SQL filter. Also covers the case where the FTS stage returned 0 rows
+    // but vec returned chunks from a doc in another tier.
+    if (memoryTier && memoryTier !== "any") {
+      filtered = filtered.filter((r) => {
+        const tier = this.db.getMemoryTier(r.id);
+        // When column absent (v2 schema) treat as "doc"
+        return (tier ?? "doc") === memoryTier;
+      });
+    }
+
+    // Enrich with chunk meta when chunk data is available (best-scoring
+    // chunk per doc).
+    for (const r of filtered) {
+      const best = bestChunkByDoc.get(r.id);
+      if (!best) continue;
+      const chunk = this.fetchChunk(best.chunkId);
+      if (!chunk) continue;
+      r.bestChunkId = chunk.id;
+      r.chunkIndex = chunk.chunk_index;
+      r.charStart = chunk.char_start;
+      r.charEnd = chunk.char_end;
+      r.contextPrefix = chunk.context_prefix;
     }
 
     return filtered.slice(0, limit);

--- a/plugin/ralph-knowledge/src/index.ts
+++ b/plugin/ralph-knowledge/src/index.ts
@@ -22,12 +22,60 @@ function resolveEnv(name: string): string | undefined {
   return val;
 }
 
-export function createServer(dbPath: string) {
+/**
+ * True when the `chunks` table exists in the schema (v3+). When absent,
+ * `knowledge_memory_stats` reports 0 chunks-per-doc percentiles.
+ */
+function chunksTableExists(db: KnowledgeDB): boolean {
+  const row = db.db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='chunks'",
+    )
+    .get();
+  return row !== undefined;
+}
+
+/**
+ * True when the `documents.memory_tier` column exists (v3+). Used to decide
+ * whether tier-level stats can be produced from the schema at all.
+ */
+function memoryTierColumnExists(db: KnowledgeDB): boolean {
+  const rows = db.db
+    .prepare("PRAGMA table_info(documents)")
+    .all() as Array<{ name: string }>;
+  return rows.some((r) => r.name === "memory_tier");
+}
+
+/**
+ * Percentile helper using nearest-rank. For n sorted values returns the value
+ * at index `floor(n * p)` clamped to [0, n-1]. Returns 0 on empty input.
+ * Matches the spec in Phase 8 Task 8.4: "pick index at floor(n*0.5)".
+ */
+function percentile(sortedValues: number[], p: number): number {
+  if (sortedValues.length === 0) return 0;
+  const idx = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.floor(sortedValues.length * p)),
+  );
+  return sortedValues[idx];
+}
+
+/**
+ * Options for `createServer`. When `embedFn` is provided it replaces the
+ * production `embed` import, allowing tests to bypass the HuggingFace model
+ * download.
+ */
+export interface CreateServerOptions {
+  embedFn?: (text: string) => Promise<Float32Array>;
+}
+
+export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
   const server = new McpServer({ name: "ralph-hero-knowledge", version: "0.1.0" });
   const db = new KnowledgeDB(dbPath);
   const fts = new FtsSearch(db);
   const vec = new VectorSearch(db);
-  const hybrid = new HybridSearch(db, fts, vec, embed);
+  const embedImpl = opts.embedFn ?? embed;
+  const hybrid = new HybridSearch(db, fts, vec, embedImpl);
   const traverser = new Traverser(db);
 
   server.tool(
@@ -40,6 +88,16 @@ export function createServer(dbPath: string) {
       limit: z.number().optional().describe("Max results (default: 10)"),
       includeSuperseded: z.boolean().optional().describe("Include superseded documents (default: false)"),
       brief: z.boolean().optional().describe("Return minimal metadata only (default: false)"),
+      memory_tier: z
+        .enum(["doc", "raw", "reflection", "any"])
+        .optional()
+        .default("any")
+        .describe("Filter by memory tier: 'doc' (curated), 'raw' (dream-loop ingest), 'reflection' (synthesized), 'any' (default)"),
+      return_chunk_meta: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Include chunk_index/char_start/char_end/context_prefix in each hit when chunk data is available"),
     },
     async (args) => {
       try {
@@ -48,18 +106,33 @@ export function createServer(dbPath: string) {
           type: args.type,
           limit: args.limit ?? 10,
           includeSuperseded: args.includeSuperseded,
+          memoryTier: args.memory_tier,
         });
-        const enriched = results.map(r => {
-          const base = { ...r, tags: db.getTags(r.id) };
+        const enriched = results.map((r) => {
+          // Start with the camelCase SearchResult shape so existing callers
+          // keep working, then optionally add snake_case aliases for new
+          // chunk fields and strip them when callers didn't opt in.
+          const { chunkIndex, charStart, charEnd, contextPrefix, bestChunkId, ...rest } = r;
+          const base: Record<string, unknown> = { ...rest, tags: db.getTags(r.id) };
+          if (args.return_chunk_meta) {
+            if (chunkIndex !== undefined) base.chunk_index = chunkIndex;
+            if (charStart !== undefined) base.char_start = charStart;
+            if (charEnd !== undefined) base.char_end = charEnd;
+            if (contextPrefix !== undefined) base.context_prefix = contextPrefix;
+            if (bestChunkId !== undefined) base.best_chunk_id = bestChunkId;
+          }
           // SearchResult does not carry githubIssue — fetch from documents table
           const doc = db.getDocument(r.id);
           if (doc?.githubIssue) {
             const outcomes = db.getOutcomeSummary(doc.githubIssue);
-            if (outcomes) return { ...base, outcomes_summary: outcomes };
+            if (outcomes) base.outcomes_summary = outcomes;
           }
           return base;
         });
-        const formatted = formatSearchResults(enriched, args.brief ?? false);
+        const formatted = formatSearchResults(
+          enriched as unknown as Parameters<typeof formatSearchResults>[0],
+          args.brief ?? false,
+        );
         return { content: [{ type: "text" as const, text: JSON.stringify(formatted, null, 2) }] };
       } catch (e) {
         return { content: [{ type: "text" as const, text: `Error: ${(e as Error).message}` }], isError: true };
@@ -76,15 +149,137 @@ export function createServer(dbPath: string) {
       depth: z.number().optional().describe("Max traversal depth (default: 3)"),
       direction: z.enum(["outgoing", "incoming"]).optional().describe("Edge direction (default: outgoing)"),
       brief: z.boolean().optional().describe("Return minimal metadata only (default: false)"),
+      memory_tier: z
+        .enum(["doc", "raw", "reflection", "any"])
+        .optional()
+        .default("any")
+        .describe("Filter traversed nodes by memory tier (default: 'any')"),
     },
     async (args) => {
       try {
         const opts = { type: args.type, depth: args.depth ?? 3 };
-        const results = args.direction === "incoming"
+        let results = args.direction === "incoming"
           ? traverser.traverseIncoming(args.from, opts)
           : traverser.traverse(args.from, opts);
+        if (args.memory_tier && args.memory_tier !== "any") {
+          const wantedTier = args.memory_tier;
+          results = results.filter((r) => {
+            const tier = db.getMemoryTier(r.targetId);
+            // When memory_tier column is absent (pre-v3 DB) treat as "doc"
+            return (tier ?? "doc") === wantedTier;
+          });
+        }
         const formatted = formatTraverseResults(results, (id) => db.getTags(id), args.brief ?? false);
         return { content: [{ type: "text" as const, text: JSON.stringify(formatted, null, 2) }] };
+      } catch (e) {
+        return { content: [{ type: "text" as const, text: `Error: ${(e as Error).message}` }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "knowledge_memory_stats",
+    "Return counts of documents by memory_tier plus chunk percentiles and last-reflection timestamp. Used by the dream-loop to confirm ingest/reflection completion.",
+    {
+      since: z
+        .string()
+        .optional()
+        .describe("ISO timestamp — counts for 'new_since' are computed against this. Defaults to 24 hours ago."),
+    },
+    async (args) => {
+      try {
+        const since = args.since ?? new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+        const hasTier = memoryTierColumnExists(db);
+        const hasChunks = chunksTableExists(db);
+
+        const totalRow = db.db
+          .prepare("SELECT COUNT(*) AS c FROM documents")
+          .get() as { c: number };
+        const totalDocuments = totalRow.c;
+
+        const byTier: Record<"doc" | "raw" | "reflection", number> = {
+          doc: 0,
+          raw: 0,
+          reflection: 0,
+        };
+        const newSince: Record<"doc" | "raw" | "reflection", number> = {
+          doc: 0,
+          raw: 0,
+          reflection: 0,
+        };
+
+        if (hasTier) {
+          const rows = db.db
+            .prepare(
+              `SELECT memory_tier AS tier, COUNT(*) AS c
+               FROM documents GROUP BY memory_tier`,
+            )
+            .all() as Array<{ tier: string; c: number }>;
+          for (const r of rows) {
+            if (r.tier === "doc" || r.tier === "raw" || r.tier === "reflection") {
+              byTier[r.tier] = r.c;
+            }
+          }
+          const newRows = db.db
+            .prepare(
+              `SELECT memory_tier AS tier, COUNT(*) AS c
+               FROM documents
+               WHERE date IS NOT NULL AND date >= @since
+               GROUP BY memory_tier`,
+            )
+            .all({ since }) as Array<{ tier: string; c: number }>;
+          for (const r of newRows) {
+            if (r.tier === "doc" || r.tier === "raw" || r.tier === "reflection") {
+              newSince[r.tier] = r.c;
+            }
+          }
+        } else {
+          // v2 schema — everything treated as "doc"
+          byTier.doc = totalDocuments;
+          const newDocRow = db.db
+            .prepare(
+              "SELECT COUNT(*) AS c FROM documents WHERE date IS NOT NULL AND date >= ?",
+            )
+            .get(since) as { c: number };
+          newSince.doc = newDocRow.c;
+        }
+
+        let chunksPerDocP50 = 0;
+        let chunksPerDocP90 = 0;
+        if (hasChunks) {
+          const perDoc = db.db
+            .prepare(
+              `SELECT COUNT(*) AS c FROM chunks GROUP BY document_id`,
+            )
+            .all() as Array<{ c: number }>;
+          const counts = perDoc.map((r) => r.c).sort((a, b) => a - b);
+          chunksPerDocP50 = percentile(counts, 0.5);
+          chunksPerDocP90 = percentile(counts, 0.9);
+        }
+
+        let lastReflectionAt: string | null = null;
+        if (hasTier) {
+          const row = db.db
+            .prepare(
+              `SELECT date FROM documents
+               WHERE memory_tier = 'reflection' AND date IS NOT NULL
+               ORDER BY date DESC LIMIT 1`,
+            )
+            .get() as { date: string } | undefined;
+          lastReflectionAt = row?.date ?? null;
+        }
+
+        const payload = {
+          total_documents: totalDocuments,
+          by_tier: byTier,
+          new_since: newSince,
+          chunks_per_doc_p50: chunksPerDocP50,
+          chunks_per_doc_p90: chunksPerDocP90,
+          last_reflection_at: lastReflectionAt,
+          since,
+        };
+
+        return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
       } catch (e) {
         return { content: [{ type: "text" as const, text: `Error: ${(e as Error).message}` }], isError: true };
       }

--- a/plugin/ralph-knowledge/src/search.ts
+++ b/plugin/ralph-knowledge/src/search.ts
@@ -1,10 +1,13 @@
 import type { KnowledgeDB } from "./db.js";
 
+export type MemoryTier = "doc" | "raw" | "reflection" | "any";
+
 export interface SearchOptions {
   type?: string;
   tags?: string[];
   includeSuperseded?: boolean;
   limit?: number;
+  memoryTier?: MemoryTier;
 }
 
 export interface SearchResult {
@@ -16,6 +19,13 @@ export interface SearchResult {
   date: string | null;
   score: number;
   snippet: string;
+  // Optional chunk-level metadata. Populated when chunk data is available
+  // for the best-scoring chunk of this document.
+  chunkIndex?: number;
+  charStart?: number;
+  charEnd?: number;
+  contextPrefix?: string;
+  bestChunkId?: string;
 }
 
 export class FtsSearch {
@@ -99,8 +109,19 @@ export class FtsSearch {
     return tokens.map(t => '"' + t.replace(/"/g, '""') + '"').join(" ");
   }
 
+  /**
+   * Returns true when the `documents.memory_tier` column exists (schema v3+).
+   * On v2 schemas this is false and the memoryTier filter is silently ignored.
+   */
+  private memoryTierColumnExists(): boolean {
+    const rows = this.db.db
+      .prepare("PRAGMA table_info(documents)")
+      .all() as Array<{ name: string }>;
+    return rows.some((r) => r.name === "memory_tier");
+  }
+
   search(query: string, options: SearchOptions = {}): SearchResult[] {
-    const { type, tags, includeSuperseded = false, limit = 20 } = options;
+    const { type, tags, includeSuperseded = false, limit = 20, memoryTier } = options;
 
     const conditions: string[] = ["documents_fts MATCH @query"];
     const params: Record<string, unknown> = { query: this.escapeFts5Query(query), limit };
@@ -112,6 +133,11 @@ export class FtsSearch {
     if (type) {
       conditions.push("d.type = @type");
       params.type = type;
+    }
+
+    if (memoryTier && memoryTier !== "any" && this.memoryTierColumnExists()) {
+      conditions.push("d.memory_tier = @memoryTier");
+      params.memoryTier = memoryTier;
     }
 
     let joinClause = "";

--- a/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
+++ b/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
@@ -771,9 +771,9 @@ Extend `knowledge_search` Zod schema with `memory_tier` + `return_chunk_meta`; e
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `knowledge_search` schema at [index.ts:33-43](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/index.ts#L33-L43) adds `memory_tier: z.enum(["doc","raw","reflection","any"]).optional().default("any")` and `return_chunk_meta: z.boolean().optional().default(false)`
-  - [ ] Handler at [index.ts:44-67](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/index.ts#L44-L67) passes `memory_tier` into the hybrid search path (via new `SearchOptions.memoryTier?` field added in Task 8.2)
-  - [ ] When `return_chunk_meta=true`, each result is enriched with `chunk_index`, `char_start`, `char_end`, `context_prefix` (looked up via chunk id extracted from best-chunk-id stored on the search path — requires `HybridSearch` to expose best-chunk-id on results)
+  - [x] `knowledge_search` schema at [index.ts:33-43](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/index.ts#L33-L43) adds `memory_tier: z.enum(["doc","raw","reflection","any"]).optional().default("any")` and `return_chunk_meta: z.boolean().optional().default(false)`
+  - [x] Handler at [index.ts:44-67](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/index.ts#L44-L67) passes `memory_tier` into the hybrid search path (via new `SearchOptions.memoryTier?` field added in Task 8.2)
+  - [x] When `return_chunk_meta=true`, each result is enriched with `chunk_index`, `char_start`, `char_end`, `context_prefix` (looked up via chunk id extracted from best-chunk-id stored on the search path — requires `HybridSearch` to expose best-chunk-id on results)
 
 #### Task 8.2: Thread memoryTier through SearchOptions + HybridSearch
 - **files**: `plugin/ralph-knowledge/src/search.ts` (modify), `plugin/ralph-knowledge/src/hybrid-search.ts` (modify)
@@ -781,10 +781,10 @@ Extend `knowledge_search` Zod schema with `memory_tier` + `return_chunk_meta`; e
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `interface SearchOptions` in [search.ts:3-8](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/search.ts#L3-L8) gains `memoryTier?: "doc" | "raw" | "reflection" | "any"`
-  - [ ] `FtsSearch.search()` at [search.ts:102](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/search.ts#L102) adds `AND d.memory_tier = @memoryTier` to conditions when `memoryTier` is set and not `"any"`; params.memoryTier set accordingly
-  - [ ] `HybridSearch.search()` in `hybrid-search.ts` forwards `memoryTier` to `fts.search()` and post-filters vector-only results by re-fetching `doc.memory_tier` (when `memoryTier !== "any"`, skip docs whose memory_tier differs)
-  - [ ] `SearchResult` (search.ts) gains optional fields `chunkIndex?`, `charStart?`, `charEnd?`, `contextPrefix?`, `bestChunkId?` — populated from the HybridSearch bucket when chunk data is available
+  - [x] `interface SearchOptions` in [search.ts:3-8](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/search.ts#L3-L8) gains `memoryTier?: "doc" | "raw" | "reflection" | "any"`
+  - [x] `FtsSearch.search()` at [search.ts:102](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/search.ts#L102) adds `AND d.memory_tier = @memoryTier` to conditions when `memoryTier` is set and not `"any"`; params.memoryTier set accordingly
+  - [x] `HybridSearch.search()` in `hybrid-search.ts` forwards `memoryTier` to `fts.search()` and post-filters vector-only results by re-fetching `doc.memory_tier` (when `memoryTier !== "any"`, skip docs whose memory_tier differs)
+  - [x] `SearchResult` (search.ts) gains optional fields `chunkIndex?`, `charStart?`, `charEnd?`, `contextPrefix?`, `bestChunkId?` — populated from the HybridSearch bucket when chunk data is available
 
 #### Task 8.3: Extend knowledge_traverse schema
 - **files**: `plugin/ralph-knowledge/src/index.ts` (modify)
@@ -792,9 +792,9 @@ Extend `knowledge_search` Zod schema with `memory_tier` + `return_chunk_meta`; e
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `knowledge_traverse` schema at [index.ts:70-79](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/index.ts#L70-L79) adds `memory_tier: z.enum(["doc","raw","reflection","any"]).optional().default("any")`
-  - [ ] Handler post-filters the traverse result set by looking up `doc.memory_tier` for each id, dropping those that don't match when `memory_tier !== "any"`
-  - [ ] Add a helper on `KnowledgeDB` (`getMemoryTier(id: string): string | undefined` — selects the `memory_tier` column) so `index.ts` doesn't have to rewrite SQL
+  - [x] `knowledge_traverse` schema at [index.ts:70-79](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/index.ts#L70-L79) adds `memory_tier: z.enum(["doc","raw","reflection","any"]).optional().default("any")`
+  - [x] Handler post-filters the traverse result set by looking up `doc.memory_tier` for each id, dropping those that don't match when `memory_tier !== "any"`
+  - [x] Add a helper on `KnowledgeDB` (`getMemoryTier(id: string): string | undefined` — selects the `memory_tier` column) so `index.ts` doesn't have to rewrite SQL
 
 #### Task 8.4: Implement knowledge_memory_stats tool
 - **files**: `plugin/ralph-knowledge/src/index.ts` (modify)
@@ -802,11 +802,11 @@ Extend `knowledge_search` Zod schema with `memory_tier` + `return_chunk_meta`; e
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `server.tool("knowledge_memory_stats", ...)` registered with Zod schema `{ since: z.string().optional() }`
-  - [ ] Default `since` is 24h ago (`new Date(Date.now() - 24*3600*1000).toISOString()`)
-  - [ ] Returns JSON with keys: `total_documents`, `by_tier` (object keyed doc/raw/reflection), `new_since` (object same shape counting docs where `documents.date >= since`), `chunks_per_doc_p50`, `chunks_per_doc_p90`, `last_reflection_at`
-  - [ ] `last_reflection_at` = ISO timestamp of most-recent document with `memory_tier='reflection'`, or `null` when none exist
-  - [ ] `chunks_per_doc_p50`/`_p90` computed from `SELECT COUNT(*) FROM chunks GROUP BY document_id` with in-JS percentile math (sort, pick index at floor(n*0.5) and floor(n*0.9))
+  - [x] `server.tool("knowledge_memory_stats", ...)` registered with Zod schema `{ since: z.string().optional() }`
+  - [x] Default `since` is 24h ago (`new Date(Date.now() - 24*3600*1000).toISOString()`)
+  - [x] Returns JSON with keys: `total_documents`, `by_tier` (object keyed doc/raw/reflection), `new_since` (object same shape counting docs where `documents.date >= since`), `chunks_per_doc_p50`, `chunks_per_doc_p90`, `last_reflection_at`
+  - [x] `last_reflection_at` = ISO timestamp of most-recent document with `memory_tier='reflection'`, or `null` when none exist
+  - [x] `chunks_per_doc_p50`/`_p90` computed from `SELECT COUNT(*) FROM chunks GROUP BY document_id` with in-JS percentile math (sort, pick index at floor(n*0.5) and floor(n*0.9))
 
 #### Task 8.5: Test memory_tier filter + stats tool
 - **files**: `plugin/ralph-knowledge/src/__tests__/index.test.ts` (modify), `plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts` (create)
@@ -814,19 +814,19 @@ Extend `knowledge_search` Zod schema with `memory_tier` + `return_chunk_meta`; e
 - **complexity**: medium
 - **depends_on**: [8.1, 8.2, 8.3, 8.4]
 - **acceptance**:
-  - [ ] `index.test.ts`: seed 3 docs with memory_tier `doc`, `raw`, `reflection`; `knowledge_search` with `memory_tier=reflection` returns only the reflection doc
-  - [ ] `index.test.ts`: `memory_tier="any"` returns all three
-  - [ ] `index.test.ts`: `return_chunk_meta=true` produces a payload with `chunk_index` populated for at least one hit
-  - [ ] `index.test.ts`: `knowledge_traverse` with `memory_tier=reflection` filter drops non-reflection nodes from results
-  - [ ] `memory-stats.test.ts`: seed a fixture with known tier counts; assert `by_tier.doc=X`, `by_tier.raw=Y`, `by_tier.reflection=Z`
-  - [ ] `memory-stats.test.ts`: `chunks_per_doc_p50` on a fixture with chunk counts `[1,2,3,4,5]` returns `3`
-  - [ ] `memory-stats.test.ts`: empty reflection set produces `last_reflection_at: null`
+  - [x] `index.test.ts`: seed 3 docs with memory_tier `doc`, `raw`, `reflection`; `knowledge_search` with `memory_tier=reflection` returns only the reflection doc
+  - [x] `index.test.ts`: `memory_tier="any"` returns all three
+  - [x] `index.test.ts`: `return_chunk_meta=true` produces a payload with `chunk_index` populated for at least one hit
+  - [x] `index.test.ts`: `knowledge_traverse` with `memory_tier=reflection` filter drops non-reflection nodes from results
+  - [x] `memory-stats.test.ts`: seed a fixture with known tier counts; assert `by_tier.doc=X`, `by_tier.raw=Y`, `by_tier.reflection=Z`
+  - [x] `memory-stats.test.ts`: `chunks_per_doc_p50` on a fixture with chunk counts `[1,2,3,4,5]` returns `3`
+  - [x] `memory-stats.test.ts`: empty reflection set produces `last_reflection_at: null`
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` passes
-- [ ] `npm test` — index.test.ts, memory-stats.test.ts, and full suite pass
+- [x] `npm run build` passes
+- [x] `npm test` — index.test.ts, memory-stats.test.ts, and full suite pass
 
 #### Manual Verification:
 - [ ] From Claude Code (with MCP server reloaded): `knowledge_memory_stats` returns expected shape; `knowledge_search` with `memory_tier=reflection` runs against an empty reflection set and returns `[]` without error


### PR DESCRIPTION
## Summary

Extends `knowledge_search` and `knowledge_traverse` with optional `memory_tier` filter, and adds new `knowledge_memory_stats` MCP tool for inspecting document tier counts and reflection recency.

Implements Phase 4 of the ralph-knowledge chunked-embeddings dream loop (GH-761).

## Test plan

- [ ] `knowledge_search` with `memory_tier=reflection` filters to only reflection docs
- [ ] `knowledge_search` with `memory_tier='any'` (default) returns all tiers (backward compat)
- [ ] `return_chunk_meta=true` includes chunk_index, char_start, char_end, context_prefix
- [ ] `knowledge_traverse` respects memory_tier filter
- [ ] `knowledge_memory_stats({ since })` returns documented JSON shape with correct tier counts
- [ ] `npm run build` passes
- [ ] `npm test` passes

Closes #769