### PR TITLE
GH-967: fix(activity-log): record-activity.sh reads stdin JSON instead of env vars

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh
@@ -46,7 +46,7 @@ echo "Test dir: $TEST_DIR"
 echo
 echo "Test: writes one valid JSON line"
 export RALPH_ACTIVITY_DIR="$TEST_DIR/activity"
-CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__get_issue" "$SCRIPT" tool_called >/dev/null 2>&1
+echo '{"tool_name":"ralph_hero__get_issue","cwd":"/x","session_id":"S0"}' | "$SCRIPT" tool_called >/dev/null 2>&1
 TODAY=$(date -u +%Y/%m/%d)
 LOG_FILE="$RALPH_ACTIVITY_DIR/$TODAY.jsonl"
 assert_file_exists "$LOG_FILE" "log file created at expected path"
@@ -59,33 +59,33 @@ assert_eq "yes" "$JSON_VALID" "line is valid JSON"
 echo
 echo "Test: includes actor and target fields"
 rm -rf "$TEST_DIR/activity"
-CLAUDE_HOOK_EVENT="PostToolUse" \
-  CLAUDE_TOOL_NAME="ralph_hero__save_issue" \
-  CLAUDE_PROJECT="ralph-hero" \
-  "$SCRIPT" tool_called >/dev/null 2>&1
+echo '{"tool_name":"ralph_hero__save_issue","cwd":"/Users/dubiel/projects/ralph-hero","session_id":"S1"}' \
+  | "$SCRIPT" tool_called >/dev/null 2>&1
 TODAY=$(date -u +%Y/%m/%d)
 LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
 LINE=$(head -1 "$LOG_FILE" 2>/dev/null)
 ACTOR=$(echo "$LINE" | jq -r '.actor // "missing"' 2>/dev/null)
 TARGET_TOOL=$(echo "$LINE" | jq -r '.target.tool // "missing"' 2>/dev/null)
 PROJECT=$(echo "$LINE" | jq -r '.project // "missing"' 2>/dev/null)
-assert_eq "ralph_hero__save_issue" "$TARGET_TOOL" "target.tool populated from CLAUDE_TOOL_NAME"
-assert_eq "ralph-hero" "$PROJECT" "project field populated from CLAUDE_PROJECT"
+SESSION=$(echo "$LINE" | jq -r '.session_id // "missing"' 2>/dev/null)
+assert_eq "ralph_hero__save_issue" "$TARGET_TOOL" "target.tool populated from stdin tool_name"
+assert_eq "ralph-hero" "$PROJECT" "project field populated from basename of stdin cwd"
+assert_eq "S1" "$SESSION" "session_id populated from stdin session_id"
 
 echo
 echo "Test: categorization rules"
 rm -rf "$TEST_DIR/activity"
 
 # Work: state-mutating tool
-CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__save_issue" "$SCRIPT" tool_called >/dev/null 2>&1
+echo '{"tool_name":"ralph_hero__save_issue"}' | "$SCRIPT" tool_called >/dev/null 2>&1
 # Meta: read-only tool
-CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__get_issue" "$SCRIPT" tool_called >/dev/null 2>&1
+echo '{"tool_name":"ralph_hero__get_issue"}' | "$SCRIPT" tool_called >/dev/null 2>&1
 # Meta: recent_activity (the canonical example)
-CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__recent_activity" "$SCRIPT" tool_called >/dev/null 2>&1
-# Work: skill invocation
-CLAUDE_HOOK_EVENT="PostSkillInvoke" CLAUDE_SKILL_NAME="ralph-hero:hello" "$SCRIPT" skill_invoked >/dev/null 2>&1
+echo '{"tool_name":"ralph_hero__recent_activity"}' | "$SCRIPT" tool_called >/dev/null 2>&1
+# Work: skill invocation (production never fires this kind, but the test exercises the code path)
+echo '{"skill_name":"ralph-hero:hello"}' | "$SCRIPT" skill_invoked >/dev/null 2>&1
 # Meta: session boundary
