### PR TITLE
GH-809: ralph-playwright: baseline trace-YAML refs + step matcher for semantic diff

### DIFF
--- a/plugin/ralph-playwright/schemas/journey-trace.schema.yaml
+++ b/plugin/ralph-playwright/schemas/journey-trace.schema.yaml
@@ -114,6 +114,15 @@ properties:
               type: string
               enum: [pass, fail, out_of_bounds]
               description: "Dispatch-level outcome: pass = eval click succeeded; fail = locator returned None or eval errored; out_of_bounds = pre-dispatch bounds check rejected coords."
+        # --- Semantic visual diff baseline reference (GH-809, additive, backward-compatible) ---
+        # `baseline_ref` is populated by the reflect-phase wiring (GH-816) when a
+        # baseline is available for this step. The matcher in
+        # plugin/ralph-playwright/scripts/match-steps.mjs (GH-809) consumes the
+        # baseline trace to find the corresponding step; the diff emitter (GH-813)
+        # then loads the PNG via baseline-store.mjs#readBaseline().
+        baseline_ref:
+          type: string
+          description: "Optional. Relative path under `thoughts/local/baselines/<session-slug>/` to the baseline screenshot used for semantic-diff comparison (GH-791). When absent, no baseline is available for this step and the diff emitter skips it. When present, `plugin/ralph-playwright/scripts/baseline-store.mjs#readBaseline()` must be able to resolve the path; otherwise the emitter fails loudly (see GH-816)."
         capture:
           type: object
           description: "Optional capture metadata. Present when step opted into --high-res or otherwise used a non-default resolution. Absence means default viewport capture. Added in GH-794."

