### PR TITLE
feat(ralph-playwright): vision-grounded sad-path inference for story-gen (GH-796)

### DIFF
--- a/plugin/ralph-playwright/schemas/example-vision-sad-paths.yaml
+++ b/plugin/ralph-playwright/schemas/example-vision-sad-paths.yaml
@@ -1,0 +1,59 @@
+# Example vision-inferred sad paths output (pre-merge, pre-review shape).
+# Demonstrates three of the four named detection categories, with both
+# bbox and description forms of `evidence.bbox_or_description`.
+#
+# This file is a sibling illustration to example-auth.yaml. It does NOT
+# replace any existing example; it shows the `inferred_sad_paths:` section
+# shape produced by the vision step before the user-review gate prunes it
+# and merges kept entries into the final stories YAML.
+
+inferred_sad_paths:
+  - category: missing_validation_hint
+    evidence:
+      screenshot_path: "fixtures/01-form-no-validation-hints.png"
+      bbox_or_description: "Email and Password input fields at top of login form — no asterisks, no helper text, no placeholder format hints visible"
+      rationale: "Users cannot determine whether fields are required or what format is expected before submitting the form."
+    proposed_story:
+      name: "Login form exposes required and format expectations before submit"
+      type: sad
+      url: "http://localhost:3000/login"
+      workflow: |
+        Navigate to http://localhost:3000/login
+        Observe the Email and Password field labels and nearby text
+        Verify at least one of: asterisk marker, "Required" text, or helper text describing expected format is visible
+        (Expected: guidance present; observed in fixture: none visible)
+    source: "vision"
+
+  - category: missing_error_handler
+    evidence:
+      screenshot_path: "fixtures/01-form-no-validation-hints.png"
+      bbox_or_description: "{x: 180, y: 320, w: 420, h: 60}"
+      rationale: "No visible error-surfacing container exists between the form fields and the submit button; server-side errors have no obvious render target."
+    proposed_story:
+      name: "Login form surfaces server-side authentication errors in a visible container"
+      type: sad
+      url: "http://localhost:3000/login"
+      workflow: |
+        Navigate to http://localhost:3000/login
+        Fill Email with "test@example.com"
+        Fill Password with "wrong-password"
+        Click the Sign In button
+        Verify a visible error message appears (role=alert, red-bordered container, or inline error text)
+        (Expected: error visible; observed in fixture: no container appears to exist)
+    source: "vision"
+
+  - category: empty_state_gap
+    evidence:
+      screenshot_path: "fixtures/02-list-no-empty-state.png"
+      bbox_or_description: "Dashboard activity list region, center of viewport — table header rendered with column labels but no body rows and no empty-state message, illustration, or populate-CTA below"
+      rationale: "First-time users and users with filters that exclude all rows see only an empty table with no guidance on how to populate it."
+    proposed_story:
+      name: "Activity list shows an empty-state message when no items exist"
+      type: sad
+      url: "http://localhost:3000/dashboard"
+      workflow: |
+        Navigate to http://localhost:3000/dashboard as a first-time user (no activity yet)
+        Locate the activity list region
+        Verify an empty-state message, illustration, or "Add your first item" CTA is visible
+        (Expected: empty-state UI present; observed in fixture: blank table body)
+    source: "vision"

--- a/plugin/ralph-playwright/skills/story-gen/SKILL.md
+++ b/plugin/ralph-playwright/skills/story-gen/SKILL.md
@@ -52,6 +52,57 @@ Produce stories in these categories:
 - Too many attempts / rate limited → throttle message
 - Network error mid-flow → graceful error, no data loss (if applicable)
 
