### PR TITLE
GH-983: bug(impl-branch-gate): reads git branch from agent cwd instead of worktree

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh
@@ -7,6 +7,8 @@
 #   3. cd-prefix resolving to main branch is blocked
 #   4. git checkout is always allowed (existing behavior preserved)
 #   5. non-impl context falls through allow
+#   6. cd-prefix with double-quoted path containing space is allowed
+#   7. cd-prefix with single-quoted path containing space is allowed
 
 set -euo pipefail
 
@@ -53,7 +55,18 @@ MAIN_TMP_DIR=$(mktemp -d)
   && git config user.name "test" \
   && git commit --allow-empty -qm "init" ) > /dev/null
 
-trap 'rm -rf "$TMP_DIR" "$MAIN_TMP_DIR"' EXIT
+# ── Fixture: feature-branch worktree at a path containing a space ─────────
+SPACE_PARENT=$(mktemp -d)
+SPACE_DIR="$SPACE_PARENT/path with space"
+mkdir -p "$SPACE_DIR"
+( cd "$SPACE_DIR" \
+  && git -c init.defaultBranch=main init -q \
+  && git config user.email "test@test" \
+  && git config user.name "test" \
+  && git commit --allow-empty -qm "init" \
+  && git checkout -qb GH-983-test ) > /dev/null
+
+trap 'rm -rf "$TMP_DIR" "$MAIN_TMP_DIR" "$SPACE_PARENT"' EXIT
 
 # Sanity-check the fixtures so failures here are obvious.
 fixture_branch=$(cd "$TMP_DIR" && git branch --show-current)
@@ -86,6 +99,20 @@ assert_eq "0" "$result" "git checkout is always allowed (existing behavior prese
 input=$(make_input "git commit" "")
 result=$(echo "$input" | bash "$GATE" 2>/dev/null; echo $?)
 assert_eq "0" "$result" "non-impl context falls through allow"
+
+# ── Test 6: cd-prefix with double-quoted path containing space is allowed ─
+# Regression: the original `cd <path>` regex stopped at the first whitespace,
+# so `cd "/tmp/foo bar" && ...` captured only `"/tmp/foo`. With a quote-aware
+# parser, the double-quoted alternative should match the full path and the
+# branch lookup should succeed (worktree feature branch -> exit 0).
+input=$(make_input "cd \"$SPACE_DIR\" && git commit -m test" "impl-agent")
+result=$(echo "$input" | RALPH_COMMAND=impl bash "$GATE" 2>/dev/null; echo $?)
+assert_eq "0" "$result" "cd-prefix with double-quoted path containing space is allowed"
+
+# ── Test 7: cd-prefix with single-quoted path containing space is allowed ─
+input=$(make_input "cd '$SPACE_DIR' && git commit -m test" "impl-agent")
+result=$(echo "$input" | RALPH_COMMAND=impl bash "$GATE" 2>/dev/null; echo $?)
+assert_eq "0" "$result" "cd-prefix with single-quoted path containing space is allowed"
 
 echo ""
 echo "Results: $pass passed, $fail failed"

