### PR TITLE
[731d] feat(loop): wire integrator phases + autonomous merge gate

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -160,6 +160,39 @@ impl *args:
     set -- $_args
     dispatch "ralph-impl" "$@"
 
+# Validate completed implementation - run tests, smoke checks, summarize verdict
+[group('workflow')]
+val *args:
+    #!/usr/bin/env bash
+    set -eu
+    source "{{justfile_directory()}}/scripts/cli-dispatch.sh"
+    DEFAULT_BUDGET=1.00 DEFAULT_TIMEOUT=10m
+    _args={{quote(args)}}
+    set -- $_args
+    dispatch "ralph-val" "$@"
+
+# Open a pull request for an "In Progress" issue with a feature branch
+[group('workflow')]
+pr *args:
+    #!/usr/bin/env bash
+    set -eu
+    source "{{justfile_directory()}}/scripts/cli-dispatch.sh"
+    DEFAULT_BUDGET=1.00 DEFAULT_TIMEOUT=10m
+    _args={{quote(args)}}
+    set -- $_args
+    dispatch "ralph-pr" "$@"
+
+# Merge an approved PR after code review and move issues to Done
+[group('workflow')]
+merge *args:
+    #!/usr/bin/env bash
+    set -eu
+    source "{{justfile_directory()}}/scripts/cli-dispatch.sh"
+    DEFAULT_BUDGET=1.00 DEFAULT_TIMEOUT=10m
+    _args={{quote(args)}}
+    set -- $_args
+    dispatch "ralph-merge" "$@"
+
 # Run project hygiene check - stale items, archive candidates
 [group('workflow')]
 hygiene *args:
@@ -211,14 +244,15 @@ hero *args:
     set -- $_args
     dispatch "hero" "$@"
 
-# Sequential autonomous loop - hygiene, triage, split, research, plan, review, impl
+# Sequential autonomous loop - hygiene, triage, split, research, plan, review, impl, val, pr, code-review, [merge]
 [group('orchestrate')]
-loop mode="all" review="auto" split="auto" hygiene="auto" budget="8.00" timeout="60m":
+loop mode="all" review="auto" split="auto" hygiene="auto" budget="8.00" timeout="60m" auto-merge="false":
     #!/usr/bin/env bash
     set -eu
     args=""
     if [ "{{mode}}" != "all" ]; then args="--{{mode}}-only"; fi
     args="$args --review={{review}} --split={{split}} --hygiene={{hygiene}}"
+    if [ "{{auto-merge}}" = "true" ]; then args="$args --auto-merge"; fi
     RALPH_BUDGET="{{budget}}" TIMEOUT="{{timeout}}" "{{justfile_directory()}}"/scripts/ralph-loop.sh $args
 
 # One-time project setup - create GitHub Project V2 with required fields

--- a/plugin/ralph-hero/scripts/ralph-loop.sh
+++ b/plugin/ralph-hero/scripts/ralph-loop.sh
@@ -2,11 +2,13 @@
 # Run the Ralph GitHub workflow loop until all queues are empty
 #
 # Usage: ./scripts/ralph-loop.sh [--triage-only|--split-only|--research-only|--plan-only|--review-only|--impl-only|--hygiene-only]
+#        ./scripts/ralph-loop.sh [--val-only|--pr-only|--code-review-only|--merge-only]
 #        ./scripts/ralph-loop.sh [--analyst-only|--builder-only|--integrator-only]
 #        ./scripts/ralph-loop.sh --split=auto|skip --review=auto|skip|interactive --hygiene=auto|skip
-#        ./scripts/ralph-loop.sh --budget=5.00
+#        ./scripts/ralph-loop.sh --budget=5.00 [--auto-merge]
 #
-# Runs: hygiene (optional) -> triage -> split (optional) -> research -> plan -> review (optional) -> implement in sequence
+# Runs: hygiene (optional) -> triage -> split (optional) -> research -> plan -> review (optional) -> implement
+#    -> val -> pr -> code-review -> [merge] in sequence
 # Repeats until no eligible tickets in any queue
 #
 # Review modes:
@@ -17,6 +19,11 @@
 # Hygiene modes:
 #   --hygiene=auto       Run hygiene before triage (default)
 #   --hygiene=skip       Skip hygiene phase
+#
+# Auto-merge:
+#   --auto-merge         Enable autonomous merge gate (RALPH_AUTO_MERGE=true).
+#                        Without this flag, the merge phase is a no-op (issues
+#                        end at "In Review" with a code-reviewed PR).
 
 set -e
 