-CLAUDE_HOOK_EVENT="SessionStart" "$SCRIPT" session_start >/dev/null 2>&1
+echo '{"hook_event_name":"SessionStart"}' | "$SCRIPT" session_start >/dev/null 2>&1
 
 TODAY=$(date -u +%Y/%m/%d)
 LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
@@ -105,15 +105,13 @@ assert_eq "meta" "$CAT_SESSION" "session_start categorized as meta"
 echo
 echo "Test: silent failure on read-only path"
 RALPH_ACTIVITY_DIR="/dev/null/cannot-create-here" \
-  CLAUDE_HOOK_EVENT="PostToolUse" \
-  CLAUDE_TOOL_NAME="ralph_hero__get_issue" \
-  "$SCRIPT" tool_called
+  bash -c "echo '{}' | '$SCRIPT' tool_called"
 EXIT_CODE=$?
 assert_eq "0" "$EXIT_CODE" "script exits 0 even with unwritable path"
 
 echo
 echo "Test: missing kind argument"
-"$SCRIPT" >/dev/null 2>&1
+echo "" | "$SCRIPT" >/dev/null 2>&1
 EXIT_CODE=$?
 assert_eq "0" "$EXIT_CODE" "script exits 0 even with no args (defaults to unknown)"
 
@@ -124,7 +122,7 @@ export RALPH_ACTIVITY_DIR="$TEST_DIR/activity"
 
 # Fire 50 parallel writes
 for i in $(seq 1 50); do
-  CLAUDE_HOOK_EVENT="PostToolUse" CLAUDE_TOOL_NAME="ralph_hero__test_$i" "$SCRIPT" tool_called &
+  echo "{\"tool_name\":\"ralph_hero__test_$i\"}" | "$SCRIPT" tool_called &
 done
 wait
 
@@ -138,6 +136,75 @@ INVALID=$(grep -v '^$' "$LOG_FILE" | while IFS= read -r line; do
   echo "$line" | jq -e . >/dev/null 2>&1 || echo "BAD"
 done | wc -l | tr -d ' ')
 assert_eq "0" "$INVALID" "no corrupt lines from concurrent writes"