--- a/plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Test impl-branch-gate.sh worktree-aware branch detection
+#
+# Covers:
+#   1. cd-prefix to worktree feature branch is allowed
+#   2. RALPH_WORKTREE_PATHS substring match without leading cd is allowed
+#   3. cd-prefix resolving to main branch is blocked
+#   4. git checkout is always allowed (existing behavior preserved)
+#   5. non-impl context falls through allow
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOKS_DIR="$(dirname "$SCRIPT_DIR")"
+GATE="$HOOKS_DIR/impl-branch-gate.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+  local expected="$1" actual="$2" desc="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $desc — expected '$expected', got '$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+# Build a minimal hook input JSON for testing
+make_input() {
+  local cmd="$1"
+  local agent_type="${2:-}"
+  # Use jq to safely escape the command string for embedding in JSON
+  jq -n --arg cmd "$cmd" --arg at "$agent_type" \
+    '{tool_name:"Bash", agent_type:$at, tool_input:{command:$cmd}}'
+}
+
+# ── Fixture: feature-branch worktree ──────────────────────────────────────
+TMP_DIR=$(mktemp -d)
+( cd "$TMP_DIR" \
+  && git -c init.defaultBranch=main init -q \
+  && git config user.email "test@test" \
+  && git config user.name "test" \
+  && git commit --allow-empty -qm "init" \
+  && git checkout -qb GH-983-test ) > /dev/null
+
+# ── Fixture: main-branch repo (deterministically named "main") ────────────
+MAIN_TMP_DIR=$(mktemp -d)
+( cd "$MAIN_TMP_DIR" \
+  && git -c init.defaultBranch=main init -q \
+  && git config user.email "test@test" \
+  && git config user.name "test" \
+  && git commit --allow-empty -qm "init" ) > /dev/null
+
+trap 'rm -rf "$TMP_DIR" "$MAIN_TMP_DIR"' EXIT
+
+# Sanity-check the fixtures so failures here are obvious.
+fixture_branch=$(cd "$TMP_DIR" && git branch --show-current)
+assert_eq "GH-983-test" "$fixture_branch" "Fixture: TMP_DIR is on feature branch GH-983-test"
+
+main_branch=$(cd "$MAIN_TMP_DIR" && git branch --show-current)
+assert_eq "main" "$main_branch" "Fixture: MAIN_TMP_DIR is on main branch"
+
+# ── Test 1: cd-prefix to worktree feature branch is allowed ───────────────
+input=$(make_input "cd $TMP_DIR && git commit -m test" "impl-agent")
+result=$(echo "$input" | RALPH_COMMAND=impl bash "$GATE" 2>/dev/null; echo $?)
+assert_eq "0" "$result" "cd-prefix to worktree feature branch is allowed"
+
+# ── Test 2: RALPH_WORKTREE_PATHS substring match (no leading cd) ──────────
+input=$(make_input "git -C $TMP_DIR add file.txt" "impl-agent")
+result=$(echo "$input" | RALPH_COMMAND=impl RALPH_WORKTREE_PATHS="$TMP_DIR" bash "$GATE" 2>/dev/null; echo $?)
+assert_eq "0" "$result" "RALPH_WORKTREE_PATHS substring match without leading cd is allowed"
+
+# ── Test 3: cd-prefix resolving to main branch is blocked ─────────────────
+input=$(make_input "cd $MAIN_TMP_DIR && git commit -m test" "impl-agent")
+result=$(echo "$input" | RALPH_COMMAND=impl bash "$GATE" 2>/dev/null; echo $?)
+assert_eq "2" "$result" "cd-prefix resolving to main branch is blocked"
+
+# ── Test 4: git checkout is always allowed ────────────────────────────────
+input=$(make_input "git checkout -b foo" "impl-agent")
+result=$(echo "$input" | RALPH_COMMAND=impl bash "$GATE" 2>/dev/null; echo $?)
+assert_eq "0" "$result" "git checkout is always allowed (existing behavior preserved)"
+
+# ── Test 5: non-impl context falls through allow ──────────────────────────
+input=$(make_input "git commit" "")
+result=$(echo "$input" | bash "$GATE" 2>/dev/null; echo $?)
+assert_eq "0" "$result" "non-impl context falls through allow"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[[ $fail -eq 0 ]] || exit 1

--- a/plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh
@@ -37,11 +37,79 @@ if [[ "$command" =~ ^[[:space:]]*git[[:space:]]+(checkout|switch) ]]; then
   allow
 fi
 