+**Vision-grounded sad paths (optional, opt-in)** — fired only when the user passes `--vision-sad-paths` or a natural-language equivalent ("generate vision sad paths", "inspect the UI for sad paths"). When absent, behavior is identical to pre-merge: only the 8 heuristics above run. This step is **additive** — it augments, never replaces, the heuristic pipeline.
+
+**Input requirements** — at least one screenshot path is required. Screenshots may come from:
+- A user-supplied path (manual mode): single PNG or a directory of PNGs, absolute or repo-relative
+- A prior session's journey trace: the user points at `.playwright-cli/<session>/`
+- The explorer-agent journey trace auto-feed (URL mode — see Step 0 for auto-pickup semantics)
+
+**Execution steps:**
+1. Read the prompt at `plugin/ralph-playwright/skills/story-gen/prompts/sad-path-vision.md`
+2. For each input screenshot, invoke the prompt with the screenshot as vision input (Opus 4.7 multi-image batching is acceptable — a single call per screenshot keeps cost bounded and makes per-fixture attribution clean)
+3. Collect structured output conforming to the `inferred_sad_paths:` shape (see `plugin/ralph-playwright/schemas/example-vision-sad-paths.yaml`)
+4. Tag each vision entry internally with `source: vision` (already in the prompt output)
+5. Tag the existing 8-heuristic entries internally with `source: heuristic` (added pre-merge)
+6. Merge both sets into a single review list
+
+**User-review gate (between generation and YAML write):**
+- Present the merged list with per-entry metadata: `[source: vision | heuristic]`, category, `proposed_story.name`
+- Offer three actions: **keep-all**, **drop-all**, **per-entry** (default)
+- Per-entry mode: prompt y/n for each candidate
+- Only kept entries proceed to the YAML write in Step 3
+
+**YAML-output behavior:**
+- Heuristic-kept entries write exactly as today (unchanged shape under `stories:`)
+- Vision-kept entries write under `stories:` with the same canonical shape (`name`, `type: sad`, `url`, `workflow`, `persona`, `tags`)
+- The `source: vision` provenance is preserved as a YAML comment above each vision-derived story, e.g. `# source: vision (category: empty_state_gap)` — does NOT break parsers; gives humans attribution
+
+**Worked example** (manual mode):
+
+Input: `--screenshots fixtures/01-form-no-validation-hints.png` against a description "login page at http://localhost:3000/login".
+
+Vision output (2 entries):
+```yaml
+inferred_sad_paths:
+  - category: missing_validation_hint
+    proposed_story:
+      name: "Login form exposes required/format expectations before submit"
+      ...
+  - category: missing_error_handler
+    proposed_story:
+      name: "Login form surfaces server-side auth errors in a visible container"
+      ...
+```
+
+Heuristic output: the 8 heuristics applied to `http://localhost:3000/login` (required-field-empty, wrong-credentials, rate-limited, unauthenticated-redirect, etc.).
+
+Merged review list (10 candidates) presented to the user. User keeps 5 (3 heuristic + 2 vision). Final YAML has 5 `stories:` entries; the 2 vision-derived entries carry `# source: vision (category: ...)` YAML comments.
+
+**Cost note**: In URL mode, Step 0's filter heuristic restricts screenshot volume (see Step 0). In manual mode, the user controls input volume directly.
+
+**When to use**: prefer vision mode when you have actually seen the target UI and want sad paths grounded in its current rendering. Prefer heuristics-only when generating baseline stories from a description alone (no UI rendered yet).
+
 **Edge paths** — include at minimum:
 - Empty/zero state (no items, first-time user)
 - Maximum/boundary input values

--- a/plugin/ralph-playwright/skills/story-gen/SKILL.md
+++ b/plugin/ralph-playwright/skills/story-gen/SKILL.md
@@ -147,3 +147,5 @@ Persona is optional but recommended.
 Show the generated file path and count:
 - N happy paths, N sad paths, N edge paths
 - Ask: any missing cases? Should we run them now? (`/ralph-playwright:test-e2e`)
+
+**Testing**: see `fixtures/TESTING.md` for fixture-based confidence tests of the vision sad-path step.

--- a/plugin/ralph-playwright/skills/story-gen/SKILL.md
+++ b/plugin/ralph-playwright/skills/story-gen/SKILL.md
@@ -27,6 +27,35 @@ If a running app URL is available and the user wants stories generated from obse
 
 This produces more accurate stories because the agent observes actual UI elements, form fields, and navigation paths rather than inferring them from a description.
 
+**Auto-feed screenshots into vision sad-paths (when `--vision-sad-paths` is also active):**
+
+When both URL mode (Step 0) and `--vision-sad-paths` (Step 2) are active, the screenshots referenced by `steps[].screenshot` in `.playwright-cli/<session>/journey-trace.yaml` auto-feed the vision step — the user does not need to supply screenshots manually. See Step 2 → "Vision-grounded sad paths" for the full invocation semantics.
+
+**Filter heuristic (deterministic, applied before vision calls to bound cost):**
+
+Apply these rules in order. Each rule is independent; a step matching any rule is included.
+
+1. **Include** any step where `outcome == "fail"` — failures are always interesting for sad-path analysis.
+2. **Include** any step where `action == "navigate"` AND the resolved URL is a first-visit (captures initial-state screenshots of each distinct page).
+3. **Include** any step where `action` is `fill` or `click` AND the `target` string contains any of these keywords (case-insensitive): `form`, `submit`, `login`, `sign`, `search`, `filter`, `cart`, `checkout`, `list`, `table`, `empty`, `error`.
+4. **Exclude** steps where `action == "verify"` (verification steps rarely add new visual state).
+5. **Exclude** steps whose screenshot path does not resolve to a readable PNG on disk (broken references).
+
+**Cap**: the filtered set is capped at **8 screenshots maximum**. If more than 8 match, prioritize in this order: (a) all fail-outcome steps, (b) all first-visit navigates, (c) distribute remaining budget across keyword matches (earliest steps first).
+
+**Overrides:**
+- `--all-screenshots` (or natural-language equivalent): disables the filter AND the 8-cap; feeds every screenshot in the trace to vision.
+- `--screenshots <path1>,<path2>,...`: bypasses the filter entirely and uses the user's explicit list. The manual-path code path from Step 2 remains unchanged.
+
+**Filter worked example** — a 15-step journey trace with: step 0 navigate `/login`, step 3 navigate `/dashboard`, step 5 click `search-filter-button`, step 7 fail submit, step 12 fill `checkout-email`. The filter yields 5 screenshots (fail at 7, first-visit navigates at 0 and 3, keyword matches at 5 and 12). The vision step runs 5 times.
+
+**Graceful-fallback paths:**
+- **Zero usable screenshots** (filter yields none AND no manual paths supplied): log a one-line note ("Skipped vision sad-path inference — no suitable screenshots found") and continue with heuristics-only sad-path generation. The `story-gen` run succeeds.
+- **Broken screenshot reference** (path does not resolve on disk): log a one-line warning ("screenshot not found: <path>, skipping") and continue with the remaining screenshots. If ALL references are broken, fall back to the zero-screenshot case.
+- **Manual-path preservation**: when the user supplies explicit screenshots via `--screenshots`, the filter heuristic is NOT applied; the user's list is used verbatim.
+
+This Step 0 extension is strictly **additive**. The manual-screenshot-path code path documented in Step 2 continues to work unchanged; URL mode simply adds an auto-discovery convenience on top.
+
 ### Step 1: Gather input
 Ask for (or use provided arguments):
 - Feature or page description (minimum 1-2 sentences)

