### PR TITLE
feat(security): GH-1028 enable Dependabot version + security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,89 @@
+# Dependabot configuration
+#
+# Manages version updates for npm packages across all workspaces and for
+# GitHub Actions workflows. Security updates are delivered as separate
+# (ungrouped) PRs so they land immediately rather than waiting for the
+# weekly grouped batch.
+#
+# Note: enabling "Dependabot security updates" is a separate repo-settings
+# toggle (see GH-1028 PR body for the gh api command).
+version: 2
+
+updates:
+  # ---- npm: ralph-hero MCP server ----
+  - package-ecosystem: "npm"
+    directory: "/plugin/ralph-hero/mcp-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      ralph-hero-mcp-server-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- npm: ralph-knowledge plugin ----
+  - package-ecosystem: "npm"
+    directory: "/plugin/ralph-knowledge"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      ralph-knowledge-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- npm: ralph-demo remotion (uses pnpm; Dependabot reads package.json) ----
+  - package-ecosystem: "npm"
+    directory: "/plugin/ralph-demo/remotion"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      ralph-demo-remotion-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- npm: .github/scripts/sync ----
+  - package-ecosystem: "npm"
+    directory: "/.github/scripts/sync"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-scripts-sync-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- npm: scripts/routing ----
+  - package-ecosystem: "npm"
+    directory: "/scripts/routing"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      scripts-routing-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- GitHub Actions ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` covering all 5 npm ecosystems (ralph-hero MCP server, ralph-knowledge, ralph-demo/remotion, .github/scripts/sync, scripts/routing) plus github-actions at the repo root. Weekly schedule with grouped minor/patch updates per ecosystem; security updates remain ungrouped (immediate, separate PRs).

Closes #1028. Part of #1027 (security hardening epic). Spec: `thoughts/shared/research/2026-05-05-security-hardening-design.md` section S1.

## Manual follow-up required after merge

Enabling Dependabot security updates is a separate repo settings toggle that cannot be set from the config file. After merge, run:

```
gh api -X PUT /repos/cdubiel08/ralph-hero/automated-security-fixes
```

Verify with:

```
gh api repos/cdubiel08/ralph-hero --jq '.security_and_analysis.dependabot_security_updates.status'
```

Expected: `enabled`.

## Test plan

- [ ] Dependabot config validates on GitHub (no parse errors in repo Insights -> Dependency graph -> Dependabot)
- [ ] First weekly Dependabot PR opens within one week of merge
- [ ] After enabling automated-security-fixes, security advisories produce ungrouped PRs

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>