### PR TITLE
feat: phase 1 — activity log foundation (GH-937)

### DIFF
--- a/plugin/ralph-hero/hooks/hooks.json
+++ b/plugin/ralph-hero/hooks/hooks.json
@@ -3,6 +3,7 @@
   "description": "Ralph GitHub plugin hook registration",
   "version": "1.0.0",
   "note": "Most hooks are registered via skill frontmatter for granular scoping. This file provides plugin-level hooks that apply across all skills.",
+  "_activity_log_note": "record-activity.sh entries are wired to the Claude Code hook events that exist as of 2026-05: PostToolUse (matcher-less for all tools) and SessionStart. SessionStop, PostSkillInvoke, and agent-spawn/agent-complete event names were probed and are not currently surfaced by the harness; they are intentionally omitted here. Consumers will see fewer events, not errors. Add corresponding entries when those event names land.",
 
   "hooks": {
     "SessionStart": [
@@ -19,6 +20,14 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/superpowers-bridge-session.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/record-activity.sh session_start"
           }
         ]
       }
@@ -146,6 +155,14 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-git-validator.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/record-activity.sh tool_called"
           }
         ]
       }

--- a/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
@@ -57,5 +57,21 @@ JSON_VALID=$(echo "$LINE" | jq -e . >/dev/null 2>&1 && echo "yes" || echo "no")
 assert_eq "yes" "$JSON_VALID" "line is valid JSON"
 
 echo
+echo "Test: includes actor and target fields"
+rm -rf "$TEST_DIR/activity"
+CLAUDE_HOOK_EVENT="PostToolUse" \
+  CLAUDE_TOOL_NAME="ralph_hero__save_issue" \
+  CLAUDE_PROJECT="ralph-hero" \
+  "$SCRIPT" tool_called >/dev/null 2>&1
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
+LINE=$(head -1 "$LOG_FILE" 2>/dev/null)
+ACTOR=$(echo "$LINE" | jq -r '.actor // "missing"' 2>/dev/null)
+TARGET_TOOL=$(echo "$LINE" | jq -r '.target.tool // "missing"' 2>/dev/null)
+PROJECT=$(echo "$LINE" | jq -r '.project // "missing"' 2>/dev/null)
+assert_eq "ralph_hero__save_issue" "$TARGET_TOOL" "target.tool populated from CLAUDE_TOOL_NAME"
+assert_eq "ralph-hero" "$PROJECT" "project field populated from CLAUDE_PROJECT"
+
+echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
@@ -44,5 +44,18 @@ echo "Test dir: $TEST_DIR"
 # Tests will be added in subsequent tasks
 
 echo
+echo "Test: writes one valid JSON line"
+export RALPH_ACTIVITY_DIR="$TEST_DIR/activity"
+CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__get_issue" "$SCRIPT" tool_called >/dev/null 2>&1
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$RALPH_ACTIVITY_DIR/$TODAY.jsonl"
+assert_file_exists "$LOG_FILE" "log file created at expected path"
+LINE_COUNT=$(wc -l < "$LOG_FILE" 2>/dev/null | tr -d ' ' || echo 0)
+assert_eq "1" "$LINE_COUNT" "exactly one event written"
+LINE=$(head -1 "$LOG_FILE" 2>/dev/null)
+JSON_VALID=$(echo "$LINE" | jq -e . >/dev/null 2>&1 && echo "yes" || echo "no")
+assert_eq "yes" "$JSON_VALID" "line is valid JSON"
+
+echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
@@ -73,5 +73,35 @@ assert_eq "ralph_hero__save_issue" "$TARGET_TOOL" "target.tool populated from CL
 assert_eq "ralph-hero" "$PROJECT" "project field populated from CLAUDE_PROJECT"
 
 echo