--- a/plugin/ralph-playwright/skills/story-gen/fixtures/01-form-no-validation-hints.svg
+++ b/plugin/ralph-playwright/skills/story-gen/fixtures/01-form-no-validation-hints.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture 01: form with NO validation hints.
+  Primary category: missing_validation_hint
+  Secondary (plausible): missing_error_handler (no error container between fields and Sign In)
+
+  Rendered state: a login form with two input fields (Email, Password) showing
+  plain labels with no asterisk, no helper text, no placeholder format hint,
+  and no visible error-surfacing container below them.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="768" viewBox="0 0 1024 768">
+  <rect width="1024" height="768" fill="#f5f6f8"/>
+
+  <!-- Top nav bar -->
+  <rect x="0" y="0" width="1024" height="56" fill="#ffffff"/>
+  <text x="32" y="36" font-family="Inter, sans-serif" font-size="18" fill="#111827" font-weight="600">Acme App</text>
+
+  <!-- Centered login card -->
+  <rect x="312" y="160" width="400" height="420" fill="#ffffff" stroke="#e5e7eb" stroke-width="1" rx="8"/>
+
+  <!-- Card heading -->
+  <text x="512" y="210" font-family="Inter, sans-serif" font-size="22" fill="#111827" text-anchor="middle" font-weight="600">Sign in</text>
+
+  <!-- Email label — NO asterisk, NO helper text -->
+  <text x="344" y="272" font-family="Inter, sans-serif" font-size="14" fill="#374151">Email</text>
+  <rect x="344" y="284" width="336" height="44" fill="#ffffff" stroke="#d1d5db" stroke-width="1" rx="6"/>
+
+  <!-- Password label — NO asterisk, NO helper text, NO format hint -->
+  <text x="344" y="360" font-family="Inter, sans-serif" font-size="14" fill="#374151">Password</text>
+  <rect x="344" y="372" width="336" height="44" fill="#ffffff" stroke="#d1d5db" stroke-width="1" rx="6"/>
+
+  <!-- Gap region: where an error container would go, but NOTHING is rendered -->
+  <!-- (Intentionally blank from y=420 to y=472) -->
+
+  <!-- Submit button -->
+  <rect x="344" y="472" width="336" height="44" fill="#2563eb" rx="6"/>
+  <text x="512" y="501" font-family="Inter, sans-serif" font-size="15" fill="#ffffff" text-anchor="middle" font-weight="500">Sign In</text>
+
+  <!-- Footer link -->
+  <text x="512" y="548" font-family="Inter, sans-serif" font-size="13" fill="#6b7280" text-anchor="middle">Forgot password?</text>
+</svg>

--- a/plugin/ralph-playwright/skills/story-gen/fixtures/02-list-no-empty-state.svg
+++ b/plugin/ralph-playwright/skills/story-gen/fixtures/02-list-no-empty-state.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture 02: table / list UI rendered with zero items and NO empty-state message.
+  Primary category: empty_state_gap
+
+  Rendered state: a dashboard with a table header ("Name", "Status", "Updated")
+  but no rows in the body, and no empty-state text, illustration, or CTA
+  telling the user how to populate the list.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="768" viewBox="0 0 1024 768">
+  <rect width="1024" height="768" fill="#f5f6f8"/>
+
+  <!-- Top nav -->
+  <rect x="0" y="0" width="1024" height="56" fill="#ffffff"/>
+  <text x="32" y="36" font-family="Inter, sans-serif" font-size="18" fill="#111827" font-weight="600">Acme Dashboard</text>
+  <text x="932" y="36" font-family="Inter, sans-serif" font-size="14" fill="#6b7280">user@acme.com</text>
+
+  <!-- Page heading -->
+  <text x="32" y="112" font-family="Inter, sans-serif" font-size="24" fill="#111827" font-weight="600">Your Activity</text>
+  <text x="32" y="140" font-family="Inter, sans-serif" font-size="14" fill="#6b7280">Recent items across your workspace</text>
+
+  <!-- Table container -->
+  <rect x="32" y="176" width="960" height="368" fill="#ffffff" stroke="#e5e7eb" stroke-width="1" rx="8"/>
+
+  <!-- Table header row -->
+  <rect x="32" y="176" width="960" height="48" fill="#f9fafb" rx="8"/>
+  <rect x="32" y="220" width="960" height="4" fill="#e5e7eb"/>
+  <text x="56" y="206" font-family="Inter, sans-serif" font-size="13" fill="#374151" font-weight="600">Name</text>
+  <text x="420" y="206" font-family="Inter, sans-serif" font-size="13" fill="#374151" font-weight="600">Status</text>
+  <text x="680" y="206" font-family="Inter, sans-serif" font-size="13" fill="#374151" font-weight="600">Updated</text>
+
+  <!-- Table body: EMPTY.
+       No rows.
+       No "No items yet" empty-state text.
+       No illustration.
+       No "Add item" CTA button.
+       Just a blank region. -->
+
+  <!-- (Intentionally blank from y=224 to y=544 — this is the whole failure mode) -->
+</svg>

