### PR TITLE
fix(ralph-knowledge): unbreak memory_tier search tests

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/search.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/search.test.ts
@@ -207,11 +207,6 @@ describe("FtsSearch", () => {
 
   describe("memory_tier filter", () => {
     it("filters by memory_tier when schema has the column", () => {
-      // Phase 1 (GH-762) owns the production migration; add the column here
-      // so we can exercise the Phase 8 filter independently.
-      db.db.exec(
-        "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))",
-      );
       db.db
         .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
         .run("reflection", "auth-doc");
@@ -235,9 +230,6 @@ describe("FtsSearch", () => {
     });
 
     it("returns all tiers when memoryTier='any'", () => {
-      db.db.exec(
-        "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))",
-      );
       db.db
         .prepare("UPDATE documents SET memory_tier = ? WHERE id = ?")
         .run("reflection", "auth-doc");


### PR DESCRIPTION
## Summary
- `KnowledgeDB` constructor always runs the `memory_tier` migration ([db.ts:189-195](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/db.ts#L189-L195)), so the manual `ALTER TABLE documents ADD COLUMN memory_tier ...` in `search.test.ts:212,238` was failing with `SqliteError: duplicate column name: memory_tier` — breaking CI on `main` and on every open PR.
- The test comment anticipated this: *"Phase 1 (GH-762) owns the production migration; add the column here so we can exercise the Phase 8 filter independently."* Phase 1 shipped, so the scaffold is now redundant.
- Removed the two redundant ALTERs. The `UPDATE` statements still set the column value needed to exercise the filter.

## Why now
Blocking the merge train for issue [#784](https://github.com/cdubiel08/ralph-hero/issues/784) Round 1 (PRs #825-#834). All 10 of those PRs only touch `plugin/ralph-playwright/` but inherit this pre-existing `plugin/ralph-knowledge/` test failure.

## Out of scope
The middle test `ignores memory_tier silently when column is absent (v2 schema)` is now testing a code path (`memoryTierColumnExists() === false`) that's unreachable from `KnowledgeDB(":memory:")` since the migration always runs. The test still passes (asserts `Array.isArray`) but its name is stale. Leaving for a separate cleanup so this PR stays surgical.

## Test plan
- [x] `cd plugin/ralph-knowledge && npm test` → 378 passed (was 376 passed, 2 failed)
- [x] `npx vitest run src/__tests__/search.test.ts` → 23 passed
- [ ] Verify CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)