### PR TITLE
feat: knowledge-aware research skills (GH-725 group)

### DIFF
--- a/plugin/ralph-hero/agents/research-agent.md
+++ b/plugin/ralph-hero/agents/research-agent.md
@@ -2,7 +2,7 @@
 name: research-agent
 description: Research issues - investigates codebase, creates findings document, updates workflow state
 model: sonnet
-tools: Read, Write, Glob, Grep, Bash, Agent, WebSearch, WebFetch, mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency, mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
+tools: Read, Write, Glob, Grep, Bash, Agent, WebSearch, WebFetch, mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency, mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
 skills:
   - ralph-hero:ralph-research
 ---

--- a/plugin/ralph-hero/agents/thoughts-analyzer.md
+++ b/plugin/ralph-hero/agents/thoughts-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: thoughts-analyzer
 description: Extracts key decisions, constraints, and actionable insights from thought documents. Use for deep analysis of research docs, plans, and prior decisions.
-tools: Read, Grep, Glob, Bash, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
+tools: Read, Grep, Glob, Bash, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_paths, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_common, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
 model: sonnet
 color: blue
 ---
@@ -43,7 +43,12 @@ You are a specialist at extracting actionable insights from thought documents. Y
 ### Step 1: Discover Context
 - Use knowledge_search to find related documents if available
 - Use knowledge_traverse to follow relationship chains
+- Use `knowledge_paths` between two documents to understand how they connect through the graph. Assess path quality — short paths through topically relevant intermediaries are stronger.
+- Use `knowledge_common` to find documents that two analyzed docs share as neighbors — these often provide missing context.
+- Use `knowledge_query_outcomes` to check whether conclusions from prior research were validated by implementation (pass/fail verdicts, drift counts). Treat outcomes as evidence: research validated by a passed implementation is primary; an unvalidated plan is weak; an idea not yet picked up is the weakest signal.
 - Fall back to Grep/Glob for pattern matching if knowledge tools unavailable
+
+**Availability check**: All tools are optional. If unavailable, fall back to existing grep/glob + Read patterns.
 
 ### Step 2: Read with Purpose
 - Read each document fully — do not skim

--- a/plugin/ralph-hero/agents/thoughts-locator.md
+++ b/plugin/ralph-hero/agents/thoughts-locator.md
@@ -1,7 +1,7 @@
 ---
 name: thoughts-locator
 description: Discovers relevant documents in thoughts/ directory -- research docs, plans, tickets, handoffs. Use when researching to find prior context.
-tools: Grep, Glob, Bash, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
+tools: Grep, Glob, Bash, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_communities, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_central, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_bridges
 model: haiku
 color: purple
 ---