--- a/plugin/ralph-playwright/skills/story-gen/fixtures/03-tooltip-viewport-overflow.svg
+++ b/plugin/ralph-playwright/skills/story-gen/fixtures/03-tooltip-viewport-overflow.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture 03: tooltip clipping at viewport right edge.
+  Primary category: tooltip_overflow
+
+  Rendered state: a toolbar at the top right of the viewport. A tooltip
+  emerging from an icon near the right edge extends past the viewport
+  right boundary and its content is visibly truncated.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="768" viewBox="0 0 1024 768">
+  <rect width="1024" height="768" fill="#f5f6f8"/>
+
+  <!-- Top nav -->
+  <rect x="0" y="0" width="1024" height="56" fill="#ffffff"/>
+  <text x="32" y="36" font-family="Inter, sans-serif" font-size="18" fill="#111827" font-weight="600">Acme</text>
+
+  <!-- Icon toolbar near right edge -->
+  <circle cx="920" cy="28" r="14" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1"/>
+  <text x="920" y="33" font-family="Inter, sans-serif" font-size="14" fill="#6b7280" text-anchor="middle" font-weight="600">?</text>
+
+  <circle cx="972" cy="28" r="14" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1"/>
+  <text x="972" y="33" font-family="Inter, sans-serif" font-size="14" fill="#6b7280" text-anchor="middle" font-weight="600">i</text>
+
+  <!-- Tooltip: anchored at the rightmost icon, extends past right edge.
+       Viewport ends at x=1024. Tooltip spans x=900 to x=1180 — the
+       final 156px are OFF-SCREEN, truncating the message. -->
+  <rect x="900" y="60" width="280" height="80" fill="#1f2937" rx="6"/>
+  <polygon points="970,60 978,52 986,60" fill="#1f2937"/>
+  <text x="914" y="86" font-family="Inter, sans-serif" font-size="13" fill="#ffffff">Information about this</text>
+  <text x="914" y="106" font-family="Inter, sans-serif" font-size="13" fill="#ffffff">particular feature — user</text>
+  <text x="914" y="126" font-family="Inter, sans-serif" font-size="13" fill="#ffffff">cannot see the full messa</text>
+
+  <!-- Viewport right-edge marker (conceptual — shows where the tooltip gets clipped) -->
+  <line x1="1024" y1="0" x2="1024" y2="200" stroke="#ef4444" stroke-width="2" stroke-dasharray="4,4"/>
+  <text x="1028" y="158" font-family="Inter, sans-serif" font-size="10" fill="#ef4444">viewport edge</text>
+
+  <!-- Rest of page content (so the fixture is not tiny) -->
+  <text x="32" y="112" font-family="Inter, sans-serif" font-size="24" fill="#111827" font-weight="600">Settings</text>
+  <rect x="32" y="156" width="960" height="500" fill="#ffffff" stroke="#e5e7eb" stroke-width="1" rx="8"/>
+  <text x="56" y="190" font-family="Inter, sans-serif" font-size="14" fill="#374151">Account</text>
+  <text x="56" y="220" font-family="Inter, sans-serif" font-size="13" fill="#6b7280">Manage your account preferences.</text>
+</svg>

--- a/plugin/ralph-playwright/skills/story-gen/fixtures/README.md
+++ b/plugin/ralph-playwright/skills/story-gen/fixtures/README.md
@@ -1,0 +1,25 @@
+# Vision Sad-Path Fixtures
+
+Fixture screenshots for confidence-checking the vision sad-path inference prompt (`../prompts/sad-path-vision.md`) against the schema documented in `../../../schemas/user-story.schema.yaml` and illustrated in `../../../schemas/example-vision-sad-paths.yaml`.
+
+Format is SVG — small, human-inspectable in diffs, deterministic, and representative of the categories. Opus 4.7 vision consumes SVG fine via Read; the underlying UI pattern is what matters, not the file format.
+
+## Fixtures
+
+| File | Primary category | Plausible secondary | Source |
+|------|------------------|---------------------|--------|
+| `01-form-no-validation-hints.svg` | `missing_validation_hint` | `missing_error_handler` (no error container between fields and Sign In) | Synthesized by author (Apr 2026) |
+| `02-list-no-empty-state.svg` | `empty_state_gap` | — | Synthesized by author (Apr 2026) |
+| `03-tooltip-viewport-overflow.svg` | `tooltip_overflow` | — | Synthesized by author (Apr 2026) |
+
+## Not yet covered — follow-up fixture
+
+- **`missing_error_handler` as a primary** category is only incidentally exhibited by fixture 01. A dedicated fixture (e.g., destructive button with no confirmation affordance, or submit with no toast mount point) is a follow-up — the parent issue acceptance criterion asks for 2-3 representative fixtures, which the three above satisfy.
+
+## Provenance
+
+All fixtures were authored by the plan author in the feature PR for GH-796. No external / third-party UIs were snapshotted. Each SVG is hand-drawn to deterministically exhibit its declared category without external IP concerns.
+
+## Running the confidence test
+
+See `TESTING.md` in this directory.