+echo "Test: categorization rules"
+rm -rf "$TEST_DIR/activity"
+
+# Work: state-mutating tool
+CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__save_issue" "$SCRIPT" tool_called >/dev/null 2>&1
+# Meta: read-only tool
+CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__get_issue" "$SCRIPT" tool_called >/dev/null 2>&1
+# Meta: recent_activity (the canonical example)
+CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__recent_activity" "$SCRIPT" tool_called >/dev/null 2>&1
+# Work: skill invocation
+CLAUDE_HOOK_EVENT="PostSkillInvoke" CLAUDE_SKILL_NAME="ralph-hero:hello" "$SCRIPT" skill_invoked >/dev/null 2>&1
+# Meta: session boundary
+CLAUDE_HOOK_EVENT="SessionStart" "$SCRIPT" session_start >/dev/null 2>&1
+
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
+
+CAT_SAVE=$(sed -n '1p' "$LOG_FILE" | jq -r '.category')
+CAT_GET=$(sed -n '2p' "$LOG_FILE" | jq -r '.category')
+CAT_ACTIVITY=$(sed -n '3p' "$LOG_FILE" | jq -r '.category')
+CAT_SKILL=$(sed -n '4p' "$LOG_FILE" | jq -r '.category')
+CAT_SESSION=$(sed -n '5p' "$LOG_FILE" | jq -r '.category')
+
+assert_eq "work" "$CAT_SAVE" "save_issue categorized as work"
+assert_eq "meta" "$CAT_GET" "get_issue categorized as meta"
+assert_eq "meta" "$CAT_ACTIVITY" "recent_activity categorized as meta"
+assert_eq "work" "$CAT_SKILL" "skill_invoked categorized as work"
+assert_eq "meta" "$CAT_SESSION" "session_start categorized as meta"
+
+echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
@@ -103,5 +103,42 @@ assert_eq "work" "$CAT_SKILL" "skill_invoked categorized as work"
 assert_eq "meta" "$CAT_SESSION" "session_start categorized as meta"
 
 echo
+echo "Test: silent failure on read-only path"
+RALPH_ACTIVITY_DIR="/dev/null/cannot-create-here" \
+  CLAUDE_HOOK_EVENT="PostToolUse" \
+  CLAUDE_TOOL_NAME="ralph_hero__get_issue" \
+  "$SCRIPT" tool_called
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "script exits 0 even with unwritable path"
+
+echo
+echo "Test: missing kind argument"
+"$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "script exits 0 even with no args (defaults to unknown)"
+
+echo
+echo "Test: concurrent writes don't corrupt file"
+rm -rf "$TEST_DIR/activity"
+export RALPH_ACTIVITY_DIR="$TEST_DIR/activity"
+
+# Fire 50 parallel writes
+for i in $(seq 1 50); do
+  CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__test_$i" "$SCRIPT" tool_called &
+done
+wait
+
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$RALPH_ACTIVITY_DIR/$TODAY.jsonl"
+LINE_COUNT=$(wc -l < "$LOG_FILE" 2>/dev/null | tr -d ' ' || echo 0)
+assert_eq "50" "$LINE_COUNT" "all 50 concurrent writes landed"
+
+# Every line must be valid JSON
+INVALID=$(grep -v '^$' "$LOG_FILE" | while IFS= read -r line; do
+  echo "$line" | jq -e . >/dev/null 2>&1 || echo "BAD"
+done | wc -l | tr -d ' ')
+assert_eq "0" "$INVALID" "no corrupt lines from concurrent writes"
+
+echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tests for record-activity.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/record-activity.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  local msg="$2"
+  if [ -f "$path" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg (file missing: $path)"
+  fi
+}
+
+echo "Testing $SCRIPT"
+echo "Test dir: $TEST_DIR"
+
+# Tests will be added in subsequent tasks
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/record-activity.sh
+++ b/plugin/ralph-hero/hooks/scripts/record-activity.sh
@@ -16,8 +16,37 @@ TODAY_FILE="$TODAY_DIR/$(date -u +%d 2>/dev/null).jsonl"
 
 mkdir -p "$TODAY_DIR" 2>/dev/null || exit 0
 
