### PR TITLE
feat(security): GH-1032 add top-level permissions blocks to all workflows

### DIFF
--- a/.github/workflows/advance-parent.yml
+++ b/.github/workflows/advance-parent.yml
@@ -22,6 +22,11 @@ on:
         required: true
         type: number
 
+# Least-privilege permissions: GITHUB_TOKEN is read-only.
+# All writes (Workflow State updates, parent issue close) go through ROUTING_PAT.
+permissions:
+  contents: read
+
 jobs:
   advance-parent:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test-hero:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-knowledge.yml
+++ b/.github/workflows/release-knowledge.yml
@@ -31,6 +31,11 @@ concurrency:
   group: release-knowledge
   cancel-in-progress: false
 
+# Top-level default: read-only. The release job widens to contents: write +
+# id-token: write at the job level (needed for tag/push and npm provenance).
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: plugin/ralph-knowledge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+# Top-level default: read-only. The release job widens to contents: write +
+# id-token: write at the job level (needed for tag/push and npm provenance).
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: plugin/ralph-hero/mcp-server

--- a/.github/workflows/route-issues.yml
+++ b/.github/workflows/route-issues.yml
@@ -27,6 +27,12 @@ on:
         description: 'GitHub PAT with repo + project scopes'
         required: true
 
+# Least-privilege permissions: GITHUB_TOKEN is read-only here.
+# All Projects V2 + issue label/comment writes go through ROUTING_PAT.
+permissions:
+  contents: read
+  issues: read
+
 # Prevent concurrent routing for the same issue/PR.
 # cancel-in-progress: false ensures a routing run isn't killed mid-mutation.
 concurrency:

--- a/.github/workflows/sync-issue-state.yml
+++ b/.github/workflows/sync-issue-state.yml
@@ -34,6 +34,11 @@ on:
           - Canceled
           - Backlog
 
+# Least-privilege permissions: GITHUB_TOKEN is read-only.
+# All writes (Workflow State updates) go through ROUTING_PAT.
+permissions:
+  contents: read
+
 concurrency:
   group: sync-issue-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: false

--- a/.github/workflows/sync-pr-merge.yml
+++ b/.github/workflows/sync-pr-merge.yml
@@ -27,6 +27,11 @@ on:
         required: true
         type: number
 
+# Least-privilege permissions: GITHUB_TOKEN is read-only.
+# All writes (Workflow State updates) go through ROUTING_PAT.
+permissions:
+  contents: read
+
 concurrency:
   group: pr-merge-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false

--- a/.github/workflows/sync-project-state.yml
+++ b/.github/workflows/sync-project-state.yml
@@ -16,6 +16,11 @@ on:
   repository_dispatch:
     types: [project-item-workflow-state-changed]
 
+# Least-privilege permissions: GITHUB_TOKEN is read-only.
+# All writes (Workflow State propagation) go through ROUTING_PAT.
+permissions:
+  contents: read
+
 concurrency:
   group: sync-project-state-${{ github.event.inputs.content_node_id || github.event.client_payload.content_node_id }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary

Adds a top-level `permissions:` block to every `.github/workflows/*.yml`, defaulting `GITHUB_TOKEN` to `contents: read` (least privilege). Widens only where the workflow demonstrably needs more.

Closes #1032. Part of the security-hardening epic #1027.

## Per-file rationale

| Workflow | Top-level perms | Notes |
|---|---|---|
| `ci.yml` | `contents: read` | Pure build/test — no writes. |
| `route-issues.yml` | `contents: read`, `issues: read` | Reads issue/PR metadata. All writes (labels, project mutations) go through `ROUTING_PAT`. |
| `sync-issue-state.yml` | `contents: read` | All Workflow-State writes go through `ROUTING_PAT` (`GH_TOKEN: secrets.ROUTING_PAT`). |
| `sync-pr-merge.yml` | `contents: read` | Same — `GH_TOKEN: secrets.ROUTING_PAT`. |
| `sync-project-state.yml` | `contents: read` | Same — Node script uses `SYNC_PAT` (=`ROUTING_PAT`). |
| `advance-parent.yml` | `contents: read` | Same — including `gh issue close` is via `ROUTING_PAT`. |
| `release.yml` | `contents: read` (top-level) | Existing job-level `permissions: { contents: write, id-token: write }` preserved — needed for tag/push and npm provenance. `gh release create` uses `secrets.GITHUB_TOKEN` covered by job-level `contents: write`. |
| `release-knowledge.yml` | `contents: read` (top-level) | Same pattern as `release.yml`. |

## GITHUB_TOKEN write audit

Audited each workflow for any write operation that uses `secrets.GITHUB_TOKEN` (rather than `ROUTING_PAT`):

- **release.yml / release-knowledge.yml**: `gh release create` and `git push --tags` use `GITHUB_TOKEN` — already covered by job-level `contents: write`. No change needed.
- **All sync/route/advance workflows**: Writes are funneled exclusively through `ROUTING_PAT`. The default `GITHUB_TOKEN` is unused for writes, so `contents: read` is safe.
- **ci.yml**: No write operations whatsoever.

No silent reliance on the default `write-all` token was found.

## Test plan

- [ ] PR's own CI run (`ci.yml`) passes — proves `contents: read` is sufficient for build/test.
- [ ] After merge, observe next `route-issues` / `sync-*` / `advance-parent` runs succeed with `ROUTING_PAT`-driven writes (no permission-denied errors).
- [ ] Next release run (`release.yml` or `release-knowledge.yml`) succeeds — proves job-level overrides still grant tag-push + npm provenance.

## Blocks / unblocks

This unblocks #1033 (S6: SHA-pin GitHub Actions to commit SHAs) — SHA-pinning should land on top of permission-scoped workflows so any compromised action runs with minimum blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)