--- a/plugin/ralph-playwright/scripts/match-steps.mjs
+++ b/plugin/ralph-playwright/scripts/match-steps.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+// match-steps.mjs — pair current and baseline journey-trace steps for the
+// in-loop semantic visual diff (Atomic #809 of Feature G / parent #791 / epic
+// #784).
+//
+// Contract (locked here; downstream atomics depend on the shape):
+//
+//   matchSteps(currentTrace, baselineTrace) -> {
+//     pairs: Array<{ current: Step, baseline: Step, via: 'action-target' | 'index' }>,
+//     addedInCurrent: Array<Step>,
+//     missingFromCurrent: Array<Step>,
+//   }
+//
+//   normalizeActionTarget(action, target) -> string
+//
+// Matching algorithm:
+//   1. Primary key = normalized `(action, target)` tuple.
+//      Normalization: trim both sides, lowercase, collapse internal whitespace
+//      runs to a single space.
+//   2. Build a multimap from primary key -> baseline steps. Steps with a
+//      "missing" key (action OR target absent / empty after normalization) are
+//      excluded from the primary-key map and queued for index-fallback.
+//   3. For each current step:
+//      a. If its key is "missing", queue for index-fallback.
+//      b. If the bucket is unambiguous (exactly one baseline entry exists for
+//         the key — original bucket size 1), pair with `via: 'action-target'`
+//         and consume the baseline entry.
+//      c. If the bucket has multiple baseline entries for the key (duplicates,
+//         original bucket size >= 2), the pair was disambiguated by position:
+//         pick the first un-consumed baseline step whose `index` matches the
+//         current step's `index`. If none match, pick the first un-consumed
+//         baseline step regardless. Mark `via: 'index'`.
+//      d. If no baseline entry remains for the key (all consumed), the current
+//         step falls to `addedInCurrent`.
+//   4. Index-fallback pass: for each current step queued in step (3a), pair
+//      with the baseline step at the same index that is STILL un-consumed.
+//      Mark `via: 'index'`. Unmatched -> `addedInCurrent`.
+//   5. Any baseline step not consumed after both passes -> `missingFromCurrent`.
+//
+// Design constraints (parent feature plan §Feature-specific constraints):
+//   - Pure functions: no I/O, no module-level state.
+//   - No external dependencies; Node stdlib only.
+//   - Consumes the contract — does NOT call into baseline-store.mjs at all.
+//     Trace-vs-trace matching is independent of whether the PNGs exist on disk.
+//     The emitter (#813) checks for PNG presence via baseline-store.mjs.
+
+// -------------------------------------------------------------------- //
+// Normalization
+// -------------------------------------------------------------------- //
+
+/**
+ * Normalize a single string: trim, lowercase, collapse internal whitespace runs.
+ *
+ * Null/undefined inputs are coerced to the empty string. The caller decides
+ * whether an empty-after-normalization value is "missing" — see
+ * `isMissingNormalizedToken` below.
+ *
+ * @param {string|null|undefined} s
+ * @returns {string}
+ */
+function normalizeOne(s) {
+  if (s === null || s === undefined) return "";
+  if (typeof s !== "string") {
+    // Defensive: schema requires action/target to be strings, but be tolerant
+    // and stringify rather than throw — matchSteps is consumed by an emitter
+    // that should never crash on malformed traces.
+    s = String(s);
+  }
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Normalize an `(action, target)` tuple into a single string key.
+ *
+ * Format: `"<normalized-action>::<normalized-target>"`. The double-colon
+ * separator avoids accidental collisions (e.g., a literal colon inside a
+ * URL target).
+ *
+ * Exposed alongside `matchSteps` so #813's prompt context can produce
+ * deterministic, human-readable keys when listing pairs in the prompt.
+ *
+ * @param {string|null|undefined} action
+ * @param {string|null|undefined} target
+ * @returns {string}
+ */
+export function normalizeActionTarget(action, target) {
+  return `${normalizeOne(action)}::${normalizeOne(target)}`;
+}
+
+/**
+ * A primary key is "missing" when either side normalizes to the empty string.
+ * Such steps fall through to the index-fallback pass — the matcher cannot
+ * disambiguate them by `(action, target)` alone.
+ *
+ * @param {string} key - Output of normalizeActionTarget()
+ * @returns {boolean}
+ */
+function isMissingNormalizedKey(key) {
+  // Key shape is `${action}::${target}`. Either side empty => missing.
+  const idx = key.indexOf("::");
+  if (idx < 0) return true; // shouldn't happen; defensive
+  const a = key.slice(0, idx);
+  const t = key.slice(idx + 2);
+  return a.length === 0 || t.length === 0;
+}
+
+// -------------------------------------------------------------------- //
+// Matcher
+// -------------------------------------------------------------------- //
+
+/**
+ * @typedef {Object} Step
+ * @property {number} [index] - Step index in trace (0-based)
+ * @property {string} [action] - Action verb (click, fill, navigate, ...)
+ * @property {string} [target] - Action target (URL, selector, locator description)
+ *
+ * The full schema has many more fields (outcome, screenshot, snapshot, ...) but
+ * the matcher only inspects these three. Extra fields are passed through verbatim
+ * in the `pairs` output.
+ */
+
+/**
+ * @typedef {Object} Trace
+ * @property {Array<Step>} steps
+ *
+ * Matches the journey-trace schema's top-level shape; matcher only requires
+ * `steps`. All other top-level fields are ignored.
+ */
+
+/**
+ * @typedef {Object} MatchPair
+ * @property {Step} current
+ * @property {Step} baseline
+ * @property {'action-target' | 'index'} via
+ */
+
+/**
+ * @typedef {Object} MatchResult
+ * @property {Array<MatchPair>} pairs
+ * @property {Array<Step>} addedInCurrent - Current-trace steps with no baseline counterpart
+ * @property {Array<Step>} missingFromCurrent - Baseline-trace steps with no current counterpart
+ */
+
+/**
+ * Pair the steps of a current trace against a baseline trace.
+ *
+ * @param {Trace} currentTrace - Trace produced this run
+ * @param {Trace} baselineTrace - Trace previously promoted as the baseline
+ * @returns {MatchResult}
+ */
+export function matchSteps(currentTrace, baselineTrace) {
+  // Defensive normalization: tolerate missing/empty `steps` so #813's emitter
+  // can call this even when one side has zero steps.
+  const currentSteps = Array.isArray(currentTrace?.steps)
+    ? currentTrace.steps
+    : [];
+  const baselineSteps = Array.isArray(baselineTrace?.steps)
+    ? baselineTrace.steps
+    : [];
+
+  // Pre-compute normalized keys for both traces so we don't re-normalize on
+  // every lookup.
+  const currentKeys = currentSteps.map((s) =>
+    normalizeActionTarget(s?.action, s?.target),
+  );
+  const baselineKeys = baselineSteps.map((s) =>
+    normalizeActionTarget(s?.action, s?.target),
+  );
+
+  // Build a multimap from key -> Array<{ idx, step }> over baseline steps.
+  // Skip "missing" keys; those baseline steps participate only in the
+  // index-fallback pass.
+  /** @type {Map<string, Array<{ idx: number, step: Step }>>} */
+  const baselineByKey = new Map();
+  for (let idx = 0; idx < baselineSteps.length; idx++) {
+    const key = baselineKeys[idx];
+    if (isMissingNormalizedKey(key)) continue;
+    const bucket = baselineByKey.get(key);
+    if (bucket) {
+      bucket.push({ idx, step: baselineSteps[idx] });
+    } else {
+      baselineByKey.set(key, [{ idx, step: baselineSteps[idx] }]);
+    }
+  }
+
+  // Track which baseline indices have been consumed.
+  const baselineConsumed = new Array(baselineSteps.length).fill(false);
+
+  /** @type {Array<MatchPair>} */
+  const pairs = [];
+  /** @type {Array<Step>} */
+  const addedInCurrent = [];
+  // Steps that need the index-fallback pass after the primary-key pass.
+  /** @type {Array<{ currentIdx: number, step: Step }>} */
+  const indexFallbackQueue = [];
+
+  // -------- Pass 1: primary-key matching -------- //
+  for (let i = 0; i < currentSteps.length; i++) {
+    const cur = currentSteps[i];
+    const key = currentKeys[i];
+
+    if (isMissingNormalizedKey(key)) {
+      // Defer to index-fallback pass.
+      indexFallbackQueue.push({ currentIdx: i, step: cur });
+      continue;
+    }
+
+    const bucket = baselineByKey.get(key);
+    if (!bucket) {
+      // No baseline candidate for this key.
+      addedInCurrent.push(cur);
+      continue;
+    }
+
+    // Filter to un-consumed entries.
+    const live = bucket.filter((b) => !baselineConsumed[b.idx]);
+    if (live.length === 0) {
+      addedInCurrent.push(cur);
+      continue;
+    }
+
+    // `via` is determined by the ORIGINAL bucket size (i.e., whether the
+    // baseline trace had duplicates for this key at all), not the live count.
+    // Even if only one un-consumed entry remains by the time we process this
+    // current step, the pair's identity was disambiguated by position when
+    // duplicates existed — record that as `via: 'index'`.
+    const isDuplicateKey = bucket.length > 1;
+
+    if (!isDuplicateKey) {
+      // Unambiguous primary-key match — bucket has exactly one baseline entry.
+      const chosen = live[0];
+      baselineConsumed[chosen.idx] = true;
+      pairs.push({
+        current: cur,
+        baseline: chosen.step,
+        via: "action-target",
+      });
+      continue;
+    }
+
+    // Duplicate (action, target) — disambiguate by index.
+    // Prefer baseline step whose `index` matches the current step's `index`;
+    // fall back to the first un-consumed entry.
+    const curIndex = cur?.index;
+    let chosen = null;
+    if (typeof curIndex === "number") {
+      chosen = live.find((b) => b.step?.index === curIndex) ?? null;
+    }
+    if (!chosen) {
+      chosen = live[0];
+    }
+    baselineConsumed[chosen.idx] = true;
+    pairs.push({
+      current: cur,
+      baseline: chosen.step,
+      via: "index",
+    });
+  }
+
+  // -------- Pass 2: index-fallback for current steps with "missing" keys -------- //
+  for (const queued of indexFallbackQueue) {
+    const { currentIdx, step: cur } = queued;
+    // Look for the un-consumed baseline step at the same index.
+    if (currentIdx < baselineSteps.length && !baselineConsumed[currentIdx]) {
+      baselineConsumed[currentIdx] = true;
+      pairs.push({
+        current: cur,
+        baseline: baselineSteps[currentIdx],
+        via: "index",
+      });
+    } else {
+      addedInCurrent.push(cur);
+    }
+  }
+
+  // -------- Collect missingFromCurrent: any baseline step not consumed -------- //
+  /** @type {Array<Step>} */
+  const missingFromCurrent = [];
+  for (let i = 0; i < baselineSteps.length; i++) {
+    if (!baselineConsumed[i]) {
+      missingFromCurrent.push(baselineSteps[i]);
+    }
+  }
+
+  return { pairs, addedInCurrent, missingFromCurrent };
+}
+
+// -------------------------------------------------------------------- //
+// No CLI entrypoint — this module is imported by #813's emitter only.
+// (Mirrors baseline-store.mjs's posture; see parent plan §What We're NOT Doing.)
+// -------------------------------------------------------------------- //
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.error(
+    "match-steps.mjs has no CLI. Import it from another module:",
+  );
+  console.error(
+    "  import { matchSteps, normalizeActionTarget } from './match-steps.mjs';",
+  );
+  process.exit(2);
+}

