### PR TITLE
GH-765: ralph-knowledge: HybridSearch chunk-to-doc dedup + snippet

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/hybrid-search.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/hybrid-search.test.ts
@@ -217,3 +217,230 @@ describe("HybridSearch chunk metadata enrichment", () => {
     expect(hit!.chunkIndex).toBeUndefined();
   });
 });
+
+describe("HybridSearch chunk-to-doc dedup", () => {
+  let dedupDb: KnowledgeDB;
+  let dedupFts: FtsSearch;
+  let dedupVec: VectorSearch;
+  let dedupHybrid: HybridSearch;
+
+  /**
+   * Deterministic embed function for dedup tests: always returns the same
+   * vector as mockEmbedding(42). Paired with chunk embeddings that use the
+   * same seed so the chunks rank near-perfectly for any query.
+   */
+  const fixedEmbedFn: EmbedFn = async () => mockEmbedding(42);
+
+  /** Insert a chunk row into the chunks table. */
+  function insertChunk(
+    db: KnowledgeDB,
+    chunkId: string,
+    docId: string,
+    index: number,
+    content: string,
+  ): void {
+    db.db
+      .prepare(
+        `INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .run(chunkId, docId, index, content, 0, content.length);
+  }
+
+  beforeEach(() => {
+    dedupDb = new KnowledgeDB(":memory:");
+
+    dedupDb.upsertDocument({
+      id: "chunk-doc",
+      path: "thoughts/shared/research/chunking-strategies.md",
+      title: "Chunking Strategies Deep Dive",
+      date: "2026-03-01",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content:
+        "Header paragraph not a chunk match. Body discusses recursive character splitter tradeoffs.",
+    });
+
+    dedupDb.upsertDocument({
+      id: "other-doc",
+      path: "thoughts/shared/plans/other.md",
+      title: "Unrelated Plan",
+      date: "2026-03-02",
+      type: "plan",
+      status: "draft",
+      githubIssue: null,
+      content: "This is a completely different topic unrelated to the query.",
+    });
+
+    ensureV3Schema(dedupDb);
+
+    dedupFts = new FtsSearch(dedupDb);
+    dedupFts.rebuildIndex();
+
+    dedupVec = new VectorSearch(dedupDb);
+    dedupVec.createIndex();
+
+    // Five chunks from chunk-doc, all seeded identically so they rank as
+    // the top-5 vector hits for fixedEmbedFn. Distinct content per chunk so
+    // we can verify which one becomes the snippet.
+    for (let i = 0; i < 5; i++) {
+      const id = `chunk-doc#c${i}`;
+      const content = `Chunk ${i} content about recursive character splitter tradeoffs — paragraph ${i}.`;
+      insertChunk(dedupDb, id, "chunk-doc", i, content);
+      // Slight seed variation so distance differs per chunk; chunk 0 is best.
+      dedupVec.upsertEmbedding(id, mockEmbedding(42 + i * 0.0001));
+    }
+
+    // other-doc has a single chunk embedded with a very different seed so
+    // it ranks well below chunk-doc's chunks.
+    insertChunk(
+      dedupDb,
+      "other-doc#c0",
+      "other-doc",
+      0,
+      "Unrelated single chunk content.",
+    );
+    dedupVec.upsertEmbedding("other-doc#c0", mockEmbedding(900));
+
+    dedupHybrid = new HybridSearch(
+      dedupDb,
+      dedupFts,
+      dedupVec,
+      fixedEmbedFn,
+    );
+  });
+
+  it("deduplicates: 5 chunks from same doc yield exactly 1 result entry", async () => {
+    const results = await dedupHybrid.search("anything");
+
+    const chunkDocHits = results.filter((r) => r.id === "chunk-doc");
+    expect(chunkDocHits).toHaveLength(1);
+    // Also ensure no chunk-level id leaks into the results
+    const chunkIds = results.filter((r) => r.id.includes("#c"));
+    expect(chunkIds).toHaveLength(0);
+  });
+
+  it("surfaced entry's snippet comes from the highest-ranked chunk", async () => {
+    const results = await dedupHybrid.search("anything");
+
+    const chunkDocHit = results.find((r) => r.id === "chunk-doc");
+    expect(chunkDocHit).toBeDefined();
+    // Chunk 0 has the smallest seed offset (mockEmbedding(42 + 0)) so it
+    // should have the smallest distance to fixedEmbedFn = mockEmbedding(42).
+    expect(chunkDocHit!.snippet).toContain("Chunk 0");
+  });
+
+  it("snippet length is at most 300 characters", async () => {
+    // Add a chunk with very long content to chunk-doc and re-embed so it
+    // becomes chunk 0's rival.
+    const longContent = "X".repeat(5000);
+    dedupDb.db
+      .prepare(
+        `INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .run("chunk-doc#c99", "chunk-doc", 99, longContent, 0, longContent.length);
+    // Embed with seed exactly 42 so it becomes the best hit (distance 0).
+    dedupVec.upsertEmbedding("chunk-doc#c99", mockEmbedding(42));
+
+    const results = await dedupHybrid.search("anything");
+    const hit = results.find((r) => r.id === "chunk-doc");
+    expect(hit).toBeDefined();
+    expect(hit!.snippet.length).toBeLessThanOrEqual(300);
+  });
+
+  it("title-only FTS match still returns the doc (no regression on legacy doc-level hits)", async () => {
+    // Document with a doc-level vec row (no chunks) — simulates a legacy
+    // record that predates the chunks table.
+    dedupDb.upsertDocument({
+      id: "legacy-doc",
+      path: "thoughts/legacy.md",
+      title: "Legacy Title Only Matching Query",
+      date: "2026-02-01",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "Legacy body text",
+    });
+    dedupFts.rebuildIndex();
+    dedupVec.upsertEmbedding("legacy-doc", mockEmbedding(800));
+
+    const results = await dedupHybrid.search("Legacy");
+    const legacyHit = results.find((r) => r.id === "legacy-doc");
+    expect(legacyHit).toBeDefined();
+    // FTS contributed the snippet (no chunk content to override it).
+    expect(legacyHit!.snippet).toBeDefined();
+  });
+
+  it("RRF score: bucketed rank 0 + FTS rank 2 equals 1/(60+1) + 1/(60+3)", async () => {
+    // Force a known configuration by clearing and rebuilding:
+    // - chunk-doc is the #1 vector hit (bucketed rank 0)
+    // - chunk-doc is the #3 FTS hit (index 2)
+    // We arrange this by inserting three docs that match "match" in FTS,
+    // ordered by BM25 so chunk-doc ends up at rank 2.
+    //
+    // Simpler: test this using a fresh controlled fixture.
+    const tdb = new KnowledgeDB(":memory:");
+
+    tdb.upsertDocument({
+      id: "d-fts-top",
+      path: "a.md",
+      title: "match match match match",
+      date: "2026-01-01",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "match match match match match",
+    });
+    tdb.upsertDocument({
+      id: "d-fts-second",
+      path: "b.md",
+      title: "match match match",
+      date: "2026-01-02",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "match match match",
+    });
+    tdb.upsertDocument({
+      id: "target",
+      path: "c.md",
+      title: "Target Doc",
+      date: "2026-01-03",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "target doc with match keyword once",
+    });
+
+    const tfts = new FtsSearch(tdb);
+    tfts.rebuildIndex();
+
+    const tvec = new VectorSearch(tdb);
+    tvec.createIndex();
+
+    // One chunk for target, seeded exactly 42 so it's the only/best vec hit.
+    insertChunk(tdb, "target#c0", "target", 0, "Chunk content for target.");
+    tvec.upsertEmbedding("target#c0", mockEmbedding(42));
+    // Add far-away embeddings for the other docs so they don't contribute
+    // to the vector bucket's top ranks for target.
+    tvec.upsertEmbedding("d-fts-top", mockEmbedding(900));
+    tvec.upsertEmbedding("d-fts-second", mockEmbedding(901));
+
+    const thybrid = new HybridSearch(tdb, tfts, tvec, fixedEmbedFn);
+    const results = await thybrid.search("match");
+
+    const target = results.find((r) => r.id === "target");
+    expect(target).toBeDefined();
+
+    // Verify FTS rank of target is 2 (third position) by fetching raw FTS.
+    const ftsRaw = tfts.search("match", { includeSuperseded: true, limit: 40 });
+    const ftsRankOfTarget = ftsRaw.findIndex((r) => r.id === "target");
+    expect(ftsRankOfTarget).toBe(2);
+
+    const K = 60;
+    const expected = 1 / (K + 0 + 1) + 1 / (K + 2 + 1);
+    expect(target!.score).toBeCloseTo(expected, 10);
+  });
+});

--- a/plugin/ralph-knowledge/src/__tests__/vector-search.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/vector-search.test.ts
@@ -63,4 +63,30 @@ describe("VectorSearch", () => {
     const results = vecSearch.search(mockEmbedding(1), 1);
     expect(results).toHaveLength(1);
   });
+
+  it("returns content = null when vec id has no matching chunks row (back-compat)", () => {
+    // doc-1 has no chunks row; vec id is doc-level. LEFT JOIN should yield null.
+    const results = vecSearch.search(mockEmbedding(1), 5);
+    const hit = results.find((r) => r.id === "doc-1");
+    expect(hit).toBeDefined();
+    expect(hit!.content).toBeNull();
+  });
+
+  it("returns content populated when vec id matches a chunks row", () => {
+    // Insert a chunk-level vec row + matching chunks row for doc-1
+    db.db
+      .prepare(
+        `INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .run("doc-1#c0", "doc-1", 0, "This is the first chunk content.", 0, 32);
+    vecSearch.upsertEmbedding("doc-1#c0", mockEmbedding(1));
+    // Remove the doc-level vec row so chunk-level wins
+    vecSearch.deleteEmbedding("doc-1");
+
+    const results = vecSearch.search(mockEmbedding(1), 5);
+    const hit = results.find((r) => r.id === "doc-1#c0");
+    expect(hit).toBeDefined();
+    expect(hit!.content).toBe("This is the first chunk content.");
+  });
 });

