### PR TITLE
fix(mcp-server): hotfix v2.5.72 silent-exit regression on bin-shim launch

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/entry-point.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/entry-point.test.ts
@@ -1,0 +1,119 @@
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir, platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const distPath = resolve(__dirname, "../../dist/index.js");
+const distExists = existsSync(distPath);
+
+// Skip these tests if the build hasn't run. CI runs `npm run build && npm test`,
+// and `prepublishOnly` runs build before publish — so dist/ is present in the
+// scenarios that matter. Local `npm test` without a prior build will skip.
+const describeIfBuilt = distExists ? describe : describe.skip;
+
+describeIfBuilt("entry-point guard (regression for v2.5.72 bin-shim silent exit)", () => {
+  it("starts main() and connects when launched directly via dist/index.js", async () => {
+    const stderr = await spawnUntilConnected(distPath);
+    expect(stderr).toContain("[ralph-hero] Starting MCP server...");
+    expect(stderr).toContain("MCP server connected and ready");
+  }, 10000);
+
+  // Skip on Windows: symlink creation requires elevated privileges or
+  // developer mode. The realpath check is platform-agnostic; the npm bin-shim
+  // pattern is what we care about and it's posix-typical.
+  const itPosix = platform() === "win32" ? it.skip : it;
+
+  itPosix(
+    "starts main() and connects when launched via a bin-shim symlink (the npx -y …@VERSION case)",
+    async () => {
+      const tmp = mkdtempSync(join(tmpdir(), "ralph-mcp-entry-"));
+      const shim = join(tmp, "ralph-hero-mcp-server");
+      symlinkSync(distPath, shim);
+      try {
+        const stderr = await spawnUntilConnected(shim);
+        expect(stderr).toContain("[ralph-hero] Starting MCP server...");
+        expect(stderr).toContain("MCP server connected and ready");
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+    10000,
+  );
+});
+
+/**
+ * Spawn the MCP server at `scriptPath`, wait for the "connected and ready"
+ * banner on stderr, then terminate. Returns the captured stderr text.
+ *
+ * The escape-hatch env var `RALPH_HERO_RUN_MAIN` is explicitly cleared so the
+ * test exercises only the argv[1]-based detection path. A fake token is fine
+ * because startup does not make any GitHub API calls.
+ */
+function spawnUntilConnected(scriptPath: string): Promise<string> {
+  return new Promise((resolveReady, rejectReady) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      env: {
+        ...process.env,
+        RALPH_GH_OWNER: "test-owner",
+        RALPH_GH_REPO: "test-repo",
+        RALPH_GH_PROJECT_NUMBER: "1",
+        RALPH_HERO_GITHUB_TOKEN: "test-token-not-real",
+        RALPH_HERO_RUN_MAIN: "",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      rejectReady(
+        new Error(
+          `Did not see "MCP server connected and ready" within 5s.\nstderr so far:\n${stderr || "(empty)"}`,
+        ),
+      );
+    }, 5000);
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (!settled && stderr.includes("MCP server connected and ready")) {
+        settled = true;
+        clearTimeout(timeout);
+        child.kill("SIGTERM");
+        resolveReady(stderr);
+      }
+    });
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      rejectReady(err);
+    });
+
+    child.on("exit", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      rejectReady(
+        new Error(
+          `Process exited (code=${code}) before banner appeared.\nstderr:\n${stderr || "(empty)"}`,
+        ),
+      );
+    });
+
+    child.stdin!.end();
+  });
+}

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -8,6 +8,8 @@
  */
 
 import { execSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -488,19 +490,20 @@ async function main(): Promise<void> {
 }
 
 // Run only when invoked as the entry point (not when imported by tests).
-// `process.argv[1]` is the script path Node was started with; if it ends with
-// this module's compiled filename, we're the entry point. The fallback covers
-// edge cases (e.g. argv[1] missing) by also accepting an environment opt-in.
+// `process.argv[1]` is the script path Node was started with. When npm/npx
+// invokes a `bin` script it sets argv[1] to the bin-shim symlink (e.g.
+// `node_modules/.bin/ralph-hero-mcp-server`), not the resolved target — so
+// a string-suffix match on `/dist/index.js` would miss the bin-shim case
+// and silently skip main(). Compare realpath(argv[1]) to this module's
+// own URL instead; that's the canonical ESM "am I the entry point?" check.
 const isEntryPoint = (() => {
   try {
-    const argv1 = process.argv[1] ?? "";
-    return (
-      argv1.endsWith("/dist/index.js") ||
-      argv1.endsWith("\\dist\\index.js") ||
-      process.env.RALPH_HERO_RUN_MAIN === "true"
-    );
+    if (!process.argv[1]) return process.env.RALPH_HERO_RUN_MAIN === "true";
+    const argvReal = realpathSync(process.argv[1]);
+    const moduleReal = fileURLToPath(import.meta.url);
+    return argvReal === moduleReal || process.env.RALPH_HERO_RUN_MAIN === "true";
   } catch {
-    return false;
+    return process.env.RALPH_HERO_RUN_MAIN === "true";
   }
 })();
 


### PR DESCRIPTION
## Summary

- **Regression**: v2.5.72's entry-point guard checks `argv[1].endsWith("/dist/index.js")`, but npm/npx invokes `bin` scripts via the bin-shim symlink path (`node_modules/.bin/ralph-hero-mcp-server`). The suffix match fails, `main()` never runs, the MCP transport never connects — every Claude Code session loading the plugin saw "Failed to reconnect to plugin:ralph-hero:ralph-github" with no diagnostic output.
- **Fix**: compare `realpathSync(argv[1])` to `fileURLToPath(import.meta.url)` — the canonical ESM "am I the entry point?" pattern. Robust to symlinks, bin-shims, and path separators.
- **Regression test**: new `entry-point.test.ts` spawns the built `dist/index.js` two ways — direct and via a fresh bin-shim symlink — and asserts the startup banner appears on stderr. The new test fails on v2.5.72 and passes here.

## Repro (on v2.5.72)

```
$ RALPH_GH_OWNER=… RALPH_GH_REPO=… RALPH_GH_PROJECT_NUMBER=3 RALPH_HERO_GITHUB_TOKEN=… \
    npx -y ralph-hero-mcp-server@2.5.72
$ # → silent exit 0, no banner, MCP transport never opens
```

`argv[1]` was `…/node_modules/.bin/ralph-hero-mcp-server` → did **not** end with `/dist/index.js` → `isEntryPoint=false` → `main()` skipped.

## Why the regression escaped CI

The build + 1031 unit tests all run by **importing** `index.ts` (or by invoking the simulator helpers). None of them spawned a built binary via the `bin` symlink. The new test fills that gap: it actually `spawn()`s `node <symlink>` and asserts `"MCP server connected and ready"` on stderr.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 45 files / 1033 tests pass (added 2)
- [x] New regression test passes on this branch
- [x] Manual: `node node_modules/.bin/ralph-hero-mcp-server` (via fresh symlink) prints `Starting MCP server` + `connected and ready`
- [ ] After merge → auto-release → npm publish → reload plugin in Claude Code → MCP tools reconnect

## Notes

- The `RALPH_HERO_RUN_MAIN=true` escape hatch is preserved (also now used as the realpath-throws fallback).
- Skipped on Windows (symlink creation needs elevated privileges); the realpath check itself is platform-agnostic.
- This will trigger an auto-release of v2.5.73 since `mcp-server/src/` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)