@@ -54,6 +61,7 @@ MODE="all"
 REVIEW_MODE="${RALPH_REVIEW_MODE:-auto}"
 SPLIT_MODE="${RALPH_SPLIT_MODE:-auto}"
 HYGIENE_MODE="${RALPH_HYGIENE_MODE:-auto}"
+AUTO_MERGE="${RALPH_AUTO_MERGE:-false}"
 for arg in "$@"; do
     case "$arg" in
         --review=*)
@@ -68,7 +76,13 @@ for arg in "$@"; do
         --budget=*)
             BUDGET="${arg#*=}"
             ;;
+        --auto-merge)
+            AUTO_MERGE="true"
+            ;;
         --triage-only|--split-only|--research-only|--plan-only|--review-only|--impl-only|--hygiene-only)
+            MODE="$arg"
+            ;;
+        --val-only|--pr-only|--code-review-only|--merge-only)
             MODE="$arg"
             ;;
         --analyst-only|--builder-only|--integrator-only)
@@ -79,6 +93,7 @@ done
 export RALPH_REVIEW_MODE="$REVIEW_MODE"
 export RALPH_SPLIT_MODE="$SPLIT_MODE"
 export RALPH_HYGIENE_MODE="$HYGIENE_MODE"
+export RALPH_AUTO_MERGE="$AUTO_MERGE"
 MAX_ITERATIONS="${MAX_ITERATIONS:-10}"
 TIMEOUT="${TIMEOUT:-15m}"
 BUDGET="${RALPH_BUDGET:-5.00}"
@@ -90,6 +105,7 @@ echo "Mode: $MODE"
 echo "Hygiene mode: $HYGIENE_MODE"
 echo "Split mode: $SPLIT_MODE"
 echo "Review mode: $REVIEW_MODE"
+echo "Auto-merge: $AUTO_MERGE"
 echo "Max iterations: $MAX_ITERATIONS"
 echo "Timeout per task: $TIMEOUT"
 echo "Budget per task: \$${BUDGET}"
@@ -217,9 +233,46 @@ while [ $iteration -lt $MAX_ITERATIONS ]; do
     fi
 
     # === INTEGRATOR PHASE ===
-    if [ "$MODE" = "all" ] || [ "$MODE" = "--integrator-only" ]; then
-        echo "--- Integrator Phase (report only) ---"
-        # Future: run_claude "/ralph-hero:ralph-integrate" "integrate"
+
+    # Validation phase
+    if [ "$MODE" = "all" ] || [ "$MODE" = "--val-only" ] || [ "$MODE" = "--integrator-only" ]; then
+        echo "--- Integrator: Validation Phase ---"
+        if run_claude "/ralph-hero:ralph-val" "val"; then
+            work_done=true
+        fi
+    fi
+
+    # PR phase
+    if [ "$MODE" = "all" ] || [ "$MODE" = "--pr-only" ] || [ "$MODE" = "--integrator-only" ]; then
+        echo "--- Integrator: PR Phase ---"
+        if run_claude "/ralph-hero:ralph-pr" "pr"; then
+            work_done=true
+        fi
+    fi
+
+    # Code review phase
+    if [ "$MODE" = "all" ] || [ "$MODE" = "--code-review-only" ] || [ "$MODE" = "--integrator-only" ]; then
+        echo "--- Integrator: Code Review Phase ---"
+        if run_claude "/ralph-hero:ralph-code-review" "code-review"; then
+            work_done=true
+        fi
+    fi
+
+    # Merge phase (gated by --auto-merge to remain safe-by-default)
+    if [ "$MODE" = "all" ] || [ "$MODE" = "--merge-only" ] || [ "$MODE" = "--integrator-only" ]; then
+        if [ "$AUTO_MERGE" = "true" ]; then
+            echo "--- Integrator: Merge Phase (auto-merge enabled) ---"
+            if run_claude "/ralph-hero:ralph-merge" "merge"; then
+                work_done=true
+            fi
+        elif [ "$MODE" = "--merge-only" ]; then
+            # Explicit warning so --merge-only is never silent
+            echo ">>> --merge-only requires --auto-merge or auto-merge=true; skipping merge phase."
+            echo "    To enable autonomous merging: just loop --merge-only --auto-merge"
+            echo "    Or:                          RALPH_AUTO_MERGE=true just loop --merge-only"
+        else
+            echo "--- Integrator: Merge Phase: SKIPPED (auto-merge disabled) ---"
+        fi
     fi
 
     # Exit early if no work found in any queue