--- a/plugin/ralph-knowledge/src/hybrid-search.ts
+++ b/plugin/ralph-knowledge/src/hybrid-search.ts
@@ -1,6 +1,6 @@
 import type { KnowledgeDB } from "./db.js";
 import type { FtsSearch, SearchOptions, SearchResult } from "./search.js";
-import type { VectorSearch } from "./vector-search.js";
+import type { VectorResult, VectorSearch } from "./vector-search.js";
 
 export type EmbedFn = (text: string) => Promise<Float32Array>;
 
@@ -12,6 +12,23 @@ interface ChunkRow {
   char_end: number;
   context_prefix: string;
   content: string;
+}
+
+/**
+ * Maximum snippet length (in characters) when the snippet is sourced from a
+ * chunk's content. Keeps the MCP payload compact while still representative.
+ */
+const SNIPPET_MAX_CHARS = 300;
+
+/**
+ * Per-document bucket tracking the best-ranked chunk for a given doc_id in
+ * the vector result list. The "rank" is the index of the first occurrence of
+ * the document in the distance-sorted vector results (smaller = better).
+ */
+interface DocBucket {
+  bestRank: number;
+  bestChunkId: string;
+  bestContent: string;
 }
 
 export class HybridSearch {
@@ -75,11 +92,27 @@ export class HybridSearch {
     });
 
     const queryEmbedding = await this.embedFn(query);
