### PR TITLE
feat: phase 2 — next_actions tool with recommended + audience (GH-938)

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
@@ -655,3 +655,78 @@ describe("ralph_hero__next_actions", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 2.5 — hello_directions backwards-compat parity
+// ---------------------------------------------------------------------------
+
+describe("hello_directions backwards-compat", () => {
+  let server: McpServer;
+  let fieldCache: FieldOptionCache;
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "0.0.0" });
+    fieldCache = new FieldOptionCache();
+  });
+
+  it("hello_directions still returns same shape as next_actions(audience=human)", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fixtures = [
+      rawIssue({
+        number: 800,
+        title: "P0 plan-in-review",
+        workflowState: "Plan in Review",
+        priority: "P0",
+        updatedAt: oneHourAgo,
+      }),
+      rawIssue({
+        number: 801,
+        title: "P1 ready-for-plan",
+        workflowState: "Ready for Plan",
+        priority: "P1",
+        updatedAt: oneHourAgo,
+      }),
+      rawIssue({
+        number: 802,
+        title: "P2 in-review",
+        workflowState: "In Review",
+        priority: "P2",
+        updatedAt: oneHourAgo,
+      }),
+    ];
+
+    const { client } = createMockClient(
+      { projectNumber: 3 },
+      { itemsByProject: { 3: fixtures } },
+    );
+
+    registerDirectionsTools(server, client, fieldCache);
+
+    const oldTool = getTool(server, "ralph_hero__hello_directions");
+    const newTool = getTool(server, "ralph_hero__next_actions");
+
+    const oldResult = await oldTool.handler(
+      buildArgs({ limit: 3, openPRs: [] }),
+      {},
+    );
+    const newResult = await newTool.handler(
+      buildArgs({ limit: 3, audience: "human", openPRs: [] }),
+      {},
+    );
+
+    const oldPayload = parsePayload(oldResult) as {
+      directions: Array<{ recommended: boolean }>;
+    };
+    const newPayload = parsePayload(newResult) as {
+      directions: Array<{ recommended: boolean }>;
+    };
+
+    expect(oldResult.isError).toBeUndefined();
+    expect(newResult.isError).toBeUndefined();
+    expect(oldPayload.directions.length).toBe(newPayload.directions.length);
+    if (oldPayload.directions.length > 0) {
+      expect(oldPayload.directions[0].recommended).toBe(true);
+      expect(newPayload.directions[0].recommended).toBe(true);
+    }
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
@@ -603,3 +603,55 @@ describe("ralph_hero__hello_directions", () => {
     expect(payload.directions.map((d) => d.issue?.number)).toEqual([500, 501, 502]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 2.4 — ralph_hero__next_actions
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__next_actions", () => {
+  let server: McpServer;
+  let fieldCache: FieldOptionCache;
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "0.0.0" });
+    fieldCache = new FieldOptionCache();
+  });
+
+  it("registers under the new name and accepts audience param", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fixtures = [
+      rawIssue({
+        number: 700,
+        title: "P0 plan-in-review",
+        workflowState: "Plan in Review",
+        priority: "P0",
+        updatedAt: oneHourAgo,
+      }),
+    ];
+
+    const { client } = createMockClient(
+      { projectNumber: 3 },
+      { itemsByProject: { 3: fixtures } },
+    );
+
+    registerDirectionsTools(server, client, fieldCache);
+
+    // Tool is registered under the new name
+    const tool = getTool(server, "ralph_hero__next_actions");
+    expect(tool).toBeDefined();
+
+    // Call with audience=agent
+    const result = await tool.handler(
+      buildArgs({ limit: 1, audience: "agent" }),
+      {},
+    );
+    const payload = parsePayload(result) as {
+      directions: Array<{ recommended: boolean }>;
+    };
+    expect(result.isError).toBeUndefined();
+    expect(payload.directions).toBeDefined();
+    if (payload.directions.length > 0) {
+      expect(payload.directions[0].recommended).toBe(true);
+    }
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
@@ -92,6 +92,56 @@ describe("recommended flag", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 0b. Audience param (Phase 2.2)
+// ---------------------------------------------------------------------------
+
+describe("audience param", () => {
+  it("audience='human' (default) does not penalize XL items", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Ready for Plan",
+        priority: "P2",
+        estimate: "XL",
+        updatedAt: new Date(NOW.getTime() - 10 * DAY_MS).toISOString(),
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Ready for Plan",
+        priority: "P2",
+        estimate: "S",
+        updatedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+      }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 2, audience: "human" }));
+    // The XL item is much staler so should rank first under human audience
+    expect(result[0].issue?.number).toBe(1);
+  });
+
+  it("audience='agent' penalizes XL items, preferring smaller", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Ready for Plan",
+        priority: "P2",
+        estimate: "XL",
+        updatedAt: new Date(NOW.getTime() - 10 * DAY_MS).toISOString(),
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Ready for Plan",
+        priority: "P2",
+        estimate: "S",
+        updatedAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+      }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 2, audience: "agent" }));
+    // The S item should rank first because XL is penalized
+    expect(result[0].issue?.number).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 1. Empty input
 // ---------------------------------------------------------------------------
 

