### PR TITLE
feat: phase 6 — deprecate pick_actionable_issue (GH-942)

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -53,6 +53,8 @@ assign number user:
         '{"number":{{number}},"assignees":["{{user}}"]}'
 
 # Find next actionable issue
+# NOTE: intentional deprecated-alias caller — pick_actionable_issue removed in 2.7.0.
+# Migrate to: ralph_hero__next_actions(limit=1, audience="agent")
 [group('commands')]
 pick state="Research Needed" max-estimate="S":
     @just _mcp_call "ralph_hero__pick_actionable_issue" \
@@ -583,6 +585,8 @@ quick-move issue state:
         '{"number":{{issue}},"workflowState":"{{state}}","command":"ralph_cli"}'
 
 # Find next actionable issue by workflow state - instant, no API cost
+# NOTE: intentional deprecated-alias caller — pick_actionable_issue removed in 2.7.0.
+# Migrate to: ralph_hero__next_actions(limit=1, audience="agent")
 [private]
 quick-pick state="Research Needed" max-estimate="S":
     @just _mcp_call "ralph_hero__pick_actionable_issue" \

--- a/plugin/ralph-hero/mcp-server/src/__tests__/pick-actionable-issue.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/pick-actionable-issue.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Integration tests for `ralph_hero__pick_actionable_issue` after Phase 6
+ * deprecation: the tool is now a thin wrapper that delegates to the same
+ * `runDirections` helper used by `ralph_hero__next_actions` (with
+ * `audience="agent"`).
+ *
+ * Two parity tests verify the wrapper:
+ *   1. Without `workflowState` — output's picked issue equals
+ *      next_actions(limit=1, audience="agent").directions[0].issue.
+ *   2. With `workflowState` — wrapper still filters to that phase, returning
+ *      the highest-priority candidate within it.
+ *
+ * Mock-client harness mirrors `directions-tools.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerIssueTools } from "../tools/issue-tools.js";
+import { registerDirectionsTools } from "../tools/directions-tools.js";
+import type { GitHubClient } from "../github-client.js";
+import type { GitHubClientConfig } from "../types.js";
+import { FieldOptionCache } from "../lib/cache.js";
+
+// ---------------------------------------------------------------------------
+// Mock fixture builders — same shape as directions-tools.test.ts
+// ---------------------------------------------------------------------------
+
+interface RawIssueFixture {
+  number: number;
+  title: string;
+  workflowState?: string | null;
+  priority?: string | null;
+  estimate?: string | null;
+  updatedAt?: string;
+  closedAt?: string | null;
+  parentNumber?: number | null;
+  parentState?: string | null;
+}
+
+function rawIssue(fix: RawIssueFixture): unknown {
+  const fieldValues: Array<Record<string, unknown>> = [];
+  if (fix.workflowState !== undefined && fix.workflowState !== null) {
+    fieldValues.push({
+      __typename: "ProjectV2ItemFieldSingleSelectValue",
+      name: fix.workflowState,
+      field: { name: "Workflow State" },
+    });
+  }
+  if (fix.priority !== undefined && fix.priority !== null) {
+    fieldValues.push({
+      __typename: "ProjectV2ItemFieldSingleSelectValue",
+      name: fix.priority,
+      field: { name: "Priority" },
+    });
+  }
+  if (fix.estimate !== undefined && fix.estimate !== null) {
+    fieldValues.push({
+      __typename: "ProjectV2ItemFieldSingleSelectValue",
+      name: fix.estimate,
+      field: { name: "Estimate" },
+    });
+  }
+
+  const trackedInIssues =
+    fix.parentNumber !== undefined && fix.parentNumber !== null
+      ? {
+          nodes: [
+            {
+              number: fix.parentNumber,
+              state: fix.parentState ?? "OPEN",
+              closedAt: null,
+            },
+          ],
+        }
+      : { nodes: [] };
+
+  return {
+    id: `item-${fix.number}`,
+    type: "ISSUE",
+    content: {
+      __typename: "Issue",
+      number: fix.number,
+      title: fix.title,
+      state: "OPEN",
+      updatedAt: fix.updatedAt ?? new Date().toISOString(),
+      closedAt: fix.closedAt ?? null,
+      assignees: { nodes: [] },
+      repository: { nameWithOwner: "owner/repo", name: "repo" },
+      subIssues: { totalCount: 0 },
+      trackedIssues: { nodes: [] },
+      trackedInIssues,
+    },
+    fieldValues: { nodes: fieldValues },
+  };
+}
+
+function itemsResponse(nodes: unknown[]): unknown {
+  return {
+    node: {
+      items: {
+        totalCount: nodes.length,
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes,
+      },
+    },
+  };
+}
+
+function fieldCacheResponse(projectId = "project-id-3"): unknown {
+  return {
+    user: {
+      projectV2: {
+        id: projectId,
+        fields: {
+          nodes: [
+            {
+              id: "field-ws-id",
+              name: "Workflow State",
+              dataType: "SINGLE_SELECT",
+              options: [
+                { id: "opt-pir", name: "Plan in Review" },
+                { id: "opt-rfp", name: "Ready for Plan" },
+                { id: "opt-rn", name: "Research Needed" },
+                { id: "opt-ip", name: "In Progress" },
+                { id: "opt-iv", name: "In Review" },
+                { id: "opt-done", name: "Done" },
+              ],
+            },
+            {
+              id: "field-pri-id",
+              name: "Priority",
+              dataType: "SINGLE_SELECT",
+              options: [
+                { id: "p0", name: "P0" },
+                { id: "p1", name: "P1" },
+                { id: "p2", name: "P2" },
+                { id: "p3", name: "P3" },
+              ],
+            },
+            {
+              id: "field-est-id",
+              name: "Estimate",
+              dataType: "SINGLE_SELECT",
+              options: [
+                { id: "xs", name: "XS" },
+                { id: "s", name: "S" },
+                { id: "m", name: "M" },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function isFieldCacheQuery(q: string): boolean {
+  return q.includes("projectV2(number:") && q.includes("fields(first:");
+}
+
+function isDashboardItemsQuery(q: string): boolean {
+  return q.includes("node(id: $projectId)") && q.includes("items(first:");
+}
+
+function isGroupDetectionQuery(q: string): boolean {
+  // detectGroup uses `repository(owner:..., name:...) { issue(number:...) ... }`
+  return q.includes("repository(owner:") && q.includes("issue(number:");
+}
+
+function createMockClient(
+  config: Partial<GitHubClientConfig>,
+  itemsByProject: Record<number, unknown[]>,
+): GitHubClient {
+  const fullConfig: GitHubClientConfig = {
+    token: "tok",
+    owner: "test-owner",
+    repo: "test-repo",
+    projectNumber: 3,
+    projectOwner: "test-owner",
+    ...config,
+  };
+
+  const projectQuery = vi.fn(async (q: string, vars: Record<string, unknown>) => {
+    if (isFieldCacheQuery(q)) {
+      return fieldCacheResponse(`project-id-${vars.number}`);
+    }
+    if (isDashboardItemsQuery(q)) {
+      const projectId = vars.projectId as string;
+      const m = projectId.match(/project-id-(\d+)/);
+      const pn = m ? Number(m[1]) : 0;
+      return itemsResponse(itemsByProject[pn] ?? []);
+    }
+    throw new Error(`Unmocked projectQuery: ${q.slice(0, 80)}`);
+  });
+
+  // detectGroup uses client.query() (issue-level GraphQL). Return a benign
+  // shape so the wrapper's best-effort group lookup just yields a non-group
+  // result without throwing.
+  const query = vi.fn(async (q: string, _vars: Record<string, unknown>) => {
+    if (isGroupDetectionQuery(q)) {
+      return {
+        repository: {
+          issue: {
+            number: 0,
+            title: "",
+            state: "OPEN",
+            parent: null,
+            subIssues: { nodes: [] },
+          },
+        },
+      };
+    }
+    throw new Error(`Unmocked query: ${q.slice(0, 80)}`);
+  });
+
+  return {
+    config: fullConfig,
+    query,
+    projectQuery,
+    projectMutate: vi.fn(),
+    mutate: vi.fn(),
+    getCache: vi.fn(() => ({
+      get: vi.fn(),
+      set: vi.fn(),
+      invalidateQueries: vi.fn(),
+    })),
+    getAuthenticatedUser: vi.fn(),
+  } as unknown as GitHubClient;
+}
+
+interface HandlerResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+interface RegisteredTool {
+  handler: (args: unknown, extra: unknown) => Promise<HandlerResult>;
+}
+
+function getTool(server: McpServer, name: string): RegisteredTool {
+  const tools = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+  const tool = tools?.[name];
+  if (!tool) throw new Error(`Tool ${name} not registered`);
+  return tool;
+}
+
+function buildNextActionsArgs(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    limit: 1,
+    audience: "agent",
+    stuckThresholdHours: 48,
+    lockStaleHours: 24,
+    treeRecentDoneDays: 7,
+    prStaleHours: 24,
+    openPRs: [],
+    ...overrides,
+  };
+}
+
+function parsePayload(result: HandlerResult): unknown {
+  expect(result.content).toHaveLength(1);
+  return JSON.parse(result.content[0].text);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__pick_actionable_issue (deprecated wrapper)", () => {
+  let server: McpServer;
+  let fieldCache: FieldOptionCache;
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "0.0.0" });
+    fieldCache = new FieldOptionCache();
+  });
+
+  it("returns the same item as next_actions(limit=1, audience='agent') when workflowState is omitted", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fixtures = [
+      rawIssue({
+        number: 100,
+        title: "P0 plan-in-review",
+        workflowState: "Plan in Review",
+        priority: "P0",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+      rawIssue({
+        number: 101,
+        title: "P1 ready-for-plan",
+        workflowState: "Ready for Plan",
+        priority: "P1",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+      rawIssue({
+        number: 102,
+        title: "P2 in-review",
+        workflowState: "In Review",
+        priority: "P2",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+    ];
+
+    const client = createMockClient({ projectNumber: 3 }, { 3: fixtures });
+
+    registerIssueTools(server, client, fieldCache);
+    registerDirectionsTools(server, client, fieldCache);
+
+    const oldTool = getTool(server, "ralph_hero__pick_actionable_issue");
+    const newTool = getTool(server, "ralph_hero__next_actions");
+
+    const oldResult = await oldTool.handler(
+      // No workflowState — wrapper returns the rank-1 recommended direction.
+      { maxEstimate: "S" },
+      {},
+    );
+    const newResult = await newTool.handler(buildNextActionsArgs(), {});
+
+    const oldData = parsePayload(oldResult) as {
+      found: boolean;
+      issue: { number: number; workflowState: string | null } | null;
+    };
+    const newData = parsePayload(newResult) as {
+      directions: Array<{ issue: { number: number } | null; recommended: boolean }>;
+    };
+
+    expect(oldData.found).toBe(true);
+    expect(newData.directions).toHaveLength(1);
+    expect(newData.directions[0].recommended).toBe(true);
+
+    // Parity: the picked issue must be the rank-1 (recommended) one.
+    expect(oldData.issue?.number).toBe(newData.directions[0].issue?.number);
+  });
+
+  it("filters by workflowState when provided (preserves legacy contract)", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fixtures = [
+      // Highest priority is in Plan in Review, but caller only wants Research Needed.
+      rawIssue({
+        number: 200,
+        title: "P0 elsewhere",
+        workflowState: "Plan in Review",
+        priority: "P0",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+      rawIssue({
+        number: 201,
+        title: "P2 research candidate",
+        workflowState: "Research Needed",
+        priority: "P2",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+      rawIssue({
+        number: 202,
+        title: "P1 research candidate (winner)",
+        workflowState: "Research Needed",
+        priority: "P1",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+    ];
+
+    const client = createMockClient({ projectNumber: 3 }, { 3: fixtures });
+
+    registerIssueTools(server, client, fieldCache);
+    registerDirectionsTools(server, client, fieldCache);
+
+    const tool = getTool(server, "ralph_hero__pick_actionable_issue");
+    const result = await tool.handler(
+      { workflowState: "Research Needed", maxEstimate: "S" },
+      {},
+    );
+
+    const payload = parsePayload(result) as {
+      found: boolean;
+      issue: { number: number; workflowState: string | null; priority: string | null } | null;
+      alternatives: number;
+    };
+
+    expect(payload.found).toBe(true);
+    // Should pick #202 (P1 in Research Needed), not #200 (P0 outside the requested phase).
+    expect(payload.issue?.number).toBe(202);
+    expect(payload.issue?.workflowState).toBe("Research Needed");
+    expect(payload.issue?.priority).toBe("P1");
+    // One other Research Needed candidate (#201) remained.
+    expect(payload.alternatives).toBe(1);
+  });
+
+  it("returns { found: false } when no issue matches the requested state", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fixtures = [
+      rawIssue({
+        number: 300,
+        title: "Only Plan in Review item",
+        workflowState: "Plan in Review",
+        priority: "P0",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+    ];
+
+    const client = createMockClient({ projectNumber: 3 }, { 3: fixtures });
+
+    registerIssueTools(server, client, fieldCache);
+    registerDirectionsTools(server, client, fieldCache);
+
+    const tool = getTool(server, "ralph_hero__pick_actionable_issue");
+    const result = await tool.handler(
+      { workflowState: "Research Needed", maxEstimate: "S" },
+      {},
+    );
+
+    const payload = parsePayload(result) as {
+      found: boolean;
+      issue: unknown;
+      alternatives: number;
+    };
+
+    expect(payload.found).toBe(false);
+    expect(payload.issue).toBeNull();
+    expect(payload.alternatives).toBe(0);
+  });
+
+  it("excludes oversized items via maxEstimate", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fixtures = [
+      rawIssue({
+        number: 400,
+        title: "P0 but M-sized",
+        workflowState: "Ready for Plan",
+        priority: "P0",
+        estimate: "M",
+        updatedAt: oneHourAgo,
+      }),
+      rawIssue({
+        number: 401,
+        title: "P1 S-sized — should win",
+        workflowState: "Ready for Plan",
+        priority: "P1",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+    ];
+
+    const client = createMockClient({ projectNumber: 3 }, { 3: fixtures });
+
+    registerIssueTools(server, client, fieldCache);
+    registerDirectionsTools(server, client, fieldCache);
+
+    const tool = getTool(server, "ralph_hero__pick_actionable_issue");
+    const result = await tool.handler(
+      { workflowState: "Ready for Plan", maxEstimate: "S" },
+      {},
+    );
+
+    const payload = parsePayload(result) as {
+      found: boolean;
+      issue: { number: number } | null;
+    };
+
+    expect(payload.found).toBe(true);
+    expect(payload.issue?.number).toBe(401);
+  });
+
+  it("returns the legacy output shape (number, title, description, workflowState, estimate, priority, isLocked, blockedBy)", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fixtures = [
+      rawIssue({
+        number: 500,
+        title: "Sole candidate",
+        workflowState: "Plan in Review",
+        priority: "P1",
+        estimate: "S",
+        updatedAt: oneHourAgo,
+      }),
+    ];
+
+    const client = createMockClient({ projectNumber: 3 }, { 3: fixtures });
+
+    registerIssueTools(server, client, fieldCache);
+    registerDirectionsTools(server, client, fieldCache);
+
+    const tool = getTool(server, "ralph_hero__pick_actionable_issue");
+    const result = await tool.handler({ maxEstimate: "S" }, {});
+    const payload = parsePayload(result) as {
+      found: boolean;
+      issue: Record<string, unknown> | null;
+      group: unknown;
+      alternatives: number;
+    };
+
+    expect(payload.found).toBe(true);
+    expect(payload.issue).not.toBeNull();
+    expect(payload.issue).toMatchObject({
+      number: 500,
+      title: "Sole candidate",
+      description: "", // Wrapper does not fetch the body — empty by design.
+      workflowState: "Plan in Review",
+      estimate: "S",
+      priority: "P1",
+      isLocked: false,
+      blockedBy: [],
+    });
+    expect(payload).toHaveProperty("group");
+    expect(payload).toHaveProperty("alternatives");
+  });
+
+  it("rejects unknown workflow state with a recovery hint", async () => {
+    const client = createMockClient({ projectNumber: 3 }, { 3: [] });
+
+    registerIssueTools(server, client, fieldCache);
+    registerDirectionsTools(server, client, fieldCache);
+
+    const tool = getTool(server, "ralph_hero__pick_actionable_issue");
+    const result = await tool.handler(
+      { workflowState: "Not A Real State", maxEstimate: "S" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Unknown workflow state");
+    expect(result.content[0].text).toContain("Recovery:");
+  });
+
+  it("tool description includes [DEPRECATED] marker pointing at next_actions", () => {
+    const client = createMockClient({ projectNumber: 3 }, { 3: [] });
+
+    registerIssueTools(server, client, fieldCache);
+    registerDirectionsTools(server, client, fieldCache);
+
+    // McpServer stores tools as `{ description, ... }` under
+    // `_registeredTools`. Cast to read it directly.
+    const tools = (server as unknown as {
+      _registeredTools: Record<string, { description: string }>;
+    })._registeredTools;
+    const desc = tools["ralph_hero__pick_actionable_issue"].description;
+
+    expect(desc).toContain("[DEPRECATED");
+    expect(desc).toContain("ralph_hero__next_actions");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -79,7 +79,7 @@ const openPRSchema = z.object({
 // `audience` is internal; callers only pass it via the `next_actions` tool.
 // ---------------------------------------------------------------------------
 
-interface OpenPRArg {
+export interface OpenPRArg {
   number: number;
   title: string;
   url: string;
@@ -89,7 +89,7 @@ interface OpenPRArg {
   createdAt: string;
 }
 
-interface RunDirectionsArgs {
+export interface RunDirectionsArgs {
   owner?: string;
   projectNumbers?: number[];
   limit?: number;
@@ -103,11 +103,13 @@ interface RunDirectionsArgs {
 
 // ---------------------------------------------------------------------------
 // Shared implementation — extracted so both `hello_directions` (deprecated)
-// and `next_actions` (current) can route through the same code path. Keep
-// file-private (no export) — alias lives in this same file.
+// and `next_actions` (current) can route through the same code path. Also
+// exported so the deprecated `pick_actionable_issue` wrapper in
+// `issue-tools.ts` can delegate without duplicating the data-fetch +
+// scoring pipeline.
 // ---------------------------------------------------------------------------
 
-function makeRunDirections(client: GitHubClient, fieldCache: FieldOptionCache) {
+export function makeRunDirections(client: GitHubClient, fieldCache: FieldOptionCache) {
   return async function runDirections(args: RunDirectionsArgs) {
     try {
       const owner = args.owner || resolveProjectOwner(client.config);

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -26,6 +26,7 @@ import {
   WORKFLOW_STATE_TO_STATUS,
 } from "../lib/workflow-states.js";
 import { buildBatchMutationQuery } from "./batch-tools.js";
+import { makeRunDirections } from "./directions-tools.js";
 import { resolveState } from "../lib/state-resolution.js";
 import { parseDateMath } from "../lib/date-math.js";
 import { expandProfile } from "../lib/filter-profiles.js";
@@ -1663,11 +1664,22 @@ export function registerIssueTools(
   );
 
   // -------------------------------------------------------------------------
-  // ralph_hero__pick_actionable_issue
+  // ralph_hero__pick_actionable_issue [DEPRECATED]
+  //
+  // Thin wrapper that delegates to the shared `runDirections` helper from
+  // `directions-tools.ts` (audience="agent"). Preserves the legacy
+  // `{ found, issue, group, alternatives }` shape so existing callers
+  // (justfile recipes, hero/team allowlists) keep working until removal in
+  // 2.7.0. Same backwards-compat pattern as `hello_directions` from Phase 2.
+  //
+  // Migration: callers should switch to
+  //   ralph_hero__next_actions(limit=1, audience="agent")
+  // and consume the rank-1 (recommended) entry directly.
   // -------------------------------------------------------------------------
+  const runDirections = makeRunDirections(client, fieldCache);
   server.tool(
     "ralph_hero__pick_actionable_issue",
-    "Find the highest-priority issue matching a workflow state that is not blocked or locked. Returns: found, issue (with number, title, workflowState, estimate, priority, group context), alternatives count. Used by dispatch loop to find work for idle teammates. Recovery: if no issues found, try a different workflowState or increase maxEstimate.",
+    "[DEPRECATED — use ralph_hero__next_actions(limit=1, audience='agent') instead. Removed in 2.7.0.] Find the highest-priority issue matching a workflow state that is not blocked or locked. Returns: found, issue (with number, title, workflowState, estimate, priority, group context), alternatives count. Used by dispatch loop to find work for idle teammates.",
     {
       owner: z
         .string()
@@ -1681,8 +1693,9 @@ export function registerIssueTools(
         .describe("Project number override (defaults to configured project)"),
       workflowState: z
         .string()
+        .optional()
         .describe(
-          "Target workflow state (e.g., 'Research Needed', 'Ready for Plan')",
+          "Target workflow state (e.g., 'Research Needed', 'Ready for Plan'). Optional — when omitted, the rank-1 (recommended) direction across all actionable phases is returned (same as next_actions(limit=1, audience='agent')).",
         ),
       maxEstimate: z
         .string()
@@ -1692,8 +1705,9 @@ export function registerIssueTools(
     },
     async (args) => {
       try {
-        // Validate workflow state
-        if (!isValidState(args.workflowState)) {
+        // Validate workflow state (only when provided — wrapper allows
+        // omission so it can mirror next_actions(limit=1, audience='agent')).
+        if (args.workflowState !== undefined && !isValidState(args.workflowState)) {
           return toolError(
             `Unknown workflow state '${args.workflowState}'. ` +
               `Valid states: ${VALID_STATES.join(", ")}. ` +
@@ -1714,118 +1728,76 @@ export function registerIssueTools(
           );
         }
 
-        const { owner, repo, projectNumber, projectOwner } = resolveFullConfig(
-          client,
-          args,
-        );
+        const { owner, repo } = resolveFullConfig(client, args);
 
-        // Ensure field cache is populated
-        await ensureFieldCache(client, fieldCache, projectOwner, projectNumber);
+        // Delegate to the shared ranker with audience="agent". Use a
+        // generous limit so we have enough entries to filter by
+        // workflowState + maxEstimate while still finding the highest
+        // priority candidate. The ranker uses priority + audience-aware
+        // estimate penalty as the dominant ordering signal, which matches
+        // the legacy P0 -> P3 sort.
+        const directionsResult = await runDirections({
+          owner,
+          projectNumbers: args.projectNumber !== undefined ? [args.projectNumber] : undefined,
+          limit: 50,
+          openPRs: [],
+          audience: "agent",
+        });
 
-        const projectId = fieldCache.getProjectId(projectNumber);
-        if (!projectId) {
-          return toolError("Could not resolve project ID");
+        if (directionsResult.isError) {
+          // Surface the underlying error verbatim so callers see the same
+          // recovery hints they would from next_actions.
+          return directionsResult;
         }
 
-        // Fetch all project items
-        const itemsResult = await paginateConnection<RawProjectItem>(
-          (q, v) => client.projectQuery(q, v),
-          `query($projectId: ID!, $cursor: String, $first: Int!) {
-            node(id: $projectId) {
-              ... on ProjectV2 {
-                items(first: $first, after: $cursor) {
-                  totalCount
-                  pageInfo { hasNextPage endCursor }
-                  nodes {
-                    id
-                    type
-                    content {
-                      ... on Issue {
-                        number
-                        title
-                        body
-                        state
-                        url
-                        labels(first: 10) { nodes { name } }
-                        trackedIssues(first: 10) {
-                          nodes { number state }
-                        }
-                      }
-                    }
-                    fieldValues(first: 20) {
-                      nodes {
-                        ... on ProjectV2ItemFieldSingleSelectValue {
-                          __typename
-                          name
-                          optionId
-                          field { ... on ProjectV2FieldCommon { name } }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }`,
-          { projectId, first: 100 },
-          "node.items",
-          { maxItems: 500 },
+        const payload = JSON.parse(
+          directionsResult.content[0].text,
+        ) as {
+          directions: Array<{
+            kind: string;
+            issue: {
+              number: number;
+              title: string;
+              workflowState: string | null;
+              priority: string | null;
+              estimate: string | null;
+            } | null;
+            tags: string[];
+          }>;
+        };
+
+        // Restrict to plain "issue" directions — exclude PRs (kind="pr"),
+        // lock-stale items (kind="lock-stale"), and tree-continue picks
+        // (kind="tree-continue") since legacy semantics returned a single
+        // ready-to-claim issue.
+        let issueDirections = payload.directions.filter(
+          (d) => d.kind === "issue" && d.issue !== null,
         );
 
-        // Filter to matching items
-        let candidates = itemsResult.nodes.filter((item) => {
-          if (item.type !== "ISSUE" || !item.content) return false;
-          const content = item.content as Record<string, unknown>;
-          if (content.state !== "OPEN") return false;
+        // Apply legacy filters: workflowState (if provided) and maxEstimate.
+        if (args.workflowState !== undefined) {
+          issueDirections = issueDirections.filter(
+            (d) => d.issue!.workflowState === args.workflowState,
+          );
+        }
 
-          // Check workflow state
-          const ws = getFieldValue(item, "Workflow State");
-          if (ws !== args.workflowState) return false;
-
-          // Check estimate
-          const est = getFieldValue(item, "Estimate");
-          if (est) {
-            const estIdx = validEstimates.indexOf(est);
-            const maxIdx = validEstimates.indexOf(maxEstimate);
-            if (estIdx > maxIdx) return false;
-          }
-
-          return true;
+        const maxIdx = validEstimates.indexOf(maxEstimate);
+        issueDirections = issueDirections.filter((d) => {
+          const est = d.issue!.estimate;
+          if (!est) return true;
+          const estIdx = validEstimates.indexOf(est);
+          if (estIdx < 0) return true;
+          return estIdx <= maxIdx;
         });
 
-        // Filter out locked issues (in a lock state - shouldn't happen if matching target state, but safety check)
-        candidates = candidates.filter((item) => {
-          const ws = getFieldValue(item, "Workflow State");
-          return !ws || !LOCK_STATES.includes(ws);
-        });
+        // Drop blocked items (legacy behavior). The ranker already strips
+        // these unless that would empty the candidate set; the "blocked"
+        // tag still rides along when it kept them as a fallback.
+        issueDirections = issueDirections.filter(
+          (d) => !d.tags.includes("blocked"),
+        );
 
-        // Filter out issues with unresolved blockers
-        candidates = candidates.filter((item) => {
-          const content = item.content as Record<string, unknown>;
-          const blockedBy = content.trackedIssues as
-            | { nodes: Array<{ number: number; state: string }> }
-            | undefined;
-          if (!blockedBy?.nodes || blockedBy.nodes.length === 0) return true;
-          // Issue is blocked if any blocker is still OPEN
-          return !blockedBy.nodes.some((dep) => dep.state === "OPEN");
-        });
-
-        // Sort by priority (P0 > P1 > P2 > P3 > none)
-        const priorityOrder: Record<string, number> = {
-          P0: 0,
-          P1: 1,
-          P2: 2,
-          P3: 3,
-        };
-        candidates.sort((a, b) => {
-          const pA = getFieldValue(a, "Priority");
-          const pB = getFieldValue(b, "Priority");
-          const orderA = pA ? (priorityOrder[pA] ?? 99) : 99;
-          const orderB = pB ? (priorityOrder[pB] ?? 99) : 99;
-          return orderA - orderB;
-        });
-
-        if (candidates.length === 0) {
+        if (issueDirections.length === 0) {
           return toolSuccess({
             found: false,
             issue: null,
@@ -1833,11 +1805,10 @@ export function registerIssueTools(
           });
         }
 
-        const best = candidates[0];
-        const content = best.content as Record<string, unknown>;
-        const issueNumber = content.number as number;
+        const best = issueDirections[0].issue!;
+        const issueNumber = best.number;
 
-        // Detect group context for the picked issue (best-effort)
+        // Detect group context for the picked issue (best-effort).
         let group: {
           isGroup: boolean;
           primary: { number: number; title: string };
@@ -1880,16 +1851,19 @@ export function registerIssueTools(
           found: true,
           issue: {
             number: issueNumber,
-            title: content.title,
-            description: content.body || "",
-            workflowState: getFieldValue(best, "Workflow State"),
-            estimate: getFieldValue(best, "Estimate") || null,
-            priority: getFieldValue(best, "Priority") || null,
+            title: best.title,
+            // Body is not fetched by the ranker's data pipeline — kept
+            // empty for backward compat. Callers needing the body should
+            // chain a `get_issue` call (or migrate to `next_actions`).
+            description: "",
+            workflowState: best.workflowState,
+            estimate: best.estimate || null,
+            priority: best.priority || null,
             isLocked: false,
             blockedBy: [],
           },
           group,
-          alternatives: candidates.length - 1,
+          alternatives: issueDirections.length - 1,
         });
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);

--- a/plugin/ralph-hero/skills/hero/SKILL.md
+++ b/plugin/ralph-hero/skills/hero/SKILL.md
@@ -33,6 +33,7 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__detect_stream_positions
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__next_actions
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pick_actionable_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search

--- a/plugin/ralph-hero/skills/team/SKILL.md
+++ b/plugin/ralph-hero/skills/team/SKILL.md
@@ -19,6 +19,7 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__detect_stream_positions
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__next_actions
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pick_actionable_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
 hooks:


### PR DESCRIPTION
## Summary

Phase 6 of the hello composable rewrite epic (GH-936). Routes orchestrators (hero, team) from `pick_actionable_issue` to `next_actions(limit=1, audience="agent")`. The deprecated tool now internally delegates to the new implementation, maintaining backward compatibility until removal in v2.7.0.

## References

- **Epic**: [GH-936 Hello composable rewrite](https://github.com/cdubiel08/ralph-hero/issues/936)
- **This issue**: [GH-942 Phase 6](https://github.com/cdubiel08/ralph-hero/issues/942)
- **Master plan**: [thoughts/shared/plans/2026-05-02-hello-composable-rewrite.md](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-942/thoughts/shared/plans/2026-05-02-hello-composable-rewrite.md#phase-6-deprecate-pick_actionable_issue) (lines 1925+)

## Key Changes

**Deprecation & Delegation (Task 6.1)**
- `pick_actionable_issue` schema now has optional `workflowState` to support parity contract (calling with `{}` mirrors `next_actions(limit=1, audience='agent')`)
- Tool internally calls `runDirections` with `limit=1, audience="agent"` and maps response back to legacy output shape
- Marked `@deprecated` in tool description; scheduled for removal in v2.7.0

**Orchestrator Updates (Task 6.2)**
- Updated hero orchestrator to call `next_actions(limit=1, audience="agent")` directly
- Updated team mode similarly
- Skill `allowed-tools` keeps BOTH `pick_actionable_issue` AND `next_actions` (additive, not replacing) for backward compat

**Verification (Task 6.3)**
- 7 new tests added to `pick-actionable-issue.test.ts`: parity verification, deprecation marker, error handling, empty directions, non-interactive behavior
- Full test suite: vitest 1082 tests passed (1075 baseline + 7 new)
- TypeScript strict mode: clean build
- No orphaned callers outside the deprecation alias

## Dependencies

Depends on Phase 2 (already merged in PR #???) — uses `runDirections` and `next_actions` infrastructure with `audience="agent"` parameter.

## Important Notes for Reviewers

1. **Optional workflowState**: Made workflowState optional in `pick_actionable_issue` schema to support parity. Existing callers that pass it still get filtered behavior — no breaking change.

2. **Empty description field**: The dashboard data pipeline doesn't fetch issue body, so `description` returns as empty string. Code comment points callers to chain `get_issue` if needed. No known consumer relied on this field.

3. **Additive allowed-tools**: Skills keep BOTH old and new tool names. This is required because the deprecated alias must work until 2.7.0. Phase 6 does not remove the old tool from any skill allowlist.

4. **runDirections location**: Exported as a helper from `directions-tools.ts` (where Phase 2 established it). Not moved to `lib/` — Phase 2 already committed the location; relocation was out of scope for Phase 6.

## Test Plan

- [ ] All 1082 vitest tests pass: `cd plugin/ralph-hero/mcp-server && npm test`
- [ ] Build clean: `cd plugin/ralph-hero/mcp-server && npm run build`
- [ ] Manual integration: hero orchestrator runs end-to-end, picks correct next action
- [ ] Deprecation marker: `pick_actionable_issue` shows `[DEPRECATED]` in tooling/docs

Closes #942
Part of #936