### PR TITLE
GH-974: bug(dream-loop): reflect.py rejects clusters whose Gemma response contains backticks in unquoted YAML scalars

### DIFF
--- a/scripts/dream/reflect.py
+++ b/scripts/dream/reflect.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import re
 import sqlite3
 import struct
@@ -58,6 +59,13 @@ MAX_SLUG_LEN = 60
 # single huge raw memory from blowing past the model's context window.
 PROMPT_CONTENT_CLIP = 800
 
+# HTTP timeout for the LLM completion call. The 26B model with
+# ``max_tokens=3000`` routinely takes 60-120s on Apple Silicon for an
+# 8-member cluster. The previous 60s default sat right on the edge and
+# timed out non-deterministically. Override with
+# ``RALPH_DREAM_LLM_TIMEOUT_S`` if your hardware needs longer.
+DEFAULT_LLM_TIMEOUT_S = int(os.environ.get("RALPH_DREAM_LLM_TIMEOUT_S", "180"))
+
 # Reuse the parent plan's A-Mem prompt header verbatim so the prompt is
 # traceable to the spec. See:
 #   thoughts/shared/plans/2026-04-16-GH-0761-...md (Phase 6 section 2)
@@ -82,7 +90,11 @@ _PROMPT_FOOTER = (
     "Do not use backtick characters to format technical identifiers "
     "inside YAML scalar values; write identifiers as plain text "
     "within the values (backticks remain fine inside the markdown "
-    "body below the frontmatter).\n\n"
+    "body below the frontmatter). Inside the YAML frontmatter, use "
+    "`- item` (a hyphen followed by a space) for list entries; do "
+    "not use markdown-style bullet markers like `* item` or "
+    "`*   item` — those are markdown, not YAML, and break the "
+    "parser.\n\n"
     "Example:\n"
     "---\n"
     "title: Example reflection title\n"
@@ -409,6 +421,17 @@ def _parse_llm_response(text: str) -> dict[str, Any] | None:
     # the markdown body is not affected (it is parsed separately).
     if front:
         front = re.sub(r"`([^`\n]+)`", r"\1", front)
+        # Convert markdown-style bullet markers (``*   item``) at line
+        # start to YAML list syntax (``- item``). Gemma occasionally
+        # uses ``*`` despite the prompt instruction; without this
+        # conversion PyYAML scans ``*`` as an anchor reference and the
+        # following ``key:`` as a mapping, raising
+        # ``mapping values are not allowed here``. The substitution is
+        # narrow: it requires the asterisk to be at line start
+        # (``re.MULTILINE``) followed by one or more spaces, so an
+        # asterisk anywhere else in a value (rare but possible) is
+        # untouched.
+        front = re.sub(r"^\*\s+", "- ", front, flags=re.MULTILINE)
     try:
         data = yaml.safe_load(front) or {}
     except yaml.YAMLError as exc:
@@ -455,12 +478,12 @@ def synthesize_reflection(
         if http_post is None:
             import httpx  # type: ignore[import-untyped]
 
-            with httpx.Client(timeout=60) as client:
+            with httpx.Client(timeout=DEFAULT_LLM_TIMEOUT_S) as client:
                 resp = client.post(url, json=body)
             status = resp.status_code
             payload = resp.json()
         else:
-            status, payload = http_post(url, body, 60)
+            status, payload = http_post(url, body, DEFAULT_LLM_TIMEOUT_S)
     except Exception as exc:  # noqa: BLE001 - network errors span many types
         log.warning("LLM call to %s failed: %s", url, exc)
         return None

--- a/scripts/dream/reflect.py
+++ b/scripts/dream/reflect.py
@@ -78,7 +78,11 @@ _PROMPT_FOOTER = (
     "YAML keys, then `---` on its own line, then the markdown body. "
     "The frontmatter must contain `title` (string), `summary` "
     "(string), `insights` (list of strings), and `source_ids` (list "
-    "of strings). Do not wrap the output in a markdown code fence.\n\n"
+    "of strings). Do not wrap the output in a markdown code fence. "
+    "Do not use backtick characters to format technical identifiers "
+    "inside YAML scalar values; write identifiers as plain text "
+    "within the values (backticks remain fine inside the markdown "
+    "body below the frontmatter).\n\n"
     "Example:\n"
     "---\n"
     "title: Example reflection title\n"
@@ -393,6 +397,18 @@ def _parse_llm_response(text: str) -> dict[str, Any] | None:
             "LLM response not parseable as frontmatter or leading YAML block"
         )
         return None
+    # GH-974: Strip markdown-style backtick wrappers from inside the
+    # frontmatter block. PyYAML's scanner rejects ``` ` ``` when it
+    # starts an unquoted scalar token (e.g., ``- `IDENTIFIER` `` after a
+    # list dash), even though the same character is valid mid-scalar.
+    # Gemma 4 26B sometimes wraps technical identifiers in markdown
+    # backticks within YAML values; sanitizing here is a deterministic
+    # backstop for the prompt-level guidance in ``_PROMPT_FOOTER``. The
+    # regex is intentionally line-bounded (``[^`\n]+``) so it only
+    # touches single-line backtick pairs in the frontmatter region —
+    # the markdown body is not affected (it is parsed separately).
+    if front:
+        front = re.sub(r"`([^`\n]+)`", r"\1", front)
     try:
         data = yaml.safe_load(front) or {}
     except yaml.YAMLError as exc:

--- a/scripts/dream/tests/test_reflect.py
+++ b/scripts/dream/tests/test_reflect.py
@@ -499,6 +499,39 @@ class TestSynthesizeReflection:
             "RALPH_GH_REPO_TOKEN" in insight for insight in r["insights"]
         )
 
+    def test_markdown_bullets_in_yaml_are_tolerated(self) -> None:
+        """Gemma occasionally emits markdown-style bullet markers
+        (``*   item``) inside the YAML frontmatter despite the prompt
+        instruction. PyYAML reads ``*`` at line-start as an anchor
+        reference, so the next ``key:`` token raises
+        ``mapping values are not allowed here``. The fix converts
+        leading ``*\\s+`` to ``-`` (proper YAML list syntax) inside
+        the frontmatter region before ``yaml.safe_load`` runs.
+        """
+        cluster = _make_cluster(n=2)
+        bulleted = (
+            "---\n"
+            "title: Cluster summary with bullets\n"
+            "summary: Memories grouped by theme.\n"
+            "insights:\n"
+            "*   First bullet using markdown asterisk\n"
+            "*   Second bullet using markdown asterisk\n"
+            "source_ids:\n"
+            "  - raw-00\n"
+            "  - raw-01\n"
+            "---\n"
+            "# Body\n"
+        )
+
+        def fake_post(url, body, timeout):  # noqa: ARG001
+            return 200, {"choices": [{"message": {"content": bulleted}}]}
+
+        r = reflect.synthesize_reflection(cluster, http_post=fake_post)
+        assert r is not None
+        assert r["title"]
+        assert len(r["insights"]) == 2
+        assert r["source_ids"] == ["raw-00", "raw-01"]
+
     def test_missing_source_ids_falls_back_to_cluster(self) -> None:
         cluster = _make_cluster()
         no_ids = (
@@ -755,3 +788,42 @@ class TestMainExitCode:
             ]
         )
         assert rc == 0
