### PR TITLE
GH-897: ralph-knowledge: stub documents leak through traverse, search (FTS leg), and memory_stats

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/graph-builder.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/graph-builder.test.ts
@@ -171,4 +171,32 @@ describe("GraphBuilder", () => {
     expect(edgeToA).toBeDefined();
     expect(graph.source(edgeToA!)).toBe("doc-b");
   });
+
+  describe("stub filtering (GH-897)", () => {
+    it("drops stub-target edges (untyped + typed) and excludes stubs from nodes", () => {
+      const freshDb = new KnowledgeDB(":memory:");
+      freshDb.upsertDocument({
+        id: "real-x",
+        path: "real-x.md",
+        title: "Real X",
+        date: "2026-04-10",
+        type: "research",
+        status: "approved",
+        githubIssue: null,
+        content: "",
+      });
+      freshDb.upsertStubDocument("stub-y");
+      freshDb.addRelationship("real-x", "stub-y", "untyped");
+      freshDb.addRelationship("real-x", "stub-y", "builds_on");
+
+      const g = new GraphBuilder(freshDb).buildGraph();
+      expect(g.hasNode("stub-y")).toBe(false);
+      expect(g.hasNode("real-x")).toBe(true);
+      expect(g.outDegree("real-x")).toBe(0);
+      expect(g.order).toBe(1);
+      expect(g.size).toBe(0);
+
+      freshDb.close();
+    });
+  });
 });

--- a/plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts
@@ -201,4 +201,82 @@ describe("knowledge_memory_stats", () => {
     expect(out.chunks_per_doc_p90).toBe(0);
     expect(out.last_reflection_at).toBeNull();
   });
+
+  describe("stub filtering (GH-897)", () => {
+    it("excludes stubs from total_documents and by_tier on v3 schema", async () => {
+      const mod = await import("../index.js");
+      const { server, db } = mod.createServer(":memory:");
+      ensureV3Schema(db);
+
+      // Two real docs across two tiers.
+      seedDoc(db, "real-doc", "doc", "2026-04-10");
+      seedDoc(db, "real-reflection", "reflection", "2026-04-11");
+
+      // Three stubs (default memory_tier = 'doc' per migration).
+      db.upsertStubDocument("stub-1");
+      db.upsertStubDocument("stub-2");
+      db.upsertStubDocument("stub-3");
+
+      const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+      expect(out.total_documents).toBe(2);
+      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 1 });
+      // new_since unaffected — stubs have date = NULL and never count regardless.
+      expect(out.new_since).toEqual({ doc: 1, raw: 0, reflection: 1 });
+    });
+
+    it("excludes stubs from total on a v2 schema (column absent)", async () => {
+      const mod = await import("../index.js");
+      const { server, db } = mod.createServer(":memory:");
+      // Do NOT call ensureV3Schema; v2 path uses the standalone total query and
+      // assigns it to byTier.doc.
+
+      db.upsertDocument({
+        id: "legacy-real",
+        path: "l.md",
+        title: "Legacy",
+        date: "2026-04-01",
+        type: null,
+        status: null,
+        githubIssue: null,
+        content: "",
+      });
+      db.upsertStubDocument("legacy-stub");
+
+      const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+      expect(out.total_documents).toBe(1);
+      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0 });
+    });
+
+    it("typed-relationship stubs are filtered identically to untyped wikilink stubs", async () => {
+      const mod = await import("../index.js");
+      const { server, db } = mod.createServer(":memory:");
+      ensureV3Schema(db);
+
+      seedDoc(db, "real-source", "doc", "2026-04-10");
+      // Stub created via typed relationship target.
+      db.upsertStubDocument("typed-stub-target");
+      db.addRelationship("real-source", "typed-stub-target", "builds_on");
+
+      const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+      expect(out.total_documents).toBe(1);
+      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0 });
+    });
+
+    it("last_reflection_at ignores stubs even if a stub somehow had a date and reflection tier", async () => {
+      const mod = await import("../index.js");
+      const { server, db } = mod.createServer(":memory:");
+      ensureV3Schema(db);
+
+      seedDoc(db, "real-reflection-old", "reflection", "2026-03-01");
+      // Force a stub into the reflection tier with a future date — defense-in-depth check.
+      db.upsertStubDocument("future-reflection-stub");
+      db.db
+        .prepare("UPDATE documents SET memory_tier = 'reflection', date = '2099-01-01' WHERE id = ?")
+        .run("future-reflection-stub");
+
+      const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
+      // Without the filter, the stub's "2099-01-01" would surface as last_reflection_at.
+      expect(out.last_reflection_at).toBe("2026-03-01");
+    });
+  });
 });

--- a/plugin/ralph-knowledge/src/__tests__/search.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/search.test.ts
@@ -242,6 +242,69 @@ describe("FtsSearch", () => {
     });
   });
 
