### PR TITLE
refactor(hello): call hello_directions instead of pipeline_dashboard (Phase 3 of GH-918)

### DIFF
--- a/plugin/ralph-hero/skills/hello/SKILL.md
+++ b/plugin/ralph-hero/skills/hello/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools:
   - Bash
   - Agent
   - AskUserQuestion
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__hello_directions
 ---
 
 # Session Companion
@@ -26,23 +26,27 @@ You are a session companion. You orient the user on where things stand and offer
 
 ## Step 1: Gather Context
 
-Fetch all three sources simultaneously (make all tool calls in one turn):
+Fetch in two waves so the directions call has the PR data it needs.
+
+**Wave A (parallel — make both calls in one turn)**:
 
 1. **Memory** (Read tool):
    Read `MEMORY.md` from the project memory directory. Then read any referenced files with `type: project` or `type: feedback` in their frontmatter. These tell you what the user was working on, recent decisions, and preferences. If `MEMORY.md` doesn't exist or is empty, skip silently — do not mention that memory is unavailable.
 
-2. **Pipeline dashboard** (MCP tool):
-   Fetch the pipeline dashboard with `format: "json"`, `includeHealth: true`, `includeMetrics: false`, `issuesPerPhase: 3`. This is enough to surface 3 directions; do not fetch more.
-
-3. **Open PRs** (Bash):
+2. **Open PRs** (Bash):
    ```bash
    gh pr list --state open --json number,title,url,isDraft,reviewDecision,headRefName,createdAt --limit 10 2>/dev/null || echo '[]'
    ```
 
+**Wave B (after Wave A completes)**:
+
+3. **Hello directions** (MCP tool):
+   Call `ralph_hero__hello_directions` with `limit: 3` and the parsed PR array as `openPRs`. The tool returns up to 3 deterministic directions plus a `totalCandidates` count.
+
 **Fallback handling**:
 - If memory read fails, continue without session context.
-- If `gh pr list` fails, note "PR data unavailable" and continue with dashboard only.
-- You must have at least the pipeline dashboard data to proceed. If it fails, report the error and stop.
+- If `gh pr list` fails, call `hello_directions` with `openPRs: []`.
+- If `hello_directions` fails, report the error and stop.
 
 ## Step 2: Orient
 
@@ -50,51 +54,50 @@ Open with a conversational greeting that weaves memory context with current boar
 
 **Structure** (3 sentences max):
 - One sentence acknowledging prior context from memory: *"Last session you were digging into the playwright plugin — that shipped in PR #627."*
-- One sentence on what changed, if memory has enough prior detail to compare: *"Since then, 2 new issues landed in backlog and PR #636 merged."* Omit this if you can't meaningfully infer a delta.
-- One sentence on current state: *"Right now there are 3 things in progress and 1 PR open for review."*
+- One sentence on what changed, if memory has enough prior detail to compare. Use `totalCandidates` as a coarse delta signal versus what memory recalls (e.g., *"Looks like a few new items have landed since then."*). Omit this if you can't meaningfully infer a delta.
+- One sentence on current state, derived from the directions returned: *"Right now there's a plan waiting review and a PR open."* Do not invent counts the tool didn't surface.
 
-**When memory is empty**: Skip the "last time" and "what changed" sentences. Open with board state directly: *"Here's where things stand — 3 items in progress, 1 PR waiting review."* Do not mention that memory is unavailable.
+**When memory is empty**: Skip the "last time" and "what changed" sentences. Open with the directions summary directly. Do not mention that memory is unavailable.
 
 **Output budget (hard limit)**:
 - The briefing (greeting + directions + picker) must be under ~40 lines of user-visible text total. If you are about to write more, you are doing the wrong thing — compress.
