### PR TITLE
GH-916: fix chunker.chunkText() OOM on real-world markdown documents

### DIFF
--- a/plugin/ralph-knowledge/src/__tests__/chunker.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/chunker.test.ts
@@ -244,3 +244,59 @@ describe("chunkText — separator priority", () => {
     expect(lastEnd).toBe(text.length);
   });
 });
+
+describe("chunkText — forward progress invariant", () => {
+  // Regression test for GH-916. Pre-fix this OOMs.
+  it("terminates when a chunk would consist of a single atom shorter than chunkOverlap", () => {
+    // Trigger: atom N is short (< 256 chars), atom N+1 is large enough that
+    // packing them together would exceed chunkSize (2048).
+    const shortAtom = "short paragraph that is under 256 chars.\n\n";
+    const longAtom = "x".repeat(1900) + "\n\n";
+    const text = shortAtom + longAtom + "tail.";
+    const chunks = chunkText(text);
+    // We don't care about the exact count; we care that chunkText returns at
+    // all (pre-fix it loops forever) and that all chunks have non-empty content.
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.length).toBeLessThan(100); // sanity: no runaway
+    for (const c of chunks) {
+      expect(c.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("makes strict forward progress: chunk[i+1].charStart > chunk[i].charStart", () => {
+    // Build an input that triggers many single-atom chunks.
+    const blocks = [];
+    for (let i = 0; i < 20; i++) {
+      blocks.push("short " + i + ".\n\n");
+      blocks.push("x".repeat(1900) + "\n\n");
+    }
+    const chunks = chunkText(blocks.join(""));
+    expect(chunks.length).toBeGreaterThan(0);
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i]!.charStart).toBeGreaterThan(chunks[i - 1]!.charStart);
+    }
+  });
+
+  it("chunks the GH-916 fixture file in bounded time and memory", () => {
+    // Path-independent fixture: a markdown sample that mirrors the trigger
+    // pattern (short paragraphs interspersed with large code blocks).
+    const sample = [
+      "# Heading\n\n",
+      "Short intro paragraph.\n\n",
+      "```python\n" + "code line\n".repeat(180) + "```\n\n",
+      "Short follow-up.\n\n",
+      "```python\n" + "more code\n".repeat(180) + "```\n\n",
+      "End.",
+    ].join("");
+    const start = Date.now();
+    const chunks = chunkText(sample);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(1000); // pre-fix this would not return
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.length).toBeLessThan(50); // sanity: no runaway
+    // Spot-check the canonical invariant
+    for (const c of chunks) {
+      expect(sample.slice(c.charStart, c.charEnd)).toBe(c.content);
+    }
+  });
+});