--- a/plugin/ralph-hero/skills/ralph-merge/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-merge/SKILL.md
@@ -209,6 +209,57 @@ And stop.
    - If user selects **"Merge without review"**: proceed to Step 5.
    - If user selects **"Stop"** or **"Other"**: stop.
 
+## Step 4a: Autonomous Merge Gate
+
+**Runs only when `RALPH_AUTO_MERGE=true`.** When the env var is unset or set to anything else (the standalone `just merge NNN` case), skip this step entirely and continue with the existing flow at Step 5 — backwards compatibility with interactive merging is preserved.
+
+This gate is the safety net that lets the loop runner (`scripts/ralph-loop.sh --auto-merge`) merge approved PRs autonomously. It is intentionally orthogonal to `RALPH_REVIEW_MODE` (which only gates the code-review step in Step 4): you can have auto code-review without auto-merge, and vice versa.
+
+```bash
+if [ "${RALPH_AUTO_MERGE:-false}" != "true" ]; then
+    echo "RALPH_AUTO_MERGE not set; skipping autonomous merge gate."
+    # fall through to Step 5 — interactive flow
+fi
+```
+
+When `RALPH_AUTO_MERGE=true`, evaluate **all** of the following criteria. If any one fails, output `AUTO-MERGE BLOCKED` (see below) and STOP. The loop will retry on the next iteration.
+
+### Criteria (ALL must hold)
+
+1. **Review approved**: `gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'` returns `APPROVED`.
+   - Exception: an XS-estimated issue with zero review comments is treated as approved (small changes do not require explicit review approval). Use `gh pr view PR_NUMBER --json comments --jq '.comments | length'` and the issue's `estimate` field to detect this case.
+2. **CI green**: `gh pr checks PR_NUMBER --json name,state,conclusion` returns checks where every entry has `state: completed` AND `conclusion: success`. Pending or failing checks block the merge.
+3. **PR open and mergeable**: `gh pr view PR_NUMBER --json state,mergeable --jq '{state,mergeable}'` shows `state: OPEN` and `mergeable: MERGEABLE`. A `CONFLICTING` or `UNKNOWN` mergeable status blocks.
+
+### Recommended invocation
+
+```bash
+review_decision=$(gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision')
+ci_status=$(gh pr checks "$PR_NUMBER" --json name,state,conclusion)
+pr_state=$(gh pr view "$PR_NUMBER" --json state,mergeable --jq '{state,mergeable}')
+```
+
+Then evaluate the three criteria together. The XS exception is checked only if `review_decision` is null/empty.
+
+### On miss — `AUTO-MERGE BLOCKED`
+
+If any criterion fails, output the following block and STOP. The block uses a distinct status string so callers (including the loop runner) can distinguish it from `MERGE BLOCKED` (human change request) and `MERGE NOT READY` (transient mergeability issue):
+
+```
+AUTO-MERGE BLOCKED
+Issue: #NNN
+PR: #PR_NUMBER
+Review: [APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED|null]
+CI: [summary — e.g., "2/5 checks pending", "1 failing: lint", "all green"]
+Reason: [first failing criterion in plain English]
+```
+
+The next loop iteration will re-evaluate. There is no fix cycle here — `RALPH_AUTO_MERGE` only merges when everything is already green; it never edits code.
+
+### On pass
+
+All criteria hold. Proceed to Step 5 (the existing readiness check + merge flow).
+
 ## Step 5: Check PR Readiness (with Rejection Detection)
 
 ```bash

--- a/thoughts/shared/plans/2026-05-06-group-GH-1015-complete-autonomous-loop.md
+++ b/thoughts/shared/plans/2026-05-06-group-GH-1015-complete-autonomous-loop.md
@@ -419,12 +419,12 @@ Extend `ralph-loop.sh` with the four integrator phases (val → pr → code-revi
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] After line 56 (init block), add `AUTO_MERGE="${RALPH_AUTO_MERGE:-false}"`
-  - [ ] In the for-arg loop (around line 76), add a `--auto-merge)` case that sets `AUTO_MERGE="true"`
-  - [ ] After the loop, add `export RALPH_AUTO_MERGE="$AUTO_MERGE"`
-  - [ ] In the banner (around line 95), add `echo "Auto-merge: $AUTO_MERGE"`
-  - [ ] `grep -c "auto-merge\|AUTO_MERGE" plugin/ralph-hero/scripts/ralph-loop.sh` returns ≥ 4 (init + flag parse + export + banner)
-  - [ ] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
+  - [x] After line 56 (init block), add `AUTO_MERGE="${RALPH_AUTO_MERGE:-false}"`
+  - [x] In the for-arg loop (around line 76), add a `--auto-merge)` case that sets `AUTO_MERGE="true"`
+  - [x] After the loop, add `export RALPH_AUTO_MERGE="$AUTO_MERGE"`
+  - [x] In the banner (around line 95), add `echo "Auto-merge: $AUTO_MERGE"`
+  - [x] `grep -c "auto-merge\|AUTO_MERGE" plugin/ralph-hero/scripts/ralph-loop.sh` returns ≥ 4 (init + flag parse + export + banner)
+  - [x] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
 
 #### Task 4.2: Add new --*-only modes to ralph-loop.sh case
 - **files**: `plugin/ralph-hero/scripts/ralph-loop.sh` (modify)
@@ -432,10 +432,10 @@ Extend `ralph-loop.sh` with the four integrator phases (val → pr → code-revi
 - **complexity**: low
 - **depends_on**: [4.1]
 - **acceptance**:
-  - [ ] The mode case statement (around line 71) extended to include: `--val-only|--pr-only|--code-review-only|--merge-only`
-  - [ ] `grep -E "val-only.*pr-only.*code-review-only.*merge-only" plugin/ralph-hero/scripts/ralph-loop.sh` matches (all four on one alternation line)
-  - [ ] Existing `--analyst-only|--builder-only|--integrator-only` still in the case
-  - [ ] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
+  - [x] The mode case statement (around line 71) extended to include: `--val-only|--pr-only|--code-review-only|--merge-only`
+  - [x] `grep -E "val-only.*pr-only.*code-review-only.*merge-only" plugin/ralph-hero/scripts/ralph-loop.sh` matches (all four on one alternation line)
+  - [x] Existing `--analyst-only|--builder-only|--integrator-only` still in the case
+  - [x] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
 
 #### Task 4.3: Replace integrator stub with four phase blocks
 - **files**: `plugin/ralph-hero/scripts/ralph-loop.sh` (modify)
@@ -443,13 +443,13 @@ Extend `ralph-loop.sh` with the four integrator phases (val → pr → code-revi
 - **complexity**: medium
 - **depends_on**: [4.2]
 - **acceptance**:
-  - [ ] Lines 219-223 (current stub `# Future: run_claude...`) replaced with four `if [ "$MODE" = ... ]` blocks: val, pr, code-review, merge
-  - [ ] Each non-merge block guarded by: `[ "$MODE" = "all" ] || [ "$MODE" = "--<phase>-only" ] || [ "$MODE" = "--integrator-only" ]`
-  - [ ] Merge block additionally guarded by `[ "$AUTO_MERGE" = "true" ]` so `just loop --merge-only` without auto-merge is a no-op
-  - [ ] When `MODE=--merge-only` and `AUTO_MERGE=false`, an explicit warning is echoed (e.g., `"--merge-only requires --auto-merge or auto-merge=true; skipping merge phase"`) — not silent
-  - [ ] Each phase calls `run_claude "/ralph-hero:ralph-<phase>" "<phase-name>"` and sets `work_done=true` on success
-  - [ ] `grep -c "ralph-val\|ralph-pr\|ralph-code-review\|ralph-merge" plugin/ralph-hero/scripts/ralph-loop.sh` returns ≥ 4
-  - [ ] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
+  - [x] Lines 219-223 (current stub `# Future: run_claude...`) replaced with four `if [ "$MODE" = ... ]` blocks: val, pr, code-review, merge
+  - [x] Each non-merge block guarded by: `[ "$MODE" = "all" ] || [ "$MODE" = "--<phase>-only" ] || [ "$MODE" = "--integrator-only" ]`
+  - [x] Merge block additionally guarded by `[ "$AUTO_MERGE" = "true" ]` so `just loop --merge-only` without auto-merge is a no-op
+  - [x] When `MODE=--merge-only` and `AUTO_MERGE=false`, an explicit warning is echoed (e.g., `"--merge-only requires --auto-merge or auto-merge=true; skipping merge phase"`) — not silent
+  - [x] Each phase calls `run_claude "/ralph-hero:ralph-<phase>" "<phase-name>"` and sets `work_done=true` on success
+  - [x] `grep -c "ralph-val\|ralph-pr\|ralph-code-review\|ralph-merge" plugin/ralph-hero/scripts/ralph-loop.sh` returns ≥ 4
+  - [x] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
 
 #### Task 4.4: Update justfile loop recipe with auto-merge parameter
 - **files**: `plugin/ralph-hero/justfile` (modify)