--- a/plugin/ralph-playwright/skills/story-gen/fixtures/TESTING.md
+++ b/plugin/ralph-playwright/skills/story-gen/fixtures/TESTING.md
@@ -1,0 +1,83 @@
+# Vision Sad-Path Testing
+
+Confidence tests for the vision sad-path step of `story-gen`.
+
+## Prerequisites
+
+- `bash` (4.x+)
+- `grep` (standard POSIX)
+- For model-in-the-loop pilots (optional): Claude Code CLI with the Opus 4.7 model available, and access to the ralph-playwright skill at `plugin/ralph-playwright/skills/story-gen/`.
+- The vision sad-paths feature merged (GH-796 and its 5 atomics): `prompts/sad-path-vision.md`, `schemas/example-vision-sad-paths.yaml`, and the Step 2 / Step 0 extensions in `SKILL.md`.
+
+## Running the static harness
+
+From the repo root:
+
+```bash
+bash plugin/ralph-playwright/skills/story-gen/fixtures/test.sh
+```
+
+Or from this directory:
+
+```bash
+./test.sh
+```
+
+Expected output: a sequence of `PASS` lines and a final summary `N passed, 0 failed`. Exit code `0`.
+
+## What the harness checks
+
+The harness is a **static invariant check** — it does not invoke a model. It verifies:
+
+1. The prompt file (`prompts/sad-path-vision.md`) exists, is non-empty, and declares all four detection category names verbatim.
+2. The schema example (`schemas/example-vision-sad-paths.yaml`) exists and is non-empty.
+3. Each fixture in this directory is present, non-empty, and its declared primary category is represented in the schema example (with `tooltip_overflow` intentionally exempted — it is the one of four categories not illustrated in the three-example YAML).
+4. The `README.md` in this directory documents each fixture by filename.
+
+## When the harness fails
+
+A failure indicates one of:
+
+- **Prompt regression**: a category name changed or was removed.
+- **Schema drift**: the example file no longer demonstrates a category declared in the prompt.
+- **Fixture drift**: a fixture file was renamed, deleted, or stripped of content.
+- **README staleness**: a fixture was added or renamed without updating the README.
+
+Read the `FAIL` line to identify which assertion tripped, and fix the underlying inconsistency.
+
+## Running a model-in-the-loop pilot (optional)
+
+The static harness does not call the model. To run an actual vision inference on a fixture:
+
+1. Start a Claude Code session in this repo.
+2. Load the `ralph-playwright:story-gen` skill.
+3. Invoke with a manual screenshot path pointing at one of the fixtures, e.g.:
+   ```
+   /ralph-playwright:story-gen --screenshots plugin/ralph-playwright/skills/story-gen/fixtures/01-form-no-validation-hints.svg --vision-sad-paths
+   ```
+4. Observe the emitted `inferred_sad_paths:` block. For fixture 01 you should see at least one entry with `category: missing_validation_hint`.
+5. Record findings in `thoughts/local/pilots/` — not committed; local notes only.
+
+## Adding a new fixture
+
+1. Drop the new SVG (or PNG) in this directory with a numbered prefix: `NN-<category-kebab>.svg`.
+2. Add a row to the table in `README.md` naming the primary category and source.
+3. Add a matching entry to the `FIXTURE_FILES` and `FIXTURE_CATEGORIES` arrays in `test.sh`.
+4. Either (a) demonstrate the new category in `schemas/example-vision-sad-paths.yaml`, or (b) add the category to the skip-list in `test.sh` (as `tooltip_overflow` is today).
+5. Re-run `test.sh` and confirm the new fixture passes.
+
+## Updating expected categories when the prompt intentionally changes
+
+If the prompt's detection categories are deliberately renamed or extended:
+
+1. Update `prompts/sad-path-vision.md` first.
+2. Update the `REQUIRED_CATEGORIES` array in `test.sh`.
+3. Update `schemas/example-vision-sad-paths.yaml` to reflect the new naming.
+4. Update `../schemas/user-story.schema.yaml` comment block if it enumerates categories.
+5. Re-run `test.sh`.
+
+## Troubleshooting
+
+- **All fixtures fail `primary category not found`**: check that `schemas/example-vision-sad-paths.yaml` was not accidentally truncated or renamed.
+- **All prompt category checks fail**: check that `prompts/sad-path-vision.md` still has the four category headers / enum names spelled identically to `test.sh`'s `REQUIRED_CATEGORIES` array.
+- **README checks fail**: a fixture was added / renamed but `README.md` was not updated.