-- Never paste raw tool output into your response. The `pipeline_dashboard` JSON, `gh pr list` JSON, and memory file contents stay in your context — they are input, not output. Synthesize; do not quote.
+- Never paste raw tool output into your response. The `hello_directions` JSON, `gh pr list` JSON, and memory file contents stay in your context — they are input, not output. Synthesize; do not quote.
 - No markdown tables, no bullet lists of issues, no JSON blocks, no code fences around tool data. If you feel the urge to render a dashboard, stop — that is the exact failure mode this skill exists to prevent.
 
 **Tone rules**:
 - No severity tags (CRITICAL, STUCK, WARNING, etc. in brackets). If something is genuinely stuck, say it plainly: *"Issue #42 has been sitting in Research for 5 days — might be blocked on something."*
 - No WIP violation language unless it's actually causing a problem. "3 items in progress" is fine — don't flag it just because a configured limit says 2.
 - Backlog items that have been sitting get context, not alarm: *"#55 has been in backlog since February — you mentioned wanting to tackle it before the API launch but it hasn't been urgent yet."*
-- If the board is healthy and quiet: *"Things look calm — nothing stuck, nothing on fire."*
+- If the directions list is empty: *"Things look calm — nothing stuck, nothing on fire."*
 
-## Step 3: Offer Directions
+## Step 3: Render Directions
 
-After the orient greeting, surface **up to 3 directions** — but only if they genuinely matter. Zero is fine.
+Render each entry from `directions[]` as a 2-3-sentence paragraph using its `reason` field. Do not re-order, do not skip entries, do not invent new ones — the ranker already picked these deterministically.
 
-**What counts as a direction**:
-- An issue ready to advance with context on *why* the user would care — *"#55 'Add webhook support' is ready for planning — this is the one you flagged as important for the API launch"*
-- A PR that needs attention with context — *"PR #640 has been open for 2 days, it's the batch update feature you were working on last week"*
-- A strategic nudge from memory — *"You mentioned wanting to clean up the auth middleware before the compliance deadline — nothing's started on that yet"*
+**Per-entry rendering**:
+- For `kind: "issue"` / `kind: "tree-continue"` / `kind: "lock-stale"`: lead with `direction.issue.number` and a short rephrase of `direction.reason`. Memory context can add color (e.g., *"#55 — the webhook support you flagged for the API launch"*) but never override the reason.
+- For `kind: "pr"`: lead with `direction.pr.number` and `direction.reason`. If memory recalls related work, weave it in.
 
-**What does NOT count as a direction**:
-- Housekeeping ("Archive 66 done items")
-- Hygiene noise ("7 issues missing estimate field")
-- WIP limit violations unless they're causing actual bottlenecks
-- Anything that reads like a project management report
-
-**Format**: Each direction is a short paragraph (2-3 sentences max) explaining what it is and why it matters. Conversational, not a numbered dashboard.
-
-**When there's nothing to surface**: End with *"Nothing urgent jumping out — what are you thinking about today?"* and stop. Do not present a picker or route to a skill — just wait for the user's response.
+**Empty case**: If `directions[]` is empty, end with *"Nothing urgent jumping out — what are you thinking about today?"* and stop. Do not present a picker, do not route to a skill — just wait for the user's response.
 
 ## Step 4: Present Picker
 
-**Skip this step entirely if no directions were surfaced in Step 3.**
+**Skip this step entirely if `directions[]` was empty in Step 3.** No picker, no `AskUserQuestion`, no placeholder option — Step 3 already exited with the "Nothing urgent jumping out…" line.
 
-Present the user with a choice using AskUserQuestion. Each option must be self-contained.
+Present the user with a choice using AskUserQuestion. Each option must be self-contained and map 1:1 to entries in `directions[]` — same order, same count.
 
 !cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
 
