### PR TITLE
GH-767: wire contextual retrieval into embedder + reindex

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/embedder.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/embedder.test.ts
@@ -15,6 +15,14 @@ vi.mock("@huggingface/transformers", () => {
 });
 
 import { prepareTextForEmbedding, embedDocument } from "../embedder.js";
+import type { LlmClient } from "../llm-client.js";
+
+function makeMockLlm(contextualize: LlmClient["contextualize"]): LlmClient {
+  return {
+    available: vi.fn(async () => true),
+    contextualize: vi.fn(contextualize),
+  };
+}
 
 describe("prepareTextForEmbedding", () => {
   it("includes title, tags, and first paragraph", () => {
@@ -195,5 +203,122 @@ describe("embedDocument", () => {
     });
     // With chunkSize=100 over 500 chars, we expect multiple chunks.
     expect(result.length).toBeGreaterThan(1);
+  });
+
+  // Phase 6 (GH-767): Contextual Retrieval integration.
+  describe("contextual retrieval", () => {
+    it("calls llm.contextualize once per chunk when llm is provided", async () => {
+      const content = "A".repeat(500);
+      const mockLlm = makeMockLlm(async () => "CTX");
+      const result = await embedDocument("T", [], content, {
+        llm: mockLlm,
+        chunkSize: 100,
+        chunkOverlap: 10,
+      });
+      expect(result.length).toBeGreaterThan(1);
+      expect(mockLlm.contextualize).toHaveBeenCalledTimes(result.length);
+    });
+
+    it("stores non-empty contextPrefix on every returned chunk", async () => {
+      const mockLlm = makeMockLlm(async () => "THIS IS CONTEXT");
+      const result = await embedDocument("Title", ["tag"], "body text", { llm: mockLlm });
+      expect(result).toHaveLength(1);
+      expect(result[0]!.contextPrefix).toBe("THIS IS CONTEXT");
+      // Embed text prepends contextPrefix ahead of title/tags/content.
+      expect(embedCalls[0]).toBe("THIS IS CONTEXT\nTitle\ntag\nbody text");
+    });
+
+    it("passes the full document (not the chunk) as the first contextualize arg", async () => {
+      const longContent = "A".repeat(500);
+      const mockLlm = makeMockLlm(async () => "CTX");
+      await embedDocument("T", [], longContent, {
+        llm: mockLlm,
+        chunkSize: 100,
+        chunkOverlap: 10,
+      });
+      const calls = (mockLlm.contextualize as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls.length).toBeGreaterThan(1);
+      for (const [fullDoc] of calls) {
+        expect(fullDoc).toBe(longContent);
+      }
+    });
+
+    it("fail-open (empty string) yields contextPrefix: '' and omits leading blank line", async () => {
+      const mockLlm = makeMockLlm(async () => "");
+      const result = await embedDocument("Title", ["tag"], "body text", { llm: mockLlm });
+      expect(result[0]!.contextPrefix).toBe("");
+      // No leading blank line from an empty contextPrefix — falls back to the
+      // no-context embed shape.
+      expect(embedCalls[0]).toBe("Title\ntag\nbody text");
+      expect(embedCalls[0]!.startsWith("\n")).toBe(false);
+    });
+
+    it("uses cachedPrefixes entry for a chunk and skips llm.contextualize for that index", async () => {
+      const content = "A".repeat(500);
+      const mockLlm = makeMockLlm(async () => "LIVE CTX");
+      // First run to discover the chunk layout.
+      const baseline = await embedDocument("T", [], content, {
+        llm: mockLlm,
+        chunkSize: 100,
+        chunkOverlap: 10,
+      });
+      const chunkCount = baseline.length;
+      expect(chunkCount).toBeGreaterThan(1);
+
+      (mockLlm.contextualize as ReturnType<typeof vi.fn>).mockClear();
+      embedCalls.length = 0;
+
+      // Cache all but the last chunk index.
+      const cached = new Map<number, string>();
+      for (let i = 0; i < chunkCount - 1; i++) {
+        cached.set(i, `CACHED-${i}`);
+      }
+
+      const result = await embedDocument("T", [], content, {
+        llm: mockLlm,
+        cachedPrefixes: cached,
+        chunkSize: 100,
+        chunkOverlap: 10,
+      });
+
+      expect(result).toHaveLength(chunkCount);
+      // Only the last (uncached) chunk triggered a live LLM call.
+      expect(mockLlm.contextualize).toHaveBeenCalledTimes(1);
+      // Cached chunks preserve the cached prefix verbatim.
+      for (let i = 0; i < chunkCount - 1; i++) {
+        expect(result[i]!.contextPrefix).toBe(`CACHED-${i}`);
+      }
+      expect(result[chunkCount - 1]!.contextPrefix).toBe("LIVE CTX");
+    });
+
+    it("with no llm, contextPrefix is '' on every chunk and no LLM calls occur", async () => {
+      const content = "A".repeat(500);
+      const mockLlm = makeMockLlm(async () => "SHOULD NOT CALL");
+      // Note: do NOT pass `llm` into opts — this is the flag-off path.
+      const result = await embedDocument("T", [], content, {
+        chunkSize: 100,
+        chunkOverlap: 10,
+      });
+      expect(result.length).toBeGreaterThan(1);
+      expect(mockLlm.contextualize).not.toHaveBeenCalled();
+      for (const chunk of result) {
+        expect(chunk.contextPrefix).toBe("");
+      }
+      // Embed text uses the no-context shape.
+      expect(embedCalls[0]!.startsWith("T\n")).toBe(true);
+    });
+
+    it("cachedPrefixes without llm has no effect (no LLM, caching is moot)", async () => {
+      const content = "short content";
+      const mockLlm = makeMockLlm(async () => "LIVE");
+      const cached = new Map<number, string>([[0, "CACHED"]]);
+      const result = await embedDocument("T", [], content, {
+        cachedPrefixes: cached,
+      });
+      // Without llm, no contextualize calls happen and no cached prefix is applied
+      // (since caching is only a fast-path on the LLM branch).
+      expect(mockLlm.contextualize).not.toHaveBeenCalled();
+      expect(result[0]!.contextPrefix).toBe("");
+    });
   });
 });

