### PR TITLE
feat(ralph-playwright): add data_interpretation signal type (#793)

### DIFF
--- a/plugin/ralph-playwright/fixtures/data-interpretation-example/README.md
+++ b/plugin/ralph-playwright/fixtures/data-interpretation-example/README.md
@@ -1,0 +1,18 @@
+# data_interpretation signal type — fixture
+
+Demonstrates the `data_interpretation` signal type added in GH-793 for dashboard / chart / data-viz misreads (see `skills/reflect/SKILL.md` taxonomy).
+
+Files:
+- `signal-report.yaml` — positive example: two valid `data_interpretation` signals (axis units missing, legend mismatch).
+- `signal-report.invalid.yaml` — negative example: `type: data_interp` (typo) — must be rejected by the hook.
+
+Manually run the hook against either file:
+
+```bash
+CLAUDE_PLUGIN_ROOT=plugin/ralph-playwright \
+  jq -nc --arg p "$(pwd)/plugin/ralph-playwright/fixtures/data-interpretation-example/signal-report.yaml" \
+  '{tool_input:{file_path:$p}}' \
+  | bash plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh
+
+# Swap the filename to signal-report.invalid.yaml and expect exit 1 with "Invalid signal types".
+```

--- a/plugin/ralph-playwright/fixtures/data-interpretation-example/signal-report.invalid.yaml
+++ b/plugin/ralph-playwright/fixtures/data-interpretation-example/signal-report.invalid.yaml
@@ -1,0 +1,19 @@
+trace_id: "99999999-8888-4777-8666-555555555555"
+timestamp: "2026-04-20T12:05:00Z"
+signals:
+  - type: data_interp
+    severity: high
+    title: "Deliberately bogus signal type for negative testing"
+    description: "This fixture exists to prove the hook rejects typos. The type 'data_interp' is not a valid enum value — the validator must exit 1 with 'Invalid signal types'."
+    evidence:
+      steps: [3]
+      screenshots: ["03_dashboard.png"]
+    tags: ["negative-test"]
+summary:
+  total_signals: 1
+  by_severity:
+    critical: 0
+    high: 1
+    medium: 0
+    low: 0
+  recommendation: "This fixture must fail hook validation. If it passes, the regex has drifted from the schema enum."

--- a/plugin/ralph-playwright/fixtures/data-interpretation-example/signal-report.yaml
+++ b/plugin/ralph-playwright/fixtures/data-interpretation-example/signal-report.yaml
@@ -1,0 +1,27 @@
+trace_id: "11111111-2222-4333-8444-555555555555"
+timestamp: "2026-04-20T12:00:00Z"
+signals:
+  - type: data_interpretation
+    severity: high
+    title: "Revenue chart Y-axis missing units"
+    description: "Dashboard revenue chart on step 3 has numeric values on the Y-axis but no unit label (dollars? thousands? millions?). Readers cannot interpret magnitudes from the chart alone."
+    evidence:
+      steps: [3]
+      screenshots: ["03_dashboard.png"]
+    tags: ["chart", "dashboard", "units", "axis-label"]
+  - type: data_interpretation
+    severity: medium
+    title: "Legend colors do not match plotted series"
+    description: "Time-series chart legend lists three products (A, B, C) in blue/orange/green, but the plotted lines use blue/green/orange — legend-to-data mismatch makes series identification error-prone."
+    evidence:
+      steps: [3]
+      screenshots: ["03_dashboard.png"]
+    tags: ["chart", "legend", "color-mapping"]
+summary:
+  total_signals: 2
+  by_severity:
+    critical: 0
+    high: 1
+    medium: 1
+    low: 0
+  recommendation: "Add explicit unit labels to chart axes and verify legend color mapping matches plotted series. Both issues are chart-comprehension blockers for decision-making dashboards."

--- a/plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh
+++ b/plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh
@@ -91,7 +91,7 @@ if [[ "$SCHEMA" == "journey-trace.schema.yaml" ]]; then
 fi
 
 if [[ "$SCHEMA" == "signal-report.schema.yaml" ]]; then
-  INVALID_TYPES=$(yq '.signals[].type' "$FILE_PATH" 2>/dev/null | grep -v -E '^(anomaly|regression|a11y_violation|ux_issue|error)$' || true)
+  INVALID_TYPES=$(yq '.signals[].type' "$FILE_PATH" 2>/dev/null | grep -v -E '^(anomaly|regression|a11y_violation|ux_issue|error|data_interpretation)$' || true)
   if [[ -n "$INVALID_TYPES" ]]; then
     echo "ERROR: Invalid signal types in ${FILE_PATH}: ${INVALID_TYPES}" >&2
     exit 1

--- a/plugin/ralph-playwright/schemas/signal-report.schema.yaml
+++ b/plugin/ralph-playwright/schemas/signal-report.schema.yaml
@@ -20,7 +20,7 @@ properties:
       properties:
         type:
           type: string
-          enum: [anomaly, regression, a11y_violation, ux_issue, error]
+          enum: [anomaly, regression, a11y_violation, ux_issue, error, data_interpretation]
         severity:
           type: string
           enum: [critical, high, medium, low]

--- a/plugin/ralph-playwright/skills/reflect/SKILL.md
+++ b/plugin/ralph-playwright/skills/reflect/SKILL.md
@@ -39,6 +39,7 @@ For each finding, classify as:
 | `a11y_violation` | WCAG non-compliance: missing labels, broken tab order, contrast |
 | `ux_issue` | Confusing navigation, dead ends, unclear feedback |
 | `error` | Console errors, failed steps, broken interactions |
+| `data_interpretation` | Dashboard or chart misinterpretation: axis label missing, legend does not match data, unreadable density, unlabeled units, incorrect numeric callouts, misleading visualizations. Distinct from `anomaly` (which covers layout/visual glitches) and `ux_issue` (which covers nav/feedback confusion) — use this when the chart *renders* fine but *communicates* wrong. |
 
 Assign severity:
 - `critical`: Blocks core functionality or causes data loss

--- a/thoughts/shared/plans/2026-04-20-GH-0793-data-interpretation-signal-type.md
+++ b/thoughts/shared/plans/2026-04-20-GH-0793-data-interpretation-signal-type.md
@@ -189,12 +189,12 @@ Extend the signal-type enum in the schema, update the hook validator regex, docu
 
 #### Automated Verification
 
-- [ ] `yq '.properties.signals.items.properties.type.enum' plugin/ralph-playwright/schemas/signal-report.schema.yaml` outputs 6 values in the expected order.
-- [ ] `bash -n plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh` — no syntax errors.
-- [ ] `echo 'data_interpretation' | grep -v -E '^(anomaly|regression|a11y_violation|ux_issue|error|data_interpretation)$'` — empty output (accepted).
-- [ ] `echo 'data_interp' | grep -v -E '^(anomaly|regression|a11y_violation|ux_issue|error|data_interpretation)$'` — prints `data_interp` (rejected).
-- [ ] Positive fixture passes the hook script (exit 0) when stdin carries its absolute path.
-- [ ] Negative fixture fails the hook script (exit 1) with `Invalid signal types` in stderr.
+- [x] `yq '.properties.signals.items.properties.type.enum' plugin/ralph-playwright/schemas/signal-report.schema.yaml` outputs 6 values in the expected order.
+- [x] `bash -n plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh` — no syntax errors.
+- [x] `echo 'data_interpretation' | grep -v -E '^(anomaly|regression|a11y_violation|ux_issue|error|data_interpretation)$'` — empty output (accepted).
+- [x] `echo 'data_interp' | grep -v -E '^(anomaly|regression|a11y_violation|ux_issue|error|data_interpretation)$'` — prints `data_interp` (rejected).
+- [x] Positive fixture passes the hook script (exit 0) when stdin carries its absolute path.
+- [x] Negative fixture fails the hook script (exit 1) with `Invalid signal types` in stderr.
 
 #### Manual Verification
 


### PR DESCRIPTION
## Summary

- Extends the signal-report enum with `data_interpretation` to capture dashboard / chart / data-viz misreads that don't fit `anomaly` or `ux_issue`. Leverages Opus 4.7's +13pt CharXiv gain (research §Part 3 Item 9).
- Updates schema, hook validator regex, and reflect SKILL.md taxonomy in lockstep; seeds `fixtures/data-interpretation-example/` with positive + negative signal-reports and a README for manual verification.
- All changes are additive and backwards-compatible — existing signal-reports without `data_interpretation` continue to validate.

Closes #793. Part of #784 (epic).

## Files Modified

- `plugin/ralph-playwright/schemas/signal-report.schema.yaml` (Task 1.1) — append `data_interpretation` to the type enum
- `plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh` (Task 1.2) — extend regex alternation to match new enum
- `plugin/ralph-playwright/skills/reflect/SKILL.md` (Task 1.3) — 6th taxonomy row with 4 concrete examples (axis label, legend mismatch, density, unlabeled units) and explicit boundary against `anomaly` / `ux_issue`
- `plugin/ralph-playwright/fixtures/data-interpretation-example/` (Task 1.4) — positive + negative fixtures + README
- `thoughts/shared/plans/2026-04-20-GH-0793-data-interpretation-signal-type.md` — mark automated verification complete

## Scope Discipline

Explicitly NOT in this PR (deferred per plan):
- Structured chart fields (`chart_type`, `expected_value`, `observed_value`) — the task prompt suggested these; the plan rejected them as over-scoping for an XS. A future plan can add them under `evidence.chart_context` if warranted.
- Reflect Step 2 checklist rewrite — that's #786 (already shipped as PR #826).
- Model routing changes — that's #785 (already shipped as PR #825).

## Test plan

- [x] `yq '.properties.signals.items.properties.type.enum'` prints 6 values in expected order
- [x] `bash -n validate-primitive-io.sh` — no syntax errors
- [x] `echo 'data_interpretation' | grep -v -E '^(anomaly|regression|a11y_violation|ux_issue|error|data_interpretation)$'` — empty (accepted)
- [x] `echo 'data_interp' | grep -v -E '...'` — prints `data_interp` (rejected)
- [x] Positive fixture passes hook (exit 0)
- [x] Negative fixture fails hook (exit 1) with `Invalid signal types`
- [x] No stale 5-type enum regex remains in `plugin/ralph-playwright/` (spot-checked)
- [ ] Human reader can distinguish `data_interpretation` vs `anomaly` / `ux_issue` from the updated taxonomy alone (manual review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)