--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
@@ -69,6 +69,29 @@ function makePR(overrides: Partial<OpenPR> = {}): OpenPR {
 }
 
 // ---------------------------------------------------------------------------
+// 0. Recommended flag (Phase 2.1)
+// ---------------------------------------------------------------------------
+
+describe("recommended flag", () => {
+  it("marks rank-1 entry as recommended when directions are returned", () => {
+    const items = [
+      makeItem({ number: 1, workflowState: "Plan in Review", priority: "P1" }),
+      makeItem({ number: 2, workflowState: "Ready for Plan", priority: "P2" }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 2 }));
+    expect(result).toHaveLength(2);
+    expect(result[0].recommended).toBe(true);
+    expect(result[1].recommended).toBe(false);
+  });
+
+  it("returns no recommended flag when directions are empty", () => {
+    const result = rankDirections([], [], makeConfig({ limit: 3 }));
+    expect(result).toHaveLength(0);
+    // No assertion needed — just no crash
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 1. Empty input
 // ---------------------------------------------------------------------------
 

--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
@@ -142,6 +142,35 @@ describe("audience param", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 0c. Differentiated stale reasons (Phase 2.3)
+// ---------------------------------------------------------------------------
+
+describe("differentiated stale reasons", () => {
+  it("stale P1 produces a different reason than stale P2", () => {
+    const stale = new Date(NOW.getTime() - 5 * DAY_MS).toISOString();
+    const items = [
+      makeItem({ number: 1, workflowState: "Ready for Plan", priority: "P1", updatedAt: stale }),
+      makeItem({ number: 2, workflowState: "Ready for Plan", priority: "P2", updatedAt: stale }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 2 }));
+    const p1Reason = result.find((d) => d.issue?.priority === "P1")?.reason;
+    const p2Reason = result.find((d) => d.issue?.priority === "P2")?.reason;
+    expect(p1Reason).toBeDefined();
+    expect(p2Reason).toBeDefined();
+    expect(p1Reason).not.toBe(p2Reason);
+  });
+
+  it("stale P0 reason mentions urgency", () => {
+    const stale = new Date(NOW.getTime() - 5 * DAY_MS).toISOString();
+    const items = [
+      makeItem({ number: 1, workflowState: "Ready for Plan", priority: "P0", updatedAt: stale }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 1 }));
+    expect(result[0].reason.toLowerCase()).toMatch(/p0|urgent|top/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 1. Empty input
 // ---------------------------------------------------------------------------
 

--- a/plugin/ralph-hero/mcp-server/src/lib/directions.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/directions.ts
@@ -474,7 +474,20 @@ export function buildReason(
     const hours = Math.round(ageHours(issue.updatedAt, config.now));
     const days = Math.max(1, Math.floor(hours / 24));
     const dayLabel = days === 1 ? "day" : "days";
-    return `${phase} for ${days} ${dayLabel} — likely the most unblocking thing`;
+    const priority = issue.priority;
+    if (priority === "P0") {
+      return `P0 stalled in ${phase} for ${days} ${dayLabel} — top of the queue`;
+    }
+    if (priority === "P1") {
+      return `P1 stalled in ${phase} for ${days} ${dayLabel} — likely the most unblocking thing`;
+    }
+    if (priority === "P2") {
+      return `Sitting in ${phase} for ${days} ${dayLabel} — small unblock if you have a moment`;
+    }
+    if (priority === "P3") {
+      return `Low-priority item in ${phase} for ${days} ${dayLabel}`;
+    }
+    return `Unprioritized in ${phase} for ${days} ${dayLabel}`;
   }
   if (issue.priority === "P0") {
     return `P0 in ${phase} — top of the queue`;

--- a/plugin/ralph-hero/mcp-server/src/lib/directions.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/directions.ts
@@ -76,6 +76,14 @@ export interface Direction {
   score: number;
 }
 
+/**
+ * Consumer kind for ranking. "human" (default) keeps the existing
+ * presentation-friendly ordering. "agent" tilts scoring to honor the
+ * autonomous-loop XS/S preference, penalizing larger estimates so
+ * agent loops dispatch on bite-sized items first.
+ */
+export type Audience = "human" | "agent";
+
 export interface RankConfig {
   /** Max directions to return. Default 3. */
   limit: number;
@@ -87,6 +95,12 @@ export interface RankConfig {
   treeRecentDoneDays: number;
   /** Hours before an open PR is considered stale (older PRs rank higher). Default 24. */
   prStaleHours: number;
+  /**
+   * Tilts scoring per consumer kind. "human" (default) keeps existing
+   * behavior; "agent" penalizes large estimates to honor autonomous-loop
+   * XS/S preference.
+   */
+  audience: Audience;
   /** Injected for testability — never read from the wall clock inside the lib. */
   now: Date;
 }
@@ -97,6 +111,7 @@ export const DEFAULT_RANK_CONFIG: Omit<RankConfig, "now"> = {
   lockStaleHours: 24,
   treeRecentDoneDays: 7,
   prStaleHours: 24,
+  audience: "human",
 };
 
 // ---------------------------------------------------------------------------
@@ -128,6 +143,19 @@ const STALE_BOOST = -50;
 const LOCK_STALE_BOOST = -100;
 const TREE_CONTINUE_BOOST = -75;
 const PR_REVIEW_REQUIRED_BOOST = -200;
+
+/**
+ * Per-estimate penalty applied when audience === "agent". Larger items
+ * cost more (positive score), pushing them down the ranking so agent
+ * loops dispatch on XS/S items first.
+ */
+const ESTIMATE_PENALTY: Readonly<Record<string, number>> = {
+  XS: 0,
+  S: 0,
+  M: 20,
+  L: 40,
+  XL: 60,
+};
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
@@ -172,6 +200,19 @@ function hasOpenBlockers(item: DashboardItem): boolean {
 
 function isLockState(state: string | null): boolean {
   return state !== null && LOCK_STATES.includes(state);
+}
+
+/**
+ * Returns a positive score adjustment when audience === "agent" so larger
+ * estimates get pushed down the ranking. Returns 0 for human audience
+ * (existing behavior). Items with unknown estimate get a mid-tier penalty
+ * (30) so unestimated work doesn't accidentally outrank XS/S items.
+ */
+function audiencePenalty(item: DashboardItem, audience: Audience): number {
+  if (audience !== "agent") return 0;
+  const est = item.estimate;
+  if (est === null || est === undefined) return 30; // unknown: mid penalty
+  return ESTIMATE_PENALTY[est] ?? 30;
 }
 
 // ---------------------------------------------------------------------------
@@ -273,6 +314,10 @@ export function scoreIssue(
   const tags: string[] = [];
 
   let score = priorityScore(item.priority) + phaseScore(item.workflowState);
+
+  // Audience-aware estimate penalty (no-op for "human"; pushes XL items
+  // down for "agent" so autonomous loops favor XS/S work).
+  score += audiencePenalty(item, config.audience);
 
   const lockStale = detectLockStale(item, config);
   const treeContinue = detectTreeContinue(item, allItems, config);

--- a/plugin/ralph-hero/mcp-server/src/lib/directions.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/directions.ts
@@ -50,6 +50,12 @@ export interface OpenPR {
 
 export interface Direction {
   rank: number;
+  /**
+   * Exactly one entry has `true` (rank-1 by default). Both modes use this
+   * flag for selection: interactive picker pre-selects it; headless
+   * orchestrators dispatch on it.
+   */
+  recommended: boolean;
   kind: "issue" | "pr" | "tree-continue" | "lock-stale";
   issue: {
     number: number;
@@ -576,6 +582,7 @@ export function rankDirections(
       const reason = buildReason(c.kind, c.item, null, c.tags, config, null);
       return {
         rank,
+        recommended: false,
         kind: c.kind,
         issue: toDirectionIssue(c.item),
         pr: null,
@@ -596,6 +603,7 @@ export function rankDirections(
     );
     return {
       rank,
+      recommended: false,
       kind: "pr",
       issue: null,
       pr: toDirectionPR(p.pr),
@@ -604,6 +612,13 @@ export function rankDirections(
       score: p.score,
     };
   });
+
+  // Mark the top-ranked entry as recommended. Both modes use this
+  // flag for selection: interactive picker pre-selects it; headless
+  // orchestrators dispatch on it.
+  if (directions.length > 0) {
+    directions[0].recommended = true;
+  }
 
   return directions;
 }

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -1,11 +1,14 @@
 /**
- * MCP tool wrapping the pure ranker at `lib/directions.ts`.
+ * MCP tools wrapping the pure ranker at `lib/directions.ts`.
  *
- * Exposes `ralph_hero__hello_directions`: a single-tool, fixed-shape,
- * deterministic surface that returns up to N ranked "directions" for the
- * `hello` skill's session briefing. The skill is responsible for fetching
- * open PRs (via `gh pr list`) and passing them in as a parameter — the
- * MCP server does not itself open an Octokit-style PR API surface.
+ * Exposes two tools that share a single implementation:
+ *   - `ralph_hero__next_actions` (current name; accepts `audience` param)
+ *   - `ralph_hero__hello_directions` (DEPRECATED alias; fixed at audience="human")
+ *
+ * Both return a fixed-shape JSON payload with up to N ranked "directions"
+ * for the `hello` skill's session briefing. The skill is responsible for
+ * fetching open PRs (via `gh pr list`) and passing them in as a parameter
+ * — the MCP server does not itself open an Octokit-style PR API surface.
  *
  * Behaviour:
  *   1. Resolve owner + project numbers from args or client config.
@@ -37,6 +40,7 @@ import type { DashboardItem } from "../lib/dashboard.js";
 import {
   rankDirections,
   DEFAULT_RANK_CONFIG,
+  type Audience,
   type OpenPR,
   type RankConfig,
 } from "../lib/directions.js";
@@ -54,6 +58,146 @@ import {
 const HOUR_MS = 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
+// Shared schema fragments
+// ---------------------------------------------------------------------------
+
+const openPRSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  url: z.string(),
+  isDraft: z.boolean(),
+  reviewDecision: z
+    .string()
+    .nullable()
+    .describe("REVIEW_REQUIRED | APPROVED | CHANGES_REQUESTED | null"),
+  headRefName: z.string(),
+  createdAt: z.string().describe("ISO timestamp from gh pr list"),
+});
+
+// ---------------------------------------------------------------------------
+// Shared params type — both tools accept (almost) the same shape.
+// `audience` is internal; callers only pass it via the `next_actions` tool.
+// ---------------------------------------------------------------------------
+
+interface OpenPRArg {
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  reviewDecision: string | null;
+  headRefName: string;
+  createdAt: string;
+}
+
+interface RunDirectionsArgs {
+  owner?: string;
+  projectNumbers?: number[];
+  limit?: number;
+  stuckThresholdHours?: number;
+  lockStaleHours?: number;
+  treeRecentDoneDays?: number;
+  prStaleHours?: number;
+  openPRs?: OpenPRArg[];
+  audience: Audience;
+}
+
+// ---------------------------------------------------------------------------
+// Shared implementation — extracted so both `hello_directions` (deprecated)
+// and `next_actions` (current) can route through the same code path. Keep
+// file-private (no export) — alias lives in this same file.
+// ---------------------------------------------------------------------------
+
+function makeRunDirections(client: GitHubClient, fieldCache: FieldOptionCache) {
+  return async function runDirections(args: RunDirectionsArgs) {
+    try {
+      const owner = args.owner || resolveProjectOwner(client.config);
+      if (!owner) {
+        return toolError("owner is required");
+      }
+
+      const projectNumbers =
+        args.projectNumbers ?? resolveProjectNumbers(client.config);
+
+      if (projectNumbers.length === 0) {
+        return toolError(
+          "No project numbers configured. Set RALPH_GH_PROJECT_NUMBER or RALPH_GH_PROJECT_NUMBERS.",
+        );
+      }
+
+      // Inject `now` at the boundary so the lib remains deterministic.
+      const now = new Date();
+
+      const allItems: DashboardItem[] = [];
+
+      for (const pn of projectNumbers) {
+        await ensureFieldCache(client, fieldCache, owner, pn);
+
+        const projectId = fieldCache.getProjectId(pn);
+        if (!projectId) {
+          // Defensive: ensureFieldCache succeeded but no projectId.
+          // Skip this project rather than blowing up the whole call.
+          continue;
+        }
+
+        const result = await paginateConnection<RawDashboardItem>(
+          (q, v) => client.projectQuery(q, v),
+          DASHBOARD_ITEMS_QUERY,
+          { projectId, first: 100 },
+          "node.items",
+          { maxItems: 500 },
+        );
+
+        allItems.push(...toDashboardItems(result.nodes, pn));
+      }
+
+      // Build the RankConfig from args + defaults + injected `now`.
+      const config: RankConfig = {
+        limit: args.limit ?? DEFAULT_RANK_CONFIG.limit,
+        stuckThresholdHours:
+          args.stuckThresholdHours ?? DEFAULT_RANK_CONFIG.stuckThresholdHours,
+        lockStaleHours:
+          args.lockStaleHours ?? DEFAULT_RANK_CONFIG.lockStaleHours,
+        treeRecentDoneDays:
+          args.treeRecentDoneDays ?? DEFAULT_RANK_CONFIG.treeRecentDoneDays,
+        prStaleHours:
+          args.prStaleHours ?? DEFAULT_RANK_CONFIG.prStaleHours,
+        audience: args.audience,
+        now,
+      };
+
+      // Compute PR ageHours at the boundary so the lib never reads the wall clock.
+      const enrichedPRs: OpenPR[] = (args.openPRs ?? []).map((pr) => {
+        const t = new Date(pr.createdAt).getTime();
+        const ageHours = Number.isNaN(t)
+          ? 0
+          : Math.max(0, (now.getTime() - t) / HOUR_MS);
+        return {
+          number: pr.number,
+          title: pr.title,
+          url: pr.url,
+          isDraft: pr.isDraft,
+          reviewDecision: pr.reviewDecision,
+          headRefName: pr.headRefName,
+          createdAt: pr.createdAt,
+          ageHours,
+        };
+      });
+
+      const directions = rankDirections(allItems, enrichedPRs, config);
+
+      return toolSuccess({
+        directions,
+        fetchedAt: now.toISOString(),
+        totalCandidates: allItems.length,
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      return toolError(`Failed to compute hello directions: ${message}`);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Register
 // ---------------------------------------------------------------------------
 
@@ -62,6 +206,8 @@ export function registerDirectionsTools(
   client: GitHubClient,
   fieldCache: FieldOptionCache,
 ): void {
+  const runDirections = makeRunDirections(client, fieldCache);
+
   server.tool(
     "ralph_hero__hello_directions",
     "Compute up to N deterministic 'directions' for the hello skill's session briefing. Single tool call returns a fixed-shape JSON payload with ranked issue/PR action items. Open PRs must be passed in as a parameter (the MCP server does not fetch them itself).",
@@ -116,24 +262,7 @@ export function registerDirectionsTools(
           "Hours before an open PR is considered stale (default: 24).",
         ),
       openPRs: z
-        .array(
-          z.object({
-            number: z.number(),
-            title: z.string(),
-            url: z.string(),
-            isDraft: z.boolean(),
-            reviewDecision: z
-              .string()
-              .nullable()
-              .describe(
-                "REVIEW_REQUIRED | APPROVED | CHANGES_REQUESTED | null",
-              ),
-            headRefName: z.string(),
-            createdAt: z
-              .string()
-              .describe("ISO timestamp from gh pr list"),
-          }),
-        )
+        .array(openPRSchema)
         .optional()
         .default([])
         .describe(
@@ -141,94 +270,80 @@ export function registerDirectionsTools(
         ),
     },
     async (args) => {
-      try {
-        const owner = args.owner || resolveProjectOwner(client.config);
-        if (!owner) {
-          return toolError("owner is required");
-        }
+      return await runDirections({ ...args, audience: "human" });
+    },
+  );
 
-        const projectNumbers =
-          args.projectNumbers ?? resolveProjectNumbers(client.config);
-
-        if (projectNumbers.length === 0) {
-          return toolError(
-            "No project numbers configured. Set RALPH_GH_PROJECT_NUMBER or RALPH_GH_PROJECT_NUMBERS.",
-          );
-        }
-
-        // Inject `now` at the boundary so the lib remains deterministic.
-        const now = new Date();
-
-        const allItems: DashboardItem[] = [];
-
-        for (const pn of projectNumbers) {
-          await ensureFieldCache(client, fieldCache, owner, pn);
-
-          const projectId = fieldCache.getProjectId(pn);
-          if (!projectId) {
-            // Defensive: ensureFieldCache succeeded but no projectId.
-            // Skip this project rather than blowing up the whole call.
-            continue;
-          }
-
-          const result = await paginateConnection<RawDashboardItem>(
-            (q, v) => client.projectQuery(q, v),
-            DASHBOARD_ITEMS_QUERY,
-            { projectId, first: 100 },
-            "node.items",
-            { maxItems: 500 },
-          );
-
-          allItems.push(...toDashboardItems(result.nodes, pn));
-        }
-
-        // Build the RankConfig from args + defaults + injected `now`.
-        // audience is fixed at "human" for the legacy hello_directions
-        // handler; the new next_actions tool (Phase 2.4) accepts the
-        // audience param.
-        const config: RankConfig = {
-          limit: args.limit ?? DEFAULT_RANK_CONFIG.limit,
-          stuckThresholdHours:
-            args.stuckThresholdHours ?? DEFAULT_RANK_CONFIG.stuckThresholdHours,
-          lockStaleHours:
-            args.lockStaleHours ?? DEFAULT_RANK_CONFIG.lockStaleHours,
-          treeRecentDoneDays:
-            args.treeRecentDoneDays ?? DEFAULT_RANK_CONFIG.treeRecentDoneDays,
-          prStaleHours:
-            args.prStaleHours ?? DEFAULT_RANK_CONFIG.prStaleHours,
-          audience: DEFAULT_RANK_CONFIG.audience,
-          now,
-        };
-
-        // Compute PR ageHours at the boundary so the lib never reads the wall clock.
-        const enrichedPRs: OpenPR[] = (args.openPRs ?? []).map((pr) => {
-          const t = new Date(pr.createdAt).getTime();
-          const ageHours = Number.isNaN(t)
-            ? 0
-            : Math.max(0, (now.getTime() - t) / HOUR_MS);
-          return {
-            number: pr.number,
-            title: pr.title,
-            url: pr.url,
-            isDraft: pr.isDraft,
-            reviewDecision: pr.reviewDecision,
-            headRefName: pr.headRefName,
-            createdAt: pr.createdAt,
-            ageHours,
-          };
-        });
-
-        const directions = rankDirections(allItems, enrichedPRs, config);
-
-        return toolSuccess({
-          directions,
-          fetchedAt: now.toISOString(),
-          totalCandidates: allItems.length,
-        });
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        return toolError(`Failed to compute hello directions: ${message}`);
-      }
+  server.tool(
+    "ralph_hero__next_actions",
+    "Compute up to N deterministic 'directions' (next actions) with one flagged `recommended: true`. Used by the /hello skill picker (interactive) and by headless orchestrators (auto-select recommended). Open PRs must be passed in as a parameter.",
+    {
+      owner: z
+        .string()
+        .optional()
+        .describe("GitHub owner. Defaults to RALPH_GH_OWNER env var."),
+      projectNumbers: z
+        .array(z.coerce.number())
+        .optional()
+        .describe(
+          "Project numbers to include. Defaults to RALPH_GH_PROJECT_NUMBERS or single configured project.",
+        ),
+      limit: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .default(3)
+        .describe("Max directions to return (default: 3)."),
+      audience: z
+        .enum(["human", "agent"])
+        .optional()
+        .default("human")
+        .describe(
+          "Tilts scoring per consumer; agent penalizes large estimates to honor autonomous-loop XS/S preference (default: human).",
+        ),
+      stuckThresholdHours: z
+        .number()
+        .nonnegative()
+        .optional()
+        .default(48)
+        .describe(
+          "Hours before a non-lock issue is considered stale (default: 48).",
+        ),
+      lockStaleHours: z
+        .number()
+        .nonnegative()
+        .optional()
+        .default(24)
+        .describe(
+          "Hours before a lock-state issue is considered stalled (default: 24).",
+        ),
+      treeRecentDoneDays: z
+        .number()
+        .nonnegative()
+        .optional()
+        .default(7)
+        .describe(
+          "Days within which a sibling Done event still pulls a tree forward (default: 7).",
+        ),
+      prStaleHours: z
+        .number()
+        .nonnegative()
+        .optional()
+        .default(24)
+        .describe(
+          "Hours before an open PR is considered stale (default: 24).",
+        ),
+      openPRs: z
+        .array(openPRSchema)
+        .optional()
+        .default([])
+        .describe(
+          "Open PRs gathered by the caller (e.g. via `gh pr list`). Drafts and APPROVED PRs are filtered internally.",
+        ),
+    },
+    async (args) => {
+      return await runDirections({ ...args, audience: args.audience ?? "human" });
     },
   );
 }

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -210,7 +210,7 @@ export function registerDirectionsTools(
 
   server.tool(
     "ralph_hero__hello_directions",
-    "Compute up to N deterministic 'directions' for the hello skill's session briefing. Single tool call returns a fixed-shape JSON payload with ranked issue/PR action items. Open PRs must be passed in as a parameter (the MCP server does not fetch them itself).",
+    "[DEPRECATED — use ralph_hero__next_actions instead. Removed in 2.7.0.] Compute up to N deterministic 'directions' for the hello skill's session briefing.",
     {
       owner: z
         .string()

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -183,6 +183,9 @@ export function registerDirectionsTools(
         }
 
         // Build the RankConfig from args + defaults + injected `now`.
+        // audience is fixed at "human" for the legacy hello_directions
+        // handler; the new next_actions tool (Phase 2.4) accepts the
+        // audience param.
         const config: RankConfig = {
           limit: args.limit ?? DEFAULT_RANK_CONFIG.limit,
           stuckThresholdHours:
@@ -193,6 +196,7 @@ export function registerDirectionsTools(
             args.treeRecentDoneDays ?? DEFAULT_RANK_CONFIG.treeRecentDoneDays,
           prStaleHours:
             args.prStaleHours ?? DEFAULT_RANK_CONFIG.prStaleHours,
+          audience: DEFAULT_RANK_CONFIG.audience,
           now,
         };
 


### PR DESCRIPTION
## Summary

Refactor hello_directions into next_actions with recommended flag, audience param, and differentiated stale reasons. Keep hello_directions as @deprecated alias for backwards compatibility. All Phase 2 tasks (2.1–2.5) are bundled in this PR and verified against the acceptance criteria.

## Master Plan

[Phase 2: next_actions Tool](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-02-hello-composable-rewrite.md#phase-2-next_actions-tool) (lines 580–1054)

Part of epic [GH-936](https://github.com/cdubiel08/ralph-hero/issues/936) and coordinator [GH-938](https://github.com/cdubiel08/ralph-hero/issues/938)

## Commits

This PR bundles 5 commits (all Phase 2 task leaves):

- **2.1 (GH-946)**: Add recommended flag to Direction type and rank-1 marking
- **2.2 (GH-948)**: Add audience param to RankConfig (human|agent)
- **2.3 (GH-952)**: Differentiate stale reason templates by priority
- **2.4 (GH-957)**: Register ralph_hero__next_actions MCP tool with audience param
- **2.5 (GH-958)**: Mark hello_directions deprecated, alias to next_actions

## Implementation Notes

Helper extraction uses a makeRunDirections(client, fieldCache) factory pattern (closure over client/cache) rather than the plain function signature suggested in the plan. This matches existing codebase conventions while preserving identical behavior.

## Test Plan

- [x] All 1075 vitest tests pass in plugin/ralph-hero/mcp-server (full suite green)
- [x] Build succeeds: npm run build
- [x] next_actions tool is registered and returns directions with recommended: true flag
- [x] audience: "agent" produces different ordering than "human" when XL items present
- [x] hello_directions still works as backwards-compat alias

Closes GH-946
Closes GH-948
Closes GH-952
Closes GH-957
Closes GH-958

Part of GH-936, GH-938

🤖 Generated with [Claude Code](https://claude.com/claude-code)