### PR TITLE
refactor(catch-up): replace LLM-driven cursor Write with PostToolUse hook (GH-985)

### DIFF
--- a/plugin/ralph-hero/hooks/hooks.json
+++ b/plugin/ralph-hero/hooks/hooks.json
@@ -159,6 +159,15 @@
         ]
       },
       {
+        "matcher": "ralph_hero__recent_activity",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/cursor-advance-catch-up.sh"
+          }
+        ]
+      },
+      {
         "hooks": [
           {
             "type": "command",

--- a/plugin/ralph-hero/hooks/scripts/__tests__/cursor-advance-catch-up.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/cursor-advance-catch-up.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Tests for cursor-advance-catch-up.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/cursor-advance-catch-up.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/cursor-advance-catch-up.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  local msg="$2"
+  if [ -f "$path" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg (file missing: $path)"
+  fi
+}
+
+assert_file_missing() {
+  local path="$1"
+  local msg="$2"
+  if [ ! -e "$path" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg (file unexpectedly exists: $path)"
+  fi
+}
+
+echo "Testing $SCRIPT"
+echo "Test dir: $TEST_DIR"
+
+echo
+echo "Test case 1: non-null cursor written"
+export RALPH_CURSOR_DIR="$TEST_DIR/cursors"
+rm -rf "$RALPH_CURSOR_DIR"
+echo '{"tool_name":"ralph_hero__recent_activity","tool_response":{"cursor_advanced_to":"2026-05-03T10:00:00.000Z","events":[],"skipped_lines":0}}' \
+  | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+CURSOR_FILE="$RALPH_CURSOR_DIR/catch-up.json"
+assert_eq "0" "$EXIT_CODE" "non-null cursor: exit 0"
+assert_file_exists "$CURSOR_FILE" "non-null cursor: file created"
+TS_VALUE=$(jq -r '.last_event_ts' < "$CURSOR_FILE" 2>/dev/null || echo "")
+assert_eq "2026-05-03T10:00:00.000Z" "$TS_VALUE" "non-null cursor: last_event_ts persisted verbatim"
+
+echo
+echo "Test case 2: null cursor skipped"
+export RALPH_CURSOR_DIR="$TEST_DIR/cursors2"
+rm -rf "$RALPH_CURSOR_DIR"
+echo '{"tool_name":"ralph_hero__recent_activity","tool_response":{"cursor_advanced_to":null,"events":[],"skipped_lines":0}}' \
+  | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+CURSOR_FILE="$RALPH_CURSOR_DIR/catch-up.json"
+assert_eq "0" "$EXIT_CODE" "null cursor: exit 0"
+assert_file_missing "$CURSOR_FILE" "null cursor: no file written"
+
+echo
+echo "Test case 3: missing parent dir auto-created"
+export RALPH_CURSOR_DIR="$TEST_DIR/deeply/nested/cursors"
+rm -rf "$TEST_DIR/deeply"
+# Sanity-check the parent does not exist before invocation
+assert_file_missing "$TEST_DIR/deeply" "deep parent dir absent before invocation"
+echo '{"tool_name":"ralph_hero__recent_activity","tool_response":{"cursor_advanced_to":"2026-05-04T01:23:45.678Z"}}' \
+  | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+CURSOR_FILE="$RALPH_CURSOR_DIR/catch-up.json"
+assert_eq "0" "$EXIT_CODE" "missing parent dir: exit 0"
+DIR_EXISTS="no"
+[ -d "$RALPH_CURSOR_DIR" ] && DIR_EXISTS="yes"
+assert_eq "yes" "$DIR_EXISTS" "missing parent dir: directory created"
+assert_file_exists "$CURSOR_FILE" "missing parent dir: cursor file written"
+TS_VALUE=$(jq -r '.last_event_ts' < "$CURSOR_FILE" 2>/dev/null || echo "")
+assert_eq "2026-05-04T01:23:45.678Z" "$TS_VALUE" "missing parent dir: last_event_ts persisted"
+
+echo
+echo "Test case 4: malformed stdin doesn't crash"
+export RALPH_CURSOR_DIR="$TEST_DIR/cursors4"
+rm -rf "$RALPH_CURSOR_DIR"
+
+# 4a: literal non-JSON input
+echo "not json at all" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "malformed stdin (literal text): exit 0"
+assert_file_missing "$RALPH_CURSOR_DIR/catch-up.json" "malformed stdin (literal text): no cursor written"
+
+# 4b: empty stdin
+printf '' | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "malformed stdin (empty): exit 0"
+assert_file_missing "$RALPH_CURSOR_DIR/catch-up.json" "malformed stdin (empty): no cursor written"
+
+# 4c: valid JSON, no fields
+echo '{}' | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "malformed stdin ({}): exit 0"
+assert_file_missing "$RALPH_CURSOR_DIR/catch-up.json" "malformed stdin ({}): no cursor written"
+
+echo
+echo "Bonus case: cursor_advanced_to field missing entirely"
+export RALPH_CURSOR_DIR="$TEST_DIR/cursors5"
+rm -rf "$RALPH_CURSOR_DIR"
+echo '{"tool_name":"ralph_hero__recent_activity","tool_response":{"events":[]}}' \
+  | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "missing cursor field: exit 0"
+assert_file_missing "$RALPH_CURSOR_DIR/catch-up.json" "missing cursor field: no cursor written"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/cursor-advance-catch-up.sh
+++ b/plugin/ralph-hero/hooks/scripts/cursor-advance-catch-up.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/cursor-advance-catch-up.sh
+# PostToolUse(ralph_hero__recent_activity): persist catch-up cursor.
+#
+# Replaces the LLM-driven Write call previously emitted by Step 5 of the
+# catch-up skill. Reads tool_response.cursor_advanced_to from stdin and
+# writes ~/.ralph-hero/cursors/catch-up.json when the value is non-null.
+#
+# Honors RALPH_CURSOR_DIR env-var override so tests can redirect the write
+# target away from the real ~/.ralph-hero. Best-effort: any failure exits 0
+# without surfacing errors to the user (pattern: outcome-collector.sh:88).
+#
+# Exit codes:
+#   0 - Always (never blocks pipeline)
+
+set -euo pipefail
+
+# Read full hook input from stdin (matches outcome-collector.sh:26 pattern).
+INPUT=$(cat)
+
+# Resolve cursor dir / file. Tests override via RALPH_CURSOR_DIR.
+CURSOR_DIR="${RALPH_CURSOR_DIR:-${HOME}/.ralph-hero/cursors}"
+CURSOR_FILE="$CURSOR_DIR/catch-up.json"
+
+# Extract cursor value. The `// empty` idiom emits empty-string for
+# null/missing/malformed input — same pattern as outcome-collector.sh:108-110.
+cursor=$(echo "$INPUT" | jq -r '.tool_response.cursor_advanced_to // empty' 2>/dev/null || echo "")
+
+# Empty (null cursor or malformed stdin) — nothing to persist.
+if [[ -z "$cursor" ]]; then
+  exit 0
+fi
+
+# Ensure parent dir exists, then write {"last_event_ts":"<value>"}.
+mkdir -p "$CURSOR_DIR" 2>/dev/null || true
+jq -n --arg ts "$cursor" '{last_event_ts: $ts}' > "$CURSOR_FILE" \
+  || { echo "WARNING: cursor-advance-catch-up failed to write cursor" >&2; exit 0; }
+
+exit 0

--- a/plugin/ralph-hero/skills/catch-up/SKILL.md
+++ b/plugin/ralph-hero/skills/catch-up/SKILL.md
@@ -9,13 +9,14 @@ argument-hint: ""
 context: inline
 allowed-tools:
   - Read
-  - Write
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__recent_activity
 ---
 
 # Catch-up
 
 You synthesize a short narrative of what's changed since the user last ran catch-up.
+
+> **Note**: cursor advancement is automatic — the `cursor-advance-catch-up.sh` PostToolUse hook persists `~/.ralph-hero/cursors/catch-up.json` from the `recent_activity` response, so this skill no longer manages the cursor file directly.
 
 ## Step 1: Read cursor
 
@@ -42,7 +43,7 @@ Capture the response: `events[]` and `cursor_advanced_to`.
 
 > Nothing's changed since last time you checked.
 
-Do not advance the cursor. Stop here.
+Stop here.
 
 **Populated case**: write 2-4 sentences describing what happened. Lean on:
 - What kinds of events fired (PRs opened/merged, issues advanced, agents dispatched)
@@ -56,23 +57,11 @@ Tone rules (same as /hello):
 
 If `events.length` was at the `limit` cap, prefix with: *"A lot has happened since last time — here are the highlights:"*
 
-## Step 5: Advance cursor
-
-Only on successful synthesis: write `~/.ralph-hero/cursors/catch-up.json` with:
-
-```json
-{ "last_event_ts": "<cursor_advanced_to value from response>" }
-```
-
-Use the Write tool. Create the parent directory if needed.
-
-## Step 6: Output
+## Step 5: Output
 
 Return only the narrative text. No frontmatter, no headers, no metadata. The caller (interactive /hello, or a programmatic invoker) takes the text as-is.
 
 ## Constraints
 
 - Single output: prose narrative or the empty-case sentence
-- Cursor only advances on successful synthesis
-- Never advance cursor when `recent_activity` errors
 - No more than 4 sentences in the populated case

--- a/thoughts/shared/plans/2026-05-03-GH-0985-catch-up-cursor-hook.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0985-catch-up-cursor-hook.md
@@ -164,8 +164,8 @@ Register the new script in `hooks.json` under `PostToolUse` matched on `ralph_he
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] New entry inserted in the `"PostToolUse"` array (alongside the existing `ralph_hero__save_issue`, `ralph_hero__create_comment`, `ralph_hero__get_issue`, `Write`, `Bash` entries — see [`hooks.json:107-168`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-hero/hooks/hooks.json#L107-L168))
-  - [ ] Entry shape matches existing matchers exactly:
+  - [x] New entry inserted in the `"PostToolUse"` array (alongside the existing `ralph_hero__save_issue`, `ralph_hero__create_comment`, `ralph_hero__get_issue`, `Write`, `Bash` entries — see [`hooks.json:107-168`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-hero/hooks/hooks.json#L107-L168))
+  - [x] Entry shape matches existing matchers exactly:
     ```json
     {
       "matcher": "ralph_hero__recent_activity",
@@ -177,9 +177,9 @@ Register the new script in `hooks.json` under `PostToolUse` matched on `ralph_he
       ]
     }
     ```
-  - [ ] Inserted before the matcher-less `record-activity.sh tool_called` entry at the end of `PostToolUse` (so the cursor advance fires before the activity log records the tool call — order is best-effort but conceptually the cursor advance is more specific)
-  - [ ] `jq . plugin/ralph-hero/hooks/hooks.json` parses cleanly (validates JSON syntax)
-  - [ ] No other entries removed or reordered
+  - [x] Inserted before the matcher-less `record-activity.sh tool_called` entry at the end of `PostToolUse` (so the cursor advance fires before the activity log records the tool call — order is best-effort but conceptually the cursor advance is more specific)
+  - [x] `jq . plugin/ralph-hero/hooks/hooks.json` parses cleanly (validates JSON syntax)
+  - [x] No other entries removed or reordered
 
 #### Task 2.2: Edit catch-up SKILL.md
 
@@ -188,25 +188,25 @@ Register the new script in `hooks.json` under `PostToolUse` matched on `ralph_he
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `allowed-tools` list (currently lines 10-13) reduced to two entries: `Read` and `mcp__plugin_ralph-hero_ralph-github__ralph_hero__recent_activity`. Entry `Write` removed.
-  - [ ] Step 5 section (lines 59-67, "## Step 5: Advance cursor" through the closing `Use the Write tool...` paragraph) removed entirely
-  - [ ] Old "## Step 6: Output" section renamed to "## Step 5: Output" so step numbering remains contiguous (1-2-3-4-5)
-  - [ ] Constraints section (currently lines 73-78): "Cursor only advances on successful synthesis" bullet REMOVED (cursor advance is no longer a skill responsibility); "Never advance cursor when `recent_activity` errors" bullet REMOVED for the same reason. Other bullets (single output, sentence cap) retained.
-  - [ ] A new comment line added near the top of the skill body (after the `# Catch-up` heading or in a brief note section) explaining: cursor advancement is now automatic via the `cursor-advance-catch-up.sh` PostToolUse hook; the skill no longer manages the cursor file directly. One sentence, no extra ceremony.
-  - [ ] Step 1 (Read cursor) is UNCHANGED — the LLM still needs to read the cursor to compute the `since` parameter for `recent_activity`
-  - [ ] Step 4 empty-case wording ("Do not advance the cursor. Stop here.") is updated to drop the "Do not advance the cursor" phrase since that's now automatic; "Stop here." or equivalent terminator retained
-  - [ ] File still parses as a valid skill (frontmatter intact, code blocks balanced)
+  - [x] `allowed-tools` list (currently lines 10-13) reduced to two entries: `Read` and `mcp__plugin_ralph-hero_ralph-github__ralph_hero__recent_activity`. Entry `Write` removed.
+  - [x] Step 5 section (lines 59-67, "## Step 5: Advance cursor" through the closing `Use the Write tool...` paragraph) removed entirely
+  - [x] Old "## Step 6: Output" section renamed to "## Step 5: Output" so step numbering remains contiguous (1-2-3-4-5)
+  - [x] Constraints section (currently lines 73-78): "Cursor only advances on successful synthesis" bullet REMOVED (cursor advance is no longer a skill responsibility); "Never advance cursor when `recent_activity` errors" bullet REMOVED for the same reason. Other bullets (single output, sentence cap) retained.
+  - [x] A new comment line added near the top of the skill body (after the `# Catch-up` heading or in a brief note section) explaining: cursor advancement is now automatic via the `cursor-advance-catch-up.sh` PostToolUse hook; the skill no longer manages the cursor file directly. One sentence, no extra ceremony.
+  - [x] Step 1 (Read cursor) is UNCHANGED — the LLM still needs to read the cursor to compute the `since` parameter for `recent_activity`
+  - [x] Step 4 empty-case wording ("Do not advance the cursor. Stop here.") is updated to drop the "Do not advance the cursor" phrase since that's now automatic; "Stop here." or equivalent terminator retained
+  - [x] File still parses as a valid skill (frontmatter intact, code blocks balanced)
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `jq . plugin/ralph-hero/hooks/hooks.json > /dev/null` — JSON valid
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — TypeScript build still passes (no source changed but sanity check the workspace is healthy)
-- [ ] `cd plugin/ralph-hero/mcp-server && npm test` — full vitest suite passes (no source changed; this catches accidental cross-module breakage)
-- [ ] `bash plugin/ralph-hero/hooks/scripts/__tests__/cursor-advance-catch-up.test.sh` — still passes
-- [ ] `grep -c "^## Step " plugin/ralph-hero/skills/catch-up/SKILL.md` — returns `5` (Steps 1-5, with old Step 6 renumbered)
-- [ ] `grep "^  - Write$" plugin/ralph-hero/skills/catch-up/SKILL.md` — returns nothing (Write removed from allowed-tools)
+- [x] `jq . plugin/ralph-hero/hooks/hooks.json > /dev/null` — JSON valid
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — TypeScript build still passes (no source changed but sanity check the workspace is healthy)
+- [x] `cd plugin/ralph-hero/mcp-server && npm test` — full vitest suite passes (no source changed; this catches accidental cross-module breakage)
+- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/cursor-advance-catch-up.test.sh` — still passes
+- [x] `grep -c "^## Step " plugin/ralph-hero/skills/catch-up/SKILL.md` — returns `5` (Steps 1-5, with old Step 6 renumbered)
+- [x] `grep "^  - Write$" plugin/ralph-hero/skills/catch-up/SKILL.md` — returns nothing (Write removed from allowed-tools)
 
 #### Manual Verification:
 

--- a/thoughts/shared/plans/2026-05-03-GH-0985-catch-up-cursor-hook.md
+++ b/thoughts/shared/plans/2026-05-03-GH-0985-catch-up-cursor-hook.md
@@ -99,17 +99,17 @@ Create the new `cursor-advance-catch-up.sh` script following the `outcome-collec
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] First line is `#!/bin/bash`; second line is a header comment explaining purpose and the matched event (`PostToolUse(ralph_hero__recent_activity)`)
-  - [ ] `set -euo pipefail` at top
-  - [ ] Reads full stdin into a variable using `INPUT=$(cat)` (matches `outcome-collector.sh:26` pattern). Does NOT need to source `hook-utils.sh` — direct `jq` on `$INPUT` is fine, mirroring `outcome-collector.sh`.
-  - [ ] Resolves cursor dir as `${RALPH_CURSOR_DIR:-${HOME}/.ralph-hero/cursors}` and cursor file as `$CURSOR_DIR/catch-up.json`
-  - [ ] Extracts `tool_response.cursor_advanced_to` via `jq -r '.tool_response.cursor_advanced_to // empty'` (the `// empty` idiom emits empty-string for null/missing — same pattern as `outcome-collector.sh:108-110`)
-  - [ ] If extracted value is empty (null cursor case), exits 0 without writing
-  - [ ] If extracted value is non-empty, runs `mkdir -p "$CURSOR_DIR"` (suppressing error to `2>/dev/null || true` per `outcome-collector.sh:23` pattern) then writes `{"last_event_ts":"<value>"}` via `jq -n --arg ts "$cursor" '{last_event_ts: $ts}' > "$CURSOR_FILE"`
-  - [ ] Final line is `exit 0` so script always succeeds (best-effort)
-  - [ ] Wraps the write in `|| { echo "WARNING: cursor-advance-catch-up failed to write cursor" >&2; exit 0; }` matching `outcome-collector.sh:88` defensive style
-  - [ ] File is `chmod +x` (verify with `stat -f %p` on macOS or via `git ls-files --stage` showing `100755`)
-  - [ ] Total script length under 50 lines (sanity check on simplicity)
+  - [x] First line is `#!/bin/bash`; second line is a header comment explaining purpose and the matched event (`PostToolUse(ralph_hero__recent_activity)`)
+  - [x] `set -euo pipefail` at top
+  - [x] Reads full stdin into a variable using `INPUT=$(cat)` (matches `outcome-collector.sh:26` pattern). Does NOT need to source `hook-utils.sh` — direct `jq` on `$INPUT` is fine, mirroring `outcome-collector.sh`.
+  - [x] Resolves cursor dir as `${RALPH_CURSOR_DIR:-${HOME}/.ralph-hero/cursors}` and cursor file as `$CURSOR_DIR/catch-up.json`
+  - [x] Extracts `tool_response.cursor_advanced_to` via `jq -r '.tool_response.cursor_advanced_to // empty'` (the `// empty` idiom emits empty-string for null/missing — same pattern as `outcome-collector.sh:108-110`)
+  - [x] If extracted value is empty (null cursor case), exits 0 without writing
+  - [x] If extracted value is non-empty, runs `mkdir -p "$CURSOR_DIR"` (suppressing error to `2>/dev/null || true` per `outcome-collector.sh:23` pattern) then writes `{"last_event_ts":"<value>"}` via `jq -n --arg ts "$cursor" '{last_event_ts: $ts}' > "$CURSOR_FILE"`
+  - [x] Final line is `exit 0` so script always succeeds (best-effort)
+  - [x] Wraps the write in `|| { echo "WARNING: cursor-advance-catch-up failed to write cursor" >&2; exit 0; }` matching `outcome-collector.sh:88` defensive style
+  - [x] File is `chmod +x` (verify with `stat -f %p` on macOS or via `git ls-files --stage` showing `100755`)
+  - [x] Total script length under 50 lines (sanity check on simplicity)
 
 #### Task 1.2: Create test file with four required cases
 
@@ -118,30 +118,30 @@ Create the new `cursor-advance-catch-up.sh` script following the `outcome-collec
 - **complexity**: medium
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] Shebang `#!/usr/bin/env bash`; `set -uo pipefail` (matching `record-activity.test.sh:5`); resolves `SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/cursor-advance-catch-up.sh"`
-  - [ ] Uses `TEST_DIR="$(mktemp -d)"` with `trap "rm -rf $TEST_DIR" EXIT` (matching `record-activity.test.sh:8-9`)
-  - [ ] Defines `assert_eq` and `assert_file_exists` helpers identical in shape to `record-activity.test.sh:14-39`; tracks `PASS` and `FAIL` counters; final line `[ "$FAIL" -eq 0 ]`
-  - [ ] Sets `export RALPH_CURSOR_DIR="$TEST_DIR/cursors"` before each test block (or per-block reset via `rm -rf "$TEST_DIR/cursors"`)
-  - [ ] **Test case 1 (non-null cursor written)**: Pipe `'{"tool_name":"ralph_hero__recent_activity","tool_response":{"cursor_advanced_to":"2026-05-03T10:00:00.000Z","events":[],"skipped_lines":0}}'` to script. Assert cursor file exists at `$TEST_DIR/cursors/catch-up.json`. Assert `jq -r .last_event_ts < $CURSOR_FILE` equals `"2026-05-03T10:00:00.000Z"`. Assert script exit 0.
-  - [ ] **Test case 2 (null cursor skipped)**: Pipe `'{"tool_name":"ralph_hero__recent_activity","tool_response":{"cursor_advanced_to":null,"events":[],"skipped_lines":0}}'` to script. Assert cursor file does NOT exist. Assert script exit 0.
-  - [ ] **Test case 3 (missing parent dir auto-created)**: Set `RALPH_CURSOR_DIR="$TEST_DIR/deeply/nested/cursors"` (parent does not pre-exist). Pipe a non-null cursor payload. Assert the directory was created and the file exists.
-  - [ ] **Test case 4 (malformed stdin doesn't crash)**: Pipe literal `not json at all` to script. Assert exit 0. Pipe empty string to script. Assert exit 0. Pipe `'{}'` (valid JSON, no fields). Assert exit 0 and no cursor file written.
-  - [ ] **Bonus: `cursor_advanced_to` field missing entirely**: Pipe `'{"tool_name":"ralph_hero__recent_activity","tool_response":{"events":[]}}'` (no cursor_advanced_to key). Assert exit 0, no cursor written.
-  - [ ] Test file ends with `echo "Results: $PASS passed, $FAIL failed"` line then `[ "$FAIL" -eq 0 ]` (matches `record-activity.test.sh:210-211`)
-  - [ ] File is `chmod +x` so it can be invoked directly
+  - [x] Shebang `#!/usr/bin/env bash`; `set -uo pipefail` (matching `record-activity.test.sh:5`); resolves `SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/cursor-advance-catch-up.sh"`
+  - [x] Uses `TEST_DIR="$(mktemp -d)"` with `trap "rm -rf $TEST_DIR" EXIT` (matching `record-activity.test.sh:8-9`)
+  - [x] Defines `assert_eq` and `assert_file_exists` helpers identical in shape to `record-activity.test.sh:14-39`; tracks `PASS` and `FAIL` counters; final line `[ "$FAIL" -eq 0 ]`
+  - [x] Sets `export RALPH_CURSOR_DIR="$TEST_DIR/cursors"` before each test block (or per-block reset via `rm -rf "$TEST_DIR/cursors"`)
+  - [x] **Test case 1 (non-null cursor written)**: Pipe `'{"tool_name":"ralph_hero__recent_activity","tool_response":{"cursor_advanced_to":"2026-05-03T10:00:00.000Z","events":[],"skipped_lines":0}}'` to script. Assert cursor file exists at `$TEST_DIR/cursors/catch-up.json`. Assert `jq -r .last_event_ts < $CURSOR_FILE` equals `"2026-05-03T10:00:00.000Z"`. Assert script exit 0.
+  - [x] **Test case 2 (null cursor skipped)**: Pipe `'{"tool_name":"ralph_hero__recent_activity","tool_response":{"cursor_advanced_to":null,"events":[],"skipped_lines":0}}'` to script. Assert cursor file does NOT exist. Assert script exit 0.
+  - [x] **Test case 3 (missing parent dir auto-created)**: Set `RALPH_CURSOR_DIR="$TEST_DIR/deeply/nested/cursors"` (parent does not pre-exist). Pipe a non-null cursor payload. Assert the directory was created and the file exists.
+  - [x] **Test case 4 (malformed stdin doesn't crash)**: Pipe literal `not json at all` to script. Assert exit 0. Pipe empty string to script. Assert exit 0. Pipe `'{}'` (valid JSON, no fields). Assert exit 0 and no cursor file written.
+  - [x] **Bonus: `cursor_advanced_to` field missing entirely**: Pipe `'{"tool_name":"ralph_hero__recent_activity","tool_response":{"events":[]}}'` (no cursor_advanced_to key). Assert exit 0, no cursor written.
+  - [x] Test file ends with `echo "Results: $PASS passed, $FAIL failed"` line then `[ "$FAIL" -eq 0 ]` (matches `record-activity.test.sh:210-211`)
+  - [x] File is `chmod +x` so it can be invoked directly
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `bash plugin/ralph-hero/hooks/scripts/__tests__/cursor-advance-catch-up.test.sh` — exits 0 with all assertions passing
-- [ ] `bash plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — still passes (no regression in adjacent test file)
-- [ ] `shellcheck plugin/ralph-hero/hooks/scripts/cursor-advance-catch-up.sh` — no errors (if shellcheck available; non-blocking if not installed)
+- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/cursor-advance-catch-up.test.sh` — exits 0 with all assertions passing
+- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/record-activity.test.sh` — still passes (no regression in adjacent test file)
+- [x] `shellcheck plugin/ralph-hero/hooks/scripts/cursor-advance-catch-up.sh` — no errors (if shellcheck available; non-blocking if not installed)
 
 #### Manual Verification:
 
-- [ ] Read the script source — confirm it follows the `outcome-collector.sh` style (set -euo pipefail, INPUT=$(cat), jq extraction, defensive mkdir, exit 0)
-- [ ] Verify the script handles `RALPH_CURSOR_DIR` override correctly by running it manually with the env var set
+- [x] Read the script source — confirm it follows the `outcome-collector.sh` style (set -euo pipefail, INPUT=$(cat), jq extraction, defensive mkdir, exit 0)
+- [x] Verify the script handles `RALPH_CURSOR_DIR` override correctly by running it manually with the env var set
 
 **Creates for next phase**: A working, tested hook script ready to be wired into `hooks.json`.
 


### PR DESCRIPTION
## Summary

Replaces visible Write(catch-up.json) tool call from /hello with a PostToolUse hook on ralph_hero__recent_activity. New 39-line hook script + 18 tests. SKILL.md drops Step 5 entirely and removes Write from allowed-tools. 1100/1100 mcp-server tests still pass.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-03-GH-0985-catch-up-cursor-hook.md

Phases shipped: 2 of 2

## Test plan

- [x] Automated verification per plan Success Criteria
  - New test suite (cursor-advance-catch-up.test.sh): 18/18 pass
  - MCP server tests: 1100/1100 pass
  - Hook registration: hooks.json valid JSON, PostToolUse entry added
  - Skill cleanup: Write removed from allowed-tools, Step 5 removed
- [ ] Manual verification per plan Success Criteria
  - Run `/ralph-hero:catch-up` and confirm no visible Write(catch-up.json) in transcript but cursor file advances
  - Run `/hello` and confirm user-visible output unchanged
  - Inspect cursor file: `cat ~/.ralph-hero/cursors/catch-up.json` still has `{"last_event_ts": "..."}` shape

Closes #985