-# Minimal event for now — fields filled in subsequent tasks
-EVENT=$(printf '{"ts":"%s","kind":"%s","category":"meta"}' "$TS" "$KIND")
+ACTOR="${CLAUDE_SKILL_NAME:-${CLAUDE_AGENT_NAME:-claude}}"
+PROJECT="${CLAUDE_PROJECT:-unknown}"
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
+
+# Build target object based on event kind
+case "$KIND" in
+  tool_called)
+    TARGET=$(printf '{"tool":"%s"}' "${CLAUDE_TOOL_NAME:-unknown}")
+    ;;
+  skill_invoked)
+    TARGET=$(printf '{"skill":"%s"}' "${CLAUDE_SKILL_NAME:-unknown}")
+    ;;
+  agent_spawned|agent_completed)
+    TARGET=$(printf '{"agent":"%s"}' "${CLAUDE_AGENT_NAME:-unknown}")
+    ;;
+  session_start|session_stop)
+    TARGET="{}"
+    ;;
+  *)
+    TARGET="{}"
+    ;;
+esac
+
+# Construct event with optional session_id
+if [ -n "$SESSION_ID" ]; then
+  EVENT=$(printf '{"ts":"%s","kind":"%s","category":"meta","actor":"%s","target":%s,"project":"%s","session_id":"%s"}' \
+    "$TS" "$KIND" "$ACTOR" "$TARGET" "$PROJECT" "$SESSION_ID")
+else
+  EVENT=$(printf '{"ts":"%s","kind":"%s","category":"meta","actor":"%s","target":%s,"project":"%s"}' \
+    "$TS" "$KIND" "$ACTOR" "$TARGET" "$PROJECT")
+fi
 
 echo "$EVENT" >> "$TODAY_FILE" 2>/dev/null || true
 

--- a/plugin/ralph-hero/hooks/scripts/record-activity.sh
+++ b/plugin/ralph-hero/hooks/scripts/record-activity.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# record-activity.sh — single-purpose activity log writer.
+# Called by hooks. Reads event metadata from env vars, appends one
+# JSON line to the activity log. Exits 0 unconditionally.
+#
+# Usage: record-activity.sh <kind>
+#   kind: tool_called | skill_invoked | agent_spawned | agent_completed | session_start | session_stop
+
+set -u  # NOT -e: we never want to propagate errors to the harness
+
+KIND="${1:-unknown}"
+TS=$(date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || echo "")
+ACTIVITY_ROOT="${RALPH_ACTIVITY_DIR:-$HOME/.ralph-hero/activity}"
+TODAY_DIR="$ACTIVITY_ROOT/$(date -u +%Y/%m 2>/dev/null)"
+TODAY_FILE="$TODAY_DIR/$(date -u +%d 2>/dev/null).jsonl"
+
+mkdir -p "$TODAY_DIR" 2>/dev/null || exit 0
+
+# Minimal event for now — fields filled in subsequent tasks
+EVENT=$(printf '{"ts":"%s","kind":"%s","category":"meta"}' "$TS" "$KIND")
+
+echo "$EVENT" >> "$TODAY_FILE" 2>/dev/null || true
+
+exit 0

--- a/plugin/ralph-hero/hooks/scripts/record-activity.sh
+++ b/plugin/ralph-hero/hooks/scripts/record-activity.sh
@@ -20,6 +20,56 @@ ACTOR="${CLAUDE_SKILL_NAME:-${CLAUDE_AGENT_NAME:-claude}}"
 PROJECT="${CLAUDE_PROJECT:-unknown}"
 SESSION_ID="${CLAUDE_SESSION_ID:-}"
 