--- a/plugin/ralph-playwright/skills/story-gen/fixtures/test.sh
+++ b/plugin/ralph-playwright/skills/story-gen/fixtures/test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Vision sad-path inference — fixture confidence harness.
+#
+# This script is a lightweight confidence check on the prompt + schema +
+# pipeline chain. It is NOT a quantitative accuracy evaluation.
+#
+# What it does:
+#   - For each fixture in this directory, verify the prompt file exists
+#     and references the fixture's expected category name.
+#   - Verify the fixture itself is present and non-empty.
+#   - Verify the example YAML (example-vision-sad-paths.yaml) demonstrates
+#     each fixture's expected primary category at least once across its
+#     entries — the example acts as the "expected output shape" reference.
+#
+# We deliberately do NOT shell out to a model runtime here. Ralph-playwright
+# is skills/agents-only (no MCP server, no vitest); the vision step runs
+# inside a Claude conversation. This harness asserts the static invariants
+# that would cause a regression if the prompt or schema drifted.
+#
+# To run an actual model-in-the-loop pilot, see TESTING.md.
+
+set -euo pipefail
+
+FIXTURES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$FIXTURES_DIR/.." && pwd)"
+PROMPT_FILE="$SKILL_DIR/prompts/sad-path-vision.md"
+SCHEMA_EXAMPLE="$(cd "$SKILL_DIR/../.." && pwd)/schemas/example-vision-sad-paths.yaml"
+
+PASS=0
+FAIL=0
+
+fail() {
+  echo "FAIL $1"
+  FAIL=$((FAIL + 1))
+}
+
+pass() {
+  echo "PASS $1"
+  PASS=$((PASS + 1))
+}
+
+assert_file_exists() {
+  local path="$1"
+  local label="$2"
+  if [[ ! -s "$path" ]]; then
+    fail "$label — missing or empty: $path"
+    return 1
+  fi
+  return 0
+}
+
+# 1. Static invariants: prompt and schema example exist and are non-empty.
+if assert_file_exists "$PROMPT_FILE" "prompt file"; then
+  pass "prompt file exists and is non-empty"
+fi
+if assert_file_exists "$SCHEMA_EXAMPLE" "schema example file"; then
+  pass "schema example exists and is non-empty"
+fi
+
+# 2. The prompt declares each of the four named categories.
+REQUIRED_CATEGORIES=("missing_error_handler" "empty_state_gap" "tooltip_overflow" "missing_validation_hint")
+for cat in "${REQUIRED_CATEGORIES[@]}"; do
+  if grep -q "$cat" "$PROMPT_FILE"; then
+    pass "prompt declares category: $cat"
+  else
+    fail "prompt missing category declaration: $cat"
+  fi
+done
+
+# 3. Each fixture exists, is non-empty, and its declared primary category
+#    appears in the schema example at least once.
+declare -a FIXTURE_FILES=("01-form-no-validation-hints.svg" "02-list-no-empty-state.svg" "03-tooltip-viewport-overflow.svg")
+declare -a FIXTURE_CATEGORIES=("missing_validation_hint" "empty_state_gap" "tooltip_overflow")
+
+for i in "${!FIXTURE_FILES[@]}"; do
+  fixture="${FIXTURE_FILES[$i]}"
+  category="${FIXTURE_CATEGORIES[$i]}"
+  path="$FIXTURES_DIR/$fixture"
+
+  if ! assert_file_exists "$path" "fixture $fixture"; then
+    continue
+  fi
+  pass "fixture $fixture present"
+
+  # Fixture 03 (tooltip_overflow) is not represented in the schema example
+  # — example demonstrates 3 of 4 categories per the plan; tooltip_overflow
+  # is the one intentionally omitted. Skip the example cross-check for it.
+  if [[ "$category" == "tooltip_overflow" ]]; then
+    pass "fixture $fixture category $category (schema-example cross-check skipped — not illustrated in example-vision-sad-paths.yaml by design)"
+    continue
+  fi
+
+  if grep -q "category: $category" "$SCHEMA_EXAMPLE"; then
+    pass "fixture $fixture primary category $category appears in schema example"
+  else
+    fail "fixture $fixture primary category $category NOT found in schema example"
+  fi
+done
+
+# 4. README documents each fixture.
+README="$FIXTURES_DIR/README.md"
+if assert_file_exists "$README" "fixtures README"; then
+  for fixture in "${FIXTURE_FILES[@]}"; do
+    if grep -q "$fixture" "$README"; then
+      pass "README mentions $fixture"
+    else
+      fail "README missing entry for $fixture"
+    fi
+  done
+fi
+
+# Summary
+echo ""
+echo "──────────────────────────────────────────────"
+echo "Fixture confidence harness: $PASS passed, $FAIL failed"
+echo "──────────────────────────────────────────────"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugin/ralph-playwright/skills/story-gen/prompts/sad-path-vision.md
+++ b/plugin/ralph-playwright/skills/story-gen/prompts/sad-path-vision.md
@@ -1,0 +1,145 @@
+# Vision-Grounded Sad-Path Inference Prompt
+
+## Framing
+
+You are examining one or more screenshots of a rendered UI. Your single job is to surface **vision-grounded sad-path candidates** — failure modes that are directly visible in the pixels you can see. Output is a **structured list** of findings, not prose.
+
+**You are NOT generating happy paths.** Happy paths (primary success flows) are handled elsewhere. Do not emit them.
+
+**You are NOT inventing sad paths that are not grounded in the screenshot.** If a screenshot shows no signals in a given category, emit **zero entries** for that category. Silence is a valid answer.
+
+You are Opus 4.7. Use your 1:1 pixel coordinate capability when providing bbox values. If bbox is unreliable for a given UI region (dense/overlapping/ambiguous boundaries), fall back to a clear natural-language element description — that is acceptable and sometimes preferable.
+
+## Detection Categories
+
+Detect findings across **exactly these four categories**. Use the exact enum names when emitting output.
+
+### 1. `missing_error_handler`
+
+Forms that submit without a visible error-surfacing container. Actions (delete, archive, submit, save) without a visible confirmation affordance or without a visible result indicator.
+
+**Signals to look for:**
+- A submit button on a form, but no visible container region (no `.error`, no `[role=alert]`, no inline red/warning text zone) where errors would appear
+- Destructive buttons (Delete, Remove, Archive) with no visible "Are you sure?" confirmation pattern nearby
+- Actions whose success/failure would be invisible — no toast region, no status line, no inline feedback area
+
+**Rationale prompt**: "If this submit fails server-side, where would the error surface? The screenshot suggests: nowhere visible."
+
+### 2. `empty_state_gap`
+
+Lists, tables, card grids, drop zones, or search results that render with zero items and **no visible empty-state message, illustration, or CTA** to populate the container.
+
+**Signals to look for:**
+- A table header rendered but a blank body region below
+- A card grid placeholder with no cards and no "No items yet — click Add to create one" text
+- A search results region with no results and no "No matches found" feedback
+- An inbox / activity feed with no rows and no "You're all caught up" or equivalent empty state
+
+**Rationale prompt**: "First-time users and users with filters that exclude all rows see this state. What guidance does the UI offer? The screenshot suggests: none."
+
+### 3. `tooltip_overflow`
+
+Tooltips, popovers, dropdown menus, or floating surfaces that **clip at a viewport edge** or are visibly truncated.
+
+**Signals to look for:**
+- A tooltip whose right edge is cut off by the viewport right margin
+- A popover extending below the visible viewport (bottom-edge clip)
+- A dropdown menu near the top of the viewport that would overflow upward if it expanded
+- A context menu at the rightmost column of a table whose content is partially hidden
+
+**Rationale prompt**: "This floating surface's content is not fully readable at the current position. Users on the right / bottom viewport edge cannot see the full message."
+
+### 4. `missing_validation_hint`
+
+Form input fields with **no asterisk, no helper text, no placeholder explaining expected format, no inline validation feedback pattern**.
+
+**Signals to look for:**
+- An input field labeled "Email" with no asterisk, no "Required" marker, no helper text explaining format
+- A password field with no helper text indicating minimum length / character class requirements
+- A date or phone field with no placeholder showing the expected format (e.g., `MM/DD/YYYY`)
+- A group of form fields where the "required" vs "optional" distinction is not visually conveyed
+
+**Rationale prompt**: "Users cannot tell before submitting what this field expects or whether it is required. The screenshot suggests no visible guidance is rendered."
+
+## Required Output Structure
+
+Emit a YAML block conforming to the `inferred_sad_paths:` schema. Each entry has **all four** top-level keys:
+
+```yaml
+inferred_sad_paths:
+  - category: missing_error_handler | empty_state_gap | tooltip_overflow | missing_validation_hint | other
+    evidence:
+      screenshot_path: "<path to the PNG you examined>"
+      bbox_or_description: "<either '{x: 120, y: 340, w: 280, h: 48}' OR a natural-language element description>"
+      rationale: "<one sentence: why this is a sad-path gap>"
+    proposed_story:
+      name: "<short human-readable story name>"
+      type: sad
+      url: "<best-guess URL for this screen, placeholder ok>"
+      workflow: |
+        Navigate to <url>
+        <action that would trigger the gap>
+        Verify <the missing affordance would be expected>
+        <observation that the affordance is absent>
+    source: vision
+```
+
+**Do NOT** emit free-form prose outside the YAML block. Downstream parsers expect schema-aligned output.
+
+## Calibration: Worked Example
+
+**Input screenshot description (what you would actually see):**
+
+A login page with two input fields labeled "Email" and "Password". Neither field has an asterisk, helper text, or placeholder format hint. Below the fields is a "Sign In" button. There is no visible container region between the fields and the button that could surface server-side errors (no red bar, no alert zone, no toast mounting point). The page layout has empty whitespace where an error region would typically appear.
+
+**Expected output:**
+
+```yaml
+inferred_sad_paths:
+  - category: missing_validation_hint
+    evidence:
+      screenshot_path: "fixtures/01-form-no-validation-hints.png"
+      bbox_or_description: "Email and Password input fields, top of form region — no asterisks, no helper text, no placeholder format hints visible"
+      rationale: "Users cannot determine whether fields are required or what format is expected before submitting the form."
+    proposed_story:
+      name: "Login form exposes required/format expectations before submit"
+      type: sad
+      url: "http://localhost:3000/login"
+      workflow: |
+        Navigate to http://localhost:3000/login
+        Observe the Email and Password field labels
+        Verify at least one of: asterisk marker, "Required" text, or helper-text describing format is visible
+        (Expected: guidance present; Observed in fixture: none visible)
+
+  - category: missing_error_handler
+    evidence:
+      screenshot_path: "fixtures/01-form-no-validation-hints.png"
+      bbox_or_description: "{x: 180, y: 320, w: 420, h: 60} — whitespace region between password field and submit button"
+      rationale: "No visible error-surfacing container exists between the form fields and the submit button; server-side auth errors have no obvious render target."
+    proposed_story:
+      name: "Login form shows server-side auth errors in a visible container"
+      type: sad
+      url: "http://localhost:3000/login"
+      workflow: |
+        Navigate to http://localhost:3000/login
+        Fill Email and Password with known-invalid credentials
+        Click Sign In
+        Verify a visible error message appears (role=alert, or red-bordered container, or inline text)
+        (Expected: error visible; Observed in fixture: no container appears to exist)
+    source: vision
+```
+
+(Note the two-entry shape, bbox on one and description on the other, `source: vision` on every entry.)
+
+## Do-Not Clause
+
+- **Do not** invent sad paths that are not grounded in the screenshot. If a category has no visible signal, skip it.
+- **Do not** emit happy paths. Output is sad-path candidates only.
+- **Do not** emit prose outside the YAML block.
+- **Do not** use CSS selectors in the `bbox_or_description` field — prefer pixel coordinates OR natural-language element descriptions.
+- **Do not** repeat findings across entries. If the same UI element gives rise to two distinct sad-path candidates (e.g., a form that is both missing validation hints AND missing an error container), emit two entries with distinct `category` values.
+- **Do not** pad output. A screenshot with one gap yields one entry. A screenshot with zero gaps yields an empty `inferred_sad_paths: []`.
+
+## Final Note
+
+The `other` category exists as a safety valve for gaps that clearly fit the spirit of "visual sad-path signal" but do not map cleanly to the four named categories. Strongly prefer the four named categories. Use `other` only when a finding would otherwise be lost.