+  describe("stub filtering (GH-897)", () => {
+    it("excludes stub documents from FTS results even when their title matches", () => {
+      // Insert a real doc with a unique marker; stub created via upsertStubDocument.
+      const freshDb = new KnowledgeDB(":memory:");
+      freshDb.upsertDocument({
+        id: "real-doc-marker",
+        path: "thoughts/shared/research/marker.md",
+        title: "Marker Doc",
+        date: "2026-04-25",
+        type: "research",
+        status: "draft",
+        githubIssue: null,
+        content: "unique-marker payload contents",
+      });
+      // Stub whose title matches the marker — would surface without the filter.
+      freshDb.upsertStubDocument("unique-marker-stub-id");
+
+      const freshFts = new FtsSearch(freshDb);
+      // Rebuild AFTER both rows exist so the stub does land in documents_fts —
+      // simulates an install that bumped schema version with stubs already present.
+      freshFts.rebuildIndex();
+
+      const hits = freshFts.search("unique-marker");
+      const ids = hits.map((r) => r.id);
+      expect(ids).toContain("real-doc-marker");
+      expect(ids).not.toContain("unique-marker-stub-id");
+
+      // Even querying the stub id directly returns zero rows.
+      const stubByTitle = freshFts.search("unique-marker-stub-id");
+      const stubIds = stubByTitle.map((r) => r.id);
+      expect(stubIds).not.toContain("unique-marker-stub-id");
+
+      freshDb.close();
+    });
+
+    it("typed-relationship stubs (builds_on target) are filtered identically", () => {
+      const freshDb = new KnowledgeDB(":memory:");
+      freshDb.upsertDocument({
+        id: "real-source",
+        path: "thoughts/shared/plans/source.md",
+        title: "Source Plan",
+        date: "2026-04-25",
+        type: "plan",
+        status: "draft",
+        githubIssue: null,
+        content: "phantom-typed-marker payload",
+      });
+      // Stub created via typed relationship target (builds_on).
+      freshDb.upsertStubDocument("phantom-typed-marker");
+      freshDb.addRelationship("real-source", "phantom-typed-marker", "builds_on");
+
+      const freshFts = new FtsSearch(freshDb);
+      freshFts.rebuildIndex();
+
+      const hits = freshFts.search("phantom-typed-marker");
+      const ids = hits.map((r) => r.id);
+      expect(ids).toContain("real-source"); // matches in content
+      expect(ids).not.toContain("phantom-typed-marker"); // stub excluded
+
+      freshDb.close();
+    });
+  });
+
   describe("ensureTable", () => {
     it("creates FTS table if it does not exist", () => {
       // Create a fresh DB without FTS table

--- a/plugin/ralph-knowledge/src/__tests__/traverse.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/traverse.test.ts
@@ -183,11 +183,137 @@ describe("Traverser — untyped edges", () => {
     expect(types).toContain("builds_on");
   });
 
-  it("stub documents appear as doc in traverse results with title matching stub ID", () => {
+  it("stub documents are filtered out of traverse results (regression for GH-897)", () => {
     const results = traverser.traverse("doc-source", { type: "untyped", depth: 1 });
     const toStub = results.find(r => r.targetId === "unresolved-target");
-    expect(toStub).toBeTruthy();
-    expect(toStub!.doc).not.toBeNull();
-    expect(toStub!.doc!.title).toBe("unresolved-target");
+    expect(toStub).toBeUndefined();
+    // Real-document edges still surface
+    const toReal = results.find(r => r.targetId === "doc-target");
+    expect(toReal).toBeTruthy();
+  });
+});
+
+describe("Traverser — stub filtering (GH-897)", () => {
+  let db: KnowledgeDB;
+  let traverser: Traverser;
+
+  beforeEach(() => {
+    db = new KnowledgeDB(":memory:");
+
+    db.upsertDocument({
+      id: "real-a",
+      path: "thoughts/shared/research/real-a.md",
+      title: "Real A",
+      date: "2026-04-01",
+      type: "research",
+      status: "approved",
+      githubIssue: null,
+      content: "Real document A.",
+    });
+
+    db.upsertDocument({
+      id: "real-b",
+      path: "thoughts/shared/research/real-b.md",
+      title: "Real B",
+      date: "2026-04-02",
+      type: "research",
+      status: "approved",
+      githubIssue: null,
+      content: "Real document B.",
+    });
+
+    // Stubs created via both untyped wikilink and typed relationship paths.
+    db.upsertStubDocument("stub-untyped-target");
+    db.upsertStubDocument("stub-typed-target");
+
+    db.addRelationship("real-a", "stub-untyped-target", "untyped", "context");
+    db.addRelationship("real-a", "stub-typed-target", "builds_on");
+
+    // Stub appears as source_id of an edge to a real doc — exercises incoming filter.
+    db.addRelationship("stub-untyped-target", "real-b", "untyped");
+
+    traverser = new Traverser(db);
+  });
+
+  it("traverse() drops outgoing hops to stub targets (untyped + typed)", () => {
+    const results = traverser.traverse("real-a", { depth: 1 });
+    expect(results).toHaveLength(0);
+    // Sanity: neither stub id appears
+    const targetIds = results.map((r) => r.targetId);
+    expect(targetIds).not.toContain("stub-untyped-target");
+    expect(targetIds).not.toContain("stub-typed-target");
+  });
+
+  it("traverse() with type filter still drops stub targets", () => {
+    const buildsOn = traverser.traverse("real-a", { type: "builds_on", depth: 1 });
+    expect(buildsOn).toHaveLength(0);
+    const untyped = traverser.traverse("real-a", { type: "untyped", depth: 1 });
+    expect(untyped).toHaveLength(0);
+  });
+
+  it("traverseIncoming() returns no rows when only inbound edge is from a stub", () => {
+    const results = traverser.traverseIncoming("real-b", { depth: 1 });
+    expect(results).toHaveLength(0);
+  });
+
+  it("traverseIncoming() on a stub returns only real-source edges, never stub sources", () => {
+    // Asking "who points to this stub?" surfaces real callers (real-a here). The
+    // join in traverseIncoming is on chain.source_id, so the predicate filters by
+    // source-side stub-ness — real sources are preserved, stub sources dropped.
+    const results = traverser.traverseIncoming("stub-untyped-target", { depth: 1 });
+    expect(results).toHaveLength(1);
+    expect(results[0].sourceId).toBe("real-a");
+    // None of the rows have a stub document as source.
+    for (const r of results) {
+      // doc is hydrated from d.title; stubs would have title === sourceId.
+      if (r.doc) {
+        expect(r.doc.title).not.toBe(r.sourceId);
+      }
+    }
+  });
+
+  it("non-regression: real-only chain still works after the stub filter is applied", () => {
+    // Independent fresh DB to verify the canonical fixture still passes through the
+    // updated WHERE clause unchanged.
+    const fresh = new KnowledgeDB(":memory:");
+    fresh.upsertDocument({
+      id: "doc-a",
+      path: "doc-a.md",
+      title: "Foundation",
+      date: "2026-02-01",
+      type: "research",
+      status: "approved",
+      githubIssue: null,
+      content: "",
+    });
+    fresh.upsertDocument({
+      id: "doc-b",
+      path: "doc-b.md",
+      title: "Plan",
+      date: "2026-02-15",
+      type: "plan",
+      status: "draft",
+      githubIssue: null,
+      content: "",
+    });
+    fresh.upsertDocument({
+      id: "doc-c",
+      path: "doc-c.md",
+      title: "Revised Plan",
+      date: "2026-03-01",
+      type: "plan",
+      status: "draft",
+      githubIssue: null,
+      content: "",
+    });
+    fresh.addRelationship("doc-b", "doc-a", "builds_on");
+    fresh.addRelationship("doc-c", "doc-b", "builds_on");
+
+    const t = new Traverser(fresh);
+    const chain = t.traverse("doc-c", { type: "builds_on" });
+    expect(chain).toHaveLength(2);
+    expect(chain[0]).toMatchObject({ sourceId: "doc-c", targetId: "doc-b", depth: 1 });
+    expect(chain[1]).toMatchObject({ sourceId: "doc-b", targetId: "doc-a", depth: 2 });
+    fresh.close();
   });
 });

--- a/plugin/ralph-knowledge/src/index.ts
+++ b/plugin/ralph-knowledge/src/index.ts
@@ -193,7 +193,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
         const hasChunks = chunksTableExists(db);
 
         const totalRow = db.db
-          .prepare("SELECT COUNT(*) AS c FROM documents")
+          .prepare("SELECT COUNT(*) AS c FROM documents WHERE is_stub = 0 OR is_stub IS NULL")
           .get() as { c: number };
         const totalDocuments = totalRow.c;
 
@@ -212,7 +212,9 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
           const rows = db.db
             .prepare(
               `SELECT memory_tier AS tier, COUNT(*) AS c
-               FROM documents GROUP BY memory_tier`,
+               FROM documents
+               WHERE (is_stub = 0 OR is_stub IS NULL)
+               GROUP BY memory_tier`,
             )
             .all() as Array<{ tier: string; c: number }>;
           for (const r of rows) {
@@ -224,7 +226,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
             .prepare(
               `SELECT memory_tier AS tier, COUNT(*) AS c
                FROM documents
-               WHERE date IS NOT NULL AND date >= @since
+               WHERE date IS NOT NULL AND date >= @since AND (is_stub = 0 OR is_stub IS NULL)
                GROUP BY memory_tier`,
             )
             .all({ since }) as Array<{ tier: string; c: number }>;
@@ -238,7 +240,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
           byTier.doc = totalDocuments;
           const newDocRow = db.db
             .prepare(
-              "SELECT COUNT(*) AS c FROM documents WHERE date IS NOT NULL AND date >= ?",
+              "SELECT COUNT(*) AS c FROM documents WHERE date IS NOT NULL AND date >= ? AND (is_stub = 0 OR is_stub IS NULL)",
             )
             .get(since) as { c: number };
           newSince.doc = newDocRow.c;
@@ -262,7 +264,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
           const row = db.db
             .prepare(
               `SELECT date FROM documents
-               WHERE memory_tier = 'reflection' AND date IS NOT NULL
+               WHERE memory_tier = 'reflection' AND date IS NOT NULL AND (is_stub = 0 OR is_stub IS NULL)
                ORDER BY date DESC LIMIT 1`,
             )
             .get() as { date: string } | undefined;

--- a/plugin/ralph-knowledge/src/search.ts
+++ b/plugin/ralph-knowledge/src/search.ts
@@ -124,6 +124,7 @@ export class FtsSearch {
     const { type, tags, includeSuperseded = false, limit = 20, memoryTier } = options;
 
     const conditions: string[] = ["documents_fts MATCH @query"];
+    conditions.push("(d.is_stub = 0 OR d.is_stub IS NULL)");
     const params: Record<string, unknown> = { query: this.escapeFts5Query(query), limit };
 
     if (!includeSuperseded) {

--- a/plugin/ralph-knowledge/src/traverse.ts
+++ b/plugin/ralph-knowledge/src/traverse.ts
@@ -49,6 +49,7 @@ export class Traverser {
         d.date AS docDate
       FROM chain
       LEFT JOIN documents d ON d.id = chain.target_id
+      WHERE d.id IS NULL OR d.is_stub = 0 OR d.is_stub IS NULL
       ORDER BY chain.depth, chain.target_id
     `;
 
@@ -106,6 +107,7 @@ export class Traverser {
         d.date AS docDate
       FROM chain
       LEFT JOIN documents d ON d.id = chain.source_id
+      WHERE d.id IS NULL OR d.is_stub = 0 OR d.is_stub IS NULL
       ORDER BY chain.depth, chain.target_id
     `;
 

--- a/thoughts/shared/plans/2026-04-26-GH-0897-stub-leak-traverse-search-stats.md
+++ b/thoughts/shared/plans/2026-04-26-GH-0897-stub-leak-traverse-search-stats.md
@@ -66,11 +66,11 @@ After this plan ships:
 
 ### Verification
 
-- [ ] `knowledge_traverse` from a doc with stub-target wikilinks returns only real-document hops in both directions.
-- [ ] `knowledge_search` over an FTS index containing stubs returns zero stub rows.
-- [ ] `knowledge_memory_stats` totals match `SELECT COUNT(*) FROM documents WHERE is_stub = 0 OR is_stub IS NULL`.
-- [ ] Typed-relationship stubs (`builds_on` to non-existent target) are filtered identically to untyped-wikilink stubs by all three tools.
-- [ ] `npm test` from `plugin/ralph-knowledge/` passes.
+- [x] `knowledge_traverse` from a doc with stub-target wikilinks returns only real-document hops in both directions.
+- [x] `knowledge_search` over an FTS index containing stubs returns zero stub rows.
+- [x] `knowledge_memory_stats` totals match `SELECT COUNT(*) FROM documents WHERE is_stub = 0 OR is_stub IS NULL`.
+- [x] Typed-relationship stubs (`builds_on` to non-existent target) are filtered identically to untyped-wikilink stubs by all three tools.
+- [x] `npm test` from `plugin/ralph-knowledge/` passes.
 
 ## What We're NOT Doing
 
@@ -107,10 +107,10 @@ Add `is_stub = 0 OR is_stub IS NULL` predicates at the four bypass query sites i
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] In `traverse.ts:28-53` (outgoing CTE), add `WHERE d.is_stub = 0 OR d.is_stub IS NULL` to the outer `SELECT ... FROM chain LEFT JOIN documents d ...`. Because the current join is a `LEFT JOIN`, the predicate must NOT filter rows where `d.id IS NULL` (which would happen if a relationship target row was deleted but the relationship persisted). Use exactly: `WHERE d.id IS NULL OR d.is_stub = 0 OR d.is_stub IS NULL`.
-  - [ ] In `traverse.ts:85-110` (incoming CTE), apply the same predicate to the join on `d.id = chain.source_id`: `WHERE d.id IS NULL OR d.is_stub = 0 OR d.is_stub IS NULL`.
-  - [ ] No change to the recursive CTE body itself — the filter only constrains the outer SELECT so chains can still recurse through (then drop) any path. **Decision rationale**: filtering inside the CTE would prune mid-chain, hiding real targets reachable via a stub hop. Filtering only the final projection drops stub *results* without breaking transitive reach. (For this codebase, where stubs are never sources of edges that would extend a chain, both choices are equivalent in practice — outer-filter is simpler.)
-  - [ ] All existing tests in `__tests__/traverse.test.ts` continue to pass (no fixture currently uses stubs, so behavior is identical).
+  - [x] In `traverse.ts:28-53` (outgoing CTE), add `WHERE d.is_stub = 0 OR d.is_stub IS NULL` to the outer `SELECT ... FROM chain LEFT JOIN documents d ...`. Because the current join is a `LEFT JOIN`, the predicate must NOT filter rows where `d.id IS NULL` (which would happen if a relationship target row was deleted but the relationship persisted). Use exactly: `WHERE d.id IS NULL OR d.is_stub = 0 OR d.is_stub IS NULL`.
+  - [x] In `traverse.ts:85-110` (incoming CTE), apply the same predicate to the join on `d.id = chain.source_id`: `WHERE d.id IS NULL OR d.is_stub = 0 OR d.is_stub IS NULL`.
+  - [x] No change to the recursive CTE body itself — the filter only constrains the outer SELECT so chains can still recurse through (then drop) any path. **Decision rationale**: filtering inside the CTE would prune mid-chain, hiding real targets reachable via a stub hop. Filtering only the final projection drops stub *results* without breaking transitive reach. (For this codebase, where stubs are never sources of edges that would extend a chain, both choices are equivalent in practice — outer-filter is simpler.)
+  - [x] All existing tests in `__tests__/traverse.test.ts` continue to pass (no fixture currently uses stubs, so behavior is identical). **NOTE during impl**: one pre-existing test ("stub documents appear as doc in traverse results with title matching stub ID" at line 186) explicitly asserted the buggy stub-leak behavior. That test was inverted to assert the new correct behavior (stubs filtered out) and renamed for the GH-897 regression context. No other existing tests required changes.
 
 #### Task 1.2: Add stub filter to `FtsSearch.search()` query
 - **files**: `plugin/ralph-knowledge/src/search.ts` (modify)
@@ -118,10 +118,10 @@ Add `is_stub = 0 OR is_stub IS NULL` predicates at the four bypass query sites i
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] In `search.ts:123-153`, add a new condition to the `conditions` array (alongside the superseded/type/tag predicates): `conditions.push("(d.is_stub = 0 OR d.is_stub IS NULL)");`. Place it immediately after the `documents_fts MATCH @query` push so it always applies and runs early in the WHERE evaluation.
-  - [ ] No parameter binding required — the literal `0` is fine and avoids noise.
-  - [ ] Do NOT modify `rebuildIndex()`. Approach (b) was rejected per Shared Constraints — stubs may remain in `documents_fts` on existing installs, and the query-time filter handles them.
-  - [ ] All existing tests in `__tests__/search.test.ts` pass unchanged.
+  - [x] In `search.ts:123-153`, add a new condition to the `conditions` array (alongside the superseded/type/tag predicates): `conditions.push("(d.is_stub = 0 OR d.is_stub IS NULL)");`. Place it immediately after the `documents_fts MATCH @query` push so it always applies and runs early in the WHERE evaluation.
+  - [x] No parameter binding required — the literal `0` is fine and avoids noise.
+  - [x] Do NOT modify `rebuildIndex()`. Approach (b) was rejected per Shared Constraints — stubs may remain in `documents_fts` on existing installs, and the query-time filter handles them.
+  - [x] All existing tests in `__tests__/search.test.ts` pass unchanged.
 
 #### Task 1.3: Add stub filter to `knowledge_memory_stats` count queries
 - **files**: `plugin/ralph-knowledge/src/index.ts` (modify)
@@ -129,13 +129,13 @@ Add `is_stub = 0 OR is_stub IS NULL` predicates at the four bypass query sites i
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] At `index.ts:196`, change `SELECT COUNT(*) AS c FROM documents` to `SELECT COUNT(*) AS c FROM documents WHERE is_stub = 0 OR is_stub IS NULL`.
-  - [ ] At `index.ts:213-216`, change the by-tier query to add `WHERE (is_stub = 0 OR is_stub IS NULL)` before `GROUP BY memory_tier`.
-  - [ ] At `index.ts:224-229`, change the new-since by-tier query to add `AND (is_stub = 0 OR is_stub IS NULL)` to the existing WHERE clause (before `GROUP BY memory_tier`).
-  - [ ] At `index.ts:240-243` (the v2-schema fallback `new_since` query for `byTier.doc`), add `AND (is_stub = 0 OR is_stub IS NULL)` to the existing WHERE. Even though stubs have `date = NULL` and the existing `date IS NOT NULL` filter already excludes them, add the explicit predicate for consistency and to harden against any future stub that gets a non-null date.
-  - [ ] At `index.ts:262-268` (the `last_reflection_at` query): add `AND (is_stub = 0 OR is_stub IS NULL)` for the same defense-in-depth reason; reflection stubs cannot exist today but the predicate is cheap.
-  - [ ] When `hasTier` is false and `totalDocuments` is assigned to `byTier.doc` at `index.ts:238`, this still uses the now-stub-filtered total — correct behavior, no change needed.
-  - [ ] `chunks_per_doc_p50/p90` query at `index.ts:250-254` operates on `chunks` table (not `documents`); chunks are only created for real documents per [reindex.ts:230](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L230) (research §"Vector index is clean" and the same logic applies to chunks). No change needed.
+  - [x] At `index.ts:196`, change `SELECT COUNT(*) AS c FROM documents` to `SELECT COUNT(*) AS c FROM documents WHERE is_stub = 0 OR is_stub IS NULL`.
+  - [x] At `index.ts:213-216`, change the by-tier query to add `WHERE (is_stub = 0 OR is_stub IS NULL)` before `GROUP BY memory_tier`.
+  - [x] At `index.ts:224-229`, change the new-since by-tier query to add `AND (is_stub = 0 OR is_stub IS NULL)` to the existing WHERE clause (before `GROUP BY memory_tier`).
+  - [x] At `index.ts:240-243` (the v2-schema fallback `new_since` query for `byTier.doc`), add `AND (is_stub = 0 OR is_stub IS NULL)` to the existing WHERE. Even though stubs have `date = NULL` and the existing `date IS NOT NULL` filter already excludes them, add the explicit predicate for consistency and to harden against any future stub that gets a non-null date.
+  - [x] At `index.ts:262-268` (the `last_reflection_at` query): add `AND (is_stub = 0 OR is_stub IS NULL)` for the same defense-in-depth reason; reflection stubs cannot exist today but the predicate is cheap.
+  - [x] When `hasTier` is false and `totalDocuments` is assigned to `byTier.doc` at `index.ts:238`, this still uses the now-stub-filtered total — correct behavior, no change needed.
+  - [x] `chunks_per_doc_p50/p90` query at `index.ts:250-254` operates on `chunks` table (not `documents`); chunks are only created for real documents per [reindex.ts:230](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L230) (research §"Vector index is clean" and the same logic applies to chunks). No change needed.
 
 #### Task 1.4: Regression test — `knowledge_traverse` excludes stub hops (outgoing + incoming)
 - **files**: `plugin/ralph-knowledge/src/__tests__/traverse.test.ts` (modify)
@@ -143,12 +143,12 @@ Add `is_stub = 0 OR is_stub IS NULL` predicates at the four bypass query sites i
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] Add a `describe("stub filtering", () => {...})` block to the existing test file.
-  - [ ] Test setup: insert a real doc `real-a`, then call `db.upsertStubDocument("stub-untyped-target")` and `db.upsertStubDocument("stub-typed-target")`, then `db.addRelationship("real-a", "stub-untyped-target", "untyped", "context")` and `db.addRelationship("real-a", "stub-typed-target", "builds_on")`.
-  - [ ] Assert `traverser.traverse("real-a", { depth: 1 })` returns zero results (both stub targets filtered).
-  - [ ] Assert `traverser.traverseIncoming("stub-untyped-target")` returns zero results (the inbound edge from `real-a` is technically present, but the stub itself has no outbound chain — verify no spurious empty-target rows leak).
-  - [ ] Mirror test for incoming: insert `real-b` and `db.addRelationship("stub-untyped-target", "real-b", "untyped")` (yes, stubs CAN appear as source_id in `relationships` because the FK constraint accepts them — the row only needs the stub doc to exist). Then `traverser.traverseIncoming("real-b", { depth: 1 })` must return zero results (the only incoming edge is from a stub).
-  - [ ] Assert that the existing fixture in the file (real-only chain `doc-c -> doc-b -> doc-a`) still returns exactly the same results as before — non-regression check.
+  - [x] Add a `describe("stub filtering", () => {...})` block to the existing test file.
+  - [x] Test setup: insert a real doc `real-a`, then call `db.upsertStubDocument("stub-untyped-target")` and `db.upsertStubDocument("stub-typed-target")`, then `db.addRelationship("real-a", "stub-untyped-target", "untyped", "context")` and `db.addRelationship("real-a", "stub-typed-target", "builds_on")`.
+  - [x] Assert `traverser.traverse("real-a", { depth: 1 })` returns zero results (both stub targets filtered).
+  - [x] Assert `traverser.traverseIncoming("stub-untyped-target")` — **plan author's expectation amended during impl**: the join in `traverseIncoming` is on `chain.source_id`, so the stub filter drops rows whose *source* is a stub. When the stub is the inbound *target*, the source side (`real-a`) is real, so the row legitimately remains. The implemented test asserts exactly one result (the real-source inbound edge), and that no row has a stub doc as source. This matches the actual implementation semantics; the original "zero results" expectation in the plan was based on a misread of which side the join filter applies to.
+  - [x] Mirror test for incoming: insert `real-b` and `db.addRelationship("stub-untyped-target", "real-b", "untyped")` (yes, stubs CAN appear as source_id in `relationships` because the FK constraint accepts them — the row only needs the stub doc to exist). Then `traverser.traverseIncoming("real-b", { depth: 1 })` must return zero results (the only incoming edge is from a stub).
+  - [x] Assert that the existing fixture in the file (real-only chain `doc-c -> doc-b -> doc-a`) still returns exactly the same results as before — non-regression check.
 
 #### Task 1.5: Regression test — `FtsSearch.search()` excludes stub documents
 - **files**: `plugin/ralph-knowledge/src/__tests__/search.test.ts` (modify)
@@ -156,11 +156,11 @@ Add `is_stub = 0 OR is_stub IS NULL` predicates at the four bypass query sites i
 - **complexity**: low
 - **depends_on**: [1.2]
 - **acceptance**:
-  - [ ] Add a `describe("stub filtering", () => {...})` block.
-  - [ ] Setup: in a fresh `beforeEach` (or new `describe` with own setup), insert one real doc with content `"unique-marker payload"`, then `db.upsertStubDocument("unique-marker-stub-id")`. Call `fts.rebuildIndex()` after both inserts so the stub gets indexed (this is the unfortunate state present on installs that bumped schema version after stubs existed).
-  - [ ] Assert `fts.search("unique-marker")` returns exactly the real doc — the stub (whose `title = "unique-marker-stub-id"` matches) must be filtered out.
-  - [ ] Assert `fts.search("unique-marker-stub-id")` returns zero results — confirms the stub is invisible even when its title is queried directly.
-  - [ ] Verify the existing tests in `__tests__/search.test.ts` continue to pass.
+  - [x] Add a `describe("stub filtering", () => {...})` block.
+  - [x] Setup: in a fresh `beforeEach` (or new `describe` with own setup), insert one real doc with content `"unique-marker payload"`, then `db.upsertStubDocument("unique-marker-stub-id")`. Call `fts.rebuildIndex()` after both inserts so the stub gets indexed (this is the unfortunate state present on installs that bumped schema version after stubs existed).
+  - [x] Assert `fts.search("unique-marker")` returns exactly the real doc — the stub (whose `title = "unique-marker-stub-id"` matches) must be filtered out.
+  - [x] Assert `fts.search("unique-marker-stub-id")` returns zero results — confirms the stub is invisible even when its title is queried directly.
+  - [x] Verify the existing tests in `__tests__/search.test.ts` continue to pass.
 
 #### Task 1.6: Regression test — `knowledge_memory_stats` totals and by-tier exclude stubs
 - **files**: `plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts` (modify)
@@ -168,11 +168,11 @@ Add `is_stub = 0 OR is_stub IS NULL` predicates at the four bypass query sites i
 - **complexity**: low
 - **depends_on**: [1.3]
 - **acceptance**:
-  - [ ] Add a `describe("stub filtering", () => {...})` block using the existing `callStats` helper and `seedDoc` pattern.
-  - [ ] Setup: seed two real docs (one `doc` tier, one `reflection` tier), then create three stubs via `db.upsertStubDocument("stub-1")`, `db.upsertStubDocument("stub-2")`, `db.upsertStubDocument("stub-3")`.
-  - [ ] Assert `payload.total_documents === 2` (not 5).
-  - [ ] Assert `payload.by_tier.doc === 1`, `payload.by_tier.reflection === 1`, `payload.by_tier.raw === 0`. Stubs default to `memory_tier = 'doc'` per the migration default, so without the filter they would inflate `by_tier.doc` to 4.
-  - [ ] Assert `payload.new_since.*` are unaffected (stubs have `date = NULL` and were already excluded; this is a non-regression check).
+  - [x] Add a `describe("stub filtering", () => {...})` block using the existing `callStats` helper and `seedDoc` pattern.
+  - [x] Setup: seed two real docs (one `doc` tier, one `reflection` tier), then create three stubs via `db.upsertStubDocument("stub-1")`, `db.upsertStubDocument("stub-2")`, `db.upsertStubDocument("stub-3")`.
+  - [x] Assert `payload.total_documents === 2` (not 5).
+  - [x] Assert `payload.by_tier.doc === 1`, `payload.by_tier.reflection === 1`, `payload.by_tier.raw === 0`. Stubs default to `memory_tier = 'doc'` per the migration default, so without the filter they would inflate `by_tier.doc` to 4.
+  - [x] Assert `payload.new_since.*` are unaffected (stubs have `date = NULL` and were already excluded; this is a non-regression check).
 
 #### Task 1.7: Regression test — `GraphBuilder.buildGraph()` drops stub-target edges
 - **files**: `plugin/ralph-knowledge/src/__tests__/graph-builder.test.ts` (modify)
@@ -180,19 +180,19 @@ Add `is_stub = 0 OR is_stub IS NULL` predicates at the four bypass query sites i
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Add a test case asserting the previously-undocumented behavior at [graph-builder.ts:62-65](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/graph-builder.ts#L62-L65).
-  - [ ] Setup: insert real doc `real-x`, call `db.upsertStubDocument("stub-y")`, then `db.addRelationship("real-x", "stub-y", "untyped")` and `db.addRelationship("real-x", "stub-y", "builds_on")` (typed) to verify both relationship types drop together.
-  - [ ] Build graph: `const g = new GraphBuilder(db).buildGraph()`.
-  - [ ] Assert `g.hasNode("stub-y") === false`.
-  - [ ] Assert `g.outDegree("real-x") === 0` — both stub-target edges dropped.
-  - [ ] Assert `g.order === 1` (only `real-x`) and `g.size === 0`.
+  - [x] Add a test case asserting the previously-undocumented behavior at [graph-builder.ts:62-65](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/graph-builder.ts#L62-L65).
+  - [x] Setup: insert real doc `real-x`, call `db.upsertStubDocument("stub-y")`, then `db.addRelationship("real-x", "stub-y", "untyped")` and `db.addRelationship("real-x", "stub-y", "builds_on")` (typed) to verify both relationship types drop together.
+  - [x] Build graph: `const g = new GraphBuilder(db).buildGraph()`.
+  - [x] Assert `g.hasNode("stub-y") === false`.
+  - [x] Assert `g.outDegree("real-x") === 0` — both stub-target edges dropped.
+  - [x] Assert `g.order === 1` (only `real-x`) and `g.size === 0`.
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `cd plugin/ralph-knowledge && npm run build` — no TypeScript errors
-- [ ] `cd plugin/ralph-knowledge && npm test` — all suites pass, including the four new test blocks
-- [ ] `grep -rn "is_stub = 0 OR is_stub IS NULL" plugin/ralph-knowledge/src/` returns at least 7 hits (1 graph-builder existing, 2 traverse, 1 search, 5 index.ts memory-stats; counts approximate — confirms the canonical idiom is used everywhere)
+- [x] `cd plugin/ralph-knowledge && npm run build` — no TypeScript errors
+- [x] `cd plugin/ralph-knowledge && npm test` — all suites pass (415 tests across 19 files), including the four new test blocks
+- [x] `grep -rn "is_stub = 0 OR is_stub IS NULL" plugin/ralph-knowledge/src/` returns 9 hits in source files (`graph-builder.ts:33` existing; `traverse.ts:52,110`; `search.ts:127`; `index.ts:196,216,229,243,267`) — exceeds the plan threshold of 7 and uses the canonical idiom everywhere
 
 #### Manual Verification:
 - [ ] After patch, run the indexer against the live `~/.ralph-hero/knowledge.db` and call `knowledge_memory_stats` — `total_documents` should drop by the count of stubs (visible via `sqlite3 ~/.ralph-hero/knowledge.db "SELECT COUNT(*) FROM documents WHERE is_stub = 1"`).


### PR DESCRIPTION
## Summary

Fixed three MCP tools in ralph-knowledge that bypass the `is_stub` filter: `knowledge_traverse`, `knowledge_search` (FTS leg), and `knowledge_memory_stats`. These tools query SQLite directly and were returning stub documents materialized as foreign-key targets for unresolved wikilink references. Added the canonical `is_stub = 0 OR is_stub IS NULL` predicates at each bypass site plus regression tests.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-26-GH-0897-stub-leak-traverse-search-stats.md

## Test plan

- [ ] `knowledge_traverse` (outgoing and incoming) returns no stub-target hops
- [ ] `knowledge_search` FTS results exclude stub documents
- [ ] `knowledge_memory_stats` totals exclude stubs
- [ ] Typed-relationship stubs (`builds_on`, `tensions`, etc.) filtered identically to untyped wikilinks
- [ ] `GraphBuilder.buildGraph()` stub-drop behavior backed by explicit test
- [ ] `npm test` from `plugin/ralph-knowledge/` passes

Closes #897