+
+
+class TestLlmTimeoutConfig:
+    """Verify the LLM HTTP timeout is configurable via the
+    ``RALPH_DREAM_LLM_TIMEOUT_S`` env var with a sane default. The 60s
+    default we shipped with #966 was right at the edge for 8-member
+    clusters at ``max_tokens=3000`` on Apple Silicon, causing
+    non-deterministic timeouts; the new default is 180s.
+    """
+
+    def test_default_timeout_is_propagated_to_http_post(self) -> None:
+        cluster = _make_cluster(n=2)
+        well_formed = (
+            "---\n"
+            "title: t\n"
+            "summary: s\n"
+            "insights:\n"
+            "  - a\n"
+            "source_ids:\n"
+            "  - raw-00\n"
+            "  - raw-01\n"
+            "---\n"
+            "# t\n"
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_post(url, body, timeout):  # noqa: ARG001
+            captured["timeout"] = timeout
+            return 200, {"choices": [{"message": {"content": well_formed}}]}
+
+        r = reflect.synthesize_reflection(cluster, http_post=fake_post)
+        assert r is not None
+        # Default is read from the module-level constant which is set
+        # at import time from RALPH_DREAM_LLM_TIMEOUT_S env var (180
+        # default). Asserting >= 120 keeps the test green on an
+        # operator-overridden default while flagging accidental
+        # regressions to the old 60s value.
+        assert captured["timeout"] == reflect.DEFAULT_LLM_TIMEOUT_S
+        assert reflect.DEFAULT_LLM_TIMEOUT_S >= 120

--- a/scripts/dream/tests/test_reflect.py
+++ b/scripts/dream/tests/test_reflect.py
@@ -452,6 +452,53 @@ class TestSynthesizeReflection:
         assert len(r["insights"]) == 2
         assert r["source_ids"] == ["raw-00", "raw-01", "raw-02"]
 
+    def test_backtick_in_yaml_scalar_is_tolerated(self) -> None:
+        """Gemma 4 26B sometimes wraps technical identifiers in
+        markdown-style backticks inside YAML scalar values. PyYAML's
+        scanner rejects a backtick that starts an unquoted scalar
+        token (e.g., ``- `RALPH_GH_REPO_TOKEN` (highest priority)`` —
+        the literal failure mode captured in the GH-974 issue body
+        from the live ``reflect.py --since 30d`` run on 2026-05-03).
+        The fix sanitizes the frontmatter region by stripping the
+        backtick wrappers before ``yaml.safe_load``, so parsing
+        succeeds and the literal backticks are removed from the
+        parsed scalar values.
+        """
+        cluster = _make_cluster(n=2)
+        backticked = (
+            "---\n"
+            "title: Token resolution chain audit\n"
+            "summary: These memories trace how the token chain was hardened.\n"
+            "insights:\n"
+            "  - The two-stage chain: `RALPH_GH_REPO_TOKEN` (highest), then fallback\n"
+            "  - `gh auth token` is the keychain-backed default\n"
+            "source_ids:\n"
+            "  - raw-00\n"
+            "  - raw-01\n"
+            "---\n"
+            "# Token resolution chain audit\n"
+            "\n"
+            "Body goes here.\n"
+        )
+
+        def fake_post(url, body, timeout):  # noqa: ARG001
+            return 200, {
+                "choices": [{"message": {"content": backticked}}]
+            }
+
+        r = reflect.synthesize_reflection(cluster, http_post=fake_post)
+        assert r is not None
+        assert r["title"]  # non-empty
+        assert len(r["insights"]) == 2
+        assert r["source_ids"] == ["raw-00", "raw-01"]
+        # Backticks are stripped from the parsed scalar values; the
+        # identifier survives as plain text inside the insight string.
+        for insight in r["insights"]:
+            assert "`" not in insight
+        assert any(
+            "RALPH_GH_REPO_TOKEN" in insight for insight in r["insights"]
+        )
+
     def test_missing_source_ids_falls_back_to_cluster(self) -> None:
         cluster = _make_cluster()
         no_ids = (

--- a/thoughts/shared/plans/2026-05-03-GH-0974-reflect-backtick-yaml-scalar.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0974-reflect-backtick-yaml-scalar.md
@@ -53,9 +53,9 @@ Key facts established by research:
 
 ### Verification
 
-- [ ] `_parse_llm_response` returns a parsed dict (not None) when the LLM response contains backticks wrapping technical identifiers in YAML scalar values
-- [ ] `_PROMPT_FOOTER` instructs Gemma to avoid backtick formatting within YAML scalar values
-- [ ] New test `test_backtick_in_yaml_scalar_is_tolerated` passes; total test count moves from 22 to 23
+- [x] `_parse_llm_response` returns a parsed dict (not None) when the LLM response contains backticks wrapping technical identifiers in YAML scalar values
+- [x] `_PROMPT_FOOTER` instructs Gemma to avoid backtick formatting within YAML scalar values
+- [x] New test `test_backtick_in_yaml_scalar_is_tolerated` passes; total test count moves from 22 to 23
 - [ ] Manual gate: live `reflect.py --since 30d` writes reflections for both clusters (size 7 AND size 8) where previously cluster 2 was silently dropped
 
 ## What We're NOT Doing
@@ -93,11 +93,11 @@ Make `_parse_llm_response` tolerate Gemma responses that include markdown-style 
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] In `_parse_llm_response` (currently lines 368-404), insert a sanitization step between the `_extract_frontmatter_block(raw)` call (line 390) and the `yaml.safe_load(front)` call (line 397)
-  - [ ] The sanitization is `front = re.sub(r"`([^`\n]+)`", r"\1", front)` guarded by `if front:` to skip when extraction returned None
-  - [ ] A comment block above the substitution explains the rationale and references GH-974 (matching existing module documentation style)
-  - [ ] No new imports are added (the `re` module is already imported at line 31)
-  - [ ] All 22 existing tests in `tests/test_reflect.py` still pass
+  - [x] In `_parse_llm_response` (currently lines 368-404), insert a sanitization step between the `_extract_frontmatter_block(raw)` call (line 390) and the `yaml.safe_load(front)` call (line 397)
+  - [x] The sanitization is `front = re.sub(r"`([^`\n]+)`", r"\1", front)` guarded by `if front:` to skip when extraction returned None
+  - [x] A comment block above the substitution explains the rationale and references GH-974 (matching existing module documentation style)
+  - [x] No new imports are added (the `re` module is already imported at line 31)
+  - [x] All 22 existing tests in `tests/test_reflect.py` still pass
 
 #### Task 1.2: Add backtick instruction to _PROMPT_FOOTER
 - **files**: [scripts/dream/reflect.py](https://github.com/cdubiel08/ralph-hero/blob/main/scripts/dream/reflect.py) (modify)
@@ -105,11 +105,11 @@ Make `_parse_llm_response` tolerate Gemma responses that include markdown-style 
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `_PROMPT_FOOTER` (currently lines 69-94) includes a new sentence after "Do not wrap the output in a markdown code fence." that instructs the LLM not to use backtick characters to format technical identifiers within YAML scalar values
-  - [ ] The new instruction directs the LLM to write identifiers as plain text within scalar values
-  - [ ] The instruction is a Python string concatenation matching the existing footer style (no f-strings, no triple-quoted blocks) — keep the existing parenthesized concatenation pattern
-  - [ ] The example block in the footer remains intact and continues to demonstrate proper YAML output
-  - [ ] String concatenation is syntactically valid (the test suite still imports the module successfully)
+  - [x] `_PROMPT_FOOTER` (currently lines 69-94) includes a new sentence after "Do not wrap the output in a markdown code fence." that instructs the LLM not to use backtick characters to format technical identifiers within YAML scalar values
+  - [x] The new instruction directs the LLM to write identifiers as plain text within scalar values
+  - [x] The instruction is a Python string concatenation matching the existing footer style (no f-strings, no triple-quoted blocks) — keep the existing parenthesized concatenation pattern
+  - [x] The example block in the footer remains intact and continues to demonstrate proper YAML output
+  - [x] String concatenation is syntactically valid (the test suite still imports the module successfully)
 
 #### Task 1.3: Add test_backtick_in_yaml_scalar_is_tolerated test
 - **files**: [scripts/dream/tests/test_reflect.py](https://github.com/cdubiel08/ralph-hero/blob/main/scripts/dream/tests/test_reflect.py) (modify)
@@ -117,19 +117,19 @@ Make `_parse_llm_response` tolerate Gemma responses that include markdown-style 
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] A new test method `test_backtick_in_yaml_scalar_is_tolerated` is added to the `TestSynthesizeReflection` class
-  - [ ] The test fixture is a fenced YAML response where insights list items wrap technical identifiers in backticks (e.g., `` - The two-stage chain: `RALPH_GH_REPO_TOKEN` (highest priority) ``) — replicating the actual failure mode from production
-  - [ ] The test uses the `http_post` seam (matching existing `fake_post` pattern in `test_well_formed_yaml_parses` on line 352)
-  - [ ] The test asserts: result is not None, `r["title"]` is non-empty, `len(r["insights"]) == 2`, `r["source_ids"] == ["raw-00", "raw-01"]`
-  - [ ] The test docstring references GH-974 and explains the failure mode being covered
-  - [ ] The test passes after Task 1.1 is implemented and fails (or errors with YAMLError) without it — this is the regression test for the fix
+  - [x] A new test method `test_backtick_in_yaml_scalar_is_tolerated` is added to the `TestSynthesizeReflection` class
+  - [x] The test fixture is a fenced YAML response where insights list items wrap technical identifiers in backticks (e.g., `` - The two-stage chain: `RALPH_GH_REPO_TOKEN` (highest priority) ``) — replicating the actual failure mode from production
+  - [x] The test uses the `http_post` seam (matching existing `fake_post` pattern in `test_well_formed_yaml_parses` on line 352)
+  - [x] The test asserts: result is not None, `r["title"]` is non-empty, `len(r["insights"]) == 2`, `r["source_ids"] == ["raw-00", "raw-01"]`
+  - [x] The test docstring references GH-974 and explains the failure mode being covered
+  - [x] The test passes after Task 1.1 is implemented and fails (or errors with YAMLError) without it — this is the regression test for the fix
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `cd scripts/dream && uv run --extra test python -m pytest tests/test_reflect.py -v` — all 23 tests passing
-- [ ] `cd scripts/dream && uv run python -c "import reflect"` — module imports without syntax error
-- [ ] `cd scripts/dream && uv run --extra test python -m pytest tests/test_reflect.py -v -k test_backtick_in_yaml_scalar_is_tolerated` — new test exists and passes
+- [x] `cd scripts/dream && uv run --extra test python -m pytest tests/test_reflect.py -v` — all 23 tests passing
+- [x] `cd scripts/dream && uv run python -c "import reflect"` — module imports without syntax error
+- [x] `cd scripts/dream && uv run --extra test python -m pytest tests/test_reflect.py -v -k test_backtick_in_yaml_scalar_is_tolerated` — new test exists and passes
 
 #### Manual Verification:
 - [ ] Run `gemma-up` then `dream-now` (or directly `cd scripts/dream && uv run reflect.py --since 30d`) against the daily-driver DB at `~/.ralph-hero/knowledge.db`

--- a/thoughts/shared/plans/2026-05-03-GH-0974-reflect-backtick-yaml-scalar.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0974-reflect-backtick-yaml-scalar.md
@@ -56,7 +56,16 @@ Key facts established by research:
 - [x] `_parse_llm_response` returns a parsed dict (not None) when the LLM response contains backticks wrapping technical identifiers in YAML scalar values
 - [x] `_PROMPT_FOOTER` instructs Gemma to avoid backtick formatting within YAML scalar values
 - [x] New test `test_backtick_in_yaml_scalar_is_tolerated` passes; total test count moves from 22 to 23
-- [ ] Manual gate: live `reflect.py --since 30d` writes reflections for both clusters (size 7 AND size 8) where previously cluster 2 was silently dropped
+- [x] Manual gate: live `reflect.py --since 30d` writes reflections for both clusters (size 7 AND size 8) where previously cluster 2 was silently dropped — verified 2026-05-03; both clusters wrote reflection markdown files
+
+### Scope expansion (post-initial-implementation)
+
+During the manual verification gate, two additional reliability bugs surfaced and were fixed in the same PR rather than spawned as separate tickets:
+
+- [x] Markdown bullet markers (`*   item`) inside YAML frontmatter — Gemma occasionally produces these despite the prompt instruction; PyYAML reads `*` at line-start as an anchor reference. Fix: parser converts `^\*\s+` to `- ` inside the frontmatter region; prompt instructs against this pattern with example. New test `test_markdown_bullets_in_yaml_are_tolerated`.
+- [x] Hardcoded 60s `httpx.Client(timeout=60)` was right at the edge for 8-member clusters with `max_tokens=3000` (bumped in GH-966). Caused non-deterministic timeouts. Fix: extracted to `DEFAULT_LLM_TIMEOUT_S` module constant, default 180s, overridable via `RALPH_DREAM_LLM_TIMEOUT_S` env var. New test `test_default_timeout_is_propagated_to_http_post`.
+
+Total tests after scope expansion: 25 (was 22 pre-PR, 23 after initial backtick fix).
 
 ## What We're NOT Doing
 


### PR DESCRIPTION
## Summary

Closes #974.

Three coordinated fixes for `scripts/dream/reflect.py` LLM-output-contract robustness, all surfaced in a single live `reflect.py --since 30d` verification run on 2026-05-03.

### 1. Backticks in unquoted YAML scalars (#974 original scope)

PyYAML rejects `` ` `` at the start of an unquoted scalar token. Gemma 4 26B sometimes wraps technical identifiers in backticks inside YAML values (e.g. `` - `RALPH_GH_REPO_TOKEN` (highest priority) ``). Fix:
- `_parse_llm_response` strips ` ` `…` ` wrappers inside the extracted frontmatter region only (markdown body untouched).
- `_PROMPT_FOOTER` instructs Gemma not to use backticks in YAML scalars.

### 2. Markdown bullet markers in YAML (scope expansion)

Gemma occasionally emits `*   item` bullet markers inside the frontmatter despite the prompt. PyYAML reads `*` at line-start as an anchor reference, raising `mapping values are not allowed here` on the following `key:`. Fix:
- `_parse_llm_response` converts `^\*\s+` to `- ` inside the frontmatter region.
- `_PROMPT_FOOTER` adds an explicit instruction with example.

### 3. LLM HTTP timeout (scope expansion)

The hardcoded `httpx.Client(timeout=60)` sat right at the edge for 8-member clusters at `max_tokens=3000`, causing non-deterministic timeouts. Fix:
- Extracted to `DEFAULT_LLM_TIMEOUT_S` module constant (default 180s, overridable via `RALPH_DREAM_LLM_TIMEOUT_S` env var).

## Verification

**Unit tests: 25 pass** (was 22 pre-PR, 23 after initial backtick fix).
- `test_backtick_in_yaml_scalar_is_tolerated`
- `test_markdown_bullets_in_yaml_are_tolerated`
- `test_default_timeout_is_propagated_to_http_post`

**Live verification (manual gate from plan):**

`uv run reflect.py --since 30d` against the daily-driver `~/.ralph-hero/knowledge.db` (17 raw memories, 2 clusters of size 8 and 7) now writes reflections for **both** clusters:

```
INFO ralph.dream.reflect: Wrote .../github-auth-token-resolution-implementation.md
INFO ralph.dream.reflect: Wrote .../ralph-hero-architecture-and-retrieval.md
Wrote 2 reflection(s).
```

Previously: 0 or 1 reflections (one cluster always failed at parse or timeout).

## Plan + Research

- Plan: [thoughts/shared/plans/2026-05-03-GH-0974-reflect-backtick-yaml-scalar.md](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-974/thoughts/shared/plans/2026-05-03-GH-0974-reflect-backtick-yaml-scalar.md) — manual verification gate now flipped to `[x]`; scope expansion section added documenting fixes 2 and 3.
- Research: [thoughts/shared/research/2026-05-03-GH-0974-reflect-backtick-yaml-scalar-rejection.md](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-974/thoughts/shared/research/2026-05-03-GH-0974-reflect-backtick-yaml-scalar-rejection.md)

## Test plan

- [x] `pytest tests/test_reflect.py` — 25 pass
- [x] Live `reflect.py --since 30d` writes reflections for both clusters
- [x] `import reflect` — clean
- [ ] Reviewer sanity-check the regex narrowness: backticks (`r"`([^`\n]+)`"`) is line-bounded so it can't span newlines; bullet conversion (`r"^\*\s+"` with `re.MULTILINE`) only matches asterisk-then-whitespace at line start

🤖 Generated with [Claude Code](https://claude.com/claude-code)