### PR DESCRIPTION
## Summary

Implements GH-796 umbrella and all 5 pre-split atomics (#819, #821, #822, #823, #824) in a single PR — vision-grounded sad-path inference for the `story-gen` skill.

- Adds a new prompt fragment `prompts/sad-path-vision.md` instructing Opus 4.7 to examine screenshots and emit structured candidates across four categories: `missing_error_handler`, `empty_state_gap`, `tooltip_overflow`, `missing_validation_hint`.
- Wires an opt-in `--vision-sad-paths` flag into `story-gen` Step 2 alongside the existing 8 heuristics — heuristic-only default behavior is preserved when the flag is unset; vision-kept entries get a `# source: vision (category: ...)` YAML comment in the final stories YAML.
- Adds Step 0 auto-feed from `journey-trace.yaml` screenshots when URL mode and `--vision-sad-paths` are both active, with a deterministic filter heuristic (fail-outcome, first-nav, keyword-match) and 8-screenshot cap to bound cost; graceful zero-screenshot fallback.
- Ships 3 SVG fixtures + a static invariant `test.sh` harness (15 passing assertions) and `TESTING.md` with model-in-the-loop pilot steps.

Out of scope per plan: `journey-trace.schema.yaml`, `explorer-agent.md`, `validate-primitive-io.sh`, and structural changes to `user-story.schema.yaml` are NOT touched.

## Commits (one per phase)

| Phase | Issue | SHA | Description |
|-------|-------|-----|-------------|
| 1 | #819 | `b00f385` | prompt fragment at `prompts/sad-path-vision.md` |
| 2 | #821 | `189a4e2` | `schemas/example-vision-sad-paths.yaml` example |
| 3 | #822 | `dbbe12d` | `--vision-sad-paths` wired into SKILL.md Step 2 |
| 4 | #823 | `b2ea5e0` | URL-mode auto-feed in SKILL.md Step 0 + filter heuristic |
| 5 | #824 | `08e3a45` | fixtures (3 SVG) + test.sh + TESTING.md |

Plan: [thoughts/shared/plans/2026-04-20-group-GH-0796-story-gen-vision-sad-paths.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-20-group-GH-0796-story-gen-vision-sad-paths.md)

## Test plan

- [x] `bash plugin/ralph-playwright/skills/story-gen/fixtures/test.sh` — 15 passed, 0 failed
- [x] `yq '.' plugin/ralph-playwright/schemas/example-vision-sad-paths.yaml` exits 0
- [x] `yq '.' plugin/ralph-playwright/schemas/example-auth.yaml` still exits 0 (regression gate)
- [x] `user-story.schema.yaml` left structurally untouched per task description
- [ ] Manual model-in-the-loop pilot against fixture 01 (Opus 4.7, `--vision-sad-paths` + `--screenshots`) — see `fixtures/TESTING.md`
- [ ] Manual regression check: invoke `story-gen` WITHOUT `--vision-sad-paths` and confirm only 8 heuristics fire

Closes #819 #821 #822 #823 #824
Addresses #796

Generated with [Claude Code](https://claude.com/claude-code)