-# Check current branch
-current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+# Resolve the target branch the command will actually run on.
+#
+# Three-tier resolution:
+#   1. Parse leading `cd <path>` from $command and query that directory.
+#   2. Scan RALPH_WORKTREE_PATHS for a substring match in $command.
+#   3. Echo empty string (ambiguous) — caller falls back to current cwd
+#      with warn-not-block semantics.
+#
+# No `eval` of the command string. The path is extracted via regex,
+# tildes are expanded via ${HOME} substitution, and relative paths are
+# resolved against ${CLAUDE_PROJECT_DIR:-$(pwd)}.
+resolve_target_branch() {
+  local cmd="$1"
+  local cd_path=""
+  local resolved_path=""
 
-if [[ "$current_branch" == "main" ]] || [[ "$current_branch" == "master" ]]; then
-  block "Implementation git operations blocked on main branch
+  # Tier 1: leading `cd <path>` parse.
+  # Anchor at the start of the command (allowing leading whitespace), capture
+  # the first whitespace-delimited token after `cd` that does not contain
+  # &, ;, |, or whitespace.
+  if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^\&\;\|[:space:]]+) ]]; then
+    cd_path="${BASH_REMATCH[1]}"
+    # Strip surrounding single or double quotes if present.
+    if [[ "$cd_path" =~ ^\"(.*)\"$ ]] || [[ "$cd_path" =~ ^\'(.*)\'$ ]]; then
+      cd_path="${BASH_REMATCH[1]}"
+    fi
+    # Expand leading tilde via ${HOME} substitution (no eval).
+    if [[ "$cd_path" == "~" ]]; then
+      cd_path="${HOME}"
+    elif [[ "$cd_path" == "~/"* ]]; then
+      cd_path="${HOME}/${cd_path#~/}"
+    fi
+    # Resolve relative paths against CLAUDE_PROJECT_DIR (or pwd).
+    if [[ "$cd_path" != /* ]]; then
+      resolved_path="${CLAUDE_PROJECT_DIR:-$(pwd)}/$cd_path"
+    else
+      resolved_path="$cd_path"
+    fi
+    if [[ -d "$resolved_path" ]] && git -C "$resolved_path" rev-parse --git-dir >/dev/null 2>&1; then
+      git -C "$resolved_path" branch --show-current 2>/dev/null || true
+      return 0
+    fi
+  fi
+
+  # Tier 2: RALPH_WORKTREE_PATHS substring scan.
+  if [[ -n "${RALPH_WORKTREE_PATHS:-}" ]]; then
+    local IFS=':'
+    local wt_path
+    for wt_path in ${RALPH_WORKTREE_PATHS}; do
+      if [[ -z "$wt_path" ]]; then
+        continue
+      fi
+      if [[ "$cmd" == *"$wt_path"* ]] && git -C "$wt_path" rev-parse --git-dir >/dev/null 2>&1; then
+        git -C "$wt_path" branch --show-current 2>/dev/null || true
+        return 0
+      fi
+    done
+  fi
+
+  # Tier 3: ambiguous — echo empty string, caller decides.
+  echo ""
+}
+
+# Determine the target branch via the helper. If the helper succeeded
+# (non-empty), treat its result as authoritative. If empty (ambiguous),
+# fall back to the current cwd's branch and use warn-not-block semantics
+# on main/master to avoid false-positive blocks.
+resolved_branch=$(resolve_target_branch "$command")
+
+if [[ -n "$resolved_branch" ]]; then
+  current_branch="$resolved_branch"
+  if [[ "$current_branch" == "main" ]] || [[ "$current_branch" == "master" ]]; then
+    block "Implementation git operations blocked on main branch
 
 Current branch: $current_branch
 Command: $command
@@ -54,6 +122,16 @@ To fix:
 3. Then run your git commands
 
 Never commit implementation changes to main."
+  fi
+else
+  # Ambiguous: neither cd-prefix parse nor RALPH_WORKTREE_PATHS scan yielded
+  # a branch. Fall back to the current cwd's branch and warn-not-block on
+  # main/master to avoid false-positive blocks when detection cannot
+  # identify the command's actual target directory.
+  current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+  if [[ "$current_branch" == "main" ]] || [[ "$current_branch" == "master" ]]; then
+    warn "impl-branch-gate could not determine target branch from command; allowing with warning. Command: $command"
+  fi
 fi
 
 allow

--- a/plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh
@@ -53,16 +53,24 @@ resolve_target_branch() {
   local cd_path=""
   local resolved_path=""
 
-  # Tier 1: leading `cd <path>` parse.
-  # Anchor at the start of the command (allowing leading whitespace), capture
-  # the first whitespace-delimited token after `cd` that does not contain
-  # &, ;, |, or whitespace.
-  if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^\&\;\|[:space:]]+) ]]; then
+  # Tier 1: leading `cd <path>` parse (quote-aware).
+  # Anchor at the start of the command (allowing leading whitespace) and try
+  # three alternatives in order so quoted paths containing spaces are handled:
+  #   1a. `cd "..."`  — double-quoted path (may contain spaces)
+  #   1b. `cd '...'`  — single-quoted path (may contain spaces)
+  #   1c. `cd <bare>` — unquoted token, stops at whitespace or shell separator
+  local cd_matched=0
+  if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+\"([^\"]*)\" ]]; then
     cd_path="${BASH_REMATCH[1]}"
-    # Strip surrounding single or double quotes if present.
-    if [[ "$cd_path" =~ ^\"(.*)\"$ ]] || [[ "$cd_path" =~ ^\'(.*)\'$ ]]; then
-      cd_path="${BASH_REMATCH[1]}"
-    fi
+    cd_matched=1
+  elif [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+\'([^\']*)\' ]]; then
+    cd_path="${BASH_REMATCH[1]}"
+    cd_matched=1
+  elif [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^\&\;\|[:space:]]+) ]]; then
+    cd_path="${BASH_REMATCH[1]}"
+    cd_matched=1
+  fi
+  if [[ $cd_matched -eq 1 ]]; then
     # Expand leading tilde via ${HOME} substitution (no eval).
     if [[ "$cd_path" == "~" ]]; then
       cd_path="${HOME}"

--- a/thoughts/shared/plans/2026-05-03-GH-0983-impl-branch-gate-cwd-bug.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0983-impl-branch-gate-cwd-bug.md
@@ -63,11 +63,11 @@ After this fix:
 
 ### Verification
 
-- [ ] All four positive cases above (worktree feature branch commits) pass without false-positive blocks under `RALPH_COMMAND=impl` and `agent_type=impl-agent`.
-- [ ] Explicit-main negative case still blocks.
-- [ ] Ambiguous case (no `cd`, no `RALPH_WORKTREE_PATHS`, current cwd on main) emits a warn and allows — does not block.
-- [ ] `bash plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh` reports `0 failed`.
-- [ ] No regressions in existing `bash plugin/ralph-hero/hooks/scripts/__tests__/test-agent-phase-gate.sh` run.
+- [x] All four positive cases above (worktree feature branch commits) pass without false-positive blocks under `RALPH_COMMAND=impl` and `agent_type=impl-agent`.
+- [x] Explicit-main negative case still blocks.
+- [x] Ambiguous case (no `cd`, no `RALPH_WORKTREE_PATHS`, current cwd on main) emits a warn and allows — does not block.
+- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh` reports `0 failed`.
+- [x] No regressions in existing `bash plugin/ralph-hero/hooks/scripts/__tests__/test-agent-phase-gate.sh` run.
 
 ## What We're NOT Doing
 
@@ -156,14 +156,14 @@ Replace the broken `git branch --show-current` call at line 41 with a worktree-a
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `bash -n plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh` — no syntax errors
-- [ ] `bash plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh` — all assertions pass, exits 0
-- [ ] `bash plugin/ralph-hero/hooks/scripts/__tests__/test-agent-phase-gate.sh` — all assertions pass, exits 0
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — TypeScript build still passes (sanity, since hooks dir is sibling to mcp-server)
+- [x] `bash -n plugin/ralph-hero/hooks/scripts/impl-branch-gate.sh` — no syntax errors
+- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/test-impl-branch-gate.sh` — all assertions pass, exits 0
+- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/test-agent-phase-gate.sh` — all assertions pass, exits 0
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — TypeScript build still passes (sanity, since hooks dir is sibling to mcp-server)
 
 #### Manual Verification:
-- [ ] Manual repro of the original bug confirms the false-positive block no longer fires for `cd worktrees/GH-NNN && git commit`.
-- [ ] Manual confirmation that `cd <main-repo-root> && git commit` is still blocked (true-positive preserved).
+- [x] Manual repro of the original bug confirms the false-positive block no longer fires for `cd worktrees/GH-NNN && git commit`.
+- [x] Manual confirmation that `cd <main-repo-root> && git commit` is still blocked (true-positive preserved).
 
 **Creates for next phase**: This is the only phase; no downstream artifacts.
 


### PR DESCRIPTION
## Summary

Fixed impl-branch-gate.sh hook to correctly detect the target git branch from the worktree where the agent's command will execute, rather than reading from the hook's own cwd (the main repo). This eliminates false-positive blocks on valid feature-branch commits in worktrees.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-03-GH-0983-impl-branch-gate-cwd-bug.md

## Test plan

- [x] All existing hook tests pass (test-agent-phase-gate.sh, test-tier-detection.sh)
- [x] New test-impl-branch-gate.sh covers worktree cd-prefix detection
- [x] New test covers RALPH_WORKTREE_PATHS substring fallback
- [x] Main-branch block behavior preserved and tested
- [x] Ambiguous case (no cd, no worktree path) warns instead of blocks
- [x] Syntax check: bash -n passes

Closes #983