+
+echo
+echo "Test: PostToolUse — target.tool extracted from stdin tool_name"
+rm -rf "$TEST_DIR/activity"
+echo '{"tool_name":"ralph_hero__save_issue","tool_input":{},"tool_response":{},"hook_event_name":"PostToolUse","cwd":"/tmp/proj","session_id":"sess-A"}' \
+  | "$SCRIPT" tool_called >/dev/null 2>&1
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
+LINE=$(head -1 "$LOG_FILE" 2>/dev/null)
+PT_TOOL=$(echo "$LINE" | jq -r '.target.tool // "missing"')
+PT_PROJECT=$(echo "$LINE" | jq -r '.project // "missing"')
+PT_SESSION=$(echo "$LINE" | jq -r '.session_id // "missing"')
+PT_CATEGORY=$(echo "$LINE" | jq -r '.category // "missing"')
+assert_eq "ralph_hero__save_issue" "$PT_TOOL" "PostToolUse: target.tool from stdin tool_name"
+assert_eq "proj" "$PT_PROJECT" "PostToolUse: project from basename of stdin cwd"
+assert_eq "sess-A" "$PT_SESSION" "PostToolUse: session_id from stdin"
+assert_eq "work" "$PT_CATEGORY" "PostToolUse: save_issue categorized as work"
+
+echo
+echo "Test: SessionStart — kind lands with stdin-derived metadata"
+rm -rf "$TEST_DIR/activity"
+echo '{"hook_event_name":"SessionStart","cwd":"/Users/x/foo-repo","session_id":"sess-B"}' \
+  | "$SCRIPT" session_start >/dev/null 2>&1
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
+LINE=$(head -1 "$LOG_FILE" 2>/dev/null)
+SS_KIND=$(echo "$LINE" | jq -r '.kind // "missing"')
+SS_PROJECT=$(echo "$LINE" | jq -r '.project // "missing"')
+SS_SESSION=$(echo "$LINE" | jq -r '.session_id // "missing"')
+SS_ACTOR=$(echo "$LINE" | jq -r '.actor // "missing"')
+SS_CATEGORY=$(echo "$LINE" | jq -r '.category // "missing"')
+assert_eq "session_start" "$SS_KIND" "SessionStart: kind matches"
+assert_eq "foo-repo" "$SS_PROJECT" "SessionStart: project from basename of stdin cwd"
+assert_eq "sess-B" "$SS_SESSION" "SessionStart: session_id from stdin"
+assert_eq "claude" "$SS_ACTOR" "SessionStart: actor defaults to claude (no agent_type)"
+assert_eq "meta" "$SS_CATEGORY" "SessionStart: category is meta"
+
+echo
+echo "Test: sub-agent — actor strips plugin prefix from agent_type"
+rm -rf "$TEST_DIR/activity"
+echo '{"tool_name":"Write","agent_type":"ralph-hero:impl-agent","cwd":"/x"}' \
+  | "$SCRIPT" tool_called >/dev/null 2>&1
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
+LINE=$(head -1 "$LOG_FILE" 2>/dev/null)
+SA_ACTOR=$(echo "$LINE" | jq -r '.actor // "missing"')
+SA_TOOL=$(echo "$LINE" | jq -r '.target.tool // "missing"')
+SA_CATEGORY=$(echo "$LINE" | jq -r '.category // "missing"')
+assert_eq "impl-agent" "$SA_ACTOR" "sub-agent: actor strips ralph-hero: prefix from agent_type"
+assert_eq "Write" "$SA_TOOL" "sub-agent: target.tool from stdin"
+assert_eq "work" "$SA_CATEGORY" "sub-agent: Write categorized as work"
+
+echo
+echo "Test: empty stdin — graceful fallback to defaults"
+rm -rf "$TEST_DIR/activity"
+"$SCRIPT" tool_called < /dev/null
+EMPTY_EXIT=$?
+assert_eq "0" "$EMPTY_EXIT" "empty stdin: exit code 0"
+TODAY=$(date -u +%Y/%m/%d)
+LOG_FILE="$TEST_DIR/activity/$TODAY.jsonl"
+LINE=$(head -1 "$LOG_FILE" 2>/dev/null)
+ES_TOOL=$(echo "$LINE" | jq -r '.target.tool // "missing"')
+ES_ACTOR=$(echo "$LINE" | jq -r '.actor // "missing"')
+ES_PROJECT=$(echo "$LINE" | jq -r '.project // "missing"')
+ES_HAS_SESSION=$(echo "$LINE" | jq -r 'has("session_id") | tostring')
+assert_eq "unknown" "$ES_TOOL" "empty stdin: target.tool defaults to unknown"
+assert_eq "claude" "$ES_ACTOR" "empty stdin: actor defaults to claude"
+assert_eq "unknown" "$ES_PROJECT" "empty stdin: project defaults to unknown"
+assert_eq "false" "$ES_HAS_SESSION" "empty stdin: session_id field omitted"
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/plugin/ralph-hero/hooks/scripts/record-activity.sh
+++ b/plugin/ralph-hero/hooks/scripts/record-activity.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 # record-activity.sh — single-purpose activity log writer.
-# Called by hooks. Reads event metadata from env vars, appends one
-# JSON line to the activity log. Exits 0 unconditionally.
+# Called by hooks. Reads event metadata from stdin JSON (Claude Code hook
+# contract), appends one JSON line to the activity log. Exits 0 unconditionally.
 #
 # Usage: record-activity.sh <kind>
 #   kind: tool_called | skill_invoked | agent_spawned | agent_completed | session_start | session_stop
