### PR TITLE
feat(ralph-playwright): alt-text relevance validation in a11y-scan (#789)

### DIFF
--- a/plugin/ralph-playwright/fixtures/alt-relevance/README.md
+++ b/plugin/ralph-playwright/fixtures/alt-relevance/README.md
@@ -1,0 +1,127 @@
+# alt-relevance fixture
+
+Static HTML page exercising the alt-text relevance sub-procedure in [`plugin/ralph-playwright/skills/a11y-scan/SKILL.md`](../../skills/a11y-scan/SKILL.md). Introduced by [GH-789](https://github.com/cdubiel08/ralph-hero/issues/789) to verify that a correctly-configured `/ralph-playwright:a11y-scan` run flags images with mismatched accessible names (alt / aria-label / figcaption / aria-labelledby) while leaving good and decorative images alone. Mirrors the fixture pattern introduced by sibling [GH-788](https://github.com/cdubiel08/ralph-hero/issues/788) ([`low-contrast/`](../low-contrast/)).
+
+Uses no JavaScript and no external assets (all images are local SVGs). Servable from any static server.
+
+## Cases
+
+Each case is wrapped in a `<section>` carrying `data-alt-relevance-case="i" | "ii" | "iii" | "iv" | "v" | "vi"` and a visible `<h2>` label so the expected-signals block below and the emitted signal-report can reference cases unambiguously.
+
+| Case | Selector | Element | Accessible name source | Accessible name | Visible content | Grade | Expected signal |
+|------|----------|---------|-------------------------|-----------------|-----------------|-------|-----------------|
+| i | `[data-alt-relevance-case="i"] img` | `<img>` | `alt` | `"Golden retriever sitting on a porch"` | Golden dog sitting on wooden porch | ACCURATE | **none** |
+| ii | `[data-alt-relevance-case="ii"] img` | `<img>` | `alt` | `"Red Submit button"` | Golden dog sitting on wooden porch | INACCURATE | `a11y_violation`, severity `medium`, tags `[alt-relevance]` |
+| iii | `[data-alt-relevance-case="iii"] img` | `<img>` | `alt` | `"Weather forecast"` | Bar chart titled "Quarterly Sales 2025" (chart = information-critical) | INACCURATE | `a11y_violation`, severity `high`, tags `[alt-relevance, information-critical]` |
+| iv | `[data-alt-relevance-case="iv"] img` | `<img>` | `alt=""` | (empty — decorative) | Thin grey horizontal line | (SKIP — decorative) | **none** |
+| v | `[data-alt-relevance-case="v"] figure` | `<figure><img><figcaption>` | `figcaption` | `"Tabby cat napping on a windowsill"` | Tabby cat napping on a windowsill | ACCURATE | **none** |
+| vi | `[data-alt-relevance-case="vi"] [role="img"]` | `<div role="img">` | `aria-label` | `"Orange triangle warning icon"` | Orange warning triangle with exclamation mark | ACCURATE | **none** |
+
+Per the rubric in [`skills/a11y-scan/SKILL.md`](../../skills/a11y-scan/SKILL.md) §(d):
+
+- **ACCURATE** -> no signal.
+- **PARTIAL** -> `a11y_violation` severity `low` (no cases in this fixture hit PARTIAL; the bad alts are egregious enough to be INACCURATE. A future fixture case could exercise PARTIAL with something like `alt="image"` on a specific photo).
+- **INACCURATE** -> `a11y_violation` severity `medium`, escalated to `high` when the image is information-critical (charts, diagrams, product photos, warning icons).
+
+## How to verify
+
+1. Start a static server in this directory. From the repository root:
+
+    ```
+    python3 -m http.server 8766 --directory plugin/ralph-playwright/fixtures/alt-relevance
+    ```
+
+2. Invoke the skill against the fixture:
+
+    ```
+    /ralph-playwright:a11y-scan http://localhost:8766/
+    ```
+
+3. Open the emitted `.playwright-cli/<session>/signal-report.yaml` and confirm the signals below.
+
+## Expected Signals
+
+The correctly-configured reflect step must emit exactly two `[alt-relevance]` signals (cases ii and iii) and zero for the other four cases. Other `a11y_violation` signals (heading hierarchy, labels, contrast, etc.) may also appear from the other a11y-scan heuristics and are orthogonal to this fixture — they must NOT carry the `alt-relevance` tag.
+
+### Case i — good alt (ACCURATE)
+
+- **No `[alt-relevance]` signal expected.** Emitting one is a false-positive regression.
+- The alt `"Golden retriever sitting on a porch"` accurately describes the visible dog.
+
+### Case ii — bad alt (INACCURATE)
+
+- **Signal type**: `a11y_violation`.
+- **Severity**: `medium` (egregious mismatch but not an information-critical image — it's a decorative photo of a dog).
+- **Title pattern**: `Alt-text mismatch: 'Red Submit button'` (first 40 chars of accessible name).
+- **Description must include**:
+  - A one-line summary of the form `Image depicts: <dog on porch observation>. Author-provided alt/label: "Red Submit button". Relevance grade: INACCURATE.`
+  - `source=alt`
+  - `WCAG 2.2 SC 1.1.1 Non-text Content (Level A)`
+  - A remediation suggestion referencing the visible content (e.g., `suggested alt: "Golden retriever sitting on a porch"` or semantically equivalent).
+- **Tags** (exact, order not significant): `["alt-relevance"]`.
+- **Evidence**: at least one step index (whichever step captured case ii) and its screenshot filename.
+
+### Case iii — misleading alt on chart (INACCURATE, information-critical)
+
+- **Signal type**: `a11y_violation`.
+- **Severity**: `high` (escalated from `medium` because the image is a chart — information-critical per rubric §(e)).
+- **Title pattern**: `Alt-text mismatch: 'Weather forecast'`.
+- **Description must include**:
+  - A one-line summary noting the image depicts a bar chart of quarterly sales, with author-provided alt `"Weather forecast"`. Relevance grade INACCURATE.
+  - `source=alt`
+  - `WCAG 2.2 SC 1.1.1 Non-text Content (Level A)`
+  - A remediation suggestion referencing the chart (e.g., `suggested alt: "Bar chart of quarterly sales 2025, with Q3 highest at 85"` or semantically equivalent; the chart label "Quarterly Sales 2025" is visible in the image).
+- **Tags** (exact): `["alt-relevance", "information-critical"]`.
+- **Evidence**: step index and screenshot filename for case iii.
+
+### Case iv — decorative (alt="")
+
+- **No `[alt-relevance]` signal expected.**
+- A signal here is the primary false-positive risk for this feature — the decorative-image sanity check §(h) must catch it before emit. If case iv produces an `[alt-relevance]` signal, the prompt has regressed and the run must be discarded.
+
+### Case v — figure + figcaption (ACCURATE)
+
+- **No `[alt-relevance]` signal expected.**
+- The accessible name comes from `<figcaption>` (since the `<img>` itself has `alt=""` — within a `<figure>` the figcaption is the accessible name per HTML spec). `"Tabby cat napping on a windowsill"` accurately describes the visible cat.
+
+### Case vi — aria-label on role="img" (ACCURATE)
+
+- **No `[alt-relevance]` signal expected.**
+- The accessible name comes from `aria-label` on a `<div role="img">`. `"Orange triangle warning icon"` accurately describes the visible CSS-rendered orange warning triangle.
+
+## Severity acceptance band
+
+Per the rubric, severity for INACCURATE cases is `medium` by default, escalated to `high` when the image is information-critical. Both `medium` and `high` are acceptable for case ii (a reviewer could reasonably classify a dog photo as information-critical on, say, a pet-adoption page); `low` is **not** correct for ii or iii because the alts are egregiously mismatched, not merely weaker-than-visible. For case iii, `high` is preferred (chart is clearly information-critical), but `medium` is an acceptable miss on the escalation rule — flag as a prompt-tuning item, not a regression.
+
+## Invariants across all cases
+
+- **Schema acceptance**: `hooks/scripts/validate-primitive-io.sh` must not reject the emitted `signal-report.yaml`. This fixture reuses the existing `a11y_violation` enum entry — no new signal type is introduced. The `tags` array in the schema is already unrestricted ([`schemas/signal-report.schema.yaml:47-50`](../../schemas/signal-report.schema.yaml#L47-L50)).
+- **Decorative-image hygiene**: case iv must never appear in the emitted signals with an `[alt-relevance]` tag. This is the primary false-positive risk.
+- **Cross-skill isolation**: `/ralph-playwright:explore` (not `a11y-scan`) run against the same URL must NOT emit any `[alt-relevance]` signals. The alt-text relevance prompt lives only in `a11y-scan`.
+- **Tag hygiene**: `[alt-relevance]` is always present on signals produced by this sub-procedure. `[information-critical]` is additive (only on severity-escalated signals).
+- **Signal count**: exactly two `[alt-relevance]` violations per run (cases ii and iii). Cases i, iv, v, vi must not contribute an `[alt-relevance]` signal.
+- **WCAG citation**: every `[alt-relevance]` signal's description must cite `WCAG 2.2 SC 1.1.1 Non-text Content (Level A)` verbatim. Missing or altered citations are a prompt-adherence regression.
+
+## Fixture asset policy
+
+All six images are small local SVGs (< 3 KB each) under [`img/`](img/). SVG chosen over raster PNG because:
+
+1. No binary blobs to commit.
+2. Offline-usable with zero external dependencies.
+3. Vision models can recognize simple SVG shapes reliably (the alt-relevance judgment does not depend on photo-realism — it depends on whether the model can tell a dog from a submit button, a bar chart from a weather map, and a warning triangle from a kitten).
+
+This matches the plan's Open Question 5 fallback ("If committing small PNG assets … conflicts with repo policies about binary files … the inline SVG approach removes the binary dependency").
+
+## Recording runbook results
+
+After a run, append your observations (emitted signals, severity, timing, any false positives on case iv) to the end of this file under a dated subheading, or capture them in `.playwright-cli/<session>/signal-report.yaml` plus a short pilot note in `thoughts/shared/research/` per the "Act" step's research-note convention. If the run emits an `[alt-relevance]` signal for case iv, treat it as a high-priority prompt-tuning follow-up.
+
+## Related
+
+- Skill: [`plugin/ralph-playwright/skills/a11y-scan/SKILL.md`](../../skills/a11y-scan/SKILL.md)
+- Fixture index: [`../README.md`](../README.md) (once GH-788 ships the shared fixture index)
+- Issue: [GH-789](https://github.com/cdubiel08/ralph-hero/issues/789)
+- Parent plan: [`thoughts/shared/plans/2026-04-20-GH-0789-ralph-playwright-alt-text-relevance-validation.md`](../../../../thoughts/shared/plans/2026-04-20-GH-0789-ralph-playwright-alt-text-relevance-validation.md)
+- Parent epic: [GH-784](https://github.com/cdubiel08/ralph-hero/issues/784)
+- Sibling fixture: [GH-788 low-contrast](https://github.com/cdubiel08/ralph-hero/issues/788)
+- WCAG 2.2 SC 1.1.1 (Non-text Content — Level A): https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html

--- a/plugin/ralph-playwright/fixtures/alt-relevance/img/cat.svg
+++ b/plugin/ralph-playwright/fixtures/alt-relevance/img/cat.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <title>Tabby cat napping on a windowsill</title>
+  <desc>A simplified illustration of a tabby cat curled up on a sunny windowsill with a window view behind it.</desc>
+
+  <!-- Window sky / outside -->
+  <rect x="0" y="0" width="200" height="140" fill="#b9d9ea"/>
+
+  <!-- Distant hill outside window -->
+  <ellipse cx="60" cy="150" rx="80" ry="30" fill="#7fa55c"/>
+  <ellipse cx="150" cy="155" rx="70" ry="25" fill="#6c9150"/>
+
+  <!-- Sun -->
+  <circle cx="160" cy="40" r="18" fill="#f7d86a"/>
+
+  <!-- Window frame (vertical mullion) -->
+  <rect x="95" y="0" width="6" height="140" fill="#5a4632"/>
+  <!-- Window frame (horizontal mullion at top of windowsill) -->
+  <rect x="0" y="136" width="200" height="4" fill="#5a4632"/>
+
+  <!-- Windowsill (wooden) -->
+  <rect x="0" y="140" width="200" height="60" fill="#a67b4c"/>
+  <line x1="0" y1="155" x2="200" y2="155" stroke="#7c5a34" stroke-width="1"/>
+
+  <!-- Cat body (curled up) -->
+  <ellipse cx="100" cy="160" rx="55" ry="20" fill="#c49a6c"/>
+
+  <!-- Cat stripes on body -->
+  <path d="M 60 156 Q 70 150 80 156" stroke="#6b4a2b" stroke-width="2" fill="none"/>
+  <path d="M 85 152 Q 95 146 105 152" stroke="#6b4a2b" stroke-width="2" fill="none"/>
+  <path d="M 110 152 Q 120 146 130 152" stroke="#6b4a2b" stroke-width="2" fill="none"/>
+  <path d="M 135 156 Q 145 150 155 156" stroke="#6b4a2b" stroke-width="2" fill="none"/>
+
+  <!-- Cat head (on right side of body, tucked) -->
+  <circle cx="150" cy="152" r="16" fill="#d4a87a"/>
+
+  <!-- Cat ears -->
+  <polygon points="140,142 144,128 150,142" fill="#c49a6c"/>
+  <polygon points="152,142 158,128 162,142" fill="#c49a6c"/>
+
+  <!-- Cat forehead stripes -->
+  <line x1="146" y1="144" x2="148" y2="140" stroke="#6b4a2b" stroke-width="1.5"/>
+  <line x1="150" y1="143" x2="152" y2="139" stroke="#6b4a2b" stroke-width="1.5"/>
+  <line x1="154" y1="144" x2="156" y2="140" stroke="#6b4a2b" stroke-width="1.5"/>
+
+  <!-- Cat eye (closed, napping) -->
+  <path d="M 144 152 Q 147 154 150 152" stroke="#2a1a0a" stroke-width="1.5" fill="none"/>
+
+  <!-- Cat nose & mouth -->
+  <ellipse cx="155" cy="156" rx="2" ry="1.5" fill="#8a5a4a"/>
+
+  <!-- Cat tail curled around body -->
+  <path d="M 55 162 Q 40 170 50 180 Q 65 180 70 170" stroke="#c49a6c" stroke-width="10" fill="none" stroke-linecap="round"/>
+</svg>

--- a/plugin/ralph-playwright/fixtures/alt-relevance/img/chart.svg
+++ b/plugin/ralph-playwright/fixtures/alt-relevance/img/chart.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+  <title>Quarterly sales bar chart</title>
+  <desc>A simple vertical bar chart showing four quarters of sales, with Q3 highest.</desc>
+
+  <!-- Chart area background -->
+  <rect x="0" y="0" width="300" height="200" fill="#ffffff" stroke="#333" stroke-width="1"/>
+
+  <!-- Chart title -->
+  <text x="150" y="18" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" fill="#222">Quarterly Sales 2025</text>
+
+  <!-- Y-axis -->
+  <line x1="40" y1="30" x2="40" y2="170" stroke="#555" stroke-width="1.5"/>
+  <!-- X-axis -->
+  <line x1="40" y1="170" x2="290" y2="170" stroke="#555" stroke-width="1.5"/>
+
+  <!-- Y-axis tick labels -->
+  <text x="32" y="172" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="end" fill="#444">0</text>
+  <text x="32" y="137" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="end" fill="#444">25</text>
+  <text x="32" y="102" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="end" fill="#444">50</text>
+  <text x="32" y="67" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="end" fill="#444">75</text>
+  <text x="32" y="35" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="end" fill="#444">100</text>
+
+  <!-- Gridlines -->
+  <line x1="40" y1="135" x2="290" y2="135" stroke="#eee" stroke-width="1"/>
+  <line x1="40" y1="100" x2="290" y2="100" stroke="#eee" stroke-width="1"/>
+  <line x1="40" y1="65" x2="290" y2="65" stroke="#eee" stroke-width="1"/>
+  <line x1="40" y1="33" x2="290" y2="33" stroke="#eee" stroke-width="1"/>
+
+  <!-- Bars (Q1: 40, Q2: 55, Q3: 85, Q4: 65) -->
+  <rect x="65" y="114" width="40" height="56" fill="#3a7ab8"/>
+  <rect x="120" y="93" width="40" height="77" fill="#3a7ab8"/>
+  <rect x="175" y="51" width="40" height="119" fill="#3a7ab8"/>
+  <rect x="230" y="79" width="40" height="91" fill="#3a7ab8"/>
+
+  <!-- Bar value labels -->
+  <text x="85" y="110" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">40</text>
+  <text x="140" y="89" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">55</text>
+  <text x="195" y="47" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">85</text>
+  <text x="250" y="75" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">65</text>
+
+  <!-- X-axis category labels -->
+  <text x="85" y="186" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">Q1</text>
+  <text x="140" y="186" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">Q2</text>
+  <text x="195" y="186" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">Q3</text>
+  <text x="250" y="186" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222">Q4</text>
+</svg>

--- a/plugin/ralph-playwright/fixtures/alt-relevance/img/divider.svg
+++ b/plugin/ralph-playwright/fixtures/alt-relevance/img/divider.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 4" width="300" height="4">
+  <title>Decorative horizontal divider</title>
+  <rect x="0" y="1" width="300" height="2" fill="#888888"/>
+</svg>

--- a/plugin/ralph-playwright/fixtures/alt-relevance/img/dog.svg
+++ b/plugin/ralph-playwright/fixtures/alt-relevance/img/dog.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <title>Golden retriever sitting on a wooden porch</title>
+  <desc>A simplified illustration of a golden-colored dog seated on brown wooden porch planks.</desc>
+
+  <!-- Sky / background -->
+  <rect x="0" y="0" width="200" height="130" fill="#cfe9f2"/>
+
+  <!-- Porch floor planks -->
+  <rect x="0" y="130" width="200" height="70" fill="#8b5a2b"/>
+  <line x1="0" y1="145" x2="200" y2="145" stroke="#6b4a1b" stroke-width="1"/>
+  <line x1="0" y1="165" x2="200" y2="165" stroke="#6b4a1b" stroke-width="1"/>
+  <line x1="0" y1="185" x2="200" y2="185" stroke="#6b4a1b" stroke-width="1"/>
+
+  <!-- Porch railing post (left) -->
+  <rect x="12" y="40" width="10" height="100" fill="#a67b4c"/>
+  <!-- Porch railing post (right) -->
+  <rect x="178" y="40" width="10" height="100" fill="#a67b4c"/>
+
+  <!-- Dog body (sitting) -->
+  <ellipse cx="100" cy="155" rx="45" ry="28" fill="#e3b663"/>
+
+  <!-- Dog front legs -->
+  <rect x="80" y="150" width="12" height="35" rx="4" fill="#e3b663"/>
+  <rect x="108" y="150" width="12" height="35" rx="4" fill="#e3b663"/>
+
+  <!-- Dog tail -->
+  <path d="M 140 140 Q 160 120 150 100" stroke="#c99a4a" stroke-width="10" fill="none" stroke-linecap="round"/>
+
+  <!-- Dog head -->
+  <ellipse cx="100" cy="108" rx="28" ry="26" fill="#e8c278"/>
+
+  <!-- Dog snout -->
+  <ellipse cx="100" cy="120" rx="14" ry="9" fill="#d9af5d"/>
+
+  <!-- Dog nose -->
+  <ellipse cx="100" cy="117" rx="4" ry="3" fill="#2a1a0a"/>
+
+  <!-- Dog eyes -->
+  <circle cx="91" cy="104" r="2.5" fill="#2a1a0a"/>
+  <circle cx="109" cy="104" r="2.5" fill="#2a1a0a"/>
+
+  <!-- Dog ears (floppy) -->
+  <path d="M 76 92 Q 68 102 74 120 L 84 114 Z" fill="#c99a4a"/>
+  <path d="M 124 92 Q 132 102 126 120 L 116 114 Z" fill="#c99a4a"/>
+
+  <!-- Dog tongue (small pink) -->
+  <ellipse cx="100" cy="126" rx="3" ry="2" fill="#d47070"/>
+</svg>

--- a/plugin/ralph-playwright/fixtures/alt-relevance/index.html
+++ b/plugin/ralph-playwright/fixtures/alt-relevance/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>alt-relevance fixture — ralph-playwright</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      max-width: 720px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      color: #222;
+      background: #fff;
+    }
+    h1 {
+      font-size: 1.5rem;
+      border-bottom: 2px solid #ddd;
+      padding-bottom: 0.5rem;
+    }
+    section {
+      margin: 2rem 0;
+      padding: 1rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+    section h2 {
+      font-size: 1.1rem;
+      margin-top: 0;
+    }
+    section p.caption {
+      color: #555;
+      font-size: 0.9rem;
+      margin-top: 0.25rem;
+    }
+    section img,
+    section figure img,
+    section [role="img"] {
+      display: block;
+      margin: 0.5rem 0;
+    }
+    figure {
+      margin: 0.5rem 0;
+    }
+    figcaption {
+      font-size: 0.9rem;
+      color: #444;
+      margin-top: 0.25rem;
+    }
+    .divider {
+      width: 300px;
+      height: 4px;
+      background: #888;
+      margin: 1rem 0;
+    }
+    .triangle-icon {
+      width: 120px;
+      height: 104px;
+      background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 104'><polygon points='60,8 116,96 4,96' fill='%23ff8800' stroke='%23cc6600' stroke-width='3'/><rect x='55' y='40' width='10' height='30' fill='%23222'/><circle cx='60' cy='82' r='5' fill='%23222'/></svg>") no-repeat center / contain;
+    }
+  </style>
+</head>
+<body>
+  <h1>alt-relevance fixture</h1>
+
+  <p>
+    Static fixture exercising the alt-text relevance sub-procedure in
+    <a href="../../skills/a11y-scan/SKILL.md"><code>skills/a11y-scan/SKILL.md</code></a>.
+    See <a href="README.md">README.md</a> for the expected-signal oracle.
+  </p>
+
+  <section data-alt-relevance-case="i">
+    <h2>Case i — good alt (ACCURATE)</h2>
+    <p class="caption">Image depicts a golden retriever sitting on a porch. Alt text matches. Expected: no signal.</p>
+    <img
+      src="img/dog.svg"
+      alt="Golden retriever sitting on a porch"
+      width="200"
+      height="200">
+  </section>
+
+  <section data-alt-relevance-case="ii">
+    <h2>Case ii — bad alt (INACCURATE)</h2>
+    <p class="caption">Same dog image, wildly unrelated alt text. Expected: one a11y_violation tagged [alt-relevance].</p>
+    <img
+      src="img/dog.svg"
+      alt="Red Submit button"
+      width="200"
+      height="200">
+  </section>
+
+  <section data-alt-relevance-case="iii">
+    <h2>Case iii — misleading alt (INACCURATE)</h2>
+    <p class="caption">A sales bar chart with "Weather forecast" alt text. Information-critical image (chart). Expected: one a11y_violation tagged [alt-relevance, information-critical].</p>
+    <img
+      src="img/chart.svg"
+      alt="Weather forecast"
+      width="300"
+      height="200">
+  </section>
+
+  <section data-alt-relevance-case="iv">
+    <h2>Case iv — decorative (alt="" — SKIP)</h2>
+    <p class="caption">Thin decorative horizontal rule. Author marked decorative with empty alt. Expected: no signal.</p>
+    <img
+      src="img/divider.svg"
+      alt=""
+      width="300"
+      height="4">
+  </section>
+
+  <section data-alt-relevance-case="v">
+    <h2>Case v — figure + figcaption (ACCURATE)</h2>
+    <p class="caption">Cat on a windowsill; accessible name comes from figcaption. Alt text matches. Expected: no signal.</p>
+    <figure>
+      <img
+        src="img/cat.svg"
+        width="200"
+        height="200"
+        alt="">
+      <figcaption>Tabby cat napping on a windowsill</figcaption>
+    </figure>
+  </section>
+
+  <section data-alt-relevance-case="vi">
+    <h2>Case vi — aria-label on role="img" (ACCURATE)</h2>
+    <p class="caption">CSS-rendered orange warning triangle. Accessible name via aria-label on role="img". Expected: no signal.</p>
+    <div
+      class="triangle-icon"
+      role="img"
+      aria-label="Orange triangle warning icon"></div>
+  </section>
+
+</body>
+</html>

--- a/plugin/ralph-playwright/skills/a11y-scan/SKILL.md
+++ b/plugin/ralph-playwright/skills/a11y-scan/SKILL.md
@@ -37,8 +37,67 @@ Read the journey trace. For each step, examine the accessibility snapshot (`.md`
 - **Missing ARIA**: Interactive components without `role`, `aria-expanded`, `aria-describedby` etc.
 - **Heading hierarchy**: Skipped levels (h1 → h3), missing h1, multiple h1s
 - **Color contrast**: Text against background ratios below 4.5:1 (normal) or 3:1 (large)
-- **Missing alt text**: Images without `alt` attribute
+- **Missing alt text**: Images without `alt` attribute (existence check — presence-only; the presence-but-wrong case is handled by the next bullet)
+- **Alt-text relevance (screenshot-grounded)**: For each image with a non-empty accessible name, cross-reference the author-provided text against the actual visible content in the step's screenshot PNG. Flag mismatches per the sub-procedure below. Decorative images (`alt=""`) are explicitly compliant and must be skipped.
 - **Focus management**: Modals/dialogs that don't trap focus, focus not returned on close
+
+#### Alt-text relevance sub-procedure (screenshot-grounded)
+
+The existence check above catches missing `alt`; this sub-procedure catches the distinct failure mode where the author supplied an accessible name that does not describe what the image actually depicts. This is WCAG 2.2 SC 1.1.1 Non-text Content (Level A). The accessibility snapshot (`.md`) reports alt text verbatim (e.g., `- img "alt text here" [ref=eXX]`), but has no rendered-pixel information; the step's screenshot PNG is the authoritative record of what the sighted user sees. Opus 4.7 (or a comparably vision-capable model) is the target interlocutor — see `## Reflect model notes` below.
+
+**(a) What to enumerate.** For each image reference in the accessibility snapshot with a non-empty accessible name, derived in this priority order:
+
+1. `alt` attribute on `<img>` (non-empty string).
+2. `aria-label` on `<img>` or on any element with `role="img"`.
+3. `<figcaption>` text within an enclosing `<figure>` element.
+4. `aria-labelledby` target text (resolve the referenced element's text content).
+
+If none of the above provide a non-empty name, the image falls through to the existence check (missing alt text) and is not enumerated here.
+
+**(b) What to skip.**
+
+- **If the alt attribute is present but empty (`alt=""`), the image is marked as decorative by the author. Do NOT flag. Skip to the next image.** This is the WCAG-recommended pattern for purely presentational images — flagging it would be a false positive.
+- Images with `aria-hidden="true"` — hidden from assistive technology by the author, out of scope for alt-relevance.
+- Images that are off-screen / not visible in the captured screenshot (dynamically rendered, lazy-loaded, below the fold at capture time). No pixels to judge against.
+- `<svg>` elements — their accessible name comes from `<title>` / `aria-label`; relevance scoring against rendered pixels is materially harder and is deferred to a future feature.
+- CSS `background-image` regions — not `<img>` elements and typically decorative; out of scope.
+
+**(c) The relevance judgment.** For each image with a non-empty accessible name, locate the image in the step's screenshot PNG and judge whether the accessible name accurately describes what is visible. You are reading the same screenshot the sighted user sees. Apply the rubric below.
+
+**(d) Rubric (three grades).**
+
+- **ACCURATE** — The accessible name captures the primary subject and intent of the image. Minor stylistic differences (e.g., "dog" vs "golden retriever") are acceptable as long as the core referent is correct.
+- **PARTIAL** — The accessible name is technically related but misses the key content or is overly generic (e.g., `alt="image"`, `alt="photo"`, `alt="picture of a thing"` on an image that carries specific information). A screen-reader user would receive weaker-than-visible information but not actively misleading information.
+- **INACCURATE** — The accessible name describes something not depicted in the image, or contradicts the image. A screen-reader user would be actively misled.
+
+**(e) Emit rules.**
+
+- ACCURATE -> no signal.
+- PARTIAL -> `a11y_violation` signal, severity `low`.
+- INACCURATE -> `a11y_violation` signal, severity `medium`.
+- If the image appears to convey information critical to page understanding (a chart, diagram, product photo on an e-commerce page, a data visualization, a safety or warning icon), escalate severity one step: PARTIAL -> `medium`, INACCURATE -> `high`.
+
+Reuse the existing `a11y_violation` signal type — do NOT invent a new signal-type enum value. This mirrors the `[pixel-computed]` pattern used by the contrast sub-checklist.
+
+**(f) Signal shape.** Each emitted signal:
+
+- `type`: `a11y_violation`.
+- `severity`: per the rubric in (e) above.
+- `title`: `"Alt-text mismatch: '<first 40 chars of accessible name>'"` (truncate with an ellipsis if the name is longer).
+- `description` must include the following, in this order:
+  - A one-line summary of the form: `Image depicts: <model's observation>. Author-provided alt/label: "<quoted text verbatim>". Relevance grade: <PARTIAL|INACCURATE>.`
+  - The source of the accessible name (e.g., `source=alt`, `source=aria-label`, `source=figcaption`, `source=aria-labelledby`).
+  - WCAG reference: `WCAG 2.2 SC 1.1.1 Non-text Content (Level A)`.
+  - Remediation guidance: "revise the accessible name to describe the visible subject" with one concrete suggestion derived from the model's observation (e.g., `suggested alt: "Golden retriever sitting on a porch"`).
+- `evidence.steps`: the step index where the image appeared in the journey trace.
+- `evidence.screenshots`: that step's screenshot filename.
+- `tags`: always include the literal string `alt-relevance`. Add `information-critical` when the severity was escalated per (e) above.
+
+**(g) Forward compatibility with bounding-box evidence.** If GH-790 bounding-box output is available (the `evidence.bboxes` field has been added and populated by a predecessor step), populate `evidence.bboxes` with the image's bounding rectangle in the screenshot. If not available, omit the field. Do not fabricate coordinates.
+
+**(h) Decorative-image sanity check (do before every run).** Before emitting any `[alt-relevance]` signals, verify that every image whose `alt` attribute is present and empty (`alt=""`) was skipped. If any `alt=""` image appears in the emitted signals, the prompt has regressed and the run must be discarded — decorative-image over-flagging is the primary false-positive risk for this feature.
+
+This sub-procedure lives alongside the other a11y-scan reflect heuristics; it does not shadow or short-circuit the existing "Missing alt text" existence check. An image that is both missing `alt` entirely AND has a misleading `aria-label` will surface two independent signals (one from the existence check, one from this sub-procedure).
 
 Classify all findings as `a11y_violation` signals with WCAG success criteria references.
 
@@ -68,3 +127,9 @@ WCAG 2.2 AA | playwright-cli | N violations
 
 Actions: N issues created, N screenshots promoted
 ```
+
+## Verification fixtures
+
+Known-shape fixtures for piloting this skill after prompt changes:
+
+- [`plugin/ralph-playwright/fixtures/alt-relevance/`](../../fixtures/alt-relevance/README.md) — six cases (good / bad / misleading / decorative / figcaption / aria-label) exercising the alt-text relevance sub-procedure. Expected-signal oracle documents the `[alt-relevance]` signals a correctly-configured run should emit.

--- a/thoughts/shared/plans/2026-04-20-GH-0789-ralph-playwright-alt-text-relevance-validation.md
+++ b/thoughts/shared/plans/2026-04-20-GH-0789-ralph-playwright-alt-text-relevance-validation.md
@@ -195,8 +195,8 @@ Extend the a11y-scan reflect phase with a screenshot-grounded alt-text relevance
 
 ralph-playwright is skills/agents-only — there is no build/test matrix for the plugin itself. The only automated gate that applies is the artifact validator:
 
-- [ ] `bash plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh` accepts the generated `signal-report.yaml` from Task 1.3 (invoked indirectly by the write hook; confirmed by hook-success log line).
-- [ ] `yq '.' plugin/ralph-playwright/skills/a11y-scan/SKILL.md` parses the front-matter YAML without error.
+- [x] `bash plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh` accepts the generated `signal-report.yaml` from Task 1.3 (invoked indirectly by the write hook; confirmed by hook-success log line). Verified at implementation time with a sample signal-report matching the README oracle — `type=a11y_violation` passes the enum check and `tags=["alt-relevance"]` passes the unrestricted-string-array check. Validator exit 0.
+- [x] `yq '.' plugin/ralph-playwright/skills/a11y-scan/SKILL.md` parses the front-matter YAML without error.
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

- Extends [`plugin/ralph-playwright/skills/a11y-scan/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-playwright/skills/a11y-scan/SKILL.md) Step 2 Reflect with a screenshot-grounded alt-text relevance sub-procedure. Covers all four accessible-name sources (`alt`, `aria-label`, `<figcaption>`, `aria-labelledby`), applies an ACCURATE / PARTIAL / INACCURATE rubric, and emits `a11y_violation` signals tagged `[alt-relevance]` for mismatches. Decorative images (`alt=""`) are explicitly compliant and must be skipped (verbatim sentence from the plan).
- Introduces [`plugin/ralph-playwright/fixtures/alt-relevance/`](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-789/plugin/ralph-playwright/fixtures/alt-relevance/) with six labeled cases (good / bad / misleading / decorative / figcaption / aria-label) and an expected-signal README oracle. Uses local inline SVG assets (< 3 KB each, no binaries) so the fixture is offline-usable.
- Reuses the existing `a11y_violation` signal-type enum value with a new `[alt-relevance]` tag — **zero changes** to [`schemas/signal-report.schema.yaml`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-playwright/schemas/signal-report.schema.yaml) and [`hooks/scripts/validate-primitive-io.sh`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh). Mirrors the `[pixel-computed]` pattern used by sibling [#788](https://github.com/cdubiel08/ralph-hero/issues/788) (PR [#828](https://github.com/cdubiel08/ralph-hero/pull/828)).

Closes #789.

## Details

[`skills/a11y-scan/SKILL.md:40`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-playwright/skills/a11y-scan/SKILL.md#L40) previously had only a presence-check for alt text (`Images without alt attribute`). This was insufficient: an image with `alt="Submit button"` over a photograph of a dog passed the check despite the alt being wrong. The new sub-procedure adds a distinct branch for the presence-but-wrong case, cross-referencing the accessible name against the step's screenshot PNG.

### Signal shape (no schema change)

- `type: a11y_violation` (existing enum — **not** a new type).
- `severity`: `low` for PARTIAL, `medium` for INACCURATE, escalated one step to `medium` / `high` when the image is information-critical (chart, diagram, product photo, warning icon).
- `description` cites `WCAG 2.2 SC 1.1.1 Non-text Content (Level A)` verbatim and includes the image observation, author-provided alt/label, source type (alt / aria-label / figcaption / aria-labelledby), and a concrete remediation suggestion.
- `tags` always includes `alt-relevance`. `information-critical` is additive on escalated signals.

### Decorative-image exemption

Explicit sanity check in §(h) of the sub-procedure: before emitting any `[alt-relevance]` signals, verify that every image whose `alt` attribute is present and empty (`alt=""`) was skipped. This is the primary false-positive risk and is called out in three places: shared constraints, the sub-procedure's (b) "What to skip" block, and the fixture case iv.

### Fixture cases

| Case | Selector | Element | Accessible name source | Accessible name | Expected |
|------|----------|---------|-------------------------|-----------------|----------|
| i | `[data-alt-relevance-case="i"] img` | `<img>` | `alt` | Golden retriever sitting on a porch | none |
| ii | `[data-alt-relevance-case="ii"] img` | `<img>` | `alt` | Red Submit button (dog image) | `a11y_violation` severity `medium`, `[alt-relevance]` |
| iii | `[data-alt-relevance-case="iii"] img` | `<img>` | `alt` | Weather forecast (sales chart) | `a11y_violation` severity `high`, `[alt-relevance, information-critical]` |
| iv | `[data-alt-relevance-case="iv"] img` | `<img>` | `alt=""` | (decorative) | none |
| v | `[data-alt-relevance-case="v"] figure` | `<figcaption>` | `figcaption` | Tabby cat napping on a windowsill | none |
| vi | `[data-alt-relevance-case="vi"] [role="img"]` | `<div role="img">` | `aria-label` | Orange triangle warning icon | none |

See [`fixtures/alt-relevance/README.md`](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-789/plugin/ralph-playwright/fixtures/alt-relevance/README.md) for the full oracle, including severity acceptance bands, false-positive risks, and the `python3 -m http.server` runbook.

### Forward compatibility with [#790](https://github.com/cdubiel08/ralph-hero/issues/790)

Sub-procedure §(g) instructs opportunistic population of `evidence.bboxes` if GH-790 bounding-box output is available, otherwise omit. One-line amendment if the field name differs when #790 ships.

## Test plan

- [x] `yq .` parses `plugin/ralph-playwright/skills/a11y-scan/SKILL.md` frontmatter without error (verified at commit time).
- [x] `plugin/ralph-playwright/hooks/scripts/validate-primitive-io.sh` accepts a sample `signal-report.yaml` matching the README oracle — `type=a11y_violation` passes the enum check, `tags=["alt-relevance"]` passes the unrestricted-string-array check (exit 0 verified).
- [x] Worktree-scoped diff touches only SKILL.md, the new fixtures directory, and the plan checkbox update — no schema or hook touches.
- [x] All four SVG fixture assets parse as valid XML; `index.html` parses cleanly; total fixture asset weight < 8 KB.
- [x] Six `data-alt-relevance-case` sections present in fixture HTML (grep-verified).
- [ ] Runtime pilot: invoke `/ralph-playwright:a11y-scan http://localhost:8766/` against the fixture and confirm cases ii and iii produce `[alt-relevance]` signals matching the README oracle (severity within the documented acceptance band, WCAG 1.1.1 cited verbatim, case iv NOT flagged). Documented in the fixture README runbook.
- [ ] Cross-skill isolation: `/ralph-playwright:explore` against the same URL must emit zero `[alt-relevance]` signals. The alt-text relevance prompt lives only in `a11y-scan`.
- [ ] Real-app smoke: run a11y-scan against at least one real application page with `alt=""` spacer images to confirm no regression on decorative-image handling.

## Non-goals (per plan)

- No new signal-type enum value (mirrors [#788](https://github.com/cdubiel08/ralph-hero/issues/788) pattern — `a11y_violation` with `[alt-relevance]` tag).
- No schema change to [`signal-report.schema.yaml`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-playwright/schemas/signal-report.schema.yaml). The tags array is already unrestricted (`items: type: string`).
- No hook change. The validator checks `signals[].type` and `signals[].severity` against enums; neither is affected by this change.
- No new skill. This is a reflect-step addition inside existing `a11y-scan`.
- No SVG / CSS-background / hidden-image coverage. Deferred to future features.
- No pixel-contrast coverage. That is [#788](https://github.com/cdubiel08/ralph-hero/issues/788). Orthogonal.
- No bounding-box schema change. That is [#790](https://github.com/cdubiel08/ralph-hero/issues/790). Forward-compat hook in §(g) only.
- No model-routing change. Reflect-phase Opus 4.7 routing is [#785](https://github.com/cdubiel08/ralph-hero/issues/785); this sub-procedure degrades gracefully under Sonnet (hex-in-description pattern mirrors #788).

## References

- Plan: [`thoughts/shared/plans/2026-04-20-GH-0789-ralph-playwright-alt-text-relevance-validation.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-20-GH-0789-ralph-playwright-alt-text-relevance-validation.md)
- Parent plan-of-plans: [#784](https://github.com/cdubiel08/ralph-hero/issues/784)
- Sibling feature: [#788 pixel contrast](https://github.com/cdubiel08/ralph-hero/issues/788) (PR [#828](https://github.com/cdubiel08/ralph-hero/pull/828)) — shipped the fixture directory convention
- WCAG 2.2 SC 1.1.1 (Non-text Content — Level A): https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html

Generated with [Claude Code](https://claude.com/claude-code)