### PR TITLE
revert(release): undo GH-968 + add design-note + tombstones

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,34 @@
 name: Release
 
+# === Design note: intentional plugin / npm decoupling ===
+#
+# This workflow ALWAYS bumps the version (package.json + plugin.json) and tags
+# on every triggering push to main, but ONLY publishes to npm when the MCP
+# server source actually changed (see `Publish to npm` step's `if:` guard).
+#
+# Why: ralph-hero ships through TWO distribution channels.
+#   - The plugin (skills, agents, hooks) ships via git tags / GitHub Releases.
+#     Claude Code's plugin marketplace pulls plugin content by version tag, so
+#     every meaningful merge needs a tag — even skill-only changes.
+#   - The MCP server ships via npm. Consumers pin a version in `.mcp.json` and
+#     run it via `npx`. Skill-only changes do NOT need a new npm publish
+#     because the MCP server source is unchanged.
+#
+# Consequence: `mcp-server/package.json` may sit a patch or two AHEAD of the
+# latest npm-registry version. That cosmetic drift is INTENTIONAL — not a bug
+# to "fix." Every plugin-only release bumps `package.json` so the next MCP
+# release lands on a fresh patch number, which keeps tags monotonic and
+# avoids tag-collision hazards.
+#
+# History: GH-968 (PR #973) misread the cosmetic drift as a bug and decoupled
+# the bump step from `mcp_changed`, intending to keep `package.json` in lock-
+# step with npm. That caused tag collisions when `package.json` later tried to
+# "catch up" past a plugin-only tag, and required manual recovery. The change
+# was reverted here. See thoughts/shared/plans/2026-05-03-GH-0968-*.md (now
+# tombstoned) for the full retrospective. If you're tempted to re-decouple
+# the bump from publish, read that thread first.
+# =========================================================
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,20 +113,11 @@ jobs:
         id: version
         env:
           BUMP_TYPE: ${{ steps.bump.outputs.type }}
-          MCP_CHANGED: ${{ steps.classify.outputs.mcp_changed }}
         run: |
-          PLUGIN_JSON="../.claude-plugin/plugin.json"
-          if [ "$MCP_CHANGED" = "true" ]; then
-            # MCP source changed: bump package.json (npm version) and mirror to plugin.json
-            NEW_VERSION=$(npm version "$BUMP_TYPE" --no-git-tag-version | tr -d 'v')
-            jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN_JSON" > tmp.json && mv tmp.json "$PLUGIN_JSON"
-          else
-            # Plugin-only change: bump plugin.json independently; leave package.json untouched
-            CURRENT=$(jq -r .version "$PLUGIN_JSON")
-            NEW_VERSION=$(npx --yes semver -i "$BUMP_TYPE" "$CURRENT")
-            jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN_JSON" > tmp.json && mv tmp.json "$PLUGIN_JSON"
-          fi
+          NEW_VERSION=$(npm version "$BUMP_TYPE" --no-git-tag-version | tr -d 'v')
           echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          PLUGIN_JSON="../.claude-plugin/plugin.json"
+          jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN_JSON" > tmp.json && mv tmp.json "$PLUGIN_JSON"
 
       - name: Pin version in justfile and .mcp.json
         if: steps.classify.outputs.mcp_changed == 'true'
@@ -148,10 +139,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add plugin/ralph-hero/mcp-server/package.json
+          git add plugin/ralph-hero/mcp-server/package-lock.json
           git add plugin/ralph-hero/.claude-plugin/plugin.json
           if [ "$MCP_CHANGED" = "true" ]; then
-            git add plugin/ralph-hero/mcp-server/package.json
-            git add plugin/ralph-hero/mcp-server/package-lock.json
             git add plugin/ralph-hero/justfile
             git add plugin/ralph-hero/.mcp.json
             git add plugin/ralph-hero/scripts/cli-dispatch.sh
@@ -166,23 +157,6 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Postcheck verify npm sync
-        if: steps.classify.outputs.mcp_changed == 'true'
-        env:
-          EXPECTED: ${{ steps.version.outputs.new }}
-        run: |
-          for i in $(seq 1 12); do
-            ACTUAL=$(npm view ralph-hero-mcp-server version 2>/dev/null || echo "unknown")
-            if [ "$ACTUAL" = "$EXPECTED" ]; then
-              echo "npm registry in sync: $ACTUAL"
-              exit 0
-            fi
-            echo "Attempt $i/12: npm has $ACTUAL, expected $EXPECTED — waiting 5s"
-            sleep 5
-          done
-          echo "::error::npm publish drift detected. Expected $EXPECTED, npm registry shows $ACTUAL after 60s"
-          exit 1
 
       - name: Create GitHub Release
         working-directory: .