-    const vecResults = this.vec.search(queryEmbedding, limit * 2);
+    const vecResults: VectorResult[] = this.vec.search(
+      queryEmbedding,
+      limit * 2,
+    );
 
-    // Build RRF score map, keyed by document_id. When vec ids are chunk ids
-    // like `{doc}#c{n}`, we collapse to the parent doc for scoring but
-    // remember the best-scoring chunk id per doc for later meta enrichment.
+    // Bucket vector results by doc_id, keeping the best-ranked chunk per doc.
+    // vecResults is already sorted by distance ascending, so the first
+    // occurrence of a given doc_id has the smallest rank (best match).
+    const buckets = new Map<string, DocBucket>();
+    for (let i = 0; i < vecResults.length; i++) {
+      const hit = vecResults[i];
+      const docId = this.docIdFromVecId(hit.id);
+      if (buckets.has(docId)) continue; // Already have best rank for this doc
+      buckets.set(docId, {
+        bestRank: i,
+        bestChunkId: hit.id,
+        bestContent: hit.content ?? "",
+      });
+    }
+
+    // Build RRF score map (keyed by doc_id for both FTS and vector buckets)
     const scores = new Map<string, number>();
     const bestChunkByDoc = new Map<string, { chunkId: string; rank: number }>();
 