--- a/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, unlinkSync, utimesSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -7,24 +7,46 @@ import { FtsSearch } from "../search.js";
 import { VectorSearch } from "../vector-search.js";
 
 // Mock embedder so we don't load the real transformer model during tests.
-// embedDocument returns one DocumentChunk per call with a constant 384-dim
-// embedding; this matches the new chunk-aware reindex flow.
+// embedDocument honors the Phase 6 `opts.llm` contract: when present it calls
+// `llm.contextualize(fullDoc, chunk.content)` and surfaces the returned string
+// on `DocumentChunk.contextPrefix` (empty on fail-open). When `cachedPrefixes`
+// is provided and has a value for a chunk's index, the live LLM call is skipped.
 vi.mock("../embedder.js", async () => {
   // Import the real chunker so the mock chunks content the same way as prod.
   const { chunkText } = await import("../chunker.js");
+  type LlmLike = { contextualize: (fullDoc: string, chunk: string) => Promise<string> };
+  type EmbedOpts = { llm?: LlmLike; cachedPrefixes?: Map<number, string> };
   return {
     embed: vi.fn(async () => new Float32Array(384)),
-    embedDocument: vi.fn(async (_title: string, _tags: string[], content: string) => {
+    embedDocument: vi.fn(async (
+      _title: string,
+      _tags: string[],
+      content: string,
+      opts?: EmbedOpts,
+    ) => {
       const chunks = content.length === 0
         ? [{ index: 0, content: "", charStart: 0, charEnd: 0 }]
         : chunkText(content);
-      return chunks.map(c => ({
-        index: c.index,
-        content: c.content,
-        charStart: c.charStart,
-        charEnd: c.charEnd,
-        embedding: new Float32Array(384),
-      }));
+      const out = [];
+      for (const c of chunks) {
+        let contextPrefix = "";
+        if (opts?.llm) {
+          if (opts.cachedPrefixes && opts.cachedPrefixes.has(c.index)) {
+            contextPrefix = opts.cachedPrefixes.get(c.index) ?? "";
+          } else {
+            contextPrefix = await opts.llm.contextualize(content, c.content);
+          }
+        }
+        out.push({
+          index: c.index,
+          content: c.content,
+          charStart: c.charStart,
+          charEnd: c.charEnd,
+          embedding: new Float32Array(384),
+          contextPrefix,
+        });
+      }
+      return out;
     }),
     prepareTextForEmbedding: vi.fn((title: string, tags: string[], content: string) => {
       const tagLine = tags.length > 0 ? tags.join(", ") : "";
@@ -33,6 +55,17 @@ vi.mock("../embedder.js", async () => {
     }),
   };
 });
+
+// Mock the LLM client so tests can deterministically control availability and
+// contextualize() return values without touching the network.
+const mockLlmAvailable = vi.fn(async () => true);
+const mockLlmContextualize = vi.fn(async (_fullDoc: string, _chunk: string) => "");
+vi.mock("../llm-client.js", () => ({
+  createLlmClient: vi.fn(() => ({
+    available: mockLlmAvailable,
+    contextualize: mockLlmContextualize,
+  })),
+}));
 
 import { embedDocument } from "../embedder.js";
 import { reindex } from "../reindex.js";
@@ -77,11 +110,30 @@ describe("findMarkdownFiles", () => {
 describe("incremental reindex", () => {
   let dir: string;
   let dbPath: string;
+  const originalFlag = process.env.RALPH_CONTEXTUAL_RETRIEVAL;
 
   beforeEach(() => {
     mockedEmbed.mockClear();
+    // Reset LLM mocks to defaults: available returns true, contextualize returns "".
+    // Individual tests override these before calling `reindex(...)`.
+    mockLlmAvailable.mockReset();
+    mockLlmAvailable.mockResolvedValue(true);
+    mockLlmContextualize.mockReset();
+    mockLlmContextualize.mockResolvedValue("");
+    // Default the flag to disabled for legacy tests so the existing 17 scenarios
+    // don't accidentally call the mocked LLM — the Phase 6 tests opt back in
+    // explicitly via `process.env.RALPH_CONTEXTUAL_RETRIEVAL = "1"`.
+    process.env.RALPH_CONTEXTUAL_RETRIEVAL = "0";
     dir = mkdtempSync(join(tmpdir(), "knowledge-reindex-"));
     dbPath = join(dir, "test.db");
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env.RALPH_CONTEXTUAL_RETRIEVAL;
+    } else {
+      process.env.RALPH_CONTEXTUAL_RETRIEVAL = originalFlag;
+    }
   });
 
   it("scenario 1: unchanged files are skipped on second run", async () => {
@@ -528,5 +580,158 @@ describe("incremental reindex", () => {
       .get("stable#c*") as { n: number }).n;
     expect(vecCount).toBe(secondCount);
     db2.close();
+  });
+
+  // ---- Phase 6 (GH-767): Contextual Retrieval wiring ----
+
+  it("scenario 18: RALPH_CONTEXTUAL_RETRIEVAL=0 skips LLM entirely", async () => {
+    process.env.RALPH_CONTEXTUAL_RETRIEVAL = "0";
+    mockLlmContextualize.mockResolvedValue("SHOULD NOT APPEAR");
+
+    writeFileSync(join(dir, "doc-a.md"), makeDoc("Doc A"));
+
+    await reindex([dir], dbPath);
+
+    // Zero LLM activity when the flag is off.
+    expect(mockLlmAvailable).not.toHaveBeenCalled();
+    expect(mockLlmContextualize).not.toHaveBeenCalled();
+
+    // All chunks should have empty context_prefix.
+    const db = new KnowledgeDB(dbPath);
+    const rows = db.db
+      .prepare("SELECT context_prefix FROM chunks WHERE document_id = ?")
+      .all("doc-a") as Array<{ context_prefix: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) {
+      expect(r.context_prefix).toBe("");
+    }
+    db.close();
+  });
+
+  it("scenario 19: flag on + LLM unreachable -> empty context_prefix + single warning", async () => {
+    process.env.RALPH_CONTEXTUAL_RETRIEVAL = "1";
+    mockLlmAvailable.mockResolvedValue(false);
+    // contextualize should never be called because available() returned false.
+    mockLlmContextualize.mockResolvedValue("UNREACHED");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      writeFileSync(join(dir, "doc-a.md"), makeDoc("Doc A"));
+      writeFileSync(join(dir, "doc-b.md"), makeDoc("Doc B"));
+
+      await reindex([dir], dbPath);
+
+      // available() probed exactly once per reindex call.
+      expect(mockLlmAvailable).toHaveBeenCalledTimes(1);
+      // contextualize() never invoked on the fail-open path.
+      expect(mockLlmContextualize).not.toHaveBeenCalled();
+
+      // Exactly one "unreachable" warning (other warnings like frontmatter are allowed).
+      const unreachableWarnings = warnSpy.mock.calls.filter(args =>
+        args.some(a => typeof a === "string" && /LLM endpoint unreachable/.test(a)),
+      );
+      expect(unreachableWarnings).toHaveLength(1);
+
+      const db = new KnowledgeDB(dbPath);
+      const rows = db.db
+        .prepare("SELECT context_prefix FROM chunks")
+        .all() as Array<{ context_prefix: string }>;
+      expect(rows.length).toBeGreaterThan(0);
+      for (const r of rows) {
+        expect(r.context_prefix).toBe("");
+      }
+      db.close();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("scenario 20: flag on + reachable LLM -> non-empty context_prefix persisted", async () => {
+    process.env.RALPH_CONTEXTUAL_RETRIEVAL = "1";
+    mockLlmAvailable.mockResolvedValue(true);
+    mockLlmContextualize.mockResolvedValue("GENERATED CONTEXT");
+
+    writeFileSync(join(dir, "doc-a.md"), makeDoc("Doc A"));
+
+    await reindex([dir], dbPath);
+
+    expect(mockLlmAvailable).toHaveBeenCalledTimes(1);
+    expect(mockLlmContextualize).toHaveBeenCalled();
+
+    const db = new KnowledgeDB(dbPath);
+    const rows = db.db
+      .prepare("SELECT context_prefix FROM chunks WHERE document_id = ?")
+      .all("doc-a") as Array<{ context_prefix: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) {
+      expect(r.context_prefix).toBe("GENERATED CONTEXT");
+    }
+    db.close();
+  });
+
+  it("scenario 21: flag defaults on (undefined env) and probes LLM", async () => {
+    delete process.env.RALPH_CONTEXTUAL_RETRIEVAL;
+    mockLlmAvailable.mockResolvedValue(true);
+    mockLlmContextualize.mockResolvedValue("DEFAULT ON");
+
+    writeFileSync(join(dir, "doc-a.md"), makeDoc("Doc A"));
+
+    await reindex([dir], dbPath);
+
+    // available() probed because flag was not "0" / "false".
+    expect(mockLlmAvailable).toHaveBeenCalledTimes(1);
+    expect(mockLlmContextualize).toHaveBeenCalled();
+  });
+
+  it("scenario 22: 'false' also disables contextual retrieval", async () => {
+    process.env.RALPH_CONTEXTUAL_RETRIEVAL = "false";
+    mockLlmContextualize.mockResolvedValue("SHOULD NOT APPEAR");
+
+    writeFileSync(join(dir, "doc-a.md"), makeDoc("Doc A"));
+
+    await reindex([dir], dbPath);
+
+    expect(mockLlmAvailable).not.toHaveBeenCalled();
+    expect(mockLlmContextualize).not.toHaveBeenCalled();
+  });
+
+  it("scenario 23: re-running with unchanged content reuses cached context_prefix (no new LLM calls)", async () => {
+    process.env.RALPH_CONTEXTUAL_RETRIEVAL = "1";
+    mockLlmAvailable.mockResolvedValue(true);
+    mockLlmContextualize.mockResolvedValue("INITIAL CTX");
+
+    const filePath = join(dir, "doc-a.md");
+    writeFileSync(filePath, makeDoc("Doc A"));
+
+    await reindex([dir], dbPath);
+    const firstCallCount = mockLlmContextualize.mock.calls.length;
+    expect(firstCallCount).toBeGreaterThan(0);
+
+    // Bump mtime without changing content — this defeats the outer mtime skip
+    // and forces the inner content-hash cache check to fire.
+    const future = Date.now() / 1000 + 2;
+    utimesSync(filePath, future, future);
+
+    mockLlmContextualize.mockClear();
+    // Swap the mock return so we can prove cached prefixes were reused: if the
+    // cache missed and a live call happened, the new return value would show up
+    // in the DB.
+    mockLlmContextualize.mockResolvedValue("LIVE (SHOULD NOT OCCUR)");
+
+    await reindex([dir], dbPath);
+
+    // Zero fresh calls because content hash matched the meta cache.
+    expect(mockLlmContextualize).not.toHaveBeenCalled();
+
+    const db = new KnowledgeDB(dbPath);
+    const rows = db.db
+      .prepare("SELECT context_prefix FROM chunks WHERE document_id = ?")
+      .all("doc-a") as Array<{ context_prefix: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) {
+      expect(r.context_prefix).toBe("INITIAL CTX");
+    }
+    db.close();
   });
 });

--- a/plugin/ralph-knowledge/src/embedder.ts
+++ b/plugin/ralph-knowledge/src/embedder.ts
@@ -3,6 +3,7 @@ import {
   type FeatureExtractionPipeline,
 } from "@huggingface/transformers";
 import { chunkText, type Chunk, type ChunkerOptions } from "./chunker.js";
+import type { LlmClient } from "./llm-client.js";
 
 const MODEL_ID = "Xenova/all-MiniLM-L6-v2";
 
@@ -40,11 +41,36 @@ export interface DocumentChunk extends Chunk {
 }
 
 /**
+ * Options accepted by `embedDocument`. Extends `ChunkerOptions` with optional
+ * Contextual Retrieval inputs:
+ *
+ * - `llm`: when present, each chunk is run through `llm.contextualize(fullDoc, chunkContent)`
+ *   and the returned string is prepended to the embed text (and persisted on the
+ *   resulting `DocumentChunk.contextPrefix`). Empty-string returns (fail-open from
+ *   the LLM client) cause the embed text to fall back to the legacy
+ *   `${title}\n${tagLine}\n${chunk.content}` shape.
+ * - `cachedPrefixes`: optional `Map<chunkIndex, contextPrefix>` from a prior run.
+ *   When a chunk's index has a cached prefix, the LLM call is skipped and the
+ *   cached string is reused verbatim. Used by the reindex content-hash cache
+ *   fast-path (Task 6.4) so unchanged docs don't re-contact the LLM endpoint.
+ */
+export interface EmbedDocumentOptions extends ChunkerOptions {
+  llm?: LlmClient;
+  cachedPrefixes?: Map<number, string>;
+}
+
+/**
  * Embed a document by splitting it into chunks and emitting one embedding
  * per chunk. The embedded text for each chunk is
  * `${title}\n${tagLine}\n${chunk.content}` so the semantic anchors (title +
  * tags) travel with every chunk embedding — matching the shape of the legacy
  * `prepareTextForEmbedding()` but without the 500-char truncation.
+ *
+ * When `opts.llm` is provided (Phase 6 — Contextual Retrieval), a short
+ * context prefix is generated per chunk via `opts.llm.contextualize(content, chunk.content)`
+ * and prepended to the embed text as `${contextPrefix}\n${title}\n${tagLine}\n${chunk.content}`.
+ * If `contextualize` returns `""` (fail-open path), the embed text reverts to the
+ * no-context shape so we never emit a leading blank line.
  *
  * Short documents (<= chunkSize) produce exactly one chunk covering the whole
  * content. Empty content yields a single chunk with empty content (so callers
@@ -54,7 +80,7 @@ export async function embedDocument(
   title: string,
   tags: string[],
   content: string,
-  opts?: ChunkerOptions,
+  opts?: EmbedDocumentOptions,
 ): Promise<DocumentChunk[]> {
   const tagLine = tags.length > 0 ? tags.join(", ") : "";
 
@@ -65,10 +91,30 @@ export async function embedDocument(
     ? [{ index: 0, content: "", charStart: 0, charEnd: 0 }]
     : chunkText(content, opts);
 
+  const llm = opts?.llm;
+  const cached = opts?.cachedPrefixes;
+
   const out: DocumentChunk[] = [];
   for (const chunk of chunks) {
-    const parts = [title, tagLine, chunk.content].filter(p => p.length > 0);
-    const embedText = parts.join("\n");
+    let contextPrefix = "";
+    if (llm) {
+      // Cache hit: reuse prior context_prefix when the caller supplied a map
+      // keyed by chunk.index. Avoids an LLM round-trip per unchanged chunk.
+      if (cached && cached.has(chunk.index)) {
+        contextPrefix = cached.get(chunk.index) ?? "";
+      } else {
+        // `contextualize` is fail-open: it returns "" on any network/timeout/
+        // malformed-response error. That empty string propagates into the
+        // returned `DocumentChunk.contextPrefix` (persisted by the caller) and
+        // causes the embed text to skip the leading blank line below.
+        contextPrefix = await llm.contextualize(content, chunk.content);
+      }
+    }
+
+    const parts = contextPrefix.length > 0
+      ? [contextPrefix, title, tagLine, chunk.content]
+      : [title, tagLine, chunk.content];
+    const embedText = parts.filter(p => p.length > 0).join("\n");
     const embedding = await embed(embedText);
     out.push({
       index: chunk.index,
@@ -76,6 +122,7 @@ export async function embedDocument(
       charStart: chunk.charStart,
       charEnd: chunk.charEnd,
       embedding,
+      contextPrefix,
     });
   }
   return out;

--- a/plugin/ralph-knowledge/src/reindex.ts
+++ b/plugin/ralph-knowledge/src/reindex.ts
@@ -1,6 +1,7 @@
 import { readFileSync, statSync } from "node:fs";
 import { join, relative, resolve, basename } from "node:path";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 import { KnowledgeDB } from "./db.js";
 import { FtsSearch } from "./search.js";
 import { VectorSearch } from "./vector-search.js";
@@ -10,7 +11,7 @@ import { findMarkdownFiles } from "./file-scanner.js";
 import { generateIndexes } from "./generate-indexes.js";
 import { loadConfig, type KnowledgeConfig } from "./config.js";
 import { loadIgnoreForRoot } from "./ignore.js";
-
+import { createLlmClient, type LlmClient } from "./llm-client.js";
 export async function reindex(
   dirs: string[],
   dbPath: string,
@@ -24,6 +25,28 @@ export async function reindex(
   fts.ensureTable();
   const vec = new VectorSearch(db);
   vec.createIndex();
+
+  // Phase 6 (GH-767): Contextual Retrieval wiring.
+  // `RALPH_CONTEXTUAL_RETRIEVAL` gates the whole feature. Default on; treat
+  // literal "0" / "false" as disabled. When enabled we probe the endpoint once
+  // and fail open on unreachable — all downstream chunks then embed without a
+  // context prefix and we log a single warning so the operator knows why.
+  const flagRaw = process.env.RALPH_CONTEXTUAL_RETRIEVAL;
+  const contextualEnabled = flagRaw !== "0" && flagRaw !== "false";
+  let llm: LlmClient | undefined;
+  if (contextualEnabled) {
+    const llmUrl = process.env.RALPH_LLM_URL ?? "http://localhost:8000";
+    const candidate = createLlmClient();
+    const llmReady = await candidate.available();
+    if (llmReady) {
+      llm = candidate;
+    } else {
+      console.warn(
+        `LLM endpoint unreachable at ${llmUrl}, contextual retrieval disabled for this run`
+      );
+      llm = undefined;
+    }
+  }
 
   // Schema version check — force full re-embed when embedding algorithm changes
   const SCHEMA_VERSION = "3";
@@ -74,6 +97,7 @@ export async function reindex(
   const parsedDocs: ParsedDocument[] = [];
   let indexed = 0;
   let skipped = 0;
+  let totalChunks = 0;
   for (const filePath of filesOnDisk) {
     const absPath = resolve(filePath);
     const mtime = Math.trunc(statSync(absPath).mtimeMs);
@@ -143,6 +167,35 @@ export async function reindex(
       db.addRelationship(edge.sourceId, edge.targetId, "untyped", edge.context);
     }
 
+    // Content-hash cache for Contextual Retrieval prefixes. The outer mtime
+    // skip at line ~75 already short-circuits the overwhelming majority of
+    // unchanged docs (no embedder or LLM calls). This inner hash check is
+    // specifically for the rare case where mtime differs but content is
+    // byte-identical (e.g., git checkout touching the file). When hash matches
+    // AND we have a live LLM AND chunks already exist, we reuse the prior
+    // context_prefix map and skip the per-chunk LLM round-trips.
+    //
+    // Simpler alternative considered: rely entirely on mtime. Rejected because
+    // the feature spec (Task 6.4 acceptance) explicitly requires re-running
+    // reindex without content changes to reuse existing context_prefix.
+    const contentHash = createHash("sha256").update(parsed.content).digest("hex").slice(0, 16);
+    const hashKey = `content_hash:${parsed.id}`;
+    const priorHash = db.getMeta(hashKey);
+
+    let cachedPrefixes: Map<number, string> | undefined;
+    if (llm && priorHash === contentHash) {
+      const priorChunks = db.db
+        .prepare(
+          "SELECT chunk_index, context_prefix FROM chunks WHERE document_id = ? ORDER BY chunk_index"
+        )
+        .all(parsed.id) as Array<{ chunk_index: number; context_prefix: string }>;
+      if (priorChunks.length > 0) {
+        cachedPrefixes = new Map(
+          priorChunks.map(r => [r.chunk_index, r.context_prefix ?? ""] as [number, string])
+        );
+      }
+    }
+
     // Chunk-aware embedding: emit one embedding per chunk, persist to both
     // the `chunks` table and the `documents_vec` virtual table with chunk ids
     // of the form `${doc.id}#c${index}`.
@@ -156,9 +209,12 @@ export async function reindex(
     vec.deleteEmbedding(parsed.id);
 
     try {
-      const chunks = await embedDocument(parsed.title, parsed.tags, parsed.content);
+      const chunks = await embedDocument(parsed.title, parsed.tags, parsed.content, {
+        llm,
+        cachedPrefixes,
+      });
       const insertChunk = db.db.prepare(
-        "INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end) VALUES (?, ?, ?, ?, ?, ?)"
+        "INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end, context_prefix) VALUES (?, ?, ?, ?, ?, ?, ?)"
       );
       for (const chunk of chunks) {
         const chunkId = `${parsed.id}#c${chunk.index}`;
@@ -169,9 +225,16 @@ export async function reindex(
           chunk.content,
           chunk.charStart,
           chunk.charEnd,
+          chunk.contextPrefix ?? "",
         );
         vec.upsertEmbedding(chunkId, chunk.embedding);
+        totalChunks++;
+        if (totalChunks % 50 === 0) {
+          console.log(`  ${totalChunks} chunks embedded`);
+        }
       }
+      // Record the content hash for the next reindex cache check.
+      db.setMeta(hashKey, contentHash);
     } catch (e) {
       console.warn(`Failed to embed ${id}: ${(e as Error).message}`);
     }

--- a/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
+++ b/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
@@ -595,8 +595,8 @@ Integrate LLM client into chunk embedding flow. Per chunk: generate context via 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` passes
-- [ ] `npm test` — embedder + reindex + full suite pass
+- [x] `npm run build` passes
+- [x] `npm test` — embedder + reindex + full suite pass
 
 #### Manual Verification:
 - [ ] With gemma-lab running, reindex of a 10-doc fixture produces non-empty `context_prefix` on every chunk (verify via `sqlite3 ... "SELECT context_prefix FROM chunks LIMIT 5"`)


### PR DESCRIPTION
## Summary

Integrate the LLM client into the chunk embedding flow. For each chunk: call `llm.contextualize(fullDoc, chunkContent)`, prepend result to the embed text, persist to `chunks.context_prefix`. Gated by `RALPH_CONTEXTUAL_RETRIEVAL` (default `1`). Skip regeneration when doc content hash matches existing row.

## Implementation

- Extended `embedDocument` to accept `{ llm?: LlmClient }` and generate `contextPrefix` per chunk
- Updated reindex flow to construct LLM client when flag enabled, with graceful fallback if endpoint unreachable
- Added context_prefix persistence to chunks table
- Implemented cache-hit detection via (doc_id, chunk_index, content_hash) matching
- Added comprehensive mocks and test coverage
- Progress logging every 50 chunks during reindex

## Changes

- `plugin/ralph-knowledge/src/embedder.ts` — wire LLM contextual retrieval
- `plugin/ralph-knowledge/src/reindex.ts` — LLM client initialization and caching
- `plugin/ralph-knowledge/src/__tests__/embedder.test.ts` — mock LLM client tests

## Acceptance Criteria

- [x] With `RALPH_CONTEXTUAL_RETRIEVAL=1` (default) and reachable LLM, every new chunk gets a non-empty `context_prefix`
- [x] With `RALPH_CONTEXTUAL_RETRIEVAL=0`, zero LLM calls occur during reindex
- [x] With flag on and unreachable endpoint, reindex completes with empty `context_prefix` and one warning logged
- [x] Re-running reindex without doc content changes reuses existing `context_prefix` (no LLM calls for unchanged chunks)
- [x] `npm run build` passes
- [x] `npm test` passes

## Related Issues

Part of GH-761 group plan. This PR includes commits from:
- GH-764: chunk-aware embedder + reindex persistence
- GH-766: LLM client for Contextual Retrieval

Closes #767