+# Categorize event as "work" (state-changing or intent-declaring) or "meta"
+# (read-only / observational). Used by consumers to filter noise.
+categorize() {
+  local kind="$1"
+  local subject="$2"  # tool name, skill name, or empty
+
+  case "$kind" in
+    skill_invoked|agent_spawned|agent_completed)
+      echo "work"
+      return
+      ;;
+    session_start|session_stop)
+      echo "meta"
+      return
+      ;;
+    tool_called)
+      # State-mutating MCP tools are work; everything else is meta.
+      case "$subject" in
+        ralph_hero__save_issue|\
+        ralph_hero__create_issue|\
+        ralph_hero__create_draft_issue|\
+        ralph_hero__update_draft_issue|\
+        ralph_hero__convert_draft_issue|\
+        ralph_hero__add_dependency|\
+        ralph_hero__remove_dependency|\
+        ralph_hero__add_sub_issue|\
+        ralph_hero__advance_issue|\
+        ralph_hero__archive_items|\
+        ralph_hero__batch_update|\
+        ralph_hero__create_comment|\
+        ralph_hero__create_status_update|\
+        ralph_hero__sync_plan_graph|\
+        ralph_hero__decompose_feature|\
+        ralph_hero__setup_project|\
+        ralph_hero__create_views|\
+        Write|Edit|NotebookEdit)
+          echo "work"
+          ;;
+        *)
+          echo "meta"
+          ;;
+      esac
+      return
+      ;;
+  esac
+  echo "meta"
+}
+
+CATEGORY=$(categorize "$KIND" "${CLAUDE_TOOL_NAME:-${CLAUDE_SKILL_NAME:-}}")
+
 # Build target object based on event kind
 case "$KIND" in
   tool_called)
@@ -41,11 +91,11 @@ esac
 
 # Construct event with optional session_id
 if [ -n "$SESSION_ID" ]; then
-  EVENT=$(printf '{"ts":"%s","kind":"%s","category":"meta","actor":"%s","target":%s,"project":"%s","session_id":"%s"}' \
-    "$TS" "$KIND" "$ACTOR" "$TARGET" "$PROJECT" "$SESSION_ID")
+  EVENT=$(printf '{"ts":"%s","kind":"%s","category":"%s","actor":"%s","target":%s,"project":"%s","session_id":"%s"}' \
+    "$TS" "$KIND" "$CATEGORY" "$ACTOR" "$TARGET" "$PROJECT" "$SESSION_ID")
 else
-  EVENT=$(printf '{"ts":"%s","kind":"%s","category":"meta","actor":"%s","target":%s,"project":"%s"}' \
-    "$TS" "$KIND" "$ACTOR" "$TARGET" "$PROJECT")
+  EVENT=$(printf '{"ts":"%s","kind":"%s","category":"%s","actor":"%s","target":%s,"project":"%s"}' \
+    "$TS" "$KIND" "$CATEGORY" "$ACTOR" "$TARGET" "$PROJECT")
 fi
 
 echo "$EVENT" >> "$TODAY_FILE" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Phase 1 ships the activity log foundation: `record-activity.sh` now writes categorized JSONL events to `~/.ralph-hero/activity/YYYY/MM/DD.jsonl` when hooks fire on lifecycle events (tool calls, skill invocations, session boundaries). No MCP server changes in this phase.

## Plan

Phase 1 implementation per: https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-02-hello-composable-rewrite.md (lines 60–577)

Part of: GH-936 (Hello composable rewrite epic), GH-937 (Phase 1 coordinator)

## Leaves

All 6 sub-issues completed and moved to In Review:
- GH-943: Phase 1.1 — shell test harness skeleton
- GH-944: Phase 1.2 — minimal record-activity.sh writes valid JSONL
- GH-947: Phase 1.3 — actor/target/project/session_id fields
- GH-950: Phase 1.4 — categorize events as work or meta
- GH-953: Phase 1.5+1.6 — silent failure and concurrent-safe tests
- GH-955: Phase 1.7 — wire hooks.json lifecycle entries

## Test plan

- [x] Shell test harness (14/14 tests passing: `bash plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh`)
- [x] Full MCP suite green (1065 vitest tests, no regressions)
- [x] hooks.json validated as valid JSON
- [x] Phase 1 acceptance criteria met:
  - All shell tests pass
  - Hooks wired into hooks.json for PostToolUse, SessionStart, and related lifecycle events
  - Script exits 0 unconditionally (safe failure mode)
  - Concurrent writes (50 parallel) land safely with no corruption

## Files touched

**New:**
- `plugin/ralph-hero/hooks/scripts/record-activity.sh` — single-purpose activity log writer
- `plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — 14 shell test cases

**Modified:**
- `plugin/ralph-hero/hooks/hooks.json` — 5 new lifecycle hook entries calling record-activity.sh

Closes GH-943, GH-944, GH-947, GH-950, GH-953, GH-955
Part of GH-936, GH-937