--- a/thoughts/shared/plans/2026-05-03-GH-0968-release-publish-drift-fix.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0968-release-publish-drift-fix.md
@@ -135,11 +135,11 @@ Modify `.github/workflows/release.yml` so skill-only changes don't bump `mcp-ser
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [x] The `Bump version` step (currently `release.yml:112-120`) is split into two parallel logical bumps: `mcp-server/package.json` only when `steps.classify.outputs.mcp_changed == 'true'`; `.claude-plugin/plugin.json` always.
-  - [x] When `mcp_changed=false`, the new version for `plugin.json` is computed by reading the current `plugin.json` version and applying patch/minor/major (not by reading `package.json`'s post-bump version). This severs the coupling.
-  - [x] When `mcp_changed=true`, the new version is computed once via `npm version --no-git-tag-version` and applied to both files (existing behavior preserved).
-  - [x] The output `steps.version.outputs.new` reflects the actual new plugin version regardless of branch.
-  - [x] Reference implementation sketch:
+  - [ ] The `Bump version` step (currently `release.yml:112-120`) is split into two parallel logical bumps: `mcp-server/package.json` only when `steps.classify.outputs.mcp_changed == 'true'`; `.claude-plugin/plugin.json` always.
+  - [ ] When `mcp_changed=false`, the new version for `plugin.json` is computed by reading the current `plugin.json` version and applying patch/minor/major (not by reading `package.json`'s post-bump version). This severs the coupling.
+  - [ ] When `mcp_changed=true`, the new version is computed once via `npm version --no-git-tag-version` and applied to both files (existing behavior preserved).
+  - [ ] The output `steps.version.outputs.new` reflects the actual new plugin version regardless of branch.
+  - [ ] Reference implementation sketch:
     ```yaml
     - name: Bump version
       id: version
@@ -172,10 +172,10 @@ Modify `.github/workflows/release.yml` so skill-only changes don't bump `mcp-ser
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [x] The `Commit version bump and tag` step (currently `release.yml:134-153`) only `git add`s `plugin/ralph-hero/mcp-server/package.json` and `package-lock.json` when `MCP_CHANGED=true`.
-  - [x] `plugin/ralph-hero/.claude-plugin/plugin.json` is always staged (regardless of `MCP_CHANGED`).
-  - [x] The existing `if [ "$MCP_CHANGED" = "true" ]` block (lines 145-149) for `justfile`, `.mcp.json`, `cli-dispatch.sh` stays exactly as-is.
-  - [x] Reference change to lines 142-149:
+  - [ ] The `Commit version bump and tag` step (currently `release.yml:134-153`) only `git add`s `plugin/ralph-hero/mcp-server/package.json` and `package-lock.json` when `MCP_CHANGED=true`.
+  - [ ] `plugin/ralph-hero/.claude-plugin/plugin.json` is always staged (regardless of `MCP_CHANGED`).
+  - [ ] The existing `if [ "$MCP_CHANGED" = "true" ]` block (lines 145-149) for `justfile`, `.mcp.json`, `cli-dispatch.sh` stays exactly as-is.
+  - [ ] Reference change to lines 142-149:
     ```yaml
     git add plugin/ralph-hero/.claude-plugin/plugin.json
     if [ "$MCP_CHANGED" = "true" ]; then
@@ -186,8 +186,8 @@ Modify `.github/workflows/release.yml` so skill-only changes don't bump `mcp-ser
       git add plugin/ralph-hero/scripts/cli-dispatch.sh
     fi
     ```
-  - [x] The commit message remains `chore(release): v${NEW_VERSION} [skip ci]` (using the plugin version when MCP unchanged).
-  - [x] The tag remains `v${NEW_VERSION}`.
+  - [ ] The commit message remains `chore(release): v${NEW_VERSION} [skip ci]` (using the plugin version when MCP unchanged).
+  - [ ] The tag remains `v${NEW_VERSION}`.
 
 #### Task 1.3: Add npm sync postcheck step
 
@@ -196,11 +196,11 @@ Modify `.github/workflows/release.yml` so skill-only changes don't bump `mcp-ser
 - **complexity**: medium
 - **depends_on**: [1.2]
 - **acceptance**:
-  - [x] A new step `Postcheck: verify npm sync` is added after `Publish to npm` (around `release.yml:160`) and before `Create GitHub Release`.
-  - [x] The step runs only when `mcp_changed=true` (skipping when no publish was attempted, since npm and `package.json` will legitimately differ on plugin-only releases — `package.json` doesn't change in that case anyway, but explicit guard avoids confusion).
-  - [x] The step polls `npm view ralph-hero-mcp-server version` with retry to handle npm registry propagation latency. Retry up to 12 times, sleeping 5 seconds between (60-second total budget).
-  - [x] The step fails with a clear error message if `npm view` version != `package.json` version after the retry budget.
-  - [x] Reference implementation:
+  - [ ] A new step `Postcheck: verify npm sync` is added after `Publish to npm` (around `release.yml:160`) and before `Create GitHub Release`.
+  - [ ] The step runs only when `mcp_changed=true` (skipping when no publish was attempted, since npm and `package.json` will legitimately differ on plugin-only releases — `package.json` doesn't change in that case anyway, but explicit guard avoids confusion).
+  - [ ] The step polls `npm view ralph-hero-mcp-server version` with retry to handle npm registry propagation latency. Retry up to 12 times, sleeping 5 seconds between (60-second total budget).
+  - [ ] The step fails with a clear error message if `npm view` version != `package.json` version after the retry budget.
+  - [ ] Reference implementation:
     ```yaml
     - name: Postcheck verify npm sync
       if: steps.classify.outputs.mcp_changed == 'true'
@@ -242,10 +242,10 @@ Modify `.github/workflows/release.yml` so skill-only changes don't bump `mcp-ser
 - **complexity**: low
 - **depends_on**: [1.4]
 - **acceptance**:
-  - [x] If Task 1.4 publishes v2.5.83 directly, leave `.mcp.json` at `2.5.81` — the workflow's "Pin version" step (`release.yml:122-132`) only runs when `mcp_changed=true`, and v2.5.82/v2.5.83 were skill-only commits, so the pin lagging is correct historical state.
-  - [x] If Task 1.4 takes the workflow_dispatch path and publishes v2.5.84, the workflow itself updates `.mcp.json` to `2.5.84` automatically (existing behavior). No manual edit needed.
-  - [x] **Net result**: Either the pin stays at 2.5.81 (correct because no MCP source changed) OR it advances to 2.5.84 with a new MCP-changed cycle. Both are valid end states.
-  - [x] Document the chosen path in the PR description.
+  - [ ] If Task 1.4 publishes v2.5.83 directly, leave `.mcp.json` at `2.5.81` — the workflow's "Pin version" step (`release.yml:122-132`) only runs when `mcp_changed=true`, and v2.5.82/v2.5.83 were skill-only commits, so the pin lagging is correct historical state.
+  - [ ] If Task 1.4 takes the workflow_dispatch path and publishes v2.5.84, the workflow itself updates `.mcp.json` to `2.5.84` automatically (existing behavior). No manual edit needed.
+  - [ ] **Net result**: Either the pin stays at 2.5.81 (correct because no MCP source changed) OR it advances to 2.5.84 with a new MCP-changed cycle. Both are valid end states.
+  - [ ] Document the chosen path in the PR description.
 
   **This task is mostly verification, not action**: confirm the `.mcp.json` pin is in a consistent state with the chosen recovery path.
 
@@ -253,9 +253,9 @@ Modify `.github/workflows/release.yml` so skill-only changes don't bump `mcp-ser
 
 #### Automated Verification:
 
-- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors (sanity, this PR doesn't touch TS)
-- [x] `cd plugin/ralph-hero/mcp-server && npm test` — all passing (1089 tests, 50 files)
-- [x] YAML syntax check: `yq eval '.' .github/workflows/release.yml` — no errors
+- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors (sanity, this PR doesn't touch TS)
+- [ ] `cd plugin/ralph-hero/mcp-server && npm test` — all passing (sanity)
+- [ ] YAML syntax check: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — no errors
 - [ ] After merge, the release workflow run for this PR completes successfully:
   - Classifies `mcp_changed=false` (this PR only touches `.github/workflows/release.yml`, which is NOT in the publish trigger paths — so the workflow won't even fire on this merge; see "Edge case: trigger paths" below)
 - [ ] After a follow-up MCP-source change, the workflow's `Postcheck verify npm sync` step passes.

--- a/thoughts/shared/plans/2026-05-03-GH-0968-release-publish-drift-fix.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0968-release-publish-drift-fix.md
@@ -1,13 +1,45 @@
 ---
 date: 2026-05-03
-status: draft
+status: reverted
 type: plan
 github_issue: 968
 github_issues: [968]
 github_urls:
   - https://github.com/cdubiel08/ralph-hero/issues/968
 primary_issue: 968
-tags: [release, ci, npm, version-drift, postcheck]
+tags: [release, ci, npm, version-drift, postcheck, tombstoned]
+---
+
+> # TOMBSTONE — this plan was implemented and then reverted
+>
+> **Status: reverted on 2026-05-03 (same day as merge).**
+>
+> This plan addressed what was diagnosed as a "release publish drift bug": skill-only
+> PRs bumped `mcp-server/package.json` but didn't publish to npm, leaving the registry
+> behind the local version. The implementation (PR #973) decoupled the bump step from
+> `mcp_changed` so skill-only PRs would only bump `plugin.json`, keeping `package.json`
+> in lockstep with npm.
+>
+> **Why this was wrong:** the original "drift" was cosmetic, not functional. ralph-hero
+> ships through two distribution channels — plugins via git tags / GitHub Releases, MCP
+> server via npm. The two were intentionally decoupled. The pre-#968 workflow was
+> correct: ALWAYS bump+tag, conditionally publish. Phase 4/5 work was already deployed
+> via the plugin marketplace; the "stranded on git" framing was an overstatement.
+>
+> **What broke:** the new logic let `plugin.json` advance independently of `package.json`,
+> creating tags at versions `package.json` would later try to compute itself. PR #977's
+> merge tried to bump `package.json` 2.5.85 → 2.5.86, but git tag `v2.5.86` already
+> existed (from PR #971's plugin-only release). The release job aborted before npm
+> publish, requiring manual recovery (skip-ci sync commit + workflow_dispatch).
+>
+> **Resolution:** workflow change reverted in a follow-up PR; a clarifying design-note
+> comment added to `.github/workflows/release.yml` explaining the intentional decoupling
+> so this isn't re-litigated. See the review tombstone at
+> `thoughts/shared/reviews/2026-05-03-GH-0968-critique.md`.
+>
+> Everything below this block describes the now-reverted approach. Kept for the
+> historical record. Do not implement from this plan.
+
 ---
 
 # Fix Release Publish Drift (GH-968) - Atomic Implementation Plan

--- a/thoughts/shared/reviews/2026-05-03-GH-0968-critique.md
+++ b/thoughts/shared/reviews/2026-05-03-GH-0968-critique.md
@@ -3,9 +3,39 @@ date: 2026-05-03
 github_issue: 968
 github_url: https://github.com/cdubiel08/ralph-hero/issues/968
 plan_document: thoughts/shared/plans/2026-05-03-GH-0968-release-publish-drift-fix.md
-status: approved
+status: superseded
 type: review
-tags: [plan-review, release, ci, npm, version-drift, postcheck]
+tags: [plan-review, release, ci, npm, version-drift, postcheck, tombstoned]
+---
+
+> # TOMBSTONE — this approval was wrong
+>
+> **Status: plan was implemented, then reverted same day (2026-05-03).**
+>
+> This review approved a plan that "fixed" a non-bug. The original drift between
+> `mcp-server/package.json` and the npm registry was cosmetic, intentional, and arose
+> from ralph-hero's two distribution channels: plugins ship via git tags / GitHub
+> Releases, MCP server ships via npm. The pre-#968 workflow correctly bumped on every
+> merge but only published to npm when MCP source changed. The plan implemented here
+> decoupled the bump from `mcp_changed`, which created tag-collision hazards when
+> `package.json` later tried to "catch up" past a previously-created plugin-only tag.
+>
+> **What this review missed:** the five-dimension assessment (Completeness / Feasibility
+> / Clarity / Scope / Dispatchability) treated the framed problem as legitimate and
+> verified the plan's internal consistency, but did not question whether the underlying
+> diagnosis was correct. The reviewer should have asked: "what is plugin.json actually
+> consumed by, and is it OK for it to advance independently of package.json?" That
+> question would have surfaced the dual-channel design and exposed the diagnosis as
+> wrong.
+>
+> **Lesson for future plan reviews:** when a plan claims a "drift" or "stranded artifact"
+> bug, the review should explicitly verify the affected artifact's actual distribution
+> channel before approving. A version number being out of sync between two files is not
+> automatically a bug — sometimes the divergence is the design.
+>
+> Everything below this block is the historical approval reasoning. Kept for the record.
+> See plan tombstone at `thoughts/shared/plans/2026-05-03-GH-0968-release-publish-drift-fix.md`.
+
 ---
 
 # Plan Critique: GH-968 Release Publish Drift Fix


### PR DESCRIPTION
## Summary

- Reverts PR #973 (the GH-968 "fix") which misread cosmetic version drift as a bug and introduced tag-collision hazards
- Adds a 22-line design-note header comment to `.github/workflows/release.yml` explaining the intentional plugin-vs-npm distribution decoupling, so this isn't re-litigated
- Tombstones both the GH-968 plan doc (`thoughts/shared/plans/2026-05-03-GH-0968-*.md`) and the GH-968 review (`thoughts/shared/reviews/2026-05-03-GH-0968-*.md`) with what went wrong + the lesson

## Why this revert

ralph-hero ships through **two distribution channels**:
- **Plugin** (skills, agents, hooks) ships via git tags / GitHub Releases — Claude Code's marketplace pulls plugin content by tag
- **MCP server** ships via npm — consumers `npx ralph-hero-mcp-server@<version>` pinned in `.mcp.json`

The pre-GH-968 release workflow correctly handled this: **always** bump version + tag, **conditionally** publish to npm (only when MCP source actually changed). That meant `mcp-server/package.json` could sit a patch or two ahead of the npm registry — cosmetically odd, **functionally correct**.

GH-968 misread that cosmetic drift as a bug ("Phase 4/5 stranded on git, not deployable" — overstated; they were already deployed via the plugin marketplace). The implementation decoupled the bump from `mcp_changed`, which let `plugin.json` advance independently of `package.json`. That created tag-collision hazards: when `package.json` later tried to "catch up" past a previously-created plugin-only tag, the workflow's `git tag` step failed.

PR #977 hit exactly this on 2026-05-03, ~1 day after PR #973 merged: tried to bump `package.json` 2.5.85 → 2.5.86, but tag `v2.5.86` already existed (from PR #971's plugin-only release). The release job aborted before npm publish, requiring manual recovery (skip-ci sync commit + workflow_dispatch to produce 2.5.87).

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | (1) reverted to pre-GH-968 form (always bump, always tag, conditionally publish); (2) added 22-line design-note comment block at the top explaining the intentional decoupling and pointing future readers at this thread |
| `thoughts/shared/plans/2026-05-03-GH-0968-release-publish-drift-fix.md` | TOMBSTONE block at top: status → `reverted`, retrospective explaining the misdiagnosis, the runtime breakage it caused, and the resolution |
| `thoughts/shared/reviews/2026-05-03-GH-0968-critique.md` | TOMBSTONE block at top: status → `superseded`, calling out what the plan review missed (didn't question whether the framed bug was real) and the lesson for future reviews |

## Test plan

- [ ] CI green on this branch (build + test for hero/knowledge/demo across Node 18/20/22)
- [ ] Manual: confirm next merge to `main` after this revert lands behaves like pre-#968 — bumps `package.json` and `plugin.json` in lockstep, tags, conditionally publishes to npm
- [ ] After merge: delete orphan tag `v2.5.86` (from PR #971's plugin-only release; never published to npm) with `gh release delete v2.5.86 --cleanup-tag`
- [ ] No further action needed for the once-stranded versions — npm registry is already correct (latest 2.5.87)

## Lesson recorded

Future plan reviews should explicitly verify the affected artifact's actual distribution channel before approving a "drift" or "stranded artifact" framing. A version number being out of sync between two files is not automatically a bug — sometimes the divergence is the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)