--- a/plugin/ralph-playwright/scripts/match-steps.test.mjs
+++ b/plugin/ralph-playwright/scripts/match-steps.test.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+// match-steps.test.mjs — unit tests for match-steps.mjs
+// Run with: node --test plugin/ralph-playwright/scripts/match-steps.test.mjs
+//
+// Covers (from Atomic #809 plan §Phase 1 Task 1.3):
+//   - normalizeActionTarget: trim, lowercase, whitespace collapse, null fallback
+//   - Scenario 1: exact match (2 pairs, 0 added, 0 missing)
+//   - Scenario 2: reorder (2 pairs by action-target, 0 added, 0 missing)
+//   - Scenario 3: extra step in current (2 pairs, 1 added, 0 missing)
+//   - Scenario 4: removed from current (2 pairs, 0 added, 1 missing)
+//   - Scenario 5: duplicate (action,target) disambiguated by index
+//   - Scenario 6: missing target triggers index fallback
+//   - Scenario 7: baseline has extra index-only noise (3 pairs, 1 missing)
+//
+// Tests are pure-function: no I/O, no fixtures, no cleanup.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  matchSteps,
+  normalizeActionTarget,
+} from "./match-steps.mjs";
+
+// -------------------------------------------------------------------- //
+// normalizeActionTarget
+// -------------------------------------------------------------------- //
+
+describe("normalizeActionTarget", () => {
+  test("trims both sides", () => {
+    assert.equal(
+      normalizeActionTarget("  click  ", "  #submit  "),
+      "click::#submit",
+    );
+  });
+
+  test("lowercases both sides", () => {
+    assert.equal(
+      normalizeActionTarget("CLICK", "#Submit-Button"),
+      "click::#submit-button",
+    );
+  });
+
+  test("collapses internal whitespace runs in target", () => {
+    assert.equal(
+      normalizeActionTarget("verify", "Welcome    back,   user"),
+      "verify::welcome back, user",
+    );
+  });
+
+  test("collapses internal whitespace runs in action", () => {
+    assert.equal(
+      normalizeActionTarget("click  twice", "#submit"),
+      "click twice::#submit",
+    );
+  });
+
+  test("null action falls through to empty-string normalization", () => {
+    assert.equal(normalizeActionTarget(null, "#submit"), "::#submit");
+  });
+
+  test("null target falls through to empty-string normalization", () => {
+    assert.equal(normalizeActionTarget("click", null), "click::");
+  });
+
+  test("undefined inputs yield empty-string sides", () => {
+    assert.equal(normalizeActionTarget(undefined, undefined), "::");
+  });
+
+  test("treats tabs and newlines as whitespace", () => {
+    assert.equal(
+      normalizeActionTarget("\tclick\n", " #submit\t"),
+      "click::#submit",
+    );
+  });
+});
+
+// -------------------------------------------------------------------- //
+// matchSteps
+// -------------------------------------------------------------------- //
+
+describe("matchSteps — Scenario 1: exact match", () => {
+  test("identical traces yield 2 pairs, both via action-target", () => {
+    const current = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "fill", target: "email", index: 1 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "fill", target: "email", index: 1 },
+      ],
+    };
+
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 2);
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 0);
+    assert.equal(result.pairs[0].via, "action-target");
+    assert.equal(result.pairs[1].via, "action-target");
+    assert.equal(result.pairs[0].current.target, "#submit");
+    assert.equal(result.pairs[0].baseline.target, "#submit");
+    assert.equal(result.pairs[1].current.target, "email");
+    assert.equal(result.pairs[1].baseline.target, "email");
+  });
+});
+
+describe("matchSteps — Scenario 2: reorder", () => {
+  test("reordered current pairs by action-target, ignoring position", () => {
+    const current = {
+      steps: [
+        { action: "fill", target: "email", index: 0 },
+        { action: "click", target: "#submit", index: 1 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "fill", target: "email", index: 1 },
+      ],
+    };
+
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 2);
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 0);
+    // Both pairs match by primary key.
+    for (const p of result.pairs) {
+      assert.equal(p.via, "action-target");
+    }
+    // Verify pairing is by key, not position: current[0] (fill,email) pairs
+    // with baseline[1] (fill,email).
+    const fillPair = result.pairs.find(
+      (p) => p.current.action === "fill",
+    );
+    assert.ok(fillPair, "fill pair exists");
+    assert.equal(fillPair.current.index, 0);
+    assert.equal(fillPair.baseline.index, 1);
+  });
+});
+
+describe("matchSteps — Scenario 3: extra step in current", () => {
+  test("3 current vs 2 baseline yields 2 pairs + 1 added + 0 missing", () => {
+    const current = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "fill", target: "email", index: 1 },
+        { action: "verify", target: "thanks page", index: 2 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "fill", target: "email", index: 1 },
+      ],
+    };
+
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 2);
+    assert.equal(result.addedInCurrent.length, 1);
+    assert.equal(result.missingFromCurrent.length, 0);
+    assert.equal(result.addedInCurrent[0].action, "verify");
+    assert.equal(result.addedInCurrent[0].target, "thanks page");
+  });
+});
+
+describe("matchSteps — Scenario 4: removed from current", () => {
+  test("2 current vs 3 baseline yields 2 pairs + 0 added + 1 missing", () => {
+    const current = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "fill", target: "email", index: 1 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "fill", target: "email", index: 1 },
+        { action: "verify", target: "thanks page", index: 2 },
+      ],
+    };
+
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 2);
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 1);
+    assert.equal(result.missingFromCurrent[0].action, "verify");
+    assert.equal(result.missingFromCurrent[0].target, "thanks page");
+  });
+});
+
+describe("matchSteps — Scenario 5: duplicate (action,target) disambiguated by index", () => {
+  test("duplicates pair by index, second pair via 'index'", () => {
+    const current = {
+      steps: [
+        { action: "click", target: "next", index: 0 },
+        { action: "click", target: "next", index: 2 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "click", target: "next", index: 0 },
+        { action: "click", target: "next", index: 3 },
+      ],
+    };
+
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 2);
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 0);
+
+    // First duplicate: current.index=0 matches baseline.index=0 -> via 'index'
+    // (both unconsumed; algorithm marks via 'index' when bucket has multiple
+    // un-consumed entries even if one matches exactly).
+    const first = result.pairs[0];
+    assert.equal(first.via, "index");
+    assert.equal(first.current.index, 0);
+    assert.equal(first.baseline.index, 0);
+
+    // Second duplicate: current.index=2 has no baseline.index=2 candidate
+    // remaining; falls back to first un-consumed (baseline.index=3).
+    const second = result.pairs[1];
+    assert.equal(second.via, "index");
+    assert.equal(second.current.index, 2);
+    assert.equal(second.baseline.index, 3);
+  });
+});
+
+describe("matchSteps — Scenario 6: missing target triggers index fallback", () => {
+  test("step with empty target pairs at same index via 'index'", () => {
+    const current = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        // No target — primary-key matching cannot disambiguate this.
+        { action: "click", index: 1 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+        { action: "click", target: "#cancel", index: 1 },
+      ],
+    };
+
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 2);
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 0);
+
+    // First step matches by primary key.
+    assert.equal(result.pairs[0].via, "action-target");
+    assert.equal(result.pairs[0].current.target, "#submit");
+    assert.equal(result.pairs[0].baseline.target, "#submit");
+
+    // Second step has no target, so falls to index fallback against
+    // baseline[1]. The pair is recorded with via 'index'.
+    const fallbackPair = result.pairs.find((p) => p.via === "index");
+    assert.ok(fallbackPair, "index-fallback pair exists");
+    assert.equal(fallbackPair.current.index, 1);
+    assert.equal(fallbackPair.baseline.index, 1);
+    assert.equal(fallbackPair.baseline.target, "#cancel");
+  });
+});
+
+describe("matchSteps — Scenario 7: baseline has extra index-only noise", () => {
+  test("3 current all match baseline by action-target; 1 baseline missing", () => {
+    const current = {
+      steps: [
+        { action: "navigate", target: "/", index: 0 },
+        { action: "click", target: "#submit", index: 1 },
+        { action: "verify", target: "thanks", index: 2 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "navigate", target: "/", index: 0 },
+        { action: "click", target: "#submit", index: 1 },
+        { action: "verify", target: "thanks", index: 2 },
+        { action: "click", target: "#orphan", index: 3 },
+      ],
+    };
+
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 3);
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 1);
+    for (const p of result.pairs) {
+      assert.equal(p.via, "action-target");
+    }
+    assert.equal(result.missingFromCurrent[0].target, "#orphan");
+  });
+});
+
+// -------------------------------------------------------------------- //
+// Edge cases — defensive contract verification
+// -------------------------------------------------------------------- //
+
+describe("matchSteps — edge cases", () => {
+  test("empty traces yield empty result with stable shape", () => {
+    const result = matchSteps({ steps: [] }, { steps: [] });
+    assert.deepEqual(result, {
+      pairs: [],
+      addedInCurrent: [],
+      missingFromCurrent: [],
+    });
+  });
+
+  test("missing steps array on either side is tolerated", () => {
+    const result = matchSteps({}, { steps: [] });
+    assert.deepEqual(result, {
+      pairs: [],
+      addedInCurrent: [],
+      missingFromCurrent: [],
+    });
+  });
+
+  test("normalization treats different casings/whitespace as equal", () => {
+    const current = {
+      steps: [{ action: "Click", target: "  #submit  ", index: 0 }],
+    };
+    const baseline = {
+      steps: [{ action: "click", target: "#submit", index: 0 }],
+    };
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0].via, "action-target");
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 0);
+  });
+
+  test("trailing-slash URL targets compare as written (not URL-aware)", () => {
+    // Documenting current behavior: the matcher does NOT canonicalize URLs.
+    // Callers writing `navigate https://example.com` vs
+    // `navigate https://example.com/` get two distinct keys. This is by
+    // design — see plan §Out of Scope (no fuzzy matching).
+    const current = {
+      steps: [
+        { action: "navigate", target: "https://example.com", index: 0 },
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "navigate", target: "https://example.com/", index: 0 },
+      ],
+    };
+    const result = matchSteps(current, baseline);
+    assert.equal(result.pairs.length, 0);
+    assert.equal(result.addedInCurrent.length, 1);
+    assert.equal(result.missingFromCurrent.length, 1);
+  });
+
+  test("missing key on baseline step keeps it for index-fallback consumption", () => {
+    const current = {
+      steps: [
+        { action: "click", index: 0 }, // missing target
+      ],
+    };
+    const baseline = {
+      steps: [
+        { action: "click", target: "#submit", index: 0 },
+      ],
+    };
+    const result = matchSteps(current, baseline);
+    // Current step has missing key -> index fallback. baseline[0] is at
+    // same index and unconsumed -> pair with via 'index'.
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0].via, "index");
+    assert.equal(result.addedInCurrent.length, 0);
+    assert.equal(result.missingFromCurrent.length, 0);
+  });
+});

