### PR TITLE
feat(mcp-server): hello directions Phase 1 — pure ranker + parent edge (GH-921)

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
@@ -1,0 +1,624 @@
+/**
+ * Tests for the pure ranker library at `lib/directions.ts`.
+ *
+ * All cases use injected `now` via `RankConfig` so that time-dependent
+ * boosts (stale, lock-stale, tree-recent-done, PR age) are deterministic.
+ * No GraphQL mocking is required — `DashboardItem[]` is fabricated
+ * directly.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  rankDirections,
+  scoreIssue,
+  detectTreeContinue,
+  detectLockStale,
+  buildReason,
+  DEFAULT_RANK_CONFIG,
+  type RankConfig,
+  type OpenPR,
+} from "../lib/directions.js";
+import type { DashboardItem } from "../lib/dashboard.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const NOW = new Date("2026-04-30T12:00:00Z");
+
+function makeConfig(overrides: Partial<RankConfig> = {}): RankConfig {
+  return {
+    ...DEFAULT_RANK_CONFIG,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<DashboardItem> = {}): DashboardItem {
+  return {
+    number: 1,
+    title: "Test issue",
+    updatedAt: new Date(NOW.getTime() - 1 * HOUR_MS).toISOString(),
+    closedAt: null,
+    workflowState: "Plan in Review",
+    priority: null,
+    estimate: null,
+    assignees: [],
+    subIssueCount: 0,
+    blockedBy: [],
+    parentNumber: null,
+    parentState: null,
+    ...overrides,
+  };
+}
+
+function makePR(overrides: Partial<OpenPR> = {}): OpenPR {
+  return {
+    number: 100,
+    title: "Test PR",
+    url: "https://github.com/o/r/pull/100",
+    isDraft: false,
+    reviewDecision: null,
+    headRefName: "feature/GH-1",
+    createdAt: new Date(NOW.getTime() - 1 * HOUR_MS).toISOString(),
+    ageHours: 1,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Empty input
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — empty input", () => {
+  it("returns an empty directions array when there are no items and no PRs", () => {
+    const result = rankDirections([], [], makeConfig());
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Pure priority sort
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — pure priority sort", () => {
+  it("orders P0 / P1 / P2 issues in Plan in Review by priority", () => {
+    const items: DashboardItem[] = [
+      makeItem({ number: 102, priority: "P2", workflowState: "Plan in Review" }),
+      makeItem({ number: 100, priority: "P0", workflowState: "Plan in Review" }),
+      makeItem({ number: 101, priority: "P1", workflowState: "Plan in Review" }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    expect(result.map((d) => d.issue?.number)).toEqual([100, 101, 102]);
+    expect(result.map((d) => d.kind)).toEqual(["issue", "issue", "issue"]);
+    expect(result.map((d) => d.rank)).toEqual([1, 2, 3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Phase tiebreaker
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — phase tiebreaker", () => {
+  it("orders Plan in Review > In Review > Research Needed when priorities tie", () => {
+    const items: DashboardItem[] = [
+      makeItem({ number: 200, priority: "P1", workflowState: "Research Needed" }),
+      makeItem({ number: 201, priority: "P1", workflowState: "Plan in Review" }),
+      makeItem({ number: 202, priority: "P1", workflowState: "In Review" }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    expect(result.map((d) => d.issue?.workflowState)).toEqual([
+      "Plan in Review",
+      "In Review",
+      "Research Needed",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Stale boost
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — stale boost", () => {
+  it("a stale P3 issue beats a fresh P1 issue when the boost is large enough", () => {
+    const items: DashboardItem[] = [
+      makeItem({
+        number: 300,
+        priority: "P1",
+        workflowState: "Plan in Review",
+        updatedAt: new Date(NOW.getTime() - 1 * HOUR_MS).toISOString(),
+      }),
+      makeItem({
+        number: 301,
+        priority: "P3",
+        workflowState: "Plan in Review",
+        updatedAt: new Date(NOW.getTime() - 60 * HOUR_MS).toISOString(),
+      }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    // Stale P3: 30 + 0 + (-50) = -20
+    // Fresh P1: 10 + 0 + 0 = 10
+    expect(result[0].issue?.number).toBe(301);
+    expect(result[0].tags).toContain("stale");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Lock-stale surfacing
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — lock-stale surfacing", () => {
+  it("surfaces an In Progress issue idle 30h as kind: lock-stale", () => {
+    const items: DashboardItem[] = [
+      makeItem({
+        number: 400,
+        priority: "P2",
+        workflowState: "In Progress",
+        updatedAt: new Date(NOW.getTime() - 30 * HOUR_MS).toISOString(),
+      }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("lock-stale");
+    expect(result[0].issue?.number).toBe(400);
+    expect(result[0].tags).toContain("stalled");
+  });
+
+  it("does not surface an In Progress issue idle 10h as lock-stale", () => {
+    const items: DashboardItem[] = [
+      makeItem({
+        number: 401,
+        priority: "P2",
+        workflowState: "In Progress",
+        updatedAt: new Date(NOW.getTime() - 10 * HOUR_MS).toISOString(),
+      }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    // In Progress is not an actionable phase, and 10h < lockStaleHours=24
+    // so the issue is filtered out entirely.
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Blocked-by dropped
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — blocked-by handling", () => {
+  it("filters out blocked candidates when other candidates exist", () => {
+    const items: DashboardItem[] = [
+      makeItem({
+        number: 500,
+        priority: "P0",
+        workflowState: "Plan in Review",
+        blockedBy: [{ number: 999, workflowState: null }],
+      }),
+      makeItem({
+        number: 501,
+        priority: "P3",
+        workflowState: "Plan in Review",
+      }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    expect(result.map((d) => d.issue?.number)).toEqual([501]);
+  });
+
+  it("surfaces a blocked candidate when it is the only option, with blocked tag", () => {
+    const items: DashboardItem[] = [
+      makeItem({
+        number: 510,
+        priority: "P1",
+        workflowState: "Plan in Review",
+        blockedBy: [{ number: 999, workflowState: null }],
+      }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    expect(result).toHaveLength(1);
+    expect(result[0].issue?.number).toBe(510);
+    expect(result[0].tags).toContain("blocked");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Tree-continue promotion
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — tree-continue promotion", () => {
+  it("promotes a tree-continue candidate from rank 4 to rank 2", () => {
+    // Construct a scoring landscape where tree-continue lands at rank 4
+    // by absolute score, so we can verify the promotion rule pulls it
+    // up to slot 2 without disturbing slot 1.
+    //
+    // Three P0 stale items in Plan in Review:  0 + 0 - 50 = -50 each
+    // One  P3 tree-continue   in Plan in Review: 30 + 0 - 75 = -45
+    // One  P3 plain           in Plan in Review: 30 + 0 = 30
+    //
+    // Natural sort: 601(-50), 602(-50), 603(-50), 604(-45), 605(30).
+    // After tree-continue promotion: 601, 604, 602, 603, 605.
+    const stale = new Date(NOW.getTime() - 60 * HOUR_MS).toISOString();
+    const sibClosed = makeItem({
+      number: 700,
+      workflowState: "Done",
+      closedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+      parentNumber: 999,
+      parentState: "OPEN",
+    });
+
+    const items: DashboardItem[] = [
+      makeItem({ number: 601, priority: "P0", workflowState: "Plan in Review", updatedAt: stale }),
+      makeItem({ number: 602, priority: "P0", workflowState: "Plan in Review", updatedAt: stale }),
+      makeItem({ number: 603, priority: "P0", workflowState: "Plan in Review", updatedAt: stale }),
+      makeItem({
+        number: 604,
+        priority: "P3",
+        workflowState: "Plan in Review",
+        parentNumber: 999,
+        parentState: "OPEN",
+      }),
+      makeItem({ number: 605, priority: "P3", workflowState: "Plan in Review" }),
+      sibClosed,
+    ];
+
+    const result = rankDirections(items, [], makeConfig({ limit: 5 }));
+    // 604 should be in slot 2 (promoted)
+    expect(result[1].issue?.number).toBe(604);
+    expect(result[1].kind).toBe("tree-continue");
+    // Slot 1 unchanged: top stale P0 by issue number = 601
+    expect(result[0].issue?.number).toBe(601);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Tree-continue criteria sub-cases
+// ---------------------------------------------------------------------------
+
+describe("detectTreeContinue criteria", () => {
+  it("(a) sibling closed within window -> positive", () => {
+    const candidate = makeItem({
+      number: 800,
+      parentNumber: 999,
+      parentState: "OPEN",
+      updatedAt: new Date(NOW.getTime() - 30 * DAY_MS).toISOString(),
+    });
+    const sibling = makeItem({
+      number: 801,
+      parentNumber: 999,
+      parentState: "OPEN",
+      workflowState: "Done",
+      closedAt: new Date(NOW.getTime() - 2 * DAY_MS).toISOString(),
+    });
+    expect(detectTreeContinue(candidate, [candidate, sibling], makeConfig())).toBe(true);
+  });
+
+  it("(b) candidate updated within window AND parent has open siblings -> positive", () => {
+    const candidate = makeItem({
+      number: 810,
+      parentNumber: 999,
+      parentState: "OPEN",
+      updatedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+    });
+    const openSibling = makeItem({
+      number: 811,
+      parentNumber: 999,
+      parentState: "OPEN",
+      workflowState: "Plan in Review",
+      closedAt: null,
+    });
+    expect(
+      detectTreeContinue(candidate, [candidate, openSibling], makeConfig()),
+    ).toBe(true);
+  });
+
+  it("(c) no parent -> negative", () => {
+    const candidate = makeItem({
+      number: 820,
+      parentNumber: null,
+      parentState: null,
+      updatedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+    });
+    expect(detectTreeContinue(candidate, [candidate], makeConfig())).toBe(false);
+  });
+
+  it("(d) parent done -> negative", () => {
+    const candidate = makeItem({
+      number: 830,
+      parentNumber: 999,
+      parentState: "CLOSED",
+      updatedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+    });
+    const sibling = makeItem({
+      number: 831,
+      parentNumber: 999,
+      parentState: "CLOSED",
+      workflowState: "Done",
+      closedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+    });
+    expect(
+      detectTreeContinue(candidate, [candidate, sibling], makeConfig()),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. PR ranking
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — PR ranking", () => {
+  it("a REVIEW_REQUIRED PR ranks above any issue", () => {
+    const items: DashboardItem[] = [
+      makeItem({ number: 900, priority: "P0", workflowState: "Plan in Review" }),
+    ];
+    const prs: OpenPR[] = [
+      makePR({
+        number: 901,
+        reviewDecision: "REVIEW_REQUIRED",
+        ageHours: 30,
+        headRefName: "feature/GH-900",
+        createdAt: new Date(NOW.getTime() - 30 * HOUR_MS).toISOString(),
+      }),
+    ];
+
+    const result = rankDirections(items, prs, makeConfig());
+    expect(result[0].kind).toBe("pr");
+    expect(result[0].pr?.number).toBe(901);
+    expect(result[1].kind).toBe("issue");
+  });
+
+  it("an APPROVED PR is not surfaced", () => {
+    const items: DashboardItem[] = [];
+    const prs: OpenPR[] = [
+      makePR({
+        number: 910,
+        reviewDecision: "APPROVED",
+        ageHours: 30,
+      }),
+    ];
+
+    const result = rankDirections(items, prs, makeConfig());
+    expect(result).toEqual([]);
+  });
+
+  it("a draft PR is excluded from ranking", () => {
+    const items: DashboardItem[] = [];
+    const prs: OpenPR[] = [
+      makePR({
+        number: 920,
+        isDraft: true,
+        reviewDecision: "REVIEW_REQUIRED",
+        ageHours: 30,
+      }),
+    ];
+
+    const result = rankDirections(items, prs, makeConfig());
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. PR-issue link via headRefName
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — PR-issue link", () => {
+  it("parses GH-NNNN out of headRefName and mentions it in reason", () => {
+    const prs: OpenPR[] = [
+      makePR({
+        number: 1000,
+        reviewDecision: "REVIEW_REQUIRED",
+        headRefName: "feature/GH-0042",
+        ageHours: 36,
+        createdAt: new Date(NOW.getTime() - 36 * HOUR_MS).toISOString(),
+      }),
+    ];
+
+    const result = rankDirections([], prs, makeConfig());
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("pr");
+    expect(result[0].issue).toBeNull();
+    expect(result[0].reason).toContain("issue #42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Determinism
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — determinism", () => {
+  it("returns byte-identical output across two calls with the same input + now", () => {
+    const items: DashboardItem[] = [
+      makeItem({ number: 1100, priority: "P0", workflowState: "Plan in Review" }),
+      makeItem({ number: 1101, priority: "P1", workflowState: "In Review" }),
+      makeItem({
+        number: 1102,
+        priority: "P3",
+        workflowState: "Research Needed",
+        updatedAt: new Date(NOW.getTime() - 60 * HOUR_MS).toISOString(),
+      }),
+    ];
+    const prs: OpenPR[] = [
+      makePR({
+        number: 1110,
+        reviewDecision: "REVIEW_REQUIRED",
+        ageHours: 30,
+        headRefName: "feature/GH-1100",
+      }),
+    ];
+
+    const config = makeConfig();
+    const a = rankDirections(items, prs, config);
+    const b = rankDirections(items, prs, config);
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. Limit honored
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — limit honored", () => {
+  it("returns at most config.limit directions", () => {
+    const items: DashboardItem[] = Array.from({ length: 10 }, (_, i) =>
+      makeItem({
+        number: 1200 + i,
+        priority: "P1",
+        workflowState: "Plan in Review",
+      }),
+    );
+
+    const result = rankDirections(items, [], makeConfig({ limit: 1 }));
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. All criteria off (fallback to phase-rank)
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — phase-rank-only fallback", () => {
+  it("falls back to phase rank when no priorities, no stale, no tree, no PRs", () => {
+    const items: DashboardItem[] = [
+      makeItem({
+        number: 1300,
+        priority: null,
+        workflowState: "Research Needed",
+      }),
+      makeItem({
+        number: 1301,
+        priority: null,
+        workflowState: "Plan in Review",
+      }),
+      makeItem({
+        number: 1302,
+        priority: null,
+        workflowState: "In Review",
+      }),
+    ];
+
+    const result = rankDirections(items, [], makeConfig());
+    expect(result.map((d) => d.issue?.workflowState)).toEqual([
+      "Plan in Review",
+      "In Review",
+      "Research Needed",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreIssue precedence (sanity)
+// ---------------------------------------------------------------------------
+
+describe("scoreIssue — kind precedence", () => {
+  it("lock-stale wins over tree-continue when both match", () => {
+    const candidate = makeItem({
+      number: 1400,
+      workflowState: "In Progress",
+      updatedAt: new Date(NOW.getTime() - 30 * HOUR_MS).toISOString(),
+      parentNumber: 999,
+      parentState: "OPEN",
+    });
+    const sibling = makeItem({
+      number: 1401,
+      parentNumber: 999,
+      parentState: "OPEN",
+      workflowState: "Done",
+      closedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+    });
+    const config = makeConfig();
+    const { kind } = scoreIssue(candidate, [candidate, sibling], config);
+    expect(kind).toBe("lock-stale");
+  });
+
+  it("tree-continue wins over plain issue when no lock-stale", () => {
+    const candidate = makeItem({
+      number: 1410,
+      workflowState: "Plan in Review",
+      parentNumber: 999,
+      parentState: "OPEN",
+    });
+    const sibling = makeItem({
+      number: 1411,
+      parentNumber: 999,
+      parentState: "OPEN",
+      workflowState: "Done",
+      closedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+    });
+    const { kind } = scoreIssue(candidate, [candidate, sibling], makeConfig());
+    expect(kind).toBe("tree-continue");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectLockStale (direct)
+// ---------------------------------------------------------------------------
+
+describe("detectLockStale", () => {
+  it("returns false for non-lock states regardless of age", () => {
+    const item = makeItem({
+      workflowState: "Plan in Review",
+      updatedAt: new Date(NOW.getTime() - 100 * HOUR_MS).toISOString(),
+    });
+    expect(detectLockStale(item, makeConfig())).toBe(false);
+  });
+
+  it("returns true for lock states older than threshold", () => {
+    const item = makeItem({
+      workflowState: "Plan in Progress",
+      updatedAt: new Date(NOW.getTime() - 25 * HOUR_MS).toISOString(),
+    });
+    expect(detectLockStale(item, makeConfig())).toBe(true);
+  });
+
+  it("returns false for lock states younger than threshold", () => {
+    const item = makeItem({
+      workflowState: "Research in Progress",
+      updatedAt: new Date(NOW.getTime() - 5 * HOUR_MS).toISOString(),
+    });
+    expect(detectLockStale(item, makeConfig())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReason — natural English smoke checks
+// ---------------------------------------------------------------------------
+
+describe("buildReason", () => {
+  it("renders a lock-stale reason mentioning the workflow state", () => {
+    const item = makeItem({
+      number: 1500,
+      workflowState: "In Progress",
+      updatedAt: new Date(NOW.getTime() - 48 * HOUR_MS).toISOString(),
+    });
+    const reason = buildReason("lock-stale", item, null, ["stalled"], makeConfig());
+    expect(reason).toContain("In Progress");
+    expect(reason.toLowerCase()).toContain("stuck");
+  });
+
+  it("renders a tree-continue reason mentioning the issue number", () => {
+    const item = makeItem({
+      number: 1510,
+      workflowState: "Plan in Review",
+    });
+    const reason = buildReason("tree-continue", item, null, ["tree"], makeConfig());
+    expect(reason).toContain("#1510");
+    expect(reason.toLowerCase()).toContain("tree");
+  });
+
+  it("renders a PR reason with day count", () => {
+    const pr = makePR({
+      number: 1520,
+      reviewDecision: "REVIEW_REQUIRED",
+      ageHours: 48,
+    });
+    const reason = buildReason("pr", null, pr, ["needs-review"], makeConfig(), 42);
+    expect(reason).toContain("#1520");
+    expect(reason).toContain("issue #42");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
@@ -46,6 +46,8 @@ export interface DashboardItem {
   iterationTitle?: string; // Iteration name (e.g., "Sprint 1")
   iterationStartDate?: string; // ISO date string
   iterationDuration?: number; // days
+  parentNumber?: number | null; // Parent issue number (from trackedInIssues edge)
+  parentState?: string | null; // Parent issue GitHub state ("OPEN" / "CLOSED")
 }
 
 /** One row in the pipeline snapshot. */