-**Label**: action verb + target (e.g., "Plan #55", "Review PR #640", "Start auth cleanup")
-**Description**: what it is + why it matters (e.g., "Webhook support — you flagged this for the API launch")
+**Per-direction option construction**:
+- **Label**: `[Action] [Target]` derived from `direction.kind` and the issue/PR number.
+  - `kind: "issue"` + `workflowState: "Plan in Review"` → `"Review plan #NNN"`
+  - `kind: "issue"` + `workflowState: "Ready for Plan"` → `"Plan #NNN"`
+  - `kind: "issue"` + `workflowState: "Research Needed"` → `"Research #NNN"`
+  - `kind: "issue"` + `workflowState: "In Review"` → `"Review #NNN"`
+  - `kind: "pr"` → `"Merge PR #NNN"`
+  - `kind: "tree-continue"` → `"Continue tree #NNN"`
+  - `kind: "lock-stale"` → `"Unstick #NNN"`
+- **Description**: `direction.reason` verbatim (it's already a one-sentence rationale).
 
 ```
 AskUserQuestion(
@@ -102,8 +105,7 @@ AskUserQuestion(
     "question": "Which direction would you like to take?",
     "header": "Next Step",
     "options": [
-      {"label": "[Action] [Target]", "description": "[What it is] — [why it matters]"},
-      ...one option per direction surfaced in Step 3...
+      ...one option per entry in directions[], same order...
       {"label": "Work through these in order", "description": "Address each direction in order"}
     ],
     "multiSelect": false
@@ -115,20 +117,21 @@ If the user selects "Other" (built-in option): respond with *"Got it — holler 
 
 ## Step 5: Route and Complete
 
-Dispatch the corresponding autonomous skill via Agent() based on the direction type:
+Dispatch the corresponding autonomous skill via `Agent()` based on `direction.kind` (and `direction.issue.workflowState` for the `issue` kind):
 
-| Direction Type | Agent Dispatch |
-|---|---|
-| Issue in Research/Plan phase needing attention | `Agent(subagent_type="ralph-hero:triage-agent", prompt="Triage issue #NNN", description="Triage GH-NNN")` |
-| Plan waiting review | `Agent(subagent_type="ralph-hero:review-agent", prompt="Review plan for issue #NNN", description="Review plan for GH-NNN")` |
-| PR waiting merge or review | `Agent(subagent_type="ralph-hero:merge-agent", prompt="Merge PR for issue #NNN", description="Merge PR #NNN")` |
-| Issue ready for research | `Agent(subagent_type="ralph-hero:research-agent", prompt="Research issue #NNN", description="Research GH-NNN")` |
-| Issue ready for planning | `Agent(subagent_type="ralph-hero:plan-agent", prompt="Plan issue #NNN", description="Plan GH-NNN")` |
-| Board healthy, user wants to pick work | `Agent(subagent_type="ralph-hero:triage-agent", prompt="Pick work from backlog", description="Pick work from backlog")` |
+| `direction.kind` | Workflow State | Agent Dispatch |
+|---|---|---|
+| `issue` | `Plan in Review` | `Agent(subagent_type="ralph-hero:review-agent", prompt="Review plan for issue #NNN", description="Review plan for GH-NNN")` |
+| `issue` | `Ready for Plan` | `Agent(subagent_type="ralph-hero:plan-agent", prompt="Plan issue #NNN", description="Plan GH-NNN")` |
+| `issue` | `Research Needed` | `Agent(subagent_type="ralph-hero:research-agent", prompt="Research issue #NNN", description="Research GH-NNN")` |
+| `issue` | `In Review` | `Agent(subagent_type="ralph-hero:review-agent", prompt="Review issue #NNN", description="Review GH-NNN")` |
+| `pr` | — | `Agent(subagent_type="ralph-hero:merge-agent", prompt="Merge PR #NNN", description="Merge PR #NNN")` |
+| `tree-continue` | — | `Agent(subagent_type="ralph-hero:triage-agent", prompt="Continue tree work on issue #NNN", description="Triage GH-NNN")` |
+| `lock-stale` | — | `Agent(subagent_type="ralph-hero:triage-agent", prompt="Triage stalled issue #NNN", description="Triage GH-NNN")` |
 
-Replace `NNN` with the actual issue or PR number. Each Agent() call spawns an isolated context -- the autonomous skill runs in its own fork without bloating hello's context window.
+Replace `NNN` with the actual issue or PR number from `direction.issue.number` or `direction.pr.number`. Each `Agent()` call spawns an isolated context — the autonomous skill runs in its own fork without bloating hello's context window.
 
-For **"Work through these in order"**: dispatch Agent() calls sequentially in the order directions were presented. Before each subsequent dispatch, note: "Earlier actions may have changed board state."
+For **"Work through these in order"**: dispatch `Agent()` calls sequentially in the order entries appear in `directions[]`. Before each subsequent dispatch, note: *"Earlier actions may have changed board state."*
 
 **Do not relay the dispatched agent's return value.** The Agent tool's return is input to you, not output to the user — the agent already did its work in its own context. After each dispatch, write a single sentence summarizing what was dispatched (e.g., *"Dispatched triage-agent for #55."*). Never paste the agent's report, diff, or structured output into your reply.
 
@@ -141,10 +144,11 @@ Session complete.
 ## Constraints
 
 - Read-only: this skill does not modify issues, PRs, or project state directly
-- Do not re-fetch data after the initial parallel fetch in Step 1
+- Do not re-fetch data after the initial Wave A + Wave B fetch in Step 1
 - Do not use severity tags, dashboard formatting, or project management jargon
 - Do not flag WIP limits or hygiene issues unless they're causing a concrete problem
 - If no memories exist, skip the "last time" context gracefully — do not mention memory is unavailable
-- If no directions are worth surfacing, skip the picker entirely
-- Hard output budget: briefing ≤ ~40 lines total; post-dispatch summary ≤3 lines. Never echo `pipeline_dashboard` JSON, `gh pr list` output, memory file contents, or dispatched-agent return strings verbatim — these are inputs to your synthesis, not content for the user.
+- If `directions[]` is empty, skip the picker entirely
+- Do not re-rank, re-order, skip, or invent directions — the ranker is the source of truth
+- Hard output budget: briefing ≤ ~40 lines total; post-dispatch summary ≤3 lines. Never echo `hello_directions` JSON, `gh pr list` output, memory file contents, or dispatched-agent return strings verbatim — these are inputs to your synthesis, not content for the user.
 - When dispatching via `Agent()`, summarize in ≤1 sentence. Do not relay the agent's report; the agent ran in its own context and hello's job is only to route.

--- a/thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md
+++ b/thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md
@@ -345,16 +345,16 @@ Replace the `pipeline_dashboard` call with `ralph_hero__hello_directions` in the
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Step 1 (`SKILL.md:27-46`) restructured into two waves:
+  - [x] Step 1 (`SKILL.md:27-46`) restructured into two waves:
     - **Wave A (parallel)**: Memory read + `gh pr list --state open --json number,title,url,isDraft,reviewDecision,headRefName,createdAt --limit 10 2>/dev/null || echo '[]'`.
     - **Wave B (after Wave A)**: Call `ralph_hero__hello_directions` with `limit: 3` and parsed PR array as `openPRs`.
-  - [ ] Fallback rules documented:
+  - [x] Fallback rules documented:
     - Memory read fails → continue without context.
     - `gh pr list` fails → call `hello_directions` with `openPRs: []`.
     - `hello_directions` fails → report error and stop.
-  - [ ] `grep -q "Wave A" plugin/ralph-hero/skills/hello/SKILL.md`
-  - [ ] `grep -q "Wave B" plugin/ralph-hero/skills/hello/SKILL.md`
-  - [ ] `grep -q "ralph_hero__hello_directions" plugin/ralph-hero/skills/hello/SKILL.md`
+  - [x] `grep -q "Wave A" plugin/ralph-hero/skills/hello/SKILL.md`
+  - [x] `grep -q "Wave B" plugin/ralph-hero/skills/hello/SKILL.md`
+  - [x] `grep -q "ralph_hero__hello_directions" plugin/ralph-hero/skills/hello/SKILL.md`
 
 #### Task 3.2: Update Step 2 orient and Step 3 directions
 - **files**: `plugin/ralph-hero/skills/hello/SKILL.md` (modify)
@@ -362,9 +362,9 @@ Replace the `pipeline_dashboard` call with `ralph_hero__hello_directions` in the
 - **complexity**: low
 - **depends_on**: [3.1]
 - **acceptance**:
-  - [ ] Step 2 references `totalCandidates` instead of `health.warnings[]` and `phases[]` for the "what changed" line. Tone rules unchanged.
-  - [ ] Step 3 instructs: "Render each entry from `directions[]` as a 2-3-sentence paragraph using its `reason` field. Do not re-order, do not skip entries, do not invent new ones. If `directions[]` is empty, end with *'Nothing urgent jumping out — what are you thinking about today?'* and stop."
-  - [ ] No references to `health.warnings[]` or `phases[]` remain in the skill body: `! grep -q "health.warnings" plugin/ralph-hero/skills/hello/SKILL.md` and `! grep -qE "phases\[\]" plugin/ralph-hero/skills/hello/SKILL.md`.
+  - [x] Step 2 references `totalCandidates` instead of `health.warnings[]` and `phases[]` for the "what changed" line. Tone rules unchanged.
+  - [x] Step 3 instructs: "Render each entry from `directions[]` as a 2-3-sentence paragraph using its `reason` field. Do not re-order, do not skip entries, do not invent new ones. If `directions[]` is empty, end with *'Nothing urgent jumping out — what are you thinking about today?'* and stop."
+  - [x] No references to `health.warnings[]` or `phases[]` remain in the skill body: `! grep -q "health.warnings" plugin/ralph-hero/skills/hello/SKILL.md` and `! grep -qE "phases\[\]" plugin/ralph-hero/skills/hello/SKILL.md`.
 
 #### Task 3.3: Update Step 4 picker (1:1 from `directions[]`)
 - **files**: `plugin/ralph-hero/skills/hello/SKILL.md` (modify)
@@ -372,8 +372,8 @@ Replace the `pipeline_dashboard` call with `ralph_hero__hello_directions` in the
 - **complexity**: low
 - **depends_on**: [3.2]
 - **acceptance**:
-  - [ ] Step 4 picker maps `directions[]` 1:1 to `AskUserQuestion` options. Each option's `label` is `[Action] [Target]` (e.g., "Review plan #55", "Merge PR #640", "Continue tree #42") and `description` is `direction.reason`.
-  - [ ] Empty-directions case handled: when `directions[]` is empty, Step 4 is **skipped entirely** — Step 3 already exits with the *"Nothing urgent jumping out…"* line and stops. No `AskUserQuestion`, no placeholder.
+  - [x] Step 4 picker maps `directions[]` 1:1 to `AskUserQuestion` options. Each option's `label` is `[Action] [Target]` (e.g., "Review plan #55", "Merge PR #640", "Continue tree #42") and `description` is `direction.reason`.
+  - [x] Empty-directions case handled: when `directions[]` is empty, Step 4 is **skipped entirely** — Step 3 already exits with the *"Nothing urgent jumping out…"* line and stops. No `AskUserQuestion`, no placeholder.
 
 #### Task 3.4: Update Step 5 dispatch table to use `direction.kind`
 - **files**: `plugin/ralph-hero/skills/hello/SKILL.md` (modify)
@@ -381,8 +381,8 @@ Replace the `pipeline_dashboard` call with `ralph_hero__hello_directions` in the
 - **complexity**: low
 - **depends_on**: [3.3]
 - **acceptance**:
-  - [ ] Step 5 dispatch table (currently `SKILL.md:118-129`) references `direction.kind` instead of "Direction Type" prose.
-  - [ ] Mapping per parent plan:
+  - [x] Step 5 dispatch table (currently `SKILL.md:118-129`) references `direction.kind` instead of "Direction Type" prose.
+  - [x] Mapping per parent plan:
     | `kind` | Agent |
     |---|---|
     | `issue` (workflowState=`Plan in Review`) | `review-agent` |
@@ -398,9 +398,9 @@ Replace the `pipeline_dashboard` call with `ralph_hero__hello_directions` in the
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] In `allowed-tools` frontmatter, replace `mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard` with `mcp__plugin_ralph-hero_ralph-github__ralph_hero__hello_directions`.
-  - [ ] `grep -q "mcp__plugin_ralph-hero_ralph-github__ralph_hero__hello_directions" plugin/ralph-hero/skills/hello/SKILL.md`
-  - [ ] `! grep -q "mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard" plugin/ralph-hero/skills/hello/SKILL.md`
+  - [x] In `allowed-tools` frontmatter, replace `mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard` with `mcp__plugin_ralph-hero_ralph-github__ralph_hero__hello_directions`.
+  - [x] `grep -q "mcp__plugin_ralph-hero_ralph-github__ralph_hero__hello_directions" plugin/ralph-hero/skills/hello/SKILL.md`
+  - [x] `! grep -q "mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard" plugin/ralph-hero/skills/hello/SKILL.md`
 
 #### Task 3.6: Update Constraints section wording
 - **files**: `plugin/ralph-hero/skills/hello/SKILL.md` (modify)
@@ -408,7 +408,7 @@ Replace the `pipeline_dashboard` call with `ralph_hero__hello_directions` in the
 - **complexity**: low
 - **depends_on**: [3.1]
 - **acceptance**:
-  - [ ] Constraints line updated: "Do not re-fetch data after the initial Wave A + Wave B fetch in Step 1." (was "after the initial parallel fetch").
+  - [x] Constraints line updated: "Do not re-fetch data after the initial Wave A + Wave B fetch in Step 1." (was "after the initial parallel fetch").
 
 #### Task 3.7: Verify GH-0838 output-budget regression guard
 - **files**: `plugin/ralph-hero/skills/hello/SKILL.md` (read)
@@ -416,19 +416,19 @@ Replace the `pipeline_dashboard` call with `ralph_hero__hello_directions` in the
 - **complexity**: low
 - **depends_on**: [3.1, 3.2, 3.3, 3.4, 3.5, 3.6]
 - **acceptance**:
-  - [ ] `grep -q "Output budget (hard limit)" plugin/ralph-hero/skills/hello/SKILL.md` — preserved.
-  - [ ] `grep -q "Do not relay the dispatched agent" plugin/ralph-hero/skills/hello/SKILL.md` — preserved.
-  - [ ] Skill file still parses as valid Markdown with intact YAML frontmatter (e.g., `head -20` shows valid frontmatter block).
+  - [x] `grep -q "Output budget (hard limit)" plugin/ralph-hero/skills/hello/SKILL.md` — preserved.
+  - [x] `grep -q "Do not relay the dispatched agent" plugin/ralph-hero/skills/hello/SKILL.md` — preserved.
+  - [x] Skill file still parses as valid Markdown with intact YAML frontmatter (e.g., `head -20` shows valid frontmatter block).
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `grep -q "ralph_hero__hello_directions" plugin/ralph-hero/skills/hello/SKILL.md`
-- [ ] `! grep -q "mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard" plugin/ralph-hero/skills/hello/SKILL.md`
-- [ ] `grep -q "Wave A" plugin/ralph-hero/skills/hello/SKILL.md` and `grep -q "Wave B" plugin/ralph-hero/skills/hello/SKILL.md`
-- [ ] `grep -q "Output budget (hard limit)" plugin/ralph-hero/skills/hello/SKILL.md && grep -q "Do not relay the dispatched agent" plugin/ralph-hero/skills/hello/SKILL.md`
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors (regression guard)
-- [ ] `cd plugin/ralph-hero/mcp-server && npm test` — all passing (regression guard)
+- [x] `grep -q "ralph_hero__hello_directions" plugin/ralph-hero/skills/hello/SKILL.md`
+- [x] `! grep -q "mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard" plugin/ralph-hero/skills/hello/SKILL.md`
+- [x] `grep -q "Wave A" plugin/ralph-hero/skills/hello/SKILL.md` and `grep -q "Wave B" plugin/ralph-hero/skills/hello/SKILL.md`
+- [x] `grep -q "Output budget (hard limit)" plugin/ralph-hero/skills/hello/SKILL.md && grep -q "Do not relay the dispatched agent" plugin/ralph-hero/skills/hello/SKILL.md`
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors (regression guard)
+- [x] `cd plugin/ralph-hero/mcp-server && npm test` — all passing (regression guard)
 
 #### Manual Verification:
 - [ ] `/ralph-hero:hello` in a fresh session produces a ≤40-line briefing.


### PR DESCRIPTION
## Summary

Phase 3 of 3 for [GH-918](https://github.com/cdubiel08/ralph-hero/issues/918) (this PR closes [#924](https://github.com/cdubiel08/ralph-hero/issues/924)). Refactors `plugin/ralph-hero/skills/hello/SKILL.md` to call the new deterministic ranker tool `ralph_hero__hello_directions` instead of `pipeline_dashboard`. The skill becomes a thin presenter over a fixed-shape payload — no more LLM-synthesized "pick 3" prose over a truncated dashboard dump.

PRs are still fetched via `gh pr list` in the skill (no Octokit-in-MCP scope creep) and passed into the new tool as `openPRs` so all ranking happens server-side.

## Changes

`plugin/ralph-hero/skills/hello/SKILL.md`:

- **Step 1** restructured into Wave A (memory + `gh pr list`, parallel) + Wave B (`hello_directions` with parsed PRs).
- **Step 2** references `totalCandidates` instead of `health.warnings[]` / `phases[]` for the "what changed" delta line.
- **Step 3** renders each `directions[]` entry verbatim using its `reason` field. Empty case exits with *"Nothing urgent jumping out — what are you thinking about today?"* and stops (no picker).
- **Step 4** picker maps `directions[]` 1:1 to `AskUserQuestion` options. **Empty-directions case skips the picker entirely** — no `AskUserQuestion`, no placeholder option.
- **Step 5** dispatch table keys on `direction.kind`:
  - `issue` + `Plan in Review` -> `review-agent`
  - `issue` + `Ready for Plan` -> `plan-agent`
  - `issue` + `Research Needed` -> `research-agent`
  - `issue` + `In Review` -> `review-agent`
  - `pr` -> `merge-agent`
  - `tree-continue` -> `triage-agent`
  - `lock-stale` -> `triage-agent`
- **`allowed-tools`** frontmatter swaps `pipeline_dashboard` for `hello_directions`.
- **Constraints** line updated to "Wave A + Wave B fetch".

GH-0838 output-budget rules (`Output budget (hard limit)`, `Do not relay the dispatched agent`) preserved verbatim — explicit regression check via grep.

## Test plan

Automated regression guards:
- [x] `grep -q "ralph_hero__hello_directions" plugin/ralph-hero/skills/hello/SKILL.md`
- [x] `! grep -q "mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard" plugin/ralph-hero/skills/hello/SKILL.md`
- [x] `grep -q "Wave A" plugin/ralph-hero/skills/hello/SKILL.md` and `grep -q "Wave B" plugin/ralph-hero/skills/hello/SKILL.md`
- [x] `! grep -q "health.warnings"` and `! grep -qE "phases\[\]"` in SKILL.md
- [x] `grep -q "Output budget (hard limit)"` and `grep -q "Do not relay the dispatched agent"` (GH-0838 regression guard)
- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — passes
- [x] `cd plugin/ralph-hero/mcp-server && npm test` — 1067/1067 passing across 47 files

Manual verification (post-merge in fresh session):
- [ ] `/ralph-hero:hello` produces a ≤40-line briefing
- [ ] Two consecutive runs return the identical top direction (determinism)
- [ ] Tree-continue surfaces in slot 2 when criteria match (Priority unset + recent sibling done)
- [ ] Lock-stale surfaces only when a lock-state issue has `updatedAt` >24h
- [ ] Post-dispatch summary stays ≤3 lines and does not echo agent return (GH-0838 budget guard)
- [ ] Briefing reads conversationally, not as a JSON dump or table

## References

- Parent: [#918](https://github.com/cdubiel08/ralph-hero/issues/918)
- Phase 1: [#921](https://github.com/cdubiel08/ralph-hero/issues/921) (merged) — pure ranker library + parent-edge data
- Phase 2: [#922](https://github.com/cdubiel08/ralph-hero/issues/922) (merged) — MCP tool wrapper
- Phase 3 (this PR): [#924](https://github.com/cdubiel08/ralph-hero/issues/924)
- Builds on: [#838](https://github.com/cdubiel08/ralph-hero/issues/838) (output budget — preserved here)
- Plan: [thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-30-group-GH-0921-hello-directions-implementation.md) (Phase 3)

Closes #924

Generated with [Claude Code](https://claude.com/claude-code)