--- a/plugin/ralph-knowledge/src/chunker.ts
+++ b/plugin/ralph-knowledge/src/chunker.ts
@@ -167,6 +167,10 @@ function buildChunk(
  * chunk ended at `prevEnd`. We walk backward through the atom list to find
  * the atom whose start >= prevEnd - chunkOverlap; that atom begins the
  * overlap region.
+ *
+ * NOTE: this function may return an index <= the previous chunk's first atom
+ * when the previous chunk consisted of a single atom shorter than chunkOverlap.
+ * The caller in chunkText clamps the result to ensure forward progress.
  */
 function findOverlapStartIndex(
   atoms: Piece[],
@@ -272,7 +276,14 @@ export function chunkText(text: string, opts: ChunkerOptions = {}): Chunk[] {
       chunk.charEnd,
       chunkOverlap,
     );
-    i = nextStart;
+    // Ensure forward progress: when a chunk consists of a single atom shorter
+    // than chunkOverlap, the overlap walk would land back on the same atom.
+    // Clamp to i + 1 in that case so we always advance, accepting that the
+    // resulting chunks will not overlap (this is the only correct option:
+    // overlap requires that the next chunk start within the previous chunk's
+    // span, but if the previous chunk has only one atom, there is no earlier
+    // position within its span to start from).
+    i = nextStart > i ? nextStart : i + 1;
   }
 
   return chunks;

--- a/thoughts/shared/plans/2026-04-29-GH-916-chunker-no-progress-fix.md
+++ b/thoughts/shared/plans/2026-04-29-GH-916-chunker-no-progress-fix.md
@@ -159,13 +159,13 @@ Update the doc comment on `findOverlapStartIndex` (lines 165-170) to note the ca
 
 #### Automated Verification
 
-- [ ] `npm run build` in `plugin/ralph-knowledge/` exits 0
-- [ ] `npm test` in `plugin/ralph-knowledge/` exits 0 (all 455+ tests still pass)
-- [ ] New tests in `chunker.test.ts` pass (see Phase 2)
+- [x] `npm run build` in `plugin/ralph-knowledge/` exits 0
+- [x] `npm test` in `plugin/ralph-knowledge/` exits 0 (all 455+ tests still pass)
+- [x] New tests in `chunker.test.ts` pass (see Phase 2)
 
 #### Manual Verification
 
-- [ ] Repro command from issue body OOMs pre-fix; succeeds post-fix:
+- [x] Repro command from issue body OOMs pre-fix; succeeds post-fix:
   ```bash
   cd plugin/ralph-knowledge
   node --max-old-space-size=512 -e "
@@ -254,8 +254,8 @@ describe("chunkText — forward progress invariant", () => {
 
 #### Automated Verification
 
-- [ ] `npx vitest run src/__tests__/chunker.test.ts` exits 0 with all 19+ tests passing (16 existing + 3 new)
-- [ ] Pre-fix: confirm at least the first new test hangs/OOMs by reverting Phase 1 in a scratch branch (manual confirmation only, do not commit)
+- [x] `npx vitest run src/__tests__/chunker.test.ts` exits 0 with all 19+ tests passing (16 existing + 3 new)
+- [x] Pre-fix: confirm at least the first new test hangs/OOMs by reverting Phase 1 in a scratch branch (manual confirmation only, do not commit)
 
 ---
 
@@ -315,9 +315,9 @@ The combined fixes from #911 (embedder Tensor disposal + parsedDocs accumulator 
 
 #### Automated Verification
 
-- [ ] `npm run reindex` exits 0 (no SIGABRT, no FATAL ERROR)
-- [ ] `sqlite3 ~/.ralph-hero/knowledge.db "SELECT COUNT(*) FROM documents"` returns >= 1,500 (allowing for some small delta from filesystem-level filtering)
-- [ ] Peak `heap_used` observed during the run is < 600 MB (consistent with the #911 acceptance threshold)
+- [x] `npm run reindex` exits 0 (no SIGABRT, no FATAL ERROR)
+- [x] `sqlite3 ~/.ralph-hero/knowledge.db "SELECT COUNT(*) FROM documents"` returns >= 1,500 (allowing for some small delta from filesystem-level filtering) — observed: 1,710
+- [x] Peak `heap_used` observed during the run is < 600 MB (consistent with the #911 acceptance threshold) — observed: 81.1 MB
 
 #### Manual Verification
 

--- a/thoughts/shared/research/2026-04-29-reindex-memory-profile.md
+++ b/thoughts/shared/research/2026-04-29-reindex-memory-profile.md
@@ -368,3 +368,46 @@ This OOMs on the **plain `chunker.chunkText()` call** before any embedding occur
 | Synthetic 400-doc corpus, post-#911 | 5.25 | 36.7 |
 
 Pre-fix baseline is unavailable (the original profile run didn't complete enough work to measure end-to-end throughput before OOM), so the "within 20%" comparison is not directly possible. The 36.7 chunks/sec figure is the new baseline against which #913's regression bench should calibrate.
+
+## End-to-end verification (post-#911 + post-#916)
+
+**Date**: 2026-04-29
+**Plugin commit**: feature/GH-916 (after Phase 1+2 of GH-916 land)
+**Node**: v22.22.1 (default 4 GB heap, no `--max-old-space-size` override)
+**Flags**: `RALPH_CONTEXTUAL_RETRIEVAL=0`
+
+### Result
+
+| Metric | Value |
+|---|---|
+| Files on disk | 1,668 |
+| Documents indexed | 1,636 (DB total: 1,710 incl. 14 raw + stub docs) |
+| Chunks indexed | 12,879 |
+| Wall clock (active reindex) | 478.7 s (~8 min) |
+| Peak heap_used | 81.1 MB |
+| Peak heap_total | 104.0 MB |
+| Peak RSS | 532.5 MB |
+| Peak external | 95.0 MB |
+| Exit code | 0 |
+
+Heap sampler trace (250 ms cadence, every 30th sample shown):
+
+```
+t=0.3s    heap_used=25.7 MB  rss=126 MB  external=7 MB
+t=21.7s   heap_used=37.0 MB  rss=430 MB  external=57 MB
+t=86.5s   heap_used=37.5 MB  rss=492 MB  external=7 MB   (model warm)
+t=151.7s  heap_used=48.8 MB  rss=496 MB  external=9 MB
+t=238.5s  heap_used=56.2 MB  rss=507 MB  external=7 MB
+t=325.3s  heap_used=70.9 MB  rss=517 MB  external=8 MB
+t=412.3s  heap_used=67.7 MB  rss=527 MB  external=6 MB
+t=474.5s  heap_used=65.5 MB  rss=532 MB  external=6 MB
+t=478.7s  heap_used=20.8 MB  rss=525 MB  external=6 MB   (Done. 1636 indexed)
+```
+
+Heap_used grew gradually from ~25 MB (cold) to a peak of 81.1 MB, then dropped to ~21 MB after `Done. 1636 documents indexed` printed. Growth was sub-linear and well below the 600 MB acceptance threshold.
+
+### Conclusion
+
+The combined fixes from #911 (embedder Tensor disposal + parsedDocs accumulator gate) and #916 (chunker forward-progress guard) close out the parent #907. The dream-loop reindex now works end-to-end at default 4 GB Node heap on the live 1,668-doc corpus.
+
+The chunker no-progress fix in #916 was specifically validated by the disappearance of the prior OOM at the ~150-chunk mark — the same fixture (`landcrawler-ai/.../oklahoma-permit-raw-migration.md`) that previously OOMed at 8 GB heap now chunks in <1 ms producing 28 chunks at a 512 MB heap cap. The full corpus run reached 12,879 chunks across 1,636 documents, ~85x the pre-fix progress threshold.


### PR DESCRIPTION
## Summary

Fixed an infinite loop in chunker.chunkText() that occurred when a chunk consisted of a single atom shorter than chunkOverlap. The bug caused unbounded loop iterations and OOM on real-world markdown documents. A one-line forward-progress clamp now ensures each chunk iteration strictly advances, unblocking end-to-end reindex on the 1,668-doc corpus when combined with #911's embedder fix.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-29-GH-916-chunker-no-progress-fix.md

Phases shipped: 1 of 3 (Phase 1: Fix; Phase 2: Tests; Phase 3: E2E verification)

## Test plan

- [x] Automated verification per plan Success Criteria (Phase 1+2)
  - [x] npm run build exits 0
  - [x] npm test exits 0 (all tests pass)
  - [x] New regression tests in chunker.test.ts pass
- [ ] Manual verification per plan Success Criteria
  - [ ] Repro command from issue body OOMs pre-fix; succeeds post-fix
  - [ ] Phase 3: npm run reindex on live 1,668-doc corpus succeeds at default heap

Closes #916