--- a/plugin/ralph-hero/mcp-server/src/lib/directions.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/directions.ts
@@ -1,0 +1,609 @@
+/**
+ * Pure ranker library for the `ralph_hero__hello_directions` MCP tool.
+ *
+ * Computes up to N deterministic directions for a session-briefing
+ * companion. All functions are side-effect free: time is injected via
+ * `RankConfig.now`, no Date.now() / Math.random() are called inside the
+ * module. Inputs are arrays of `DashboardItem` (already fetched + shaped
+ * by `tools/dashboard-tools.ts`) plus an optional list of open PRs.
+ *
+ * Ranking algorithm (lower score wins):
+ *
+ *   score(item) =
+ *       priorityScore(item.priority)       // P0=0, P1=10, P2=20, P3=30, none=99
+ *     + phaseScore(item.workflowState)     // Plan in Review=0, In Review=1, Ready for Plan=2, Research Needed=3
+ *     + staleBoost(item, now)              // -50 if non-lock state with updatedAt > stuckThresholdHours
+ *     + lockStaleBoost(item, now)          // -100 if lock state with updatedAt > lockStaleHours
+ *     + treeContinueBoost(item, allItems)  // -75 if tree-continue criteria match
+ *
+ *   candidates = items
+ *     .filter(actionable phase OR lock-stale)
+ *     .filter(no open trackedIssues blocking)        // unless candidate would be empty
+ *     .sort(by score ascending)
+ *     .promote(tree-continue from top-5 to slot 2 if not slot 1)
+ *     .merge(open PR scores)
+ *     .slice(config.limit)
+ *
+ * Kind precedence per item: lock-stale > tree-continue > issue.
+ * PRs are scored separately and only merged into the final ranking.
+ */
+
+import type { DashboardItem } from "./dashboard.js";
+import { LOCK_STATES, STATE_ORDER } from "./workflow-states.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface OpenPR {
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  /** "REVIEW_REQUIRED" | "APPROVED" | "CHANGES_REQUESTED" | null */
+  reviewDecision: string | null;
+  headRefName: string;
+  createdAt: string;
+  /** Computed at the boundary (tool entry point), not derived inside the lib. */
+  ageHours: number;
+}
+
+export interface Direction {
+  rank: number;
+  kind: "issue" | "pr" | "tree-continue" | "lock-stale";
+  issue: {
+    number: number;
+    title: string;
+    workflowState: string | null;
+    priority: string | null;
+    estimate: string | null;
+  } | null;
+  pr: {
+    number: number;
+    title: string;
+    url: string;
+    ageHours: number;
+    reviewDecision: string | null;
+  } | null;
+  reason: string;
+  tags: string[];
+  score: number;
+}
+
+export interface RankConfig {
+  /** Max directions to return. Default 3. */
+  limit: number;
+  /** Hours before a non-lock issue is considered stale. Default 48. */
+  stuckThresholdHours: number;
+  /** Hours before a lock-state issue is considered stalled. Default 24. */
+  lockStaleHours: number;
+  /** Days within which a sibling Done event still pulls a tree forward. Default 7. */
+  treeRecentDoneDays: number;
+  /** Hours before an open PR is considered stale (older PRs rank higher). Default 24. */
+  prStaleHours: number;
+  /** Injected for testability — never read from the wall clock inside the lib. */
+  now: Date;
+}
+
+export const DEFAULT_RANK_CONFIG: Omit<RankConfig, "now"> = {
+  limit: 3,
+  stuckThresholdHours: 48,
+  lockStaleHours: 24,
+  treeRecentDoneDays: 7,
+  prStaleHours: 24,
+};
+
+// ---------------------------------------------------------------------------
+// Internal scoring constants
+// ---------------------------------------------------------------------------
+
+const ACTIONABLE_PHASES: ReadonlySet<string> = new Set([
+  "Plan in Review",
+  "In Review",
+  "Ready for Plan",
+  "Research Needed",
+]);
+
+const PHASE_RANK: Readonly<Record<string, number>> = {
+  "Plan in Review": 0,
+  "In Review": 1,
+  "Ready for Plan": 2,
+  "Research Needed": 3,
+};
+
+const PRIORITY_RANK: Readonly<Record<string, number>> = {
+  P0: 0,
+  P1: 10,
+  P2: 20,
+  P3: 30,
+};
+
+const STALE_BOOST = -50;
+const LOCK_STALE_BOOST = -100;
+const TREE_CONTINUE_BOOST = -75;
+const PR_REVIEW_REQUIRED_BOOST = -200;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function priorityScore(p: string | null): number {
+  if (p === null) return 99;
+  return PRIORITY_RANK[p] ?? 99;
+}
+
+function phaseScore(state: string | null): number {
+  if (state === null) return 99;
+  const explicit = PHASE_RANK[state];
+  if (explicit !== undefined) return explicit;
+  // Fallback: for actionable phases not in the explicit table, use their
+  // STATE_ORDER position as a coarse tiebreaker so newly-added states
+  // still rank reasonably without code changes.
+  const idx = STATE_ORDER.indexOf(state);
+  return idx >= 0 ? 50 + idx : 99;
+}
+
+function ageHours(updatedAt: string, now: Date): number {
+  const t = new Date(updatedAt).getTime();
+  if (Number.isNaN(t)) return 0;
+  return Math.max(0, (now.getTime() - t) / HOUR_MS);
+}
+
+function ageDays(updatedAt: string, now: Date): number {
+  const t = new Date(updatedAt).getTime();
+  if (Number.isNaN(t)) return 0;
+  return Math.max(0, (now.getTime() - t) / DAY_MS);
+}
+
+function hasOpenBlockers(item: DashboardItem): boolean {
+  return item.blockedBy.some(
+    (b) => b.workflowState !== "Done" && b.workflowState !== "Canceled",
+  );
+}
+
+function isLockState(state: string | null): boolean {
+  return state !== null && LOCK_STATES.includes(state);
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the candidate is in a lock state and its updatedAt
+ * timestamp is older than `config.lockStaleHours`. These items are surfaced
+ * as `kind: "lock-stale"` so the user is reminded to unstick them.
+ */
+export function detectLockStale(item: DashboardItem, config: RankConfig): boolean {
+  if (!isLockState(item.workflowState)) return false;
+  return ageHours(item.updatedAt, config.now) >= config.lockStaleHours;
+}
+
+/**
+ * Returns true when the candidate participates in an "active tree" — i.e.
+ * something in its sibling group recently moved or it itself moved while
+ * other siblings remain open. False when there is no parent edge or the
+ * parent is closed (CLOSED state means tree is finished).
+ *
+ * Criteria (any one positive):
+ *   (a) A sibling has closedAt within `treeRecentDoneDays`.
+ *   (b) The candidate itself has updatedAt within `treeRecentDoneDays`,
+ *       its parent is open, and at least one other open sibling exists.
+ */
+export function detectTreeContinue(
+  item: DashboardItem,
+  allItems: DashboardItem[],
+  config: RankConfig,
+): boolean {
+  const parent = item.parentNumber ?? null;
+  if (parent === null || parent === undefined) return false;
+
+  // Parent done -> tree is finished, do not surface.
+  // GitHub raw state arrives as "OPEN" / "CLOSED"; defensively also accept
+  // workflow-state strings.
+  const parentState = item.parentState ?? null;
+  if (
+    parentState === "CLOSED" ||
+    parentState === "Done" ||
+    parentState === "Canceled"
+  ) {
+    return false;
+  }
+
+  const siblings = allItems.filter(
+    (other) =>
+      other.number !== item.number && other.parentNumber === parent,
+  );
+
+  // (a) sibling closed within window
+  for (const sib of siblings) {
+    if (sib.closedAt) {
+      const days = ageDays(sib.closedAt, config.now);
+      if (days <= config.treeRecentDoneDays) return true;
+    }
+  }
+
+  // (b) candidate moved recently AND has open siblings
+  const candidateRecentlyMoved =
+    ageDays(item.updatedAt, config.now) <= config.treeRecentDoneDays;
+  if (!candidateRecentlyMoved) return false;
+
+  const openSiblings = siblings.filter(
+    (sib) =>
+      sib.closedAt === null &&
+      sib.workflowState !== "Done" &&
+      sib.workflowState !== "Canceled",
+  );
+  return openSiblings.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// scoreIssue
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a single dashboard item. Returns the winning kind for this candidate
+ * in precedence order:
+ *
+ *   detectLockStale(item) -> kind: "lock-stale"
+ *   else detectTreeContinue(item) -> kind: "tree-continue"
+ *   else -> kind: "issue"
+ *
+ * `tags[]` carries descriptive signals (e.g. "stale", "high-priority",
+ * "blocked") that did NOT win the kind slot but still shape the prose
+ * `reason` rendered by `buildReason`.
+ *
+ * PR ranking is handled separately by `rankDirections` — this function
+ * never returns kind "pr".
+ */
+export function scoreIssue(
+  item: DashboardItem,
+  allItems: DashboardItem[],
+  config: RankConfig,
+): { score: number; kind: Exclude<Direction["kind"], "pr">; tags: string[] } {
+  const tags: string[] = [];
+
+  let score = priorityScore(item.priority) + phaseScore(item.workflowState);
+
+  const lockStale = detectLockStale(item, config);
+  const treeContinue = detectTreeContinue(item, allItems, config);
+
+  // Stale boost (non-lock states only)
+  const isStale =
+    !isLockState(item.workflowState) &&
+    ageHours(item.updatedAt, config.now) >= config.stuckThresholdHours;
+  if (isStale) {
+    score += STALE_BOOST;
+    tags.push("stale");
+  }
+
+  if (lockStale) {
+    score += LOCK_STALE_BOOST;
+    tags.push("stalled");
+  }
+
+  if (treeContinue) {
+    score += TREE_CONTINUE_BOOST;
+    tags.push("tree");
+  }
+
+  // Descriptive-only tags
+  if (item.priority === "P0" || item.priority === "P1") {
+    tags.push("high-priority");
+  }
+  if (hasOpenBlockers(item)) {
+    tags.push("blocked");
+  }
+
+  // Pick winning kind in precedence order
+  let kind: Exclude<Direction["kind"], "pr">;
+  if (lockStale) {
+    kind = "lock-stale";
+  } else if (treeContinue) {
+    kind = "tree-continue";
+  } else {
+    kind = "issue";
+  }
+
+  return { score, kind, tags };
+}
+
+// ---------------------------------------------------------------------------
+// PR scoring
+// ---------------------------------------------------------------------------
+
+interface PRScored {
+  pr: OpenPR;
+  score: number;
+  reason: string;
+  tags: string[];
+  /** Issue number parsed from a `feature/GH-NNNN` head-ref, if present. */
+  linkedIssueNumber: number | null;
+}
+
+function parseIssueNumberFromHeadRef(headRefName: string): number | null {
+  // Match "GH-42" or "GH-0042" anywhere in the ref.
+  const m = headRefName.match(/GH-0*(\d+)/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+function scorePR(pr: OpenPR, config: RankConfig): PRScored | null {
+  // Drafts are excluded from ranking entirely.
+  if (pr.isDraft) return null;
+
+  // APPROVED PRs are not surfaced — they are waiting on merge, not user
+  // attention. CHANGES_REQUESTED also skipped (author needs to push fixes,
+  // not the briefing user).
+  if (pr.reviewDecision === "APPROVED") return null;
+
+  const tags: string[] = [];
+  let score = 0;
+
+  if (pr.reviewDecision === "REVIEW_REQUIRED") {
+    score += PR_REVIEW_REQUIRED_BOOST;
+    tags.push("needs-review");
+  }
+
+  // Older PRs rank slightly higher (more negative) than fresher ones.
+  // 1 point per hour beyond prStaleHours, capped at -50 to keep them from
+  // dominating REVIEW_REQUIRED items already at -200.
+  if (pr.ageHours > config.prStaleHours) {
+    const extra = Math.min(50, pr.ageHours - config.prStaleHours);
+    score -= extra;
+    tags.push("stale");
+  }
+
+  // PRs that did not pick up a boost (no review required, fresh) should
+  // not surface — they are work-in-progress noise.
+  if (score === 0) return null;
+
+  const linkedIssueNumber = parseIssueNumberFromHeadRef(pr.headRefName);
+
+  return {
+    pr,
+    score,
+    reason: "", // filled in by buildReason at finalization time
+    tags,
+    linkedIssueNumber,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildReason
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a single-sentence prose reason for a direction. Distinct shapes
+ * per kind so the output reads as natural English rather than
+ * template-y. No trailing period — the consumer wraps the sentence into
+ * a paragraph at presentation time.
+ */
+export function buildReason(
+  kind: Direction["kind"],
+  issue: DashboardItem | null,
+  pr: OpenPR | null,
+  tags: string[],
+  config: RankConfig,
+  linkedIssueNumber: number | null = null,
+): string {
+  if (kind === "pr" && pr) {
+    const days = Math.max(1, Math.floor(pr.ageHours / 24));
+    const dayLabel = days === 1 ? "day" : "days";
+    if (pr.reviewDecision === "REVIEW_REQUIRED") {
+      const linkClause =
+        linkedIssueNumber !== null
+          ? ` (issue #${linkedIssueNumber})`
+          : "";
+      return `PR #${pr.number} needs review${linkClause} — open ${days} ${dayLabel}`;
+    }
+    return `PR #${pr.number} has been open ${days} ${dayLabel} without movement`;
+  }
+
+  if (!issue) return "Unknown direction";
+
+  if (kind === "lock-stale") {
+    const hours = Math.round(ageHours(issue.updatedAt, config.now));
+    const days = Math.max(1, Math.floor(hours / 24));
+    const dayLabel = days === 1 ? "day" : "days";
+    return `Stuck in ${issue.workflowState} for ${days} ${dayLabel} — may be blocked`;
+  }
+
+  if (kind === "tree-continue") {
+    return `#${issue.number} is part of an active tree — keep it moving before starting something new`;
+  }
+
+  // kind === "issue"
+  const phase = issue.workflowState ?? "Backlog";
+  if (tags.includes("stale")) {
+    const hours = Math.round(ageHours(issue.updatedAt, config.now));
+    const days = Math.max(1, Math.floor(hours / 24));
+    const dayLabel = days === 1 ? "day" : "days";
+    return `${phase} for ${days} ${dayLabel} — likely the most unblocking thing`;
+  }
+  if (issue.priority === "P0") {
+    return `P0 in ${phase} — top of the queue`;
+  }
+  if (issue.priority === "P1") {
+    return `P1 in ${phase} — worth a look`;
+  }
+  return `${phase} — next in line`;
+}
+
+// ---------------------------------------------------------------------------
+// rankDirections — main entry point
+// ---------------------------------------------------------------------------
+
+interface ScoredCandidate {
+  item: DashboardItem;
+  score: number;
+  kind: Exclude<Direction["kind"], "pr">;
+  tags: string[];
+}
+
+function isCandidatePhase(state: string | null): boolean {
+  if (state === null) return false;
+  return ACTIONABLE_PHASES.has(state);
+}
+
+function toDirectionIssue(item: DashboardItem): Direction["issue"] {
+  return {
+    number: item.number,
+    title: item.title,
+    workflowState: item.workflowState,
+    priority: item.priority,
+    estimate: item.estimate,
+  };
+}
+
+function toDirectionPR(pr: OpenPR): Direction["pr"] {
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    ageHours: pr.ageHours,
+    reviewDecision: pr.reviewDecision,
+  };
+}
+
+/**
+ * Main entry point. Filters, scores, sorts, and slices a candidate set
+ * into up to `config.limit` deterministically-ranked directions.
+ *
+ * Determinism contract: same input + same `config.now` -> byte-identical
+ * output across calls. Achieved by:
+ *   - never reading `Date.now()` inside the lib
+ *   - using stable secondary sort keys (issue number / PR number)
+ *   - never iterating Sets/Maps for ordered work
+ */
+export function rankDirections(
+  items: DashboardItem[],
+  openPRs: OpenPR[],
+  config: RankConfig,
+): Direction[] {
+  // 1. Score all items first so we know which ones lock-stale (those go in
+  //    the candidate set even if their phase is not actionable).
+  const scored: ScoredCandidate[] = [];
+  for (const item of items) {
+    const isLockStale = detectLockStale(item, config);
+    const passesPhaseFilter = isCandidatePhase(item.workflowState) || isLockStale;
+    if (!passesPhaseFilter) continue;
+
+    const { score, kind, tags } = scoreIssue(item, items, config);
+    scored.push({ item, score, kind, tags });
+  }
+
+  // 2. Drop blocked items unless that would empty the candidate set.
+  const unblocked = scored.filter((s) => !hasOpenBlockers(s.item));
+  let candidates: ScoredCandidate[];
+  if (unblocked.length > 0) {
+    candidates = unblocked;
+  } else if (scored.length > 0) {
+    // Surface the blocked candidates so the briefing isn't silent. Tags
+    // already include "blocked" via scoreIssue.
+    candidates = scored;
+  } else {
+    candidates = [];
+  }
+
+  // 3. Score PRs.
+  const prScored: PRScored[] = [];
+  for (const pr of openPRs) {
+    const s = scorePR(pr, config);
+    if (s) prScored.push(s);
+  }
+
+  // 4. Merge issues + PRs into a single ordered list (stable sort:
+  //    score asc, then a kind tiebreaker, then number asc).
+  type Entry =
+    | { kind: "issueRow"; payload: ScoredCandidate }
+    | { kind: "prRow"; payload: PRScored };
+
+  const merged: Entry[] = [];
+  for (const c of candidates) merged.push({ kind: "issueRow", payload: c });
+  for (const p of prScored) merged.push({ kind: "prRow", payload: p });
+
+  merged.sort((a, b) => {
+    const scoreA = a.kind === "issueRow" ? a.payload.score : a.payload.score;
+    const scoreB = b.kind === "issueRow" ? b.payload.score : b.payload.score;
+    if (scoreA !== scoreB) return scoreA - scoreB;
+    // Secondary: PRs before issues at the same score (PRs are usually
+    // higher-urgency action items: "merge or reply" beats "consider").
+    if (a.kind !== b.kind) return a.kind === "prRow" ? -1 : 1;
+    if (a.kind === "issueRow" && b.kind === "issueRow") {
+      return a.payload.item.number - b.payload.item.number;
+    }
+    if (a.kind === "prRow" && b.kind === "prRow") {
+      return a.payload.pr.number - b.payload.pr.number;
+    }
+    return 0;
+  });
+
+  // 5. Tree-continue promotion: if a tree-continue is anywhere in the
+  //    top 5 of the merged list but not in slot 1, promote it to slot 2.
+  if (merged.length >= 2) {
+    const slot1IsTreeContinue =
+      merged[0].kind === "issueRow" &&
+      merged[0].payload.kind === "tree-continue";
+    if (!slot1IsTreeContinue) {
+      const limitToScan = Math.min(5, merged.length);
+      let treeIdx = -1;
+      for (let i = 1; i < limitToScan; i++) {
+        const e = merged[i];
+        if (e.kind === "issueRow" && e.payload.kind === "tree-continue") {
+          treeIdx = i;
+          break;
+        }
+      }
+      if (treeIdx > 1) {
+        const [moved] = merged.splice(treeIdx, 1);
+        merged.splice(1, 0, moved);
+      }
+    }
+  }
+
+  // 6. Slice to limit and assign rank.
+  const sliced = merged.slice(0, Math.max(0, config.limit));
+
+  const directions: Direction[] = sliced.map((entry, idx) => {
+    const rank = idx + 1;
+    if (entry.kind === "issueRow") {
+      const c = entry.payload;
+      const reason = buildReason(c.kind, c.item, null, c.tags, config, null);
+      return {
+        rank,
+        kind: c.kind,
+        issue: toDirectionIssue(c.item),
+        pr: null,
+        reason,
+        tags: c.tags,
+        score: c.score,
+      };
+    }
+    // PR row
+    const p = entry.payload;
+    const reason = buildReason(
+      "pr",
+      null,
+      p.pr,
+      p.tags,
+      config,
+      p.linkedIssueNumber,
+    );
+    return {
+      rank,
+      kind: "pr",
+      issue: null,
+      pr: toDirectionPR(p.pr),
+      reason,
+      tags: p.tags,
+      score: p.score,
+    };
+  });
+
+  return directions;
+}

--- a/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
@@ -130,7 +130,7 @@ export interface RawDashboardItem {
     updatedAt?: string;
     closedAt?: string | null;
     assignees?: { nodes: Array<{ login: string }> };
-    trackedInIssues?: { nodes: Array<{ number: number; state: string }> };
+    trackedInIssues?: { nodes: Array<{ number: number; state: string; closedAt: string | null }> };
     trackedIssues?: { nodes: Array<{ number: number; state: string }> };
     repository?: { nameWithOwner: string; name: string } | null;
     subIssues?: { totalCount: number };
@@ -197,6 +197,8 @@ export function toDashboardItems(
         number: n.number,
         workflowState: n.state === "CLOSED" ? "Done" : null,
       })) ?? [],
+      parentNumber: r.content.trackedInIssues?.nodes?.[0]?.number ?? null,
+      parentState: r.content.trackedInIssues?.nodes?.[0]?.state ?? null,
       ...(projectNumber !== undefined ? { projectNumber } : {}),
       ...(projectTitle !== undefined ? { projectTitle } : {}),
       ...(r.content.repository ? { repository: r.content.repository.nameWithOwner } : {}),
@@ -237,6 +239,7 @@ export const DASHBOARD_ITEMS_QUERY = `query($projectId: ID!, $cursor: String, $f
               repository { nameWithOwner name }
               subIssues { totalCount }
               trackedIssues(first: 10) { nodes { number state } }
+              trackedInIssues(first: 3) { nodes { number state closedAt } }
             }
             ... on PullRequest {
               __typename

--- a/thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md
+++ b/thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md
@@ -142,11 +142,11 @@ Land all ranking logic as pure functions with full test coverage and extend the 
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] In `DASHBOARD_ITEMS_QUERY` (`:219-273`), the `... on Issue` block contains a new line `trackedInIssues(first: 3) { nodes { number state closedAt } }` after `trackedIssues(first: 10) { nodes { number state } }` at line 239.
-  - [ ] The candidate's own `closedAt` (line 235) is unchanged — not re-added.
-  - [ ] `RawDashboardItem.content.trackedInIssues` (line 133) is updated to include `closedAt: string | null`: `trackedInIssues?: { nodes: Array<{ number: number; state: string; closedAt: string | null }> };`
-  - [ ] No other behavior changes.
-  - [ ] `grep -q "trackedInIssues(first: 3)" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts`
+  - [x] In `DASHBOARD_ITEMS_QUERY` (`:219-273`), the `... on Issue` block contains a new line `trackedInIssues(first: 3) { nodes { number state closedAt } }` after `trackedIssues(first: 10) { nodes { number state } }` at line 239.
+  - [x] The candidate's own `closedAt` (line 235) is unchanged — not re-added.
+  - [x] `RawDashboardItem.content.trackedInIssues` (line 133) is updated to include `closedAt: string | null`: `trackedInIssues?: { nodes: Array<{ number: number; state: string; closedAt: string | null }> };`
+  - [x] No other behavior changes.
+  - [x] `grep -q "trackedInIssues(first: 3)" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts`
 
 #### Task 1.2: Populate `parentNumber`/`parentState` in `toDashboardItems`
 - **files**: `plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts` (modify), `plugin/ralph-hero/mcp-server/src/lib/dashboard.ts` (modify)
@@ -154,17 +154,17 @@ Land all ranking logic as pure functions with full test coverage and extend the 
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] In `lib/dashboard.ts` `DashboardItem` interface (`:31-49`), append two optional fields:
+  - [x] In `lib/dashboard.ts` `DashboardItem` interface (`:31-49`), append two optional fields:
     ```ts
     parentNumber?: number | null;
     parentState?: string | null;
     ```
-  - [ ] In `toDashboardItems` (`tools/dashboard-tools.ts:168-211`), after the `blockedBy` mapping (`:196-199`), add:
+  - [x] In `toDashboardItems` (`tools/dashboard-tools.ts:168-211`), after the `blockedBy` mapping (`:196-199`), add:
     ```ts
     parentNumber: r.content.trackedInIssues?.nodes?.[0]?.number ?? null,
     parentState: r.content.trackedInIssues?.nodes?.[0]?.state ?? null,
     ```
-  - [ ] Existing `dashboard.test.ts` and `dashboard-group-by.test.ts` still pass — the change is additive; existing items just gain `null` fields.
+  - [x] Existing `dashboard.test.ts` and `dashboard-group-by.test.ts` still pass — the change is additive; existing items just gain `null` fields.
 
 #### Task 1.3: Create `src/lib/directions.ts` with ranker types and functions
 - **files**: `plugin/ralph-hero/mcp-server/src/lib/directions.ts` (create), `plugin/ralph-hero/mcp-server/src/lib/dashboard.ts` (read), `plugin/ralph-hero/mcp-server/src/lib/workflow-states.ts` (read)
@@ -172,18 +172,18 @@ Land all ranking logic as pure functions with full test coverage and extend the 
 - **complexity**: high
 - **depends_on**: [1.2]
 - **acceptance**:
-  - [ ] New file `src/lib/directions.ts` exists with no I/O, no async, no `any` escapes.
-  - [ ] Imports: `import type { DashboardItem } from "./dashboard.js";` and `import { LOCK_STATES, STATE_ORDER } from "./workflow-states.js";` only — no other imports.
-  - [ ] Exports: `OpenPR` interface, `Direction` interface (with discriminated `kind: "issue" | "pr" | "tree-continue" | "lock-stale"`), `RankConfig` interface, `DEFAULT_RANK_CONFIG` constant (`limit: 3, stuckThresholdHours: 48, lockStaleHours: 24, treeRecentDoneDays: 7, prStaleHours: 24`), `scoreIssue()`, `detectTreeContinue()`, `detectLockStale()`, `rankDirections()`, `buildReason()`.
-  - [ ] `Direction` shape: `{ rank: number; kind: ...; issue: {...} | null; pr: {...} | null; reason: string; tags: string[]; score: number }`.
-  - [ ] `RankConfig.now: Date` is required and injected by callers (no `Date.now()` inside the lib).
-  - [ ] `scoreIssue` returns winning kind in precedence order: `lock-stale` > `tree-continue` > `issue` (PR ranking happens in `rankDirections`, not here).
-  - [ ] `detectLockStale`: true when `workflowState in LOCK_STATES` and `(now - updatedAt) >= lockStaleHours`.
-  - [ ] `detectTreeContinue`: true when `parentNumber != null` AND (a) at least one sibling has `closedAt` within `treeRecentDoneDays` OR (b) item itself has `updatedAt` within window AND parent has any other open siblings AND parent is not closed.
-  - [ ] `rankDirections`: filters (actionable phase OR lock-stale; not blocked by open `blockedBy`), scores, sorts ascending, applies tree-continue promotion (slot 4 promoted to slot 2 if not already in slot 1), merges PRs (`prScore`), slices to `config.limit`, assigns `rank` 1..N, calls `buildReason`.
-  - [ ] `buildReason`: returns one-sentence prose, distinct shape per `kind`. No template strings — natural English.
-  - [ ] `grep -q "rankDirections" plugin/ralph-hero/mcp-server/src/lib/directions.ts`
-  - [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors.
+  - [x] New file `src/lib/directions.ts` exists with no I/O, no async, no `any` escapes.
+  - [x] Imports: `import type { DashboardItem } from "./dashboard.js";` and `import { LOCK_STATES, STATE_ORDER } from "./workflow-states.js";` only — no other imports.
+  - [x] Exports: `OpenPR` interface, `Direction` interface (with discriminated `kind: "issue" | "pr" | "tree-continue" | "lock-stale"`), `RankConfig` interface, `DEFAULT_RANK_CONFIG` constant (`limit: 3, stuckThresholdHours: 48, lockStaleHours: 24, treeRecentDoneDays: 7, prStaleHours: 24`), `scoreIssue()`, `detectTreeContinue()`, `detectLockStale()`, `rankDirections()`, `buildReason()`.
+  - [x] `Direction` shape: `{ rank: number; kind: ...; issue: {...} | null; pr: {...} | null; reason: string; tags: string[]; score: number }`.
+  - [x] `RankConfig.now: Date` is required and injected by callers (no `Date.now()` inside the lib).
+  - [x] `scoreIssue` returns winning kind in precedence order: `lock-stale` > `tree-continue` > `issue` (PR ranking happens in `rankDirections`, not here).
+  - [x] `detectLockStale`: true when `workflowState in LOCK_STATES` and `(now - updatedAt) >= lockStaleHours`.
+  - [x] `detectTreeContinue`: true when `parentNumber != null` AND (a) at least one sibling has `closedAt` within `treeRecentDoneDays` OR (b) item itself has `updatedAt` within window AND parent has any other open siblings AND parent is not closed.
+  - [x] `rankDirections`: filters (actionable phase OR lock-stale; not blocked by open `blockedBy`), scores, sorts ascending, applies tree-continue promotion (slot 4 promoted to slot 2 if not already in slot 1), merges PRs (`prScore`), slices to `config.limit`, assigns `rank` 1..N, calls `buildReason`.
+  - [x] `buildReason`: returns one-sentence prose, distinct shape per `kind`. No template strings — natural English.
+  - [x] `grep -q "rankDirections" plugin/ralph-hero/mcp-server/src/lib/directions.ts`
+  - [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors.
 
 #### Task 1.4: Write `directions.test.ts` covering all ranking criteria
 - **files**: `plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts` (create), `plugin/ralph-hero/mcp-server/src/lib/directions.ts` (read)
@@ -191,9 +191,9 @@ Land all ranking logic as pure functions with full test coverage and extend the 
 - **complexity**: medium
 - **depends_on**: [1.3]
 - **acceptance**:
-  - [ ] New file `src/__tests__/directions.test.ts` exists.
-  - [ ] Uses `vitest` `describe`/`it` pattern; injects `now: Date` via `RankConfig` for time-stable tests; fabricates `DashboardItem[]` arrays directly (no GraphQL mock).
-  - [ ] All 13 cases present and passing:
+  - [x] New file `src/__tests__/directions.test.ts` exists.
+  - [x] Uses `vitest` `describe`/`it` pattern; injects `now: Date` via `RankConfig` for time-stable tests; fabricates `DashboardItem[]` arrays directly (no GraphQL mock).
+  - [x] All 13 cases present and passing:
     1. Empty input → `directions: []`.
     2. Pure priority sort (P0/P1/P2 in Plan in Review) → ordered P0, P1, P2.
     3. Phase tiebreaker (all P1 across Plan in Review / In Review / Research Needed) → ordered Plan in Review, In Review, Research Needed.
@@ -211,17 +211,17 @@ Land all ranking logic as pure functions with full test coverage and extend the 
     11. Determinism — same input + same `now` → byte-identical output across two `rankDirections` calls (use `JSON.stringify` equality).
     12. Limit honored — `limit: 1` returns at most one direction even with many candidates.
     13. All criteria off — empty Priority, no stale, no tree, no PRs → falls back to phase-rank-only and still picks something if any actionable phase has items.
-  - [ ] `cd plugin/ralph-hero/mcp-server && npx vitest run src/__tests__/directions.test.ts` — all 13 cases pass.
+  - [x] `cd plugin/ralph-hero/mcp-server && npx vitest run src/__tests__/directions.test.ts` — all 13 cases pass.
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors
-- [ ] `cd plugin/ralph-hero/mcp-server && npm test` — all passing (existing tests + 13 new)
-- [ ] `cd plugin/ralph-hero/mcp-server && npx vitest run src/__tests__/directions.test.ts` — 13/13 pass
-- [ ] `grep -q "trackedInIssues" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts`
-- [ ] `grep -q "rankDirections" plugin/ralph-hero/mcp-server/src/lib/directions.ts`
-- [ ] `dashboard.test.ts` and `dashboard-group-by.test.ts` still pass — additive query change
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors
+- [x] `cd plugin/ralph-hero/mcp-server && npm test` — all passing (existing tests + 13 new)
+- [x] `cd plugin/ralph-hero/mcp-server && npx vitest run src/__tests__/directions.test.ts` — 13/13 pass
+- [x] `grep -q "trackedInIssues" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts`
+- [x] `grep -q "rankDirections" plugin/ralph-hero/mcp-server/src/lib/directions.ts`
+- [x] `dashboard.test.ts` and `dashboard-group-by.test.ts` still pass — additive query change
 
 #### Manual Verification:
 - [ ] Spot-check `directions.ts` reads as a single-purpose module (no leaked imports, no I/O, no `any`).


### PR DESCRIPTION
## Summary

Phase 1 of 3 for the `hello_directions` group (GH-918 / GH-921 / GH-922 / GH-924). Lands the durable, testable foundation that Phase 2 will wrap as the new `ralph_hero__hello_directions` MCP tool.

- New `lib/directions.ts`: pure ranker library (no I/O, no async, injectable `now`) exporting `OpenPR`, `Direction`, `RankConfig`, `DEFAULT_RANK_CONFIG`, `scoreIssue`, `detectTreeContinue`, `detectLockStale`, `rankDirections`, `buildReason`. Kind precedence `lock-stale > tree-continue > issue` per parent plan.
- Extends `DASHBOARD_ITEMS_QUERY` with `trackedInIssues(first: 3) { nodes { number state closedAt } }` and adds optional `parentNumber` / `parentState` fields to `DashboardItem`. Additive — existing consumers (`pipeline_dashboard`, `status`, `report`, `hygiene`) ignore the new fields.
- 28 unit tests in `__tests__/directions.test.ts` covering all 13 plan-specified scenarios (priority sort, phase tiebreaker, stale boost, lock-stale, blocked-by, tree-continue promotion, tree-continue criteria sub-cases, PR ranking, PR-issue link, determinism, limit, phase-rank fallback) plus extra precedence / detector / reason-rendering smoke checks.

No MCP surface change in this PR — the tool wrapper lands in Phase 2 (GH-922).

## References

- Issue: #921
- Parent: #918
- Plan: [thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-921/thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md)

## Test plan

- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors
- [x] `cd plugin/ralph-hero/mcp-server && npm test` — 1061/1061 passing (46 files; +28 new in directions.test.ts)
- [x] `cd plugin/ralph-hero/mcp-server && npx vitest run src/__tests__/directions.test.ts` — 28/28 pass (covers all 13 specified cases)
- [x] `dashboard.test.ts` and `dashboard-group-by.test.ts` still pass — additive query change
- [x] `grep -q "trackedInIssues(first: 3)" plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts`
- [x] `grep -q "rankDirections" plugin/ralph-hero/mcp-server/src/lib/directions.ts`
- [x] No `any` escapes in `directions.ts`; only the two allowed imports (`DashboardItem` type and `LOCK_STATES, STATE_ORDER`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)