--- a/thoughts/shared/plans/2026-04-20-GH-0809-baseline-trace-yaml-refs-step-matcher.md
+++ b/thoughts/shared/plans/2026-04-20-GH-0809-baseline-trace-yaml-refs-step-matcher.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-04-20
-status: draft
+status: in-progress
 type: plan
 github_issue: 809
 github_issues: [809]
@@ -104,15 +104,15 @@ After this atomic merges:
 
 ### Verification
 
-- [ ] `journey-trace.schema.yaml` has `baseline_ref` under `step.properties` as an optional string with a `description` explaining the field semantics
-- [ ] A sample `journey-trace.yaml` with NO `baseline_ref` field on any step passes `validate-primitive-io.sh`
-- [ ] A sample `journey-trace.yaml` WITH `baseline_ref` set on some steps passes `validate-primitive-io.sh`
-- [ ] `match-steps.mjs` exports `matchSteps`
-- [ ] `matchSteps({steps: [...]}, {steps: [...]})` returns the exact shape `{ pairs: [{current, baseline}], addedInCurrent: [...], missingFromCurrent: [...] }`
-- [ ] Primary-key normalization is applied before equality check
-- [ ] Fallback-to-index kicks in only when primary-key matching is ambiguous / missing / duplicated
-- [ ] `node --test plugin/ralph-playwright/scripts/match-steps.test.mjs` exits 0
-- [ ] All five canonical scenarios have dedicated test cases
+- [x] `journey-trace.schema.yaml` has `baseline_ref` under `step.properties` as an optional string with a `description` explaining the field semantics
+- [x] A sample `journey-trace.yaml` with NO `baseline_ref` field on any step passes `validate-primitive-io.sh`
+- [x] A sample `journey-trace.yaml` WITH `baseline_ref` set on some steps passes `validate-primitive-io.sh`
+- [x] `match-steps.mjs` exports `matchSteps`
+- [x] `matchSteps({steps: [...]}, {steps: [...]})` returns the exact shape `{ pairs: [{current, baseline}], addedInCurrent: [...], missingFromCurrent: [...] }`
+- [x] Primary-key normalization is applied before equality check
+- [x] Fallback-to-index kicks in only when primary-key matching is ambiguous / missing / duplicated
+- [x] `node --test plugin/ralph-playwright/scripts/match-steps.test.mjs` exits 0
+- [x] All five canonical scenarios have dedicated test cases
 
 ## What We're NOT Doing
 
