### PR TITLE
GH-906: bug(ralph-knowledge): parser drops memory_tier frontmatter, all docs land as 'doc'

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/db.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/db.test.ts
@@ -689,6 +689,108 @@ describe("schema v3: memory_tier column", () => {
   });
 });
 
+describe("upsertDocument memory_tier persistence", () => {
+  it("defaults to 'doc' when memoryTier is omitted from upsert input", () => {
+    db.upsertDocument({
+      id: "no-tier",
+      path: "p",
+      title: "t",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+    });
+    expect(db.getMemoryTier("no-tier")).toBe("doc");
+  });
+
+  it("persists memoryTier: 'raw' on insert", () => {
+    db.upsertDocument({
+      id: "raw-doc",
+      path: "p",
+      title: "t",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+      memoryTier: "raw",
+    });
+    expect(db.getMemoryTier("raw-doc")).toBe("raw");
+  });
+
+  it("persists memoryTier: 'reflection' on insert", () => {
+    db.upsertDocument({
+      id: "refl-doc",
+      path: "p",
+      title: "t",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+      memoryTier: "reflection",
+    });
+    expect(db.getMemoryTier("refl-doc")).toBe("reflection");
+  });
+
+  it("preserves existing 'raw' memory_tier on re-upsert without memoryTier (COALESCE)", () => {
+    db.upsertDocument({
+      id: "preserve",
+      path: "p",
+      title: "t",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "first",
+      memoryTier: "raw",
+    });
+    expect(db.getMemoryTier("preserve")).toBe("raw");
+
+    // Re-upsert without memoryTier — COALESCE should keep the prior 'raw' value.
+    db.upsertDocument({
+      id: "preserve",
+      path: "p",
+      title: "t-updated",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "second",
+    });
+    expect(db.getMemoryTier("preserve")).toBe("raw");
+  });
+
+  it("explicit memoryTier on re-upsert wins over the prior value", () => {
+    db.upsertDocument({
+      id: "promote",
+      path: "p",
+      title: "t",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+      memoryTier: "raw",
+    });
+    expect(db.getMemoryTier("promote")).toBe("raw");
+
+    db.upsertDocument({
+      id: "promote",
+      path: "p",
+      title: "t",
+      date: null,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "",
+      memoryTier: "reflection",
+    });
+    expect(db.getMemoryTier("promote")).toBe("reflection");
+  });
+});
+
 describe("schema v3: clearAll includes chunks", () => {
   it("deletes chunks along with documents", () => {
     db.upsertDocument({ id: "doc-1", path: "p", title: "t", date: null, type: null, status: null, githubIssue: null, content: "" });

--- a/plugin/ralph-knowledge/src/__tests__/parser.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { parseDocument, inferTypeFromPath, extractUntypedWikilinks } from "../parser.js";
 
 const FULL_DOC = `---
@@ -434,3 +434,54 @@ Some prose that also mentions [[typed-target]] and [[untyped-target]].
   });
 });
 
+describe("parseDocument memory_tier", () => {
+  function makeDoc(frontmatter: string, body = "# Test\n\nContent."): string {
+    return `---\n${frontmatter}\n---\n\n${body}`;
+  }
+
+  it("extracts memory_tier: raw from frontmatter", () => {
+    const raw = makeDoc("date: 2026-04-29\ntype: research\nmemory_tier: raw");
+    const doc = parseDocument("test-raw", "thoughts/dream-memories/test-raw.md", raw);
+    expect(doc.memoryTier).toBe("raw");
+  });
+
+  it("extracts memory_tier: reflection from frontmatter", () => {
+    const raw = makeDoc("date: 2026-04-29\ntype: research\nmemory_tier: reflection");
+    const doc = parseDocument("test-reflection", "thoughts/dream-memories/reflections/test-reflection.md", raw);
+    expect(doc.memoryTier).toBe("reflection");
+  });
+
+  it("extracts memory_tier: doc from frontmatter", () => {
+    const raw = makeDoc("date: 2026-04-29\ntype: research\nmemory_tier: doc");
+    const doc = parseDocument("test-doc", "thoughts/shared/research/test-doc.md", raw);
+    expect(doc.memoryTier).toBe("doc");
+  });
+
+  it("defaults memory_tier to 'doc' when frontmatter omits the key", () => {
+    const raw = makeDoc("date: 2026-04-29\ntype: research");
+    const doc = parseDocument("test-default", "thoughts/shared/research/test-default.md", raw);
+    expect(doc.memoryTier).toBe("doc");
+  });
+
+  it("coerces invalid memory_tier to 'doc' and warns once", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const raw = makeDoc("date: 2026-04-29\ntype: research\nmemory_tier: garbage");
+      const doc = parseDocument("test-bad", "thoughts/shared/research/test-bad.md", raw);
+      expect(doc.memoryTier).toBe("doc");
+
+      const tierWarnings = warnSpy.mock.calls.filter(args =>
+        args.some(a => typeof a === "string" && /memory_tier 'garbage' on 'test-bad'/.test(a)),
+      );
+      expect(tierWarnings).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("defaults to 'doc' when memory_tier is null in frontmatter", () => {
+    const raw = makeDoc("date: 2026-04-29\ntype: research\nmemory_tier: null");
+    const doc = parseDocument("test-null", "thoughts/shared/research/test-null.md", raw);
+    expect(doc.memoryTier).toBe("doc");
+  });
+});

--- a/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/reindex.test.ts
@@ -734,4 +734,82 @@ describe("incremental reindex", () => {
     }
     db.close();
   });
+
+  // ---- GH-906: memory_tier write path round-trip ----
+  //
+  // These scenarios exercise the full parser -> upsertDocument -> documents.memory_tier
+  // path on real disk + real DB. They do NOT use ":memory:" and do NOT hand-craft
+  // INSERT statements — the bug was that frontmatter values were silently dropped
+  // before reaching the DB, so any test that bypasses parseDocument or upsertDocument
+  // is unable to catch a regression here.
+
+  it("scenario 24: memory_tier from frontmatter is persisted to the documents table", async () => {
+    writeFileSync(
+      join(dir, "raw-memory.md"),
+      `---\ndate: 2026-04-29\ntype: research\nstatus: draft\nmemory_tier: raw\n---\n\n# Raw Memory Sample\n\nDream-loop raw memory body.`,
+    );
+
+    await reindex([dir], dbPath);
+
+    const db = new KnowledgeDB(dbPath);
+    try {
+      expect(db.getMemoryTier("raw-memory")).toBe("raw");
+      // Belt-and-suspenders: assert against raw SQL too, in case getMemoryTier
+      // semantics ever change (e.g., column-existence guard, alias drift).
+      const row = db.db
+        .prepare("SELECT memory_tier FROM documents WHERE id = ?")
+        .get("raw-memory") as { memory_tier: string };
+      expect(row.memory_tier).toBe("raw");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("scenario 25: memory_tier: reflection round-trips through reindex", async () => {
+    writeFileSync(
+      join(dir, "reflection-doc.md"),
+      `---\ndate: 2026-04-29\ntype: research\nstatus: draft\nmemory_tier: reflection\n---\n\n# Reflection Sample\n\nSynthesized reflection body.`,
+    );
+
+    await reindex([dir], dbPath);
+
+    const db = new KnowledgeDB(dbPath);
+    try {
+      expect(db.getMemoryTier("reflection-doc")).toBe("reflection");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("scenario 26: missing memory_tier defaults to 'doc' end-to-end", async () => {
+    writeFileSync(
+      join(dir, "default-doc.md"),
+      `---\ndate: 2026-04-29\ntype: research\nstatus: draft\n---\n\n# Default Doc\n\nNo memory_tier in frontmatter.`,
+    );
+
+    await reindex([dir], dbPath);
+
+    const db = new KnowledgeDB(dbPath);
+    try {
+      expect(db.getMemoryTier("default-doc")).toBe("doc");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("scenario 27: invalid memory_tier in frontmatter coerces to 'doc'", async () => {
+    writeFileSync(
+      join(dir, "garbage-tier.md"),
+      `---\ndate: 2026-04-29\ntype: research\nstatus: draft\nmemory_tier: garbage\n---\n\n# Garbage Tier\n\nInvalid memory_tier value.`,
+    );
+
+    await reindex([dir], dbPath);
+
+    const db = new KnowledgeDB(dbPath);
+    try {
+      expect(db.getMemoryTier("garbage-tier")).toBe("doc");
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/plugin/ralph-knowledge/src/db.ts
+++ b/plugin/ralph-knowledge/src/db.ts
@@ -220,14 +220,26 @@ export class KnowledgeDB {
     }
   }
 
-  upsertDocument(doc: Omit<DocumentRow, "isStub"> & { isStub?: number }): void {
+  upsertDocument(
+    doc: Omit<DocumentRow, "isStub"> & { isStub?: number; memoryTier?: string | null },
+  ): void {
+    // memoryTier is intentionally optional: callers that don't pass it get the
+    // SQL column default ('doc') on insert and preserve the existing value on
+    // update via COALESCE. This keeps existing test fixtures and any future
+    // call sites that don't care about tiers compiling without changes, while
+    // still letting reindex.ts forward the parsed value through.
+    const params = {
+      ...doc,
+      memoryTier: doc.memoryTier ?? null,
+    };
     this.db.prepare(`
-      INSERT INTO documents (id, path, title, date, type, status, github_issue, content, is_stub)
-      VALUES (@id, @path, @title, @date, @type, @status, @githubIssue, @content, 0)
+      INSERT INTO documents (id, path, title, date, type, status, github_issue, content, is_stub, memory_tier)
+      VALUES (@id, @path, @title, @date, @type, @status, @githubIssue, @content, 0, COALESCE(@memoryTier, 'doc'))
       ON CONFLICT(id) DO UPDATE SET
         path = @path, title = @title, date = @date, type = @type,
-        status = @status, github_issue = @githubIssue, content = @content, is_stub = 0
-    `).run(doc);
+        status = @status, github_issue = @githubIssue, content = @content, is_stub = 0,
+        memory_tier = COALESCE(@memoryTier, memory_tier)
+    `).run(params);
   }
 
   /**

--- a/plugin/ralph-knowledge/src/parser.ts
+++ b/plugin/ralph-knowledge/src/parser.ts
@@ -25,6 +25,7 @@ export interface ParsedDocument {
   relationships: Relationship[];
   untypedEdges: UntypedEdge[];
   content: string;
+  memoryTier: string;
 }
 
 const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---/;
@@ -33,6 +34,10 @@ const WIKILINK_REL_RE = /^- (builds_on|tensions|post_mortem):: \[\[(.+?)\]\]/gm;
 const SUPERSEDED_BY_RE = /\[\[(.+?)\]\]/;
 const WIKILINK_RE = /\[\[([^\]]+)\]\]/g;
 const FENCED_CODE_RE = /```[\s\S]*?```/g;
+
+// Allowed memory_tier values mirror the SQL CHECK constraint in db.ts
+// (schema v3). The parser is forgiving: invalid/absent values coerce to 'doc'.
+const ALLOWED_MEMORY_TIERS = new Set<string>(["doc", "raw", "reflection"]);
 
 const PATH_TYPE_MAP: Array<{ segment: string; type: string }> = [
   { segment: "/research/", type: "research" },
@@ -122,6 +127,22 @@ export function parseDocument(id: string, path: string, raw: string): ParsedDocu
 
   const tags: string[] = Array.isArray(frontmatter.tags) ? frontmatter.tags.map(String) : [];
 
+  // memory_tier extraction: validate against the three allowed values from
+  // schema v3's CHECK constraint. Absent/null values default to 'doc'. Invalid
+  // values coerce to 'doc' with a single warning so the indexer never crashes
+  // on garbage frontmatter — the SQL CHECK is the hard guard.
+  const rawMemoryTier = frontmatter.memory_tier;
+  let memoryTier = "doc";
+  if (rawMemoryTier !== undefined && rawMemoryTier !== null) {
+    if (typeof rawMemoryTier === "string" && ALLOWED_MEMORY_TIERS.has(rawMemoryTier)) {
+      memoryTier = rawMemoryTier;
+    } else {
+      console.warn(
+        `memory_tier '${String(rawMemoryTier)}' on '${id}' is not one of doc|raw|reflection — coercing to 'doc'`,
+      );
+    }
+  }
+
   return {
     id, path, title,
     date: frontmatter.date ? String(frontmatter.date) : null,
@@ -139,6 +160,6 @@ export function parseDocument(id: string, path: string, raw: string): ParsedDocu
     githubIssues: Array.isArray(frontmatter.github_issues)
       ? frontmatter.github_issues.filter((n: unknown) => typeof n === "number")
       : [],
-    tags, relationships, untypedEdges, content: body,
+    tags, relationships, untypedEdges, content: body, memoryTier,
   };
 }

--- a/plugin/ralph-knowledge/src/reindex.ts
+++ b/plugin/ralph-knowledge/src/reindex.ts
@@ -141,6 +141,7 @@ export async function reindex(
       status: parsed.status,
       githubIssue: parsed.githubIssue,
       content: parsed.content,
+      memoryTier: parsed.memoryTier,
     });
 
     // Insert new FTS entry AFTER upsert

--- a/thoughts/shared/plans/2026-04-29-GH-0906-parser-memory-tier-write-path.md
+++ b/thoughts/shared/plans/2026-04-29-GH-0906-parser-memory-tier-write-path.md
@@ -55,10 +55,10 @@ The fix is two narrow edits — one in `parser.ts` (extract from frontmatter) an
 
 ### Verification
 
-- [ ] `parser.ts` extracts `memory_tier` from frontmatter alongside `date`, `type`, `status`, `github_issue`, `tags`, `superseded_by`. Validates against the three allowed values; coerces invalid/absent values to `'doc'` with a one-line warning for invalid.
-- [ ] `db.ts:upsertDocument()` includes `memory_tier` in both the INSERT column list and the `ON CONFLICT(id) DO UPDATE SET ...` clause.
-- [ ] `reindex.ts` forwards `parsed.memoryTier` into the upsert payload at the existing call site (line ~135).
-- [ ] An end-to-end test writes `memory_tier: raw` markdown to a temp dir on disk, runs `reindex(...)`, opens the produced DB via `new KnowledgeDB(dbPath)`, and asserts `SELECT memory_tier FROM documents WHERE id = ?` returns `'raw'`. The test does not use `:memory:` and does not hand-craft `INSERT` statements.
+- [x] `parser.ts` extracts `memory_tier` from frontmatter alongside `date`, `type`, `status`, `github_issue`, `tags`, `superseded_by`. Validates against the three allowed values; coerces invalid/absent values to `'doc'` with a one-line warning for invalid.
+- [x] `db.ts:upsertDocument()` includes `memory_tier` in both the INSERT column list and the `ON CONFLICT(id) DO UPDATE SET ...` clause.
+- [x] `reindex.ts` forwards `parsed.memoryTier` into the upsert payload at the existing call site (line ~135).
+- [x] An end-to-end test writes `memory_tier: raw` markdown to a temp dir on disk, runs `reindex(...)`, opens the produced DB via `new KnowledgeDB(dbPath)`, and asserts `SELECT memory_tier FROM documents WHERE id = ?` returns `'raw'`. The test does not use `:memory:` and does not hand-craft `INSERT` statements.
 - [ ] After re-running `npm run reindex` on the user's local corpus, `sqlite3 ~/.ralph-hero/knowledge.db "SELECT memory_tier, COUNT(*) FROM documents GROUP BY memory_tier"` reports non-zero counts for `raw` (and, once `reflect.py` runs successfully, for `reflection`). [Manual — depends on GH-907 to also be resolved before all 14 raw files survive a reindex.]
 - [ ] `reflect.py` finds the raw memories in its query window after the manual reindex (currently returns "Loaded 0 raw memories"). [Manual — same dependency.]
 
@@ -159,8 +159,8 @@ Extend the markdown frontmatter parser to extract `memory_tier`, extend the SQL 
 
 #### Automated Verification:
 
-- [ ] `npm run build` (in `plugin/ralph-knowledge/`) — no TypeScript errors
-- [ ] `npm test` (in `plugin/ralph-knowledge/`) — all existing tests pass + new tests in `parser.test.ts`, `db.test.ts`, and `reindex.test.ts` pass
+- [x] `npm run build` (in `plugin/ralph-knowledge/`) — no TypeScript errors
+- [x] `npm test` (in `plugin/ralph-knowledge/`) — all existing tests pass + new tests in `parser.test.ts`, `db.test.ts`, and `reindex.test.ts` pass
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

Fixed the memory_tier write path in ralph-knowledge. The schema v3 migration added the `documents.memory_tier` column with proper validation and defaults, but the indexer was not extracting `memory_tier` from frontmatter or persisting it to the database. All indexed documents were falling back to the column default ('doc'), including 14 raw-memory files written by ingest.py with explicit `memory_tier: raw` in their frontmatter.

This fix adds extraction in parser.ts, persistence in db.ts, and forwarding through reindex.ts, plus a real-disk end-to-end test that proves the round-trip works without hand-crafted SQL statements.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-29-GH-0906-parser-memory-tier-write-path.md

Single-phase implementation. Four tasks: parser extract, db persist, reindex forward, E2E test.

## Test plan

- [x] `npm run build` (no TypeScript errors)
- [x] `npm test` (all new + existing tests pass)
- [ ] Automated verification per plan Success Criteria (post-merge)
- [ ] Manual verification: reindex user corpus, confirm `sqlite3 ~/.ralph-hero/knowledge.db "SELECT memory_tier, COUNT(*) FROM documents GROUP BY memory_tier"` shows non-zero raw count (depends on GH-907 also being resolved)
- [ ] Manual verification: run `dream-now`, confirm reflect.py finds raw memories instead of "Loaded 0"

Closes #906