@@ -55,6 +55,14 @@ If `knowledge_search` or `knowledge_traverse` MCP tools are available (from the 
 2. **Relationship traversal**: `knowledge_traverse(from="[document-id]", direction="incoming")` returns all documents that `builds_on` or have `tensions` with a given document. Use this to map the knowledge web around a document.
 
 3. **Fall back to grep/glob** if the knowledge tools are not available or return no results. The grep-based patterns below always work without any index.
+
+4. **Community discovery**: `knowledge_communities(query="[search topic]")` returns clusters of documents that co-cite each other on the topic. Use `knowledge_communities` to find document clusters on the search topic. Report the community label and member count alongside individual document results so the caller can see the topic landscape, not just hits.
+
+5. **Important documents**: `knowledge_central(community_id="[id]")` returns the most-cited documents within a cluster, ranked by inbound link count. Use `knowledge_central` scoped to a community ID to find the most-cited documents in a cluster. These are likely foundational references — surface them first when the caller is new to a topic area.
+
+6. **Cross-cutting documents**: `knowledge_bridges(query="[topic]" or scope="[area]")` returns documents that link two or more otherwise-disconnected communities. Use `knowledge_bridges` to find documents that connect different topic areas — these bridge documents often contain key architectural decisions and are easy to miss when searching by single keywords.
+
+**Availability check**: All graph tools are optional. If unavailable, fall back to existing grep/glob patterns.
 
 ### Search Patterns (fallback)
 - Use grep for content searching

--- a/plugin/ralph-hero/skills/ralph-research/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-research/SKILL.md
@@ -43,6 +43,10 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
 ---
 
 ## Configuration (resolved at load time)
@@ -143,6 +147,26 @@ When cross-repo scope is detected (during the registry lookup above), add an add
 
 This information is consumed by the hero skill during tree expansion to override the default "assume independent" behavior when evidence contradicts the registry.
 
+### Step 3c: Knowledge Graph Prior Art Discovery
+
+If `knowledge_search`, `knowledge_traverse`, or `knowledge_query_outcomes` MCP tools are available (from the ralph-knowledge plugin), perform prior-art discovery directly before dispatching sub-agents. If unavailable, skip to Step 4.
+
+This step runs autonomously — no user questions, just detect-and-act. Run the following calls in order:
+
+1. `knowledge_search(query="[issue topic]", type="research", brief=true)` — find prior research documents on this topic.
+2. `knowledge_search(query="[issue topic]", type="plan", brief=true)` — find existing plans that may overlap with the issue.
+3. `knowledge_query_outcomes(component_area="[area inferred from issue]", aggregate=true)` — if a component area is identifiable from the issue body, files referenced, or the registry lookup in Step 3a, retrieve aggregate pipeline history (pass/fail trends, drift counts, common blockers).
+
+**How to use the results:**
+- Skip dispatching `thoughts-locator` for topics already comprehensively covered by prior research found here.
+- Target `thoughts-analyzer` at gap areas — components not covered by prior-art results.
+- Include outcome trends and prior-art summaries in the research document's Prior Work and Pipeline History sections.
+
+**Brief-first pattern:**
+- Use `brief: true` for discovery (returns titles + snippets without full content). Only `Read` documents you select for deep analysis. This saves context window.
+
+If the searches return nothing relevant, proceed to Step 4 with full sub-agent dispatch — the knowledge graph may be stale or sparse on this topic. Do NOT skip sub-agent dispatch on the basis of an empty knowledge result alone.
+
 ### Step 4: Conduct Research
 
 1. **Read issue thoroughly** - understand the problem from user perspective
@@ -194,17 +218,33 @@ The document must begin with a `## Prior Work` section immediately after the tit
 ```markdown
 ## Prior Work
 
-- builds_on:: [[document-filename-without-extension]]
-- tensions:: [[document-filename-without-extension]]
+- builds_on:: [[prior-research-doc]] (research — primary evidence)
+- builds_on:: [[prior-plan-doc]] (plan — describes intent, may not reflect outcome)
+- tensions:: [[conflicting-idea-doc]] (idea — unvetted, but flags a considered alternative)
 ```
 
 - `builds_on::` for documents this research extends or was informed by
 - `tensions::` for documents whose conclusions conflict with findings here
-- Populate from thoughts-locator and thoughts-analyzer results gathered during the research phase
+- Populate from thoughts-locator and thoughts-analyzer results gathered during the research phase, plus any prior-art discovered in Step 3c via `knowledge_search`
 - If no relevant prior work exists, include the section with "None identified."
 - Use filenames without extension as wikilink targets
 
+**Evidence weighting**: When citing prior work, qualify each entry with its document type to signal evidence strength: `research` is primary evidence (verified findings about what exists), `review` is secondary evidence (findings validated against actual implementation), `plan` is weak evidence (describes intent — may diverge from what was actually built), and `idea` is weakest (unvetted thinking, useful as alternative-considered context). See `plugin/ralph-hero/skills/prove-claim/SKILL.md` (lines 25-35) for the canonical weighting table. Qualifiers are encouraged for new docs; existing Prior Work entries do not need retroactive annotation.
+
 Include: problem statement, current state analysis, key discoveries with file:line references, potential approaches (pros/cons), risks, and recommended next steps.
+
+If pipeline history was retrieved in Step 3c, include a `## Pipeline History` section in the document. Use this template:
+
+```markdown
+## Pipeline History
+Based on outcome_events for component area `[area]`:
+- N total events, X passed, Y failed
+- Average drift count: Z files
+- Estimate accuracy: [summary]
+- Most common blocker: [if patterns emerge]
+```
+
+Omit this section entirely if no outcome data was retrieved or `knowledge_query_outcomes` is unavailable. Do not invent data.
 
 The document **must** include a `## Files Affected` section with two subsections:
 
@@ -345,6 +385,20 @@ git push origin main
    ```
 2. **Add summary comment** with key findings, recommended approach, and group context (if multi-issue group)
 3. **Move to "Ready for Plan"**: advance the issue to the next state (workflowState "__COMPLETE__", command "ralph_research").
+4. **Record outcome event** (if `knowledge_record_outcome` is available):
+
+   ```
+   knowledge_record_outcome(
+     event_type="research_completed",
+     issue_number=NNN,
+     component_area="[discovered area, e.g., src/tools/]",
+     verdict="complete",
+     model="sonnet",
+     agent_type="analyst"
+   )
+   ```
+
+   Skip silently if the tool is unavailable — do not fail the workflow. This builds the outcome ledger that future research can query (Step 3c).
 
 ### Step 9: Team Result Reporting
 
@@ -368,6 +422,16 @@ Status: Ready for Plan
 Group status: [M of N] issues researched
 Key recommendation: [One sentence]
 ```
+
+## Knowledge Tool Degradation
+
+The Step 3c prior-art discovery, evidence weighting, Pipeline History section, and Step 8 outcome recording all depend on optional MCP tools from the ralph-knowledge plugin. They must degrade gracefully:
+
+1. **Tools unavailable** (MCP server not running, plugin not installed, or tools not in the runtime allowlist): skip Step 3c entirely and rely on the `thoughts-locator` sub-agent in Step 4 — it always works via grep/glob and will populate Prior Work via filesystem scan. Add a footnote to the research document under Prior Work: `Knowledge graph unavailable — prior work discovery via file scan only`. Do not block the research workflow on missing knowledge tools.
+
+2. **Tools available but `knowledge_search` returns zero results**: try broader search terms first (remove specific qualifiers, drop component prefixes), then fall back to grep-based search of the `thoughts/` directory. Do NOT skip sub-agent dispatch — an empty knowledge result may indicate a stale or sparsely-indexed graph rather than a true absence of prior art. Continue with full Step 4 sub-agent dispatch and let `thoughts-locator` cross-check the filesystem.
+
+The Step 8 outcome recording (`knowledge_record_outcome`) is also subject to graceful degradation — silently skip the call if the tool is unavailable. The workflow advancement to "Ready for Plan" must still complete even when the outcome ledger cannot be written.
 
 ## Available Filter Profiles
 

--- a/plugin/ralph-hero/skills/research/SKILL.md
+++ b/plugin/ralph-hero/skills/research/SKILL.md
@@ -17,6 +17,9 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
   - AskUserQuestion
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
 ---
 
 ## Configuration (resolved at load time)
@@ -73,6 +76,24 @@ Then wait for the user's research query.
 - Identify specific components, patterns, or concepts to investigate
 - Consider which directories, files, or architectural patterns are relevant
 
+### Step 2.5: Knowledge Graph Prior Art Discovery
+
+If `knowledge_search`, `knowledge_traverse`, or `knowledge_query_outcomes` MCP tools are available (from the ralph-knowledge plugin), perform prior-art discovery directly before dispatching sub-agents. If unavailable, skip to Step 3.
+
+Run the following calls in order:
+
+1. `knowledge_search(query="[research topic]", type="research", brief=true)` — find prior research documents on this topic.
+2. `knowledge_search(query="[research topic]", type="plan", brief=true)` — find existing plans that may overlap with the question.
+3. (Optional) `knowledge_query_outcomes(component_area="[area]", aggregate=true)` — if the issue maps to a known component area (e.g., `src/tools/`, `plugin/ralph-knowledge/`), retrieve aggregate pipeline history (pass/fail trends, drift counts, common blockers).
+
+**How to use the results:**
+- Use these results to (a) skip dispatching `thoughts-locator` for topics already well-documented, (b) target `thoughts-analyzer` at the highest-relevance documents found, and (c) include prior-art summaries in the research document's Prior Work section.
+
+**Brief-first pattern:**
+- Use `brief: true` for discovery (returns titles + snippets without full content). Only `Read` documents you select for deep analysis. This saves context window.
+
+If the searches return nothing relevant, proceed to Step 3 with full sub-agent dispatch — the knowledge graph may be stale or sparse on this topic. Do NOT skip sub-agent dispatch on the basis of an empty knowledge result alone.
+
 ### Step 3: Spawn parallel sub-agent tasks for comprehensive research
 
 Create multiple Task agents to research different aspects concurrently. Use these specialized agents:
@@ -117,7 +138,8 @@ The key is to use these agents intelligently:
 - Include specific file paths and line numbers for reference
 - Highlight patterns, connections, and architectural decisions
 - Answer the user's specific questions with concrete evidence
-- Populate the `## Prior Work` section with `builds_on::` wikilinks to related research and plan documents discovered by the thoughts-locator agent
+- Populate the `## Prior Work` section with `builds_on::` wikilinks to related research and plan documents discovered by the thoughts-locator agent **and by the Step 2.5 knowledge graph search (if performed)**.
+- If pipeline history was queried in Step 2.5, summarize key outcome trends in the synthesis.
 
 ### Step 5: Gather metadata for the research document
 - Get current commit: `git rev-parse HEAD`
@@ -177,7 +199,11 @@ type: research
 
 ## Prior Work
 
-- builds_on:: [[related-research-doc-id]]
+- builds_on:: [[prior-research-doc]] (research — primary evidence)
+- builds_on:: [[prior-plan-doc]] (plan — describes intent, may not reflect outcome)
+- tensions:: [[conflicting-idea-doc]] (idea — unvetted, but flags a considered alternative)
+
+**Evidence weighting**: When citing prior work, qualify each entry with its document type to signal evidence strength: `research` is primary evidence (verified findings about what exists), `review` is secondary evidence (findings validated against actual implementation), `plan` is weak evidence (describes intent — may diverge from what was actually built), and `idea` is weakest (unvetted thinking, useful as alternative-considered context). See `plugin/ralph-hero/skills/prove-claim/SKILL.md` (lines 25-35) for the canonical weighting table. Qualifiers are encouraged for new docs; existing Prior Work entries do not need retroactive annotation.
 
 ## Research Question
 [Original user query]
@@ -339,6 +365,14 @@ AskUserQuestion(
 - Add a new section: `## Follow-up Research [timestamp]`
 - Spawn new sub-agents as needed for additional investigation
 - Continue updating the document
+
+## Knowledge Tool Degradation
+
+The Step 2.5 prior-art discovery, evidence weighting, and outcome lookups all depend on optional MCP tools from the ralph-knowledge plugin. They must degrade gracefully:
+
+1. **Tools unavailable** (MCP server not running, plugin not installed, or tools not in the runtime allowlist): skip Step 2.5 entirely and rely on the `thoughts-locator` sub-agent in Step 3 — it always works via grep/glob and will populate Prior Work via filesystem scan. Add a footnote to the research document under Prior Work: `Knowledge graph unavailable — prior work discovery via file scan only`. Do not block the research workflow on missing knowledge tools.
+
+2. **Tools available but `knowledge_search` returns zero results**: try broader search terms first (remove specific qualifiers, drop component prefixes), then fall back to grep-based search of the `thoughts/` directory. Do NOT skip sub-agent dispatch — an empty knowledge result may indicate a stale or sparsely-indexed graph rather than a true absence of prior art. Continue with full Step 3 sub-agent dispatch and let `thoughts-locator` cross-check the filesystem.
 
 ## Important notes
 - Always use parallel Task agents to maximize efficiency and minimize context usage

--- a/thoughts/shared/plans/2026-05-01-group-GH-0726-knowledge-aware-research-skills.md
+++ b/thoughts/shared/plans/2026-05-01-group-GH-0726-knowledge-aware-research-skills.md
@@ -177,9 +177,9 @@ Add three knowledge graph tools to each sub-agent's tools list and extend their 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] Both files lint as valid YAML frontmatter (no parse errors when the agent loader reads them)
-- [ ] `grep -c "knowledge_communities" plugin/ralph-hero/agents/thoughts-locator.md` returns >= 1 (tool listed and used in prose)
-- [ ] `grep -c "knowledge_paths" plugin/ralph-hero/agents/thoughts-analyzer.md` returns >= 1
+- [x] Both files lint as valid YAML frontmatter (no parse errors when the agent loader reads them)
+- [x] `grep -c "knowledge_communities" plugin/ralph-hero/agents/thoughts-locator.md` returns >= 1 (tool listed and used in prose)
+- [x] `grep -c "knowledge_paths" plugin/ralph-hero/agents/thoughts-analyzer.md` returns >= 1
 
 #### Manual Verification:
 - [ ] Reading thoughts-locator.md end-to-end, the new tools' use cases are clear and distinct from each other


### PR DESCRIPTION
## Summary

Make the research skills and their sub-agents intelligent consumers of the ralph-knowledge graph through prose-driven instructions. Skills detect whether knowledge MCP tools are available and use them for prior-art discovery, relationship mapping, and outcome history — falling back to grep/glob when they're not installed.

## Phases shipped: 3 of 3

- **Phase 1 (GH-728)** — Sub-agent enhancements: `thoughts-locator` gains `knowledge_communities`, `knowledge_central`, `knowledge_bridges`; `thoughts-analyzer` gains `knowledge_paths`, `knowledge_common`, `knowledge_query_outcomes`. All wrapped in availability-detection prose.
- **Phase 2 (GH-726)** — Interactive `research` skill: adds 3 knowledge tools, new Step 2.5 prior-art discovery, evidence weighting on Prior Work entries, and a Knowledge Tool Degradation section.
- **Phase 3 (GH-727)** — Autonomous `ralph-research` skill: adds 4 knowledge tools (incl. `record_outcome`), Step 3c discovery, Pipeline History template, outcome recording at completion (Step 8), and matching tools on the `research-agent`.

## Plan

[2026-05-01-group-GH-0726-knowledge-aware-research-skills](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-01-group-GH-0726-knowledge-aware-research-skills.md)

## Constraints honored

- Prose-only changes (no code logic)
- Backward compatible — every knowledge tool call is wrapped in availability detection
- Evidence weighting vocab consistent with `prove-claim` (research = primary, review = secondary, plan = weak, idea = weakest)
- Brief-first pattern (`brief: true` on discovery, full Read on selected docs)
- Skill `allowed-tools` and corresponding agent `tools:` lists kept in sync

## Test plan

- [ ] Skill files load (frontmatter parses)
- [ ] `grep` checks pass on each acceptance criterion in the plan
- [ ] When ralph-knowledge plugin is uninstalled: skills run via grep/glob fallbacks without errors
- [ ] When ralph-knowledge plugin is installed: skills detect tools and execute discovery steps
- [ ] `research-agent` tools list matches skill `allowed-tools` for ralph-research
- [ ] No regressions in existing PreToolUse / PostToolUse hooks

Closes #725
Closes #726
Closes #727
Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)