@@ -457,11 +457,11 @@ Extend `ralph-loop.sh` with the four integrator phases (val → pr → code-revi
 - **complexity**: low
 - **depends_on**: [4.1]
 - **acceptance**:
-  - [ ] `loop` recipe signature gains an `auto-merge="false"` parameter (last position)
-  - [ ] Recipe body conditionally appends `--auto-merge` to args when `{{auto-merge}}` is `"true"`
-  - [ ] `grep -c "auto-merge" plugin/ralph-hero/justfile` returns ≥ 2 (parameter + conditional)
-  - [ ] `just --list 2>&1 | grep -q "loop"` exits 0
-  - [ ] Backwards compat: invoking `just loop` (no args) still works (auto-merge defaults to `"false"`)
+  - [x] `loop` recipe signature gains an `auto-merge="false"` parameter (last position)
+  - [x] Recipe body conditionally appends `--auto-merge` to args when `{{auto-merge}}` is `"true"`
+  - [x] `grep -c "auto-merge" plugin/ralph-hero/justfile` returns ≥ 2 (parameter + conditional)
+  - [x] `just --list 2>&1 | grep -q "loop"` exits 0
+  - [x] Backwards compat: invoking `just loop` (no args) still works (auto-merge defaults to `"false"`)
 
 #### Task 4.5: Add val, pr, merge justfile recipes
 - **files**: `plugin/ralph-hero/justfile` (modify)
@@ -469,12 +469,12 @@ Extend `ralph-loop.sh` with the four integrator phases (val → pr → code-revi
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Three new recipes added after the `impl` recipe (around line 150): `val`, `pr`, `merge`
-  - [ ] Each follows the `dispatch "ralph-<name>"` shape used by other workflow recipes
-  - [ ] Each uses `DEFAULT_BUDGET=1.00 DEFAULT_TIMEOUT=10m`
-  - [ ] `[group('workflow')]` annotation on each
-  - [ ] `just --list 2>&1 | grep -cE "val|pr|merge|code-review"` returns ≥ 4 (val + pr + merge + code-review from Phase 3)
-  - [ ] `just --list 2>&1 | grep -q "val "` exits 0 (recipe parses)
+  - [x] Three new recipes added after the `impl` recipe (around line 150): `val`, `pr`, `merge`
+  - [x] Each follows the `dispatch "ralph-<name>"` shape used by other workflow recipes
+  - [x] Each uses `DEFAULT_BUDGET=1.00 DEFAULT_TIMEOUT=10m`
+  - [x] `[group('workflow')]` annotation on each
+  - [x] `just --list 2>&1 | grep -cE "val|pr|merge|code-review"` returns ≥ 4 (val + pr + merge + code-review from Phase 3)
+  - [x] `just --list 2>&1 | grep -q "val "` exits 0 (recipe parses)
 
 #### Task 4.6: Insert Step 4a Autonomous Merge Gate in ralph-merge
 - **files**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md` (modify)
@@ -482,26 +482,26 @@ Extend `ralph-loop.sh` with the four integrator phases (val → pr → code-revi
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] New Step 4a section inserted between existing Step 4 (Code Review Gate, line ~190) and Step 5 (Check PR Readiness)
-  - [ ] Section header: `## Step 4a: Autonomous Merge Gate`
-  - [ ] Body documents: only runs when `RALPH_AUTO_MERGE=true`; otherwise skipped entirely
-  - [ ] Documents commands: `gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'` and `gh pr checks PR_NUMBER --json name,state,conclusion`
-  - [ ] Documents merge criteria (ALL must be true): reviewDecision is APPROVED OR no review comments on XS issue; all CI `state: completed` AND `conclusion: success`; PR `OPEN` and `mergeable: MERGEABLE`
-  - [ ] On miss, outputs `AUTO-MERGE BLOCKED` block with `Issue:`, `PR:`, `Review:`, `CI:`, `Reason:` fields, then STOPs
-  - [ ] On pass, proceeds to Step 5 (existing flow)
-  - [ ] `grep -c "RALPH_AUTO_MERGE" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥ 2
-  - [ ] `grep -c "AUTO-MERGE BLOCKED" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥ 1
-  - [ ] `grep -c "gh pr checks" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥ 1
-  - [ ] No frontmatter changes (RALPH_AUTO_MERGE is read from env at runtime)
+  - [x] New Step 4a section inserted between existing Step 4 (Code Review Gate, line ~190) and Step 5 (Check PR Readiness)
+  - [x] Section header: `## Step 4a: Autonomous Merge Gate`
+  - [x] Body documents: only runs when `RALPH_AUTO_MERGE=true`; otherwise skipped entirely
+  - [x] Documents commands: `gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'` and `gh pr checks PR_NUMBER --json name,state,conclusion`
+  - [x] Documents merge criteria (ALL must be true): reviewDecision is APPROVED OR no review comments on XS issue; all CI `state: completed` AND `conclusion: success`; PR `OPEN` and `mergeable: MERGEABLE`
+  - [x] On miss, outputs `AUTO-MERGE BLOCKED` block with `Issue:`, `PR:`, `Review:`, `CI:`, `Reason:` fields, then STOPs
+  - [x] On pass, proceeds to Step 5 (existing flow)
+  - [x] `grep -c "RALPH_AUTO_MERGE" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥ 2
+  - [x] `grep -c "AUTO-MERGE BLOCKED" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥ 1
+  - [x] `grep -c "gh pr checks" plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns ≥ 1
+  - [x] No frontmatter changes (RALPH_AUTO_MERGE is read from env at runtime)
 
 ### Phase 4 Success Criteria
 
 #### Automated Verification:
-- [ ] All six Task acceptance grep checks pass
-- [ ] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
-- [ ] `just --list 2>&1 | grep -cE "val|pr|merge|code-review"` returns ≥ 4
-- [ ] `npm run build --prefix plugin/ralph-hero/mcp-server` — no errors
-- [ ] `npm test --prefix plugin/ralph-hero/mcp-server` — passes (no regressions)
+- [x] All six Task acceptance grep checks pass
+- [x] `bash -n plugin/ralph-hero/scripts/ralph-loop.sh` passes
+- [x] `just --list 2>&1 | grep -cE "val|pr|merge|code-review"` returns ≥ 4
+- [x] `npm run build --prefix plugin/ralph-hero/mcp-server` — no errors
+- [x] `npm test --prefix plugin/ralph-hero/mcp-server` — passes (no regressions)
 
 #### Manual Verification:
 - [ ] `just loop --integrator-only` on an "In Progress" issue with completed impl runs val → pr → code-review (no merge without auto-merge)


### PR DESCRIPTION
## Summary

Phase 4 of #731 (sub-issue #1018). Wires the val/pr/code-review/merge phases into `ralph-loop.sh` and adds an autonomous merge gate behind `RALPH_AUTO_MERGE=true`, completing the full autonomous loop.

- `ralph-loop.sh`: adds `--auto-merge` flag and `--val-only`, `--pr-only`, `--code-review-only`, `--merge-only` modes; explicit warning when `--merge-only` runs without auto-merge (addresses research note about silent no-op)
- `justfile`: `loop` recipe gains `auto-merge="false"` parameter; new `val`, `pr`, `merge` recipes
- `ralph-merge/SKILL.md`: new Step 4a "Autonomous Merge Gate" — gated on `RALPH_AUTO_MERGE=true`, checks review APPROVED + all CI green + PR OPEN+MERGEABLE, emits `AUTO-MERGE BLOCKED` on miss

After this lands, `just loop auto-merge=true` runs the full `hygiene → triage → split → research → plan → review → impl → val → pr → code-review → merge` pipeline unattended.

## Plan & review

- Plan: [2026-05-06-group-GH-1015-complete-autonomous-loop.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-06-group-GH-1015-complete-autonomous-loop.md) (Phase 4)
- Critique: [2026-05-05-GH-1015-critique.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-05-GH-1015-critique.md)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1100/1100 passing
- [x] `bash -n ralph-loop.sh` clean
- [x] All Phase 4 grep counts match acceptance
- [x] `just --list` shows new `val`, `pr`, `merge`, `code-review` recipes
- [x] Smoke: `--merge-only` without auto-merge emits explicit warning (not silent)
- [x] Smoke: `--merge-only --auto-merge` enters Merge Phase block
- [x] Default banner shows `Auto-merge: false` — safe-by-default preserved
- [ ] Manual: end-to-end `just loop auto-merge=true` against a live "In Progress" issue

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)