### PR TITLE
fix(hooks): tolerate zero-padded ticket ids when finding artifacts

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/hook-utils.sh
+++ b/plugin/ralph-hero/hooks/scripts/hook-utils.sh
@@ -126,7 +126,24 @@ validate_state() {
   return 1
 }
 
-# Check if file exists matching ticket pattern
+# Returns the zero-padded 4-digit form of a ticket ID (GH-NNN -> GH-0NNN),
+# or empty if the input is already padded or doesn't parse.
+# Used by callers that need to search for artifacts whose filename uses the
+# padded form while the ticket_id was derived from a worktree dir (unpadded).
+ticket_id_alt_form() {
+  local ticket_id="$1"
+  if [[ "$ticket_id" =~ ^GH-0*([0-9]+)$ ]]; then
+    local candidate
+    candidate=$(printf "GH-%04d" "${BASH_REMATCH[1]}")
+    if [[ "$candidate" != "$ticket_id" ]]; then
+      echo "$candidate"
+    fi
+  fi
+}
+
+# Check if file exists matching ticket pattern. Tolerates padding asymmetry
+# between unpadded ticket IDs (worktree dirs) and the zero-padded form used
+# in artifact filenames.
 find_existing_artifact() {
   local artifact_dir="$1"
   local ticket_id="$2"
@@ -135,7 +152,18 @@ find_existing_artifact() {
     return 1
   fi
 
-  find "$artifact_dir" -name "*${ticket_id}*" -type f 2>/dev/null | head -1
+  local result
+  result=$(find "$artifact_dir" -name "*${ticket_id}*" -type f 2>/dev/null | head -1)
+  if [[ -n "$result" ]]; then
+    echo "$result"
+    return 0
+  fi
+
+  local alt
+  alt=$(ticket_id_alt_form "$ticket_id")
+  if [[ -n "$alt" ]]; then
+    find "$artifact_dir" -name "*${alt}*" -type f 2>/dev/null | head -1
+  fi
 }
 
 # Output JSON response for allowing with context

--- a/plugin/ralph-hero/hooks/scripts/impl-plan-required.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-plan-required.sh
@@ -35,6 +35,7 @@ if [[ -z "$ticket_id" ]]; then
 fi
 
 plans_dir="$(get_project_root)/thoughts/shared/plans"
+alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
 
 # Check 1: Direct plan
 plan_doc=$(find_existing_artifact "$plans_dir" "$ticket_id")
@@ -42,11 +43,17 @@ plan_doc=$(find_existing_artifact "$plans_dir" "$ticket_id")
 # Check 2: Group plan
 if [[ -z "$plan_doc" ]]; then
   plan_doc=$(find "$plans_dir" -name "*group*${ticket_id}*" -type f 2>/dev/null | head -1)
+  if [[ -z "$plan_doc" && -n "$alt_ticket_id" ]]; then
+    plan_doc=$(find "$plans_dir" -name "*group*${alt_ticket_id}*" -type f 2>/dev/null | head -1)
+  fi
 fi
 
 # Check 3: Stream plan
 if [[ -z "$plan_doc" ]]; then
   plan_doc=$(find "$plans_dir" -name "*stream*${ticket_id}*" -type f 2>/dev/null | head -1)
+  if [[ -z "$plan_doc" && -n "$alt_ticket_id" ]]; then
+    plan_doc=$(find "$plans_dir" -name "*stream*${alt_ticket_id}*" -type f 2>/dev/null | head -1)
+  fi
 fi
 
 # Check 4: Plan Reference (parent-planned atomic issue)

--- a/plugin/ralph-hero/hooks/scripts/plan-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/plan-postcondition.sh
@@ -20,6 +20,13 @@ plans_dir="$(get_project_root)/thoughts/shared/plans"
 doc=$(find "$plans_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
 
 if [[ -z "$doc" ]]; then
+  alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
+  if [[ -n "$alt_ticket_id" ]]; then
+    doc=$(find "$plans_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+  fi
+fi
+
+if [[ -z "$doc" ]]; then
   block "Plan postcondition failed
 
 Expected: Plan document for $ticket_id

--- a/plugin/ralph-hero/hooks/scripts/research-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/research-postcondition.sh
@@ -20,6 +20,13 @@ research_dir="$(get_project_root)/thoughts/shared/research"
 doc=$(find "$research_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
 
 if [[ -z "$doc" ]]; then
+  alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
+  if [[ -n "$alt_ticket_id" ]]; then
+    doc=$(find "$research_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+  fi
+fi
+
+if [[ -z "$doc" ]]; then
   block "Research postcondition failed
 
 Expected: Research document for $ticket_id

--- a/plugin/ralph-hero/hooks/scripts/review-no-dup.sh
+++ b/plugin/ralph-hero/hooks/scripts/review-no-dup.sh
@@ -24,7 +24,7 @@ if [[ -z "$ticket_id" ]]; then
 fi
 
 project_root=$(get_project_root)
-existing=$(find "$project_root/thoughts/shared/reviews" -name "*${ticket_id}*" -type f 2>/dev/null | head -1)
+existing=$(find_existing_artifact "$project_root/thoughts/shared/reviews" "$ticket_id")
 
 if [[ -n "$existing" ]]; then
   block "DUPLICATE CRITIQUE BLOCKED


### PR DESCRIPTION
## Summary

- Adds `ticket_id_alt_form()` helper in `hook-utils.sh` that returns the 4-digit zero-padded form of a ticket id (or empty if already padded / unparseable)
- `find_existing_artifact` falls back to the alt form when the direct match misses
- Four other inline `find` call sites (group plan, stream plan, research postcondition, plan postcondition) compute the alt form once and try both

Closes #970

## Why

While running `/ralph-hero:hero 966` on 2026-05-03, the impl-agent had to create a temporary hardlink in `thoughts/shared/plans/` so `impl-plan-required.sh` could discover the plan — the plan filename uses `GH-0966` while the worktree dir uses `GH-966`. That workaround should be unnecessary.

## Verification

```
$ source plugin/ralph-hero/hooks/scripts/hook-utils.sh
$ ticket_id_alt_form GH-966
GH-0966
$ ticket_id_alt_form GH-0966   # already padded
$ find_existing_artifact thoughts/shared/plans GH-966
thoughts/shared/plans/2026-05-03-GH-0966-reflect-frontmatter-and-silent-failure.md
$ find_existing_artifact thoughts/shared/plans GH-0966
thoughts/shared/plans/2026-05-03-GH-0966-reflect-frontmatter-and-silent-failure.md
```

## Test plan

- [x] Smoke-tested helper directly via `bash -c 'source ... && ticket_id_alt_form GH-966'`
- [x] Smoke-tested `find_existing_artifact` with both padded and unpadded inputs against the real plans dir
- [ ] Optional follow-up: add a bats-style unit test in `plugin/ralph-hero/hooks/scripts/__tests__/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)