+#
+# Stdin JSON field map (extracted via jq):
+#   tool_name   -> target.tool (for kind=tool_called); also drives categorization
+#   skill_name  -> target.skill (for kind=skill_invoked; not surfaced by harness in production)
+#   agent_name  -> target.agent (for kind=agent_spawned/agent_completed; not surfaced today)
+#   agent_type  -> actor (sub-agent attribution; "ralph-hero:impl-agent" -> "impl-agent")
+#   cwd         -> project (basename only)
+#   session_id  -> session_id
+#
+# We deliberately do NOT source hook-utils.sh: its `set -euo pipefail` and
+# block/warn helpers would break our "exit 0 always" guarantee.
 
 set -u  # NOT -e: we never want to propagate errors to the harness
 
@@ -16,9 +27,50 @@ TODAY_FILE="$TODAY_DIR/$(date -u +%d 2>/dev/null).jsonl"
 
 mkdir -p "$TODAY_DIR" 2>/dev/null || exit 0
 
-ACTOR="${CLAUDE_SKILL_NAME:-${CLAUDE_AGENT_NAME:-claude}}"
-PROJECT="${CLAUDE_PROJECT:-unknown}"
-SESSION_ID="${CLAUDE_SESSION_ID:-}"
+# Read stdin JSON payload. Empty stdin must not break extraction —
+# default to "{}" so jq has a valid object to query against.
+INPUT=$(cat 2>/dev/null || echo "")
+if [ -z "$INPUT" ]; then
+  INPUT="{}"
+fi
+
+# Extract a field via jq, falling back to a default on any error
+# (missing jq, invalid JSON, missing field). Survives empty $INPUT
+# because $INPUT was forced to "{}" above.
+extract() {
+  local query="$1"
+  local default="$2"
+  local result
+  result=$(echo "$INPUT" | jq -r "$query // \"$default\"" 2>/dev/null)
+  if [ -z "$result" ] || [ "$result" = "null" ]; then
+    echo "$default"
+  else
+    echo "$result"
+  fi
+}
+
+# Sub-agent attribution: agent_type comes through as "ralph-hero:impl-agent".
+# Strip everything up to and including the last ":" (mirrors hook-utils.sh::get_agent_type).
+RAW_AGENT_TYPE=$(extract '.agent_type' "")
+ACTOR="${RAW_AGENT_TYPE##*:}"
+if [ -z "$ACTOR" ]; then
+  ACTOR="claude"
+fi
+
+# Project: basename of cwd, or "unknown" if absent.
+RAW_CWD=$(extract '.cwd' "")
+if [ -n "$RAW_CWD" ]; then
+  PROJECT=$(basename "$RAW_CWD" 2>/dev/null || echo "unknown")
+else
+  PROJECT="unknown"
+fi
+
+SESSION_ID=$(extract '.session_id' "")
+
+# Stdin-derived subject names used both for categorization and target object construction.
+TOOL_NAME=$(extract '.tool_name' "")
+SKILL_NAME=$(extract '.skill_name' "")
+AGENT_NAME=$(extract '.agent_name' "")
 
 # Categorize event as "work" (state-changing or intent-declaring) or "meta"
 # (read-only / observational). Used by consumers to filter noise.
@@ -68,18 +120,30 @@ categorize() {
   echo "meta"
 }
 
-CATEGORY=$(categorize "$KIND" "${CLAUDE_TOOL_NAME:-${CLAUDE_SKILL_NAME:-}}")
+# Pick subject for categorization based on event kind.
+case "$KIND" in
+  tool_called)
+    CAT_SUBJECT="$TOOL_NAME"
+    ;;
+  skill_invoked)
+    CAT_SUBJECT="$SKILL_NAME"
+    ;;
+  *)
+    CAT_SUBJECT=""
+    ;;
+esac
+CATEGORY=$(categorize "$KIND" "$CAT_SUBJECT")
 
 # Build target object based on event kind
 case "$KIND" in
   tool_called)
-    TARGET=$(printf '{"tool":"%s"}' "${CLAUDE_TOOL_NAME:-unknown}")
+    TARGET=$(printf '{"tool":"%s"}' "${TOOL_NAME:-unknown}")
     ;;
   skill_invoked)