@@ -149,12 +149,12 @@ Add `baseline_ref` to the journey-trace schema. Implement `matchSteps` and its t
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `step.properties` gains `baseline_ref` as a string type
-  - [ ] Field is NOT added to `step.required`
-  - [ ] `description:` explains the semantics: "Optional. Relative path under `thoughts/local/baselines/<session-slug>/` to the baseline screenshot used for semantic-diff comparison (GH-791). When absent, no baseline is available for this step and the diff emitter skips it. When present, `plugin/ralph-playwright/scripts/baseline-store.mjs#readBaseline()` must be able to resolve the path; otherwise the emitter fails loudly (see GH-816)."
-  - [ ] Field is documented alongside other optional step fields, in an order consistent with the file (group with other cross-run / session-level annotations)
-  - [ ] A sample `journey-trace.yaml` with `baseline_ref: "2026-04-20-explore-checkout/00.png"` on a step passes `validate-primitive-io.sh` when fed through the hook manually (or the test harness described in #786's plan)
-  - [ ] A pre-existing `journey-trace.yaml` with NO `baseline_ref` on any step still passes (regression proof)
+  - [x] `step.properties` gains `baseline_ref` as a string type
+  - [x] Field is NOT added to `step.required`
+  - [x] `description:` explains the semantics: "Optional. Relative path under `thoughts/local/baselines/<session-slug>/` to the baseline screenshot used for semantic-diff comparison (GH-791). When absent, no baseline is available for this step and the diff emitter skips it. When present, `plugin/ralph-playwright/scripts/baseline-store.mjs#readBaseline()` must be able to resolve the path; otherwise the emitter fails loudly (see GH-816)."
+  - [x] Field is documented alongside other optional step fields, in an order consistent with the file (group with other cross-run / session-level annotations)
+  - [x] A sample `journey-trace.yaml` with `baseline_ref: "2026-04-20-explore-checkout/00.png"` on a step passes `validate-primitive-io.sh` when fed through the hook manually (or the test harness described in #786's plan)
+  - [x] A pre-existing `journey-trace.yaml` with NO `baseline_ref` on any step still passes (regression proof)
 
 #### Task 1.2: Author `match-steps.mjs`
 
@@ -164,23 +164,23 @@ Add `baseline_ref` to the journey-trace schema. Implement `matchSteps` and its t
 - **complexity**: medium
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] ESM `.mjs`, no external deps
-  - [ ] Exports `normalizeActionTarget(action, target)` returning a normalized tuple string (e.g., `click::submit-button`). Rules: trim both, lowercase both, replace internal runs of whitespace with a single space. Null/undefined inputs are treated as the empty string for the purposes of normalization, but a "missing" (null/undefined/empty-after-normalize) action OR target signals the fallback path to the matcher.
-  - [ ] Exports `matchSteps(currentTrace, baselineTrace)`:
+  - [x] ESM `.mjs`, no external deps
+  - [x] Exports `normalizeActionTarget(action, target)` returning a normalized tuple string (e.g., `click::submit-button`). Rules: trim both, lowercase both, replace internal runs of whitespace with a single space. Null/undefined inputs are treated as the empty string for the purposes of normalization, but a "missing" (null/undefined/empty-after-normalize) action OR target signals the fallback path to the matcher.
+  - [x] Exports `matchSteps(currentTrace, baselineTrace)`:
     - Input: two objects conforming to the journey-trace schema (must have a `steps` array)
     - Output: `{ pairs: Array<{ current: Step, baseline: Step, via: 'action-target' | 'index' }>, addedInCurrent: Array<Step>, missingFromCurrent: Array<Step> }`
     - `via` is informational — #813's emitter may log it or ignore it
-  - [ ] Algorithm:
+  - [x] Algorithm:
     1. Build a map from `normalizeActionTarget(step.action, step.target)` to baseline step(s). Entries with a "missing" key (see normalization rule) are excluded from the primary-key map and queued for index-fallback.
     2. For each current step:
        a. If its key is "missing", skip to index fallback for that step.
        b. Look up the key in the baseline map. If the baseline map has exactly one un-consumed entry for this key, pair them (consume the baseline entry) with `via: 'action-target'`.
-       c. If the baseline map has multiple un-consumed entries for this key (duplicates), use index-fallback: pick the first un-consumed baseline step whose `index` matches the current step's `index`. If none match by index, pick the first un-consumed baseline step regardless; `via: 'index'`.
+       c. If the baseline map has multiple un-consumed entries for this key (duplicates), use index-fallback: pick the first un-consumed baseline step whose `index` matches the current step's `index`. If none match by index, pick the first un-consumed baseline step regardless; `via: 'index'`. Implementation note: `via` is determined by whether the ORIGINAL bucket size > 1, not the live un-consumed count, so duplicate-key pairs are consistently labelled `via: 'index'` even if only one un-consumed candidate remains by the time it is processed.
        d. If no baseline entry remains for this key, the current step falls to `addedInCurrent`.
     3. Index-fallback pass: for each current step not yet paired (those with "missing" keys), pair with the baseline step at the same index that is STILL un-consumed. Mark `via: 'index'`. Unmatched → `addedInCurrent`.
     4. Any baseline step not consumed after both passes → `missingFromCurrent`.
-  - [ ] All functions pure (no I/O; no module-level state)
-  - [ ] File exports both `matchSteps` and `normalizeActionTarget` (the latter is useful for ad-hoc matching in #813's prompt context)
+  - [x] All functions pure (no I/O; no module-level state)
+  - [x] File exports both `matchSteps` and `normalizeActionTarget` (the latter is useful for ad-hoc matching in #813's prompt context)
 
 #### Task 1.3: Test suite `match-steps.test.mjs`
 
@@ -190,25 +190,25 @@ Add `baseline_ref` to the journey-trace schema. Implement `matchSteps` and its t
 - **complexity**: medium
 - **depends_on**: [1.2]
 - **acceptance**:
-  - [ ] Uses `node:test` + `node:assert/strict`
-  - [ ] Test `normalizeActionTarget` covers: trim both sides, lowercase both sides, collapse double-space in target, null action falls through to empty-string normalization
-  - [ ] Scenario 1 (exact match): current steps `[{action:'click',target:'#submit',index:0}, {action:'fill',target:'email',index:1}]`, baseline identical. Expect: 2 pairs (both `via: 'action-target'`), 0 added, 0 missing.
-  - [ ] Scenario 2 (reorder): current has the two steps in reversed order; baseline in original order. Expect: 2 pairs by `action-target`, 0 added, 0 missing. `pairs[i].current.index` may not equal `pairs[i].baseline.index` — the matcher pairs by key not position.
-  - [ ] Scenario 3 (extra in current): current has 3 steps, baseline has 2 (the third current step's `(action,target)` is unique). Expect: 2 pairs, 1 `addedInCurrent` (the extra step), 0 missing.
-  - [ ] Scenario 4 (removed from current): current has 2, baseline has 3 (the missing one's `(action,target)` is unique). Expect: 2 pairs, 0 added, 1 `missingFromCurrent` (the baseline step not represented in current).
-  - [ ] Scenario 5 (duplicate `(action,target)` disambiguated by index): current has `[{action:'click',target:'next',index:0}, {action:'click',target:'next',index:2}]`, baseline has `[{action:'click',target:'next',index:0}, {action:'click',target:'next',index:3}]`. Expect: 2 pairs — `index:0` to `index:0`, and `index:2` to `index:3` (first un-consumed baseline step with matching key; index-fallback disambiguation). `via: 'index'` on the second pair.
-  - [ ] Scenario 6 (missing `target` triggers index fallback): one step has no `target` field. Expect: that step pairs with the same-index baseline step via index-fallback, `via: 'index'`.
-  - [ ] Scenario 7 (regression — baseline has extra index-only noise): baseline has 4 steps, current has 3 all matching `action-target`. Expect: 3 pairs (`action-target`), 1 `missingFromCurrent`.
-  - [ ] Cleanup unnecessary — tests pure-function, no I/O.
-  - [ ] `node --test plugin/ralph-playwright/scripts/match-steps.test.mjs` exits 0.
+  - [x] Uses `node:test` + `node:assert/strict`
+  - [x] Test `normalizeActionTarget` covers: trim both sides, lowercase both sides, collapse double-space in target, null action falls through to empty-string normalization
+  - [x] Scenario 1 (exact match): current steps `[{action:'click',target:'#submit',index:0}, {action:'fill',target:'email',index:1}]`, baseline identical. Expect: 2 pairs (both `via: 'action-target'`), 0 added, 0 missing.
+  - [x] Scenario 2 (reorder): current has the two steps in reversed order; baseline in original order. Expect: 2 pairs by `action-target`, 0 added, 0 missing. `pairs[i].current.index` may not equal `pairs[i].baseline.index` — the matcher pairs by key not position.
+  - [x] Scenario 3 (extra in current): current has 3 steps, baseline has 2 (the third current step's `(action,target)` is unique). Expect: 2 pairs, 1 `addedInCurrent` (the extra step), 0 missing.
+  - [x] Scenario 4 (removed from current): current has 2, baseline has 3 (the missing one's `(action,target)` is unique). Expect: 2 pairs, 0 added, 1 `missingFromCurrent` (the baseline step not represented in current).
+  - [x] Scenario 5 (duplicate `(action,target)` disambiguated by index): current has `[{action:'click',target:'next',index:0}, {action:'click',target:'next',index:2}]`, baseline has `[{action:'click',target:'next',index:0}, {action:'click',target:'next',index:3}]`. Expect: 2 pairs — `index:0` to `index:0`, and `index:2` to `index:3` (first un-consumed baseline step with matching key; index-fallback disambiguation). `via: 'index'` on the second pair.
+  - [x] Scenario 6 (missing `target` triggers index fallback): one step has no `target` field. Expect: that step pairs with the same-index baseline step via index-fallback, `via: 'index'`.
+  - [x] Scenario 7 (regression — baseline has extra index-only noise): baseline has 4 steps, current has 3 all matching `action-target`. Expect: 3 pairs (`action-target`), 1 `missingFromCurrent`.
+  - [x] Cleanup unnecessary — tests pure-function, no I/O.
+  - [x] `node --test plugin/ralph-playwright/scripts/match-steps.test.mjs` exits 0.
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `node --test plugin/ralph-playwright/scripts/match-steps.test.mjs` — exits 0, all 7 scenarios pass
-- [ ] Schema validation smoke-test: craft a minimal `journey-trace.yaml` with and without `baseline_ref`; run `validate-primitive-io.sh` on each; both exit 0
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors
-- [ ] `cd plugin/ralph-hero/mcp-server && npm test` — all passing
+- [x] `node --test plugin/ralph-playwright/scripts/match-steps.test.mjs` — exits 0, all 7 scenarios pass (20 tests including edge cases)
+- [x] Schema validation smoke-test: craft a minimal `journey-trace.yaml` with and without `baseline_ref`; run `validate-primitive-io.sh` on each; both exit 0
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors
+- [x] `cd plugin/ralph-hero/mcp-server && npm test` — all passing (1100/1100)
 
 #### Manual Verification:
 - [ ] Reviewer confirms `baseline_ref` description accurately documents the "missing means skip, present means required-to-resolve" semantics


### PR DESCRIPTION
## Summary

Extended the `journey-trace.schema.yaml` with an optional per-step `baseline_ref` field and implemented the `matchSteps(currentTrace, baselineTrace)` function that pairs current-run steps to baseline counterparts using normalized (action, target) tuples with index-position fallback.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-20-GH-0809-baseline-trace-yaml-refs-step-matcher.md

Phases shipped: 2 of 5 (group issue)

## Test plan

- [x] Schema validation confirms both traces with and without `baseline_ref` pass validation
- [x] Unit test suite passes covering exact match, reorder, extra step, removed step, and duplicate (action, target) disambiguation
- [x] Matcher return shape matches contract: `{ pairs, addedInCurrent, missingFromCurrent }` with `via` discriminator
- [x] Normalization handles realistic Playwright action strings appropriately

Closes #809