@@ -89,16 +122,13 @@ export class HybridSearch {
       scores.set(id, (scores.get(id) ?? 0) + rrfScore);
     }
 
-    for (let i = 0; i < vecResults.length; i++) {
-      const vecId = vecResults[i].id;
-      const docId = this.docIdFromVecId(vecId);
-      const rrfScore = 1 / (HybridSearch.RRF_K + i + 1);
+    for (const [docId, bucket] of buckets) {
+      const rrfScore = 1 / (HybridSearch.RRF_K + bucket.bestRank + 1);
       scores.set(docId, (scores.get(docId) ?? 0) + rrfScore);
-      if (vecId !== docId) {
-        const existing = bestChunkByDoc.get(docId);
-        if (!existing || i < existing.rank) {
-          bestChunkByDoc.set(docId, { chunkId: vecId, rank: i });
-        }
+      // Track best chunk for later enrichment
+      const existing = bestChunkByDoc.get(docId);
+      if (!existing || bucket.bestRank < existing.rank) {
+        bestChunkByDoc.set(docId, { chunkId: bucket.bestChunkId, rank: bucket.bestRank });
       }
     }
 
@@ -108,18 +138,30 @@ export class HybridSearch {
       ftsById.set(r.id, r);
     }
 
-    // Assemble combined results
+    // Assemble combined results. For vector-hit docs, replace the snippet
+    // with the winning chunk's content (truncated). FTS-only hits keep the
+    // FTS snippet.
     const combined: SearchResult[] = [];
 
     for (const [id, rrfScore] of scores) {
       const ftsHit = ftsById.get(id);
+      const bucket = buckets.get(id);
       if (ftsHit) {
-        combined.push({ ...ftsHit, score: rrfScore });
+        // FTS hit (possibly also a vector hit): prefer the chunk snippet when
+        // the vector side contributed real chunk content.
+        const snippet =
+          bucket && bucket.bestContent
+            ? bucket.bestContent.slice(0, SNIPPET_MAX_CHARS)
+            : ftsHit.snippet;
+        combined.push({ ...ftsHit, score: rrfScore, snippet });
       } else {
         // Vector-only result: fetch document metadata from db
         const doc = this.db.getDocument(id);
         // Skip stub documents — they have no real content or path
         if (!doc || doc.isStub) continue;
+        const snippet = bucket
+          ? bucket.bestContent.slice(0, SNIPPET_MAX_CHARS)
+          : "";
         combined.push({
           id: doc.id,
           path: doc.path as string,
@@ -128,7 +170,7 @@ export class HybridSearch {
           status: doc.status,
           date: doc.date,
           score: rrfScore,
-          snippet: "",
+          snippet,
         });
       }
     }

--- a/plugin/ralph-knowledge/src/vector-search.ts
+++ b/plugin/ralph-knowledge/src/vector-search.ts
@@ -4,6 +4,12 @@ import type { KnowledgeDB } from "./db.js";
 export interface VectorResult {
   id: string;
   distance: number;
+  /**
+   * Chunk content populated via LEFT JOIN to `chunks` table when the vec id
+   * matches a chunk row. When the vec id is doc-level (back-compat / legacy
+   * fixtures) or no matching chunks row exists, this is `null`.
+   */
+  content?: string | null;
 }
 
 function float32ToBuffer(arr: Float32Array): Buffer {
@@ -73,11 +79,15 @@ export class VectorSearch {
   search(queryEmbedding: Float32Array, limit: number = 10): VectorResult[] {
     this.ensureVecLoaded();
     const buf = float32ToBuffer(queryEmbedding);
+    // LEFT JOIN to `chunks` so chunk-level vec rows surface their content.
+    // Doc-level vec ids (no matching chunks row) return content = NULL, which
+    // preserves back-compat for pre-chunks callers and legacy test fixtures.
     return this.knowledgeDb.db
       .prepare(
         `
-      SELECT id, distance
+      SELECT documents_vec.id, distance, chunks.content
       FROM documents_vec
+      LEFT JOIN chunks ON chunks.id = documents_vec.id
       WHERE embedding MATCH ? AND k = ?
       ORDER BY distance
     `

--- a/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
+++ b/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
@@ -383,9 +383,9 @@ Make HybridSearch aware that vector hits are now chunk-level; deduplicate to one
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `interface VectorResult` extended with optional `content?: string` field (preserves back-compat for pre-chunks callers)
-  - [ ] `search()` method at [vector-search.ts:57-70](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/vector-search.ts#L57-L70) updated SQL: `SELECT documents_vec.id, distance, chunks.content FROM documents_vec LEFT JOIN chunks ON chunks.id = documents_vec.id WHERE embedding MATCH ? AND k = ? ORDER BY distance`
-  - [ ] `content` is populated when the vec id matches a chunks row; null/undefined when no match (keeps test fixtures working with doc-level ids)
+  - [x] `interface VectorResult` extended with optional `content?: string` field (preserves back-compat for pre-chunks callers)
+  - [x] `search()` method at [vector-search.ts:57-70](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/vector-search.ts#L57-L70) updated SQL: `SELECT documents_vec.id, distance, chunks.content FROM documents_vec LEFT JOIN chunks ON chunks.id = documents_vec.id WHERE embedding MATCH ? AND k = ? ORDER BY distance`
+  - [x] `content` is populated when the vec id matches a chunks row; null/undefined when no match (keeps test fixtures working with doc-level ids)
 
 #### Task 4.2: Test VectorSearch LEFT JOIN
 - **files**: `plugin/ralph-knowledge/src/__tests__/vector-search.test.ts` (modify)
@@ -393,8 +393,8 @@ Make HybridSearch aware that vector hits are now chunk-level; deduplicate to one
 - **complexity**: low
 - **depends_on**: [4.1]
 - **acceptance**:
-  - [ ] Test: when `chunks` table has a row matching the vec id, `search()` returns `content` populated
-  - [ ] Test: when no matching chunks row, `content` is null (back-compat preserved)
+  - [x] Test: when `chunks` table has a row matching the vec id, `search()` returns `content` populated
+  - [x] Test: when no matching chunks row, `content` is null (back-compat preserved)
 
 #### Task 4.3: Update HybridSearch to bucket by doc_id
 - **files**: `plugin/ralph-knowledge/src/hybrid-search.ts` (modify)
@@ -402,12 +402,12 @@ Make HybridSearch aware that vector hits are now chunk-level; deduplicate to one
 - **complexity**: high
 - **depends_on**: [4.1]
 - **acceptance**:
-  - [ ] After vector search at [hybrid-search.ts:30](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/hybrid-search.ts#L30), loop over `vecResults` and split each `hit.id` on `#c` to derive `docId`
-  - [ ] Build a `Map<docId, { bestRank: number; bestChunkId: string; bestContent: string }>` keeping only the entry with smallest rank index for each doc
-  - [ ] Replace the vector-results RRF loop at [hybrid-search.ts:41-45](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/hybrid-search.ts#L41-L45) so that the RRF score is computed from the best-rank-per-doc bucket (bucket rank = index of first occurrence of that doc_id in the sorted vector result list)
-  - [ ] When assembling `combined` results, populate `snippet` from the bucket's `bestContent` truncated to <=300 chars; for FTS-only hits, leave existing FTS snippet in place
-  - [ ] RRF K=60 constant unchanged
-  - [ ] When `hit.id` has no `#c` in it (back-compat with doc-level ids, e.g., from fixtures or pre-v3 vec rows), treat the entire id as `docId` and use `hit.id` as `bestChunkId`
+  - [x] After vector search at [hybrid-search.ts:30](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/hybrid-search.ts#L30), loop over `vecResults` and split each `hit.id` on `#c` to derive `docId`
+  - [x] Build a `Map<docId, { bestRank: number; bestChunkId: string; bestContent: string }>` keeping only the entry with smallest rank index for each doc
+  - [x] Replace the vector-results RRF loop at [hybrid-search.ts:41-45](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/hybrid-search.ts#L41-L45) so that the RRF score is computed from the best-rank-per-doc bucket (bucket rank = index of first occurrence of that doc_id in the sorted vector result list)
+  - [x] When assembling `combined` results, populate `snippet` from the bucket's `bestContent` truncated to <=300 chars; for FTS-only hits, leave existing FTS snippet in place
+  - [x] RRF K=60 constant unchanged
+  - [x] When `hit.id` has no `#c` in it (back-compat with doc-level ids, e.g., from fixtures or pre-v3 vec rows), treat the entire id as `docId` and use `hit.id` as `bestChunkId`
 
 #### Task 4.4: HybridSearch dedup + best-chunk tests
 - **files**: `plugin/ralph-knowledge/src/__tests__/hybrid-search.test.ts` (modify)
@@ -415,18 +415,18 @@ Make HybridSearch aware that vector hits are now chunk-level; deduplicate to one
 - **complexity**: medium
 - **depends_on**: [4.3]
 - **acceptance**:
-  - [ ] Test: 5 chunks from same doc all match query; result set contains exactly 1 entry for that doc
-  - [ ] Test: surfaced entry's `snippet` comes from the highest-ranked chunk's content (smallest rank index)
-  - [ ] Test: `snippet.length <= 300`
-  - [ ] Test: title-only matching queries still return the same top document (no regression on legacy doc-level hits)
-  - [ ] Test: RRF score for a doc with bucketed rank 0 + FTS rank 2 == `1/(60+1) + 1/(60+3)`
+  - [x] Test: 5 chunks from same doc all match query; result set contains exactly 1 entry for that doc
+  - [x] Test: surfaced entry's `snippet` comes from the highest-ranked chunk's content (smallest rank index)
+  - [x] Test: `snippet.length <= 300`
+  - [x] Test: title-only matching queries still return the same top document (no regression on legacy doc-level hits)
+  - [x] Test: RRF score for a doc with bucketed rank 0 + FTS rank 2 == `1/(60+1) + 1/(60+3)`
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` passes
-- [ ] `npm test` — hybrid-search + vector-search tests + full suite pass
-- [ ] No regression: existing `search.test.ts` cases still pass
+- [x] `npm run build` passes
+- [x] `npm test` — hybrid-search + vector-search tests + full suite pass
+- [x] No regression: existing `search.test.ts` cases still pass
 
 #### Manual Verification:
 - [ ] From Claude Code: `knowledge_search "chunking strategies recursive character"` returns a snippet drawn from the body of the doc, not the title or first paragraph


### PR DESCRIPTION
## Summary

HybridSearch now deduplicates vector hits at the document level, keeping the best-scoring chunk per document. Chunks are identified by splitting on `#c` in the chunk ID. Vector hits are bucketed by `doc_id`, and the highest-ranked chunk from each document is selected. RRF fusion combines vector bucket ranks with FTS document-level ranks using K=60.

The `snippet` field now returns the content of the best-scoring chunk (truncated to ~300 chars) instead of the document's first paragraph.

## Implementation

- **VectorSearch**: Added LEFT JOIN to chunks table so MATCH queries return `content` alongside `distance`
- **HybridSearch**: Extract doc_id from chunk IDs, bucket vector hits by document, keep best-scoring chunk, fuse with FTS ranks via RRF
- **SearchResult**: Snippet field populated from winning chunk's content

## Testing

- Dedup verified: documents with multiple chunks return single result with highest-ranked chunk
- Snippet verified: populated from chunk content, not first paragraph
- RRF fusion stable with K=60 formula
- Regression verified: title-matching queries still return same top result

Closes #765

## Note

This PR is part of the GH-761 stacked group plan (Phases 1-4). Branch stacked on GH-762, GH-763, GH-764. All commits shown are prerequisites. Target main will show all stacked commits until predecessors merge.

Related:
- Parent: #761
- Predecessor: #764
- Part of group: #762, #763, #764