-    TARGET=$(printf '{"skill":"%s"}' "${CLAUDE_SKILL_NAME:-unknown}")
+    TARGET=$(printf '{"skill":"%s"}' "${SKILL_NAME:-unknown}")
     ;;
   agent_spawned|agent_completed)
-    TARGET=$(printf '{"agent":"%s"}' "${CLAUDE_AGENT_NAME:-unknown}")
+    TARGET=$(printf '{"agent":"%s"}' "${AGENT_NAME:-unknown}")
     ;;
   session_start|session_stop)
     TARGET="{}"

--- a/thoughts/shared/plans/2026-05-03-GH-0967-record-activity-stdin-json.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0967-record-activity-stdin-json.md
@@ -183,10 +183,10 @@ Rewrite `record-activity.sh` to read its tool/agent/project/session metadata fro
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `bash plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — exits 0, all assertions pass
-- [ ] `grep -n 'CLAUDE_TOOL_NAME\|CLAUDE_SKILL_NAME\|CLAUDE_AGENT_NAME\|CLAUDE_PROJECT\|CLAUDE_SESSION_ID' plugin/ralph-hero/hooks/scripts/record-activity.sh` — no matches (env-var reads fully removed)
-- [ ] Bash syntax check: `bash -n plugin/ralph-hero/hooks/scripts/record-activity.sh && bash -n plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — exits 0
-- [ ] No build/typecheck commands needed — this is a shell-only change. The `mcp-server/` package is untouched.
+- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — exits 0, all assertions pass
+- [x] `grep -n 'CLAUDE_TOOL_NAME\|CLAUDE_SKILL_NAME\|CLAUDE_AGENT_NAME\|CLAUDE_PROJECT\|CLAUDE_SESSION_ID' plugin/ralph-hero/hooks/scripts/record-activity.sh` — no matches (env-var reads fully removed)
+- [x] Bash syntax check: `bash -n plugin/ralph-hero/hooks/scripts/record-activity.sh && bash -n plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — exits 0
+- [x] No build/typecheck commands needed — this is a shell-only change. The `mcp-server/` package is untouched.
 
 #### Manual Verification:
 - [ ] After merging and a fresh Claude Code session, watch `~/.ralph-hero/activity/$(date -u +%Y/%m/%d).jsonl` for 30 seconds. Confirm new events show `target.tool` matching real tool names (e.g., `Read`, `Bash`, `ralph_hero__list_issues`), `project` matching the cwd basename, and `session_id` populated. Confirm `actor` is `claude` for the orchestrator and a stripped agent name (e.g., `impl-agent`) when running inside a sub-agent.


### PR DESCRIPTION
## Summary

Fixes the activity log hook script to read tool/skill/agent/project metadata from stdin JSON (the actual Claude Code hook contract) instead of non-existent environment variables. This repair enables the catch-up skill to synthesize meaningful summaries from real tool telemetry.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-03-GH-0967-record-activity-stdin-json.md

Single-phase fix (1 of 1).

## Test plan

- [x] Automated verification: `bash plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — 32/32 tests pass
- [x] Grep verification: `grep -n 'CLAUDE_TOOL_NAME\|CLAUDE_SKILL_NAME\|CLAUDE_AGENT_NAME\|CLAUDE_PROJECT\|CLAUDE_SESSION_ID' plugin/ralph-hero/hooks/scripts/record-activity.sh` — no matches (all env-var reads removed)
- [x] Bash syntax check: `bash -n` on both script and test file pass
- [x] Field extraction verification: new events now populate `target.tool` from stdin's `tool_name`, `project` from `cwd` basename, `session_id` from stdin, and `actor` from `agent_type` (with plugin prefix stripped)
- [x] New regression tests added for PostToolUse, SessionStart, sub-agent actor attribution, and empty-stdin graceful fallback (32 tests total, per plan acceptance)

Closes #967

🤖 Generated with Claude Code