### PR TITLE
GH-772: ralph-knowledge: launchd plist template + log rotation for dream-loop

### DIFF
--- a/scripts/dream/README.md
+++ b/scripts/dream/README.md
@@ -1,0 +1,98 @@
+# Dream-Loop — Nightly Memory Ingestion + Reflection
+
+This directory contains the ralph-knowledge dream-loop: a nightly pipeline
+that ingests the last 24 hours of raw activity (Gemma lab logs, git
+history, `llm-cli` transcripts), writes them as `memory_tier=raw`
+documents, and then synthesizes reflection documents by clustering with
+HDBSCAN + asking Gemma to describe each cluster.
+
+The pipeline is three scripts:
+
+- `ingest.py` — pulls raw memories, writes markdown under `memory_tier=raw`.
+- `reflect.py` — clusters raw memories, writes `memory_tier=reflection` synthesis docs.
+- `logrotate.sh` — caps `/tmp/dream-loop.out` and `/tmp/dream-loop.err` at 1000 lines each.
+
+On macOS they run nightly at 03:00 via launchd using the template at
+`launchd/com.dubiel.dream-loop.plist.template`. The live plist lives in
+`~/Library/LaunchAgents/` and is NOT committed; only the template is
+in-repo.
+
+## Manual Run
+
+```bash
+cd /Users/dubiel/projects/ralph-hero/scripts/dream
+uv run ingest.py --since 24h
+uv run reflect.py --since 24h
+./logrotate.sh
+```
+
+## Install (launchd)
+
+Copy the template into the user LaunchAgents directory and load it:
+
+```bash
+cp scripts/dream/launchd/com.dubiel.dream-loop.plist.template \
+   ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
+launchctl load ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
+```
+
+To trigger an immediate run (without waiting for 03:00):
+
+```bash
+launchctl start com.dubiel.dream-loop
+```
+
+## Verify
+
+After loading, `launchctl list` should show the agent with a PID column
+(or `-` when idle) plus the label. The next scheduled fire is surfaced
+by launchd; you can confirm the agent is registered via:
+
+```bash
+launchctl list | grep dream-loop
+```
+
+Expected output (column ordering: PID, last-exit-status, label):
+
+```
+-	0	com.dubiel.dream-loop
+```
+
+A `-` in the PID column means the agent is registered but not currently
+running. The last-exit-status is `0` after a successful run.
+
+## Logs
+
+- `/tmp/dream-loop.out` — `ingest.py` + `reflect.py` stdout.
+- `/tmp/dream-loop.err` — stderr (errors, warnings, Gemma fallbacks).
+
+`logrotate.sh` runs at the end of every launchd-invoked pipeline and
+caps each file at the last 1000 lines via `tail -n 1000` + atomic
+rename. A single night's run typically produces well under that; the
+cap guards against unbounded growth over weeks of scheduling.
+
+## Uninstall
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
+rm ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
+```
+
+To stop rotating logs but keep the scripts usable manually, simply
+remove the `&& ./logrotate.sh` tail from the plist's `ProgramArguments`
+bash string and reload.
+
+## Environment Variables
+
+The plist's `EnvironmentVariables` dict sets the minimum launchd needs
+to reach Gemma and the knowledge config:
+
+| Variable | Default in plist | Purpose |
+|----------|------------------|---------|
+| `PATH` | `/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin` | Homebrew + system binaries for `uv` |
+| `RALPH_KNOWLEDGE_CONFIG` | `/Users/dubiel/.ralph/knowledge.config.json` | Roots + ignore globs for scanner |
+| `RALPH_LLM_URL` | `http://localhost:8000` | Gemma lab OpenAI-compatible endpoint |
+
+If Gemma is unreachable at fire time the pipeline fails open (empty
+reflections, single warning in stderr) per the shared constraint
+"fail-open LLM" from the group plan.

--- a/scripts/dream/launchd/com.dubiel.dream-loop.plist.template
+++ b/scripts/dream/launchd/com.dubiel.dream-loop.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.dubiel.dream-loop</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>cd /Users/dubiel/projects/ralph-hero/scripts/dream &amp;&amp; uv run ingest.py --since 24h &amp;&amp; uv run reflect.py --since 24h &amp;&amp; /Users/dubiel/projects/ralph-hero/scripts/dream/logrotate.sh</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>3</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>/tmp/dream-loop.out</string>
+	<key>StandardErrorPath</key>
+	<string>/tmp/dream-loop.err</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+		<key>RALPH_KNOWLEDGE_CONFIG</key>
+		<string>/Users/dubiel/.ralph/knowledge.config.json</string>
+		<key>RALPH_LLM_URL</key>
+		<string>http://localhost:8000</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+</dict>
+</plist>

--- a/scripts/dream/logrotate.sh
+++ b/scripts/dream/logrotate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# logrotate.sh — cap dream-loop log files at 1000 lines.
+#
+# Invoked at the end of the launchd-scheduled dream-loop pipeline
+# (see scripts/dream/launchd/com.dubiel.dream-loop.plist.template).
+# Atomically truncates /tmp/dream-loop.out and /tmp/dream-loop.err
+# to their last 1000 lines via tail + tmp file + mv.
+
+set -euo pipefail
+
+MAX_LINES=1000
+
+rotate_one() {
+    local log_path="$1"
+    if [[ ! -f "$log_path" ]]; then
+        return 0
+    fi
+
+    local tmp_path
+    tmp_path="${log_path}.rotate.$$"
+
+    # tail -n never fails on short files; mv is atomic within the same fs.
+    tail -n "$MAX_LINES" "$log_path" > "$tmp_path"
+    mv "$tmp_path" "$log_path"
+}
+
+rotate_one "/tmp/dream-loop.out"
+rotate_one "/tmp/dream-loop.err"

--- a/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
+++ b/thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md
@@ -1113,9 +1113,9 @@ Commit a launchd plist template (lives in repo; installed copy goes to `~/Librar
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `plutil -lint scripts/dream/launchd/com.dubiel.dream-loop.plist.template` passes
-- [ ] `ls -l scripts/dream/logrotate.sh` shows executable bit set
-- [ ] `bash scripts/dream/logrotate.sh` runs without error on an empty or large tmp file (cover both via quick smoke test in CI script if added)
+- [x] `plutil -lint scripts/dream/launchd/com.dubiel.dream-loop.plist.template` passes
+- [x] `ls -l scripts/dream/logrotate.sh` shows executable bit set
+- [x] `bash scripts/dream/logrotate.sh` runs without error on an empty or large tmp file (cover both via quick smoke test in CI script if added)
 
 #### Manual Verification:
 - [ ] Copy template to `~/Library/LaunchAgents/com.dubiel.dream-loop.plist`; `launchctl load` succeeds


### PR DESCRIPTION
## Summary

Phase 11 of 11 for the ralph-knowledge chunked embeddings + dream-loop group (GH-762).

Adds launchd plist template to schedule the dream-loop (ingest.py + reflect.py) nightly at 03:00 via StartCalendarInterval. Includes logrotate.sh to cap log files at 1000 lines per run, and README with installation and verification steps.

Changes:
- `scripts/dream/launchd/com.dubiel.dream-loop.plist.template` — StartCalendarInterval Hour=3 Minute=0; runs ingest.py + reflect.py + logrotate.sh; validates with plutil -lint
- `scripts/dream/logrotate.sh` — Truncates /tmp/dream-loop.out and .err to last 1000 lines
- `scripts/dream/README.md` — Install, verify, manual run, and uninstall steps

The live plist is installed to ~/Library/LaunchAgents/ and is NOT committed — only the template is in-repo.

## Cross-Repo Context

This PR is part of GH-761 (parent) and includes stacked commits from predecessor issues:
- GH-770: Dream-loop ingester (feature/GH-770)
- GH-771: Dream-loop reflection synthesis (feature/GH-771)

These commits must merge in order (GH-770 → GH-771 → GH-772) before this PR can be merged to main. Once all dependencies merge, this issue moves to Done.

Closes #772