### PR TITLE
docs(security): GH-1039 audit MCP tool input validation

### DIFF
--- a/thoughts/shared/research/2026-05-05-GH-1039-mcp-input-validation-audit.md
+++ b/thoughts/shared/research/2026-05-05-GH-1039-mcp-input-validation-audit.md
@@ -1,0 +1,175 @@
+---
+date: 2026-05-05
+status: complete
+type: research
+tags: [security, mcp, input-validation, audit]
+github_issue: 1039
+---
+
+# GH-1039: MCP tool input validation audit
+
+## Scope
+
+- All files in `plugin/ralph-hero/mcp-server/src/tools/*.ts` (13 files, 33 tool registrations).
+- All `client.query()`, `client.mutate()`, `client.projectQuery()`, `client.projectMutate()` call sites in `plugin/ralph-hero/mcp-server/src/`.
+
+## Threat model
+
+The MCP server runs locally as a child process of Claude Code. The credible attacker is a malicious or hijacked prompt that flows into a tool call, not a network attacker. Concretely:
+
+- **GraphQL injection**: prompt-controlled string interpolated into a GraphQL operation body, allowing schema-level access beyond the intended operation. Mitigated by Octokit parameterization when values flow through the second-arg `variables` object.
+- **Path traversal**: prompt-controlled path argument used by `fs.readFile` / `fs.readdir`. Note: the MCP process has the user's filesystem privileges, so traversal does not escape any sandbox; it just lets a hostile prompt read files the user could read anyway. Severity ceiling is therefore "info / hardening" unless a tool also exfiltrates the content somewhere durable.
+- **Shell/command injection**: any `execSync` / `spawn` with user input.
+- **Type confusion**: Zod schemas accepting `z.any()` / `z.unknown()` that flow into GraphQL or shell.
+
+## Methodology
+
+Grep patterns used:
+
+| Pattern | Purpose |
+|---|---|
+| `client\.(query\|mutate\|projectQuery\|projectMutate)` | Enumerate every GraphQL call site |
+| `z\.(any\|unknown)\(\)` | Detect weak Zod schemas |
+| `\$\{[a-zA-Z_]` inside GraphQL bodies | Detect string-interpolated query construction |
+| `fs\.\|readFile\|writeFile\|exec\|spawn` | Detect filesystem / shell sinks |
+| `owner: z\.string\|repo: z\.string` | Map owner/repo passthrough surface |
+| `mutationString\|buildBatchMutationQuery\|buildBatchArchiveMutation\|buildBatchFieldValueQuery` | Audit dynamic query builders |
+| `server\.tool\(` | Count tool registrations per module |
+
+## Call site inventory
+
+GraphQL operations per source file (production code only; tests excluded):
+
+| File | query | mutate | projectQuery | projectMutate | Notes |
+|---|---|---|---|---|---|
+| `index.ts` | 1 | 0 | 1 | 0 | startup health checks |
+| `tools/issue-tools.ts` | 7 | 4 | 0 | 2 | + 2 `projectMutate(mutationString,...)` from `buildBatchMutationQuery` |
+| `tools/project-tools.ts` | 3 | 0 | 4 | 4 | |
+| `tools/relationship-tools.ts` | 6 | 3 | 1 (callback) | 0 | |
+| `tools/project-management-tools.ts` | 1 | 0 | 4 | 7 | + 1 `projectMutate(mutationString,...)` from `buildBatchArchiveMutation` |
+| `tools/dashboard-tools.ts` | 0 | 0 | 3 | 0 | |
+| `tools/batch-tools.ts` | 2 | 0 | 0 | 1 | + 1 `projectMutate(mutationString,...)` from `buildBatchMutationQuery` |
+| `tools/decompose-tools.ts` | 2 | 2 | 0 | 1 | |
+| `tools/debug-tools.ts` | 1 | 2 | 0 | 0 | only registered when `RALPH_DEBUG=true` |
+| `tools/plan-graph-tools.ts` | 1 | 2 | 0 | 0 | also reads filesystem (see findings) |
+| `tools/hygiene-tools.ts` | 0 | 0 | 1 (callback) | 0 | |
+| `tools/directions-tools.ts` | 0 | 0 | 1 (callback) | 0 | |
+| `tools/view-tools.ts` | 0 | 0 | 0 | 0 | |
+| `tools/activity-tools.ts` | 0 | 0 | 0 | 0 | filesystem only, no GraphQL |
+| `lib/helpers.ts` | 6 | 0 | 2 | 1 | shared resolver helpers |
+| `lib/group-detection.ts` | 2 | 0 | 0 | 0 | |
+| `lib/registry-loader.ts` | 1 | 0 | 0 | 0 | |
+| **Totals** | **33** | **13** | **17** | **16** | **+ 4 dynamically-built `projectMutate` calls** |
+
+**Parameterization style**: every call site inspected uses Octokit's two-argument form `client.xxx(queryString, variablesObject)`. Variable references inside the query string are GraphQL `$name` placeholders; concrete values flow through the second argument and are bound by the GraphQL transport. No call site passes user-controlled data through string concatenation or template-literal interpolation into the operation body.
+
+## Dynamic GraphQL builders
+
+Three helpers in `tools/batch-tools.ts` construct mutation/query strings via template-literal concatenation:
+
+- `buildBatchMutationQuery(projectId, updates[])` — builds aliased `updateProjectV2ItemFieldValue` calls.
+- `buildBatchArchiveMutation(projectId, itemIds[])` — builds aliased `archiveProjectV2Item` calls.
+- `buildBatchFieldValueQuery(projectItemIds[])` — builds aliased `node(id:)` lookups.
+
+For each, the only fragments interpolated into the query body are:
+
+1. The literal field/option/item *variable names* (`$item_${alias}`, `$opt_${alias}`, `$id_${alias}`, etc.).
+2. The `alias` strings themselves, used as GraphQL aliases (`${alias}: updateProjectV2ItemFieldValue(...)`).
+3. The `valueType` discriminator (`singleSelectOptionId` or `iterationId`), constrained by a TypeScript union.
+
+Aliases originate at all call sites from server-controlled counters (e.g., `ws_${opIdx}`, `est_${opIdx}`, `u${num}_${opIdx}`, `s${num}_${opIdx}`, `fv${num}`, `a${i}`) where `opIdx`, `num`, and `i` are numeric. **No user-controlled string is ever interpolated into a GraphQL alias or selection set.** Real values (project IDs, item IDs, field IDs, option IDs) all flow through the variables object.
+
+## Findings
+
+### F1 — `planPath` accepts arbitrary filesystem paths (LOW)
+
+**File**: `plugin/ralph-hero/mcp-server/src/tools/plan-graph-tools.ts:87-103`
+**Tool**: `ralph_hero__sync_plan_graph`
+
+```ts
+planPath: z.string().describe("Absolute path to the plan markdown document"),
+...
+content = await readFile(args.planPath, "utf-8");
+```
+
+The path is passed straight to `fs.readFile` with no normalization, no allow-listing, and no extension check. A hostile prompt can direct the tool at any file the MCP process can read (e.g., `~/.ssh/id_rsa`, `~/.aws/credentials`, browser cookie databases).
+
+The file *content* is then passed to `parsePlanGraph`. Reading the parser:
+
+- `parsePlanGraph` extracts the YAML frontmatter and looks for `github_issues`. If frontmatter is missing or empty, the tool returns `toolError("Plan has no github_issues in frontmatter...")` with no file content leakage.
+- Otherwise, the tool computes a graph diff and either returns a JSON summary (which echoes only issue numbers, not file content) or performs `addDependency` mutations.
+
+**Exfiltration risk**: low. The tool's output to the caller does not echo arbitrary file content; the worst leak is "this file existed and parsed as YAML / it didn't." Error messages from `readFile` failures (`ENOENT`, `EACCES`) reveal existence/permission state, which is a minor information disclosure.
+
+**Recommended fix (deferred)**: in a follow-up, restrict `planPath` to paths under the user's repo root or a configured allow-list (e.g., `process.cwd()` + `thoughts/`). Not fixing here because (a) severity is low, (b) the tool's legitimate use case is "plan files anywhere on disk," and (c) the proper fix probably belongs in a broader sandbox boundary that the MCP server doesn't currently have.
+
+**Disposition**: accepted risk for this PR; recommend a follow-up issue if/when the security baseline tightens.
+
+### F2 — `client.query<any>` in `list_sub_issues` (INFO)
+
+**File**: `plugin/ralph-hero/mcp-server/src/tools/relationship-tools.ts:281`
+
+```ts
+const result = await client.query<any>(queryStr, { owner, repo, number: args.number });
+```
+
+This is a TypeScript hygiene issue, not a runtime injection: the query body and variables are built from the recursion-bounded `buildSubIssueFragment(1, depth)` (depth clamped to 1-3 at line 262) and from properly-parameterized `owner`/`repo`/`number` variables. The `any` only weakens compile-time type checking on the response shape.
+
+**Disposition**: not fixing. Annotating a proper recursive type for the dynamic-depth response is mechanical busywork; the eslint-disable comment is already in place and the runtime behavior is safe.
+
+### F3 — `${ownerType}` interpolation in startup health check (INFO)
+
+**File**: `plugin/ralph-hero/mcp-server/src/index.ts:268-296`
+
+```ts
+for (const ownerType of ["user", "organization"]) {
+  ... `query($owner: String!, $number: Int!) {
+        ${ownerType}(login: $owner) { ... }
+      }` ...
+}
+```
+
+`ownerType` is iterated from a hardcoded two-element array. Not user-controlled. Flagged here so it does not appear "fixed" in a future grep without an explanation.
+
+**Disposition**: no action.
+
+### F4 — Owner/repo passthrough validates only the type (INFO)
+
+Across `issue-tools.ts`, `relationship-tools.ts`, `project-management-tools.ts`, `project-tools.ts`, the `owner` and `repo` parameters are typed `z.string().optional()` with no shape constraint (e.g., no regex restricting to `[a-zA-Z0-9-_.]`).
+
+Auditing every call site: `owner` and `repo` only ever flow into the `variables` object of `client.query(...)`. They are never interpolated into a query body, file path, or shell command. The only string-construction sites are error messages (`"Repository ${owner}/${repo} not found"`) and cache keys (`issue-node-id:${owner}/${repo}#${number}`) — neither is a sink.
+
+The cache key is interesting: a hostile prompt could supply `owner = "evil/../../"` and shape cache key collisions. The `SessionCache` is in-process only, the cache is keyed by string equality, and the only consumers re-resolve via authoritative GraphQL on miss. Cache poisoning would only affect the current process and is bounded by the user's own GraphQL credentials.
+
+**Disposition**: no action. Adding format validation would break legitimate edge cases (dotted owners, etc.) without a corresponding security gain.
+
+### F5 — `client.projectQuery<Record<string, unknown>>` in batch_get_drafts (INFO)
+
+**File**: `plugin/ralph-hero/mcp-server/src/tools/project-management-tools.ts:362-364`
+
+The dynamic aliased query has the same shape as the batch-tools builders: aliases like `draft${i}` and `item${i}` (numeric counter), variable names `diId${i}` / `pvtiId${i}`, and IDs flowing through the variables object. Pre-validation of ID prefix at line 288-294 (`DI_` or `PVTI_`) provides defense in depth.
+
+**Disposition**: no action.
+
+## Schemas verified clean
+
+- No `z.any()` or `z.unknown()` in any tool registration in production source.
+- All GraphQL ID parameters that accept user input (issue numbers, project numbers) are typed as numbers (`z.coerce.number()` / `z.number().int()`) and flow through GraphQL variables.
+- All enum-like parameters (`workflowState`, `estimate` (XS/S/M/L/XL), `priority` (P0-P3), `state` (OPEN/CLOSED), `category` (work/meta/all)) use either `z.enum([...])` or downstream resolver tables that reject unknown values.
+- `view-tools.ts` and `activity-tools.ts` have no GraphQL surface; activity-tools constrains arrays/limits explicitly.
+
+## Disposition summary
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| F1 — `planPath` arbitrary path | LOW | Accepted risk; follow-up if sandbox boundary tightens |
+| F2 — `client.query<any>` in list_sub_issues | INFO | Not fixing (TS hygiene, not security) |
+| F3 — Health-check `${ownerType}` interpolation | INFO | Documented; no action |
+| F4 — owner/repo string format unbound | INFO | Documented; no action |
+| F5 — `Record<string, unknown>` in batch_get_drafts | INFO | Documented; no action |
+
+**No high-severity findings. No code changes shipped in this PR.** The MCP server's input-validation surface is in good shape: every GraphQL operation observed flows user input through Octokit's parameterized `variables` argument; no template-literal injection paths exist; no `z.any()` / `z.unknown()` schemas exist in production tool registrations; the only filesystem-read tool with user-controlled paths (`sync_plan_graph`) does not exfiltrate file contents in its responses.
+
+## Follow-ups
+
+None blocking. If/when a broader sandbox effort lands, revisit F1 for `planPath` constraint.

--- a/thoughts/shared/research/2026-05-05-security-hardening-design.md
+++ b/thoughts/shared/research/2026-05-05-security-hardening-design.md
@@ -1,0 +1,249 @@
+---
+date: 2026-05-05
+status: complete
+type: research
+tags: [security, hardening, github-actions, dependabot, codeql, supply-chain, oidc, npm-publish]
+github_issue: 1027
+github_url: https://github.com/cdubiel08/ralph-hero/issues/1027
+children: [1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039]
+---
+
+# Security Hardening Design
+
+Lift the ralph-hero repo to a strong baseline for a public, npm-publishing, multi-plugin codebase by leaning on GitHub-native automation wherever possible. Prefer configuration over custom code; defer hand-rolled solutions only when GitHub does not offer one.
+
+This spec is intentionally structured as **independent sections that map 1:1 to splittable sub-issues**. The split agent should be able to slice this into 9-12 atomic tickets without rewriting requirements.
+
+## Goals
+
+- Establish a documented security posture (vuln reporting, branch protection, dependency policy)
+- Eliminate floating-tag and over-scoped-token risks in CI/CD
+- Replace long-lived publish secrets with OIDC where supported
+- Add automated detection for vulnerable deps, insecure code patterns, and unsafe workflow configs
+- Audit the two custom-code surfaces (Bash hooks, MCP tool inputs) once, then rely on automation going forward
+
+## Non-Goals
+
+- Rewriting the MCP tool layer or hook architecture
+- Migrating off `ROUTING_PAT` if a viable GitHub App path doesn't exist for Projects V2
+- Securing downstream consumer projects (`thoughts/`, `gemma-lab`, etc.)
+- Runtime sandbox redesign for the worktree/hook system
+
+## Current State (verified 2026-05-05)
+
+| Surface | Status |
+|---|---|
+| Secret scanning | enabled |
+| Push protection | enabled |
+| Dependabot security updates | **disabled** |
+| Dependabot version updates | **no `dependabot.yml`** |
+| CodeQL | **not configured** |
+| `SECURITY.md` / private vuln reporting | **missing** |
+| Workflow `permissions:` blocks | only `release.yml` and `release-knowledge.yml` |
+| Action pinning | floating major tags (`@v4`, `@v2`) across all workflows |
+| npm publish auth | classic `NPM_TOKEN` secret |
+| Projects V2 PAT (`ROUTING_PAT`) | used by 5 workflows; no rotation policy documented |
+| Branch protection on `main` | **not yet audited** |
+| Bash hook input handling | **never security-reviewed** |
+
+## Design
+
+The work breaks into four tiers. Each section is self-contained: title, scope, deliverables, verification. Sections are ordered by leverage (Tier 1 = highest leverage / lowest effort).
+
+---
+
+### Tier 1 — Free GitHub-native baseline
+
+#### S1. Enable Dependabot version + security updates
+
+**Scope:** Add `.github/dependabot.yml` covering all 5 npm ecosystems and GitHub Actions.
+
+**Deliverables:**
+- `.github/dependabot.yml` with package-ecosystem entries for:
+  - `plugin/ralph-hero/mcp-server` (npm)
+  - `plugin/ralph-knowledge` (npm)
+  - `plugin/ralph-demo/remotion` (npm, pnpm-aware)
+  - `.github/scripts/sync` (npm)
+  - `scripts/routing` (npm)
+  - `github-actions` at repo root
+- Weekly schedule, grouped minor/patch updates, security updates ungrouped (immediate)
+- Enable "Dependabot security updates" toggle in repo settings (verify via API)
+
+**Verification:** `gh api repos/:owner/:repo --jq '.security_and_analysis.dependabot_security_updates.status'` returns `enabled`. First Dependabot PR opens within one week.
+
+#### S2. Enable CodeQL default setup
+
+**Scope:** Turn on GitHub-managed CodeQL for JavaScript/TypeScript.
+
+**Deliverables:**
+- Enable "default setup" via repo Security tab (no custom workflow file unless default setup misses paths — re-evaluate after first scan)
+- Document any path exclusions in `SECURITY.md`
+- Triage initial findings into one tracking issue per finding category
+
+**Verification:** CodeQL workflow runs on PR + weekly cron. First scan completes; findings visible under Security → Code scanning.
+
+#### S3. Add `SECURITY.md` and enable private vulnerability reporting
+
+**Scope:** Document supported versions, reporting channel, response SLA.
+
+**Deliverables:**
+- `SECURITY.md` at repo root: supported versions table (current major only — npm packages auto-released), report via GitHub's "Report a vulnerability" button, 7-day acknowledgement SLA
+- Enable "Private vulnerability reporting" in repo settings
+- Reference `SECURITY.md` from `README.md`
+
+**Verification:** "Report a vulnerability" button appears under repo Security tab. `gh api` shows the feature enabled.
+
+#### S4. Audit and document `main` branch protection
+
+**Scope:** Verify protections match intent; document the policy.
+
+**Deliverables:**
+- Required: PR review (≥1), required status checks (CI matrix jobs from `ci.yml`), dismiss stale reviews on push, require linear history, require conversation resolution, restrict force-push and deletion, include admins
+- Document the ruleset in `SECURITY.md` ("Branch protection" section)
+- Capture the current ruleset to `thoughts/shared/research/` for change tracking
+
+**Verification:** `gh api repos/:owner/:repo/branches/main/protection` matches documented ruleset.
+
+---
+
+### Tier 2 — Workflow hardening
+
+#### S5. Add least-privilege `permissions:` blocks to every workflow
+
+**Scope:** Top-level `permissions:` block in every `.github/workflows/*.yml`, set to `contents: read` by default; widen per-job only where required.
+
+**Deliverables:**
+- Edit each workflow file. Audit existing scopes:
+  - `ci.yml` → `contents: read`
+  - `route-issues.yml` → `contents: read, issues: read` (PAT does the writes)
+  - `sync-issue-state.yml`, `sync-pr-merge.yml`, `sync-project-state.yml`, `advance-parent.yml` → `contents: read` (PAT does writes)
+  - `release.yml`, `release-knowledge.yml` → keep existing job-level `permissions:` block (already explicit)
+- Confirm no workflow silently relied on the default `write-all` token
+
+**Verification:** All workflows still pass on a test PR. `gh api` workflow runs show no permission-denied errors.
+
+#### S6. Pin GitHub Actions to commit SHAs
+
+**Scope:** Replace floating tags (`@v4`, `@v2`, `@2.0.0`) with full commit SHAs + version comment.
+
+**Deliverables:**
+- Pin: `actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, `extractions/setup-just`, `bats-core/bats-action` (and any added later)
+- Format: `uses: actions/checkout@<sha> # v4.2.2`
+- Dependabot will keep these updated (S1 covers `package-ecosystem: github-actions`)
+
+**Verification:** `grep -E '@v[0-9]' .github/workflows/*.yml` returns no results. CI passes on PR.
+
+#### S7. Add `actionlint` and `zizmor` to CI
+
+**Scope:** Static analysis for workflow files — catches script-injection, missing permissions, unsafe `pull_request_target` patterns.
+
+**Deliverables:**
+- New job in `ci.yml` that runs `rhysd/actionlint` and `woodruffw/zizmor` against `.github/workflows/`
+- Required check on `main`
+- Resolve any findings inline before merge
+
+**Verification:** New CI job runs and is green on the same PR that introduces it.
+
+---
+
+### Tier 3 — Token reduction
+
+#### S8. Migrate npm publish to OIDC trusted publishing
+
+**Scope:** Replace `NPM_TOKEN` secret with npm's OIDC trusted-publisher flow for both `ralph-hero-mcp-server` and the ralph-knowledge package.
+
+**Deliverables:**
+- Configure trusted publisher on npmjs.com for both packages, scoped to this repo + `release.yml` / `release-knowledge.yml`
+- Update workflows: drop `NODE_AUTH_TOKEN`, add `id-token: write` permission, ensure `npm publish --provenance` continues to work (it does — provenance + OIDC are bundled)
+- After successful publish, **remove** `NPM_TOKEN` from repo secrets
+- Document the rotation/revocation flow in `SECURITY.md`
+
+**Verification:** Next auto-release publishes successfully. `npm view <pkg>` shows provenance attestation linked to the workflow run. `NPM_TOKEN` no longer in `gh secret list`.
+
+#### S9. Evaluate GitHub App alternative for `ROUTING_PAT`
+
+**Scope:** **Research-only ticket** — produce a recommendation, not necessarily a migration.
+
+**Deliverables:**
+- Research doc in `thoughts/shared/research/` covering:
+  - Whether a GitHub App can write to Projects V2 (it can, with `organization_projects: write` or `projects: write` on user scope)
+  - Comparison of App vs PAT: rotation, blast radius, audit trail, friction for self-hosters
+  - Recommendation: migrate / keep PAT with documented rotation / hybrid
+- If recommendation is "keep PAT": add a documented rotation cadence + calendar reminder; otherwise spawn a follow-up implementation issue
+
+**Verification:** Research doc merged. Follow-up issue created (or rotation policy documented), whichever the recommendation calls for.
+
+---
+
+### Tier 4 — Targeted code-level audits
+
+#### S10. CodeQL findings triage pass
+
+**Scope:** First-pass review of CodeQL output from S2.
+
+**Deliverables:**
+- Per finding category: fix, suppress with justification, or convert to tracking issue
+- One summary comment on the parent epic listing what was done
+
+**Verification:** All initial CodeQL alerts are either resolved or have a documented disposition.
+
+#### S11. Bash hook security audit
+
+**Scope:** One-time review of all 50+ scripts under `plugin/ralph-hero/hooks/` for command injection, unquoted expansions, and unsafe handling of tool-input JSON.
+
+**Deliverables:**
+- Audit findings doc in `thoughts/shared/research/`
+- Add `shellcheck` to `ci.yml` against `plugin/ralph-hero/hooks/**/*.sh` (covers regressions going forward — this is the GitHub-automation lean)
+- Fix any high-severity findings inline; file follow-up issues for low/medium
+
+**Verification:** `shellcheck` job green in CI. Audit doc merged.
+
+#### S12. MCP tool input validation review
+
+**Scope:** Audit `plugin/ralph-hero/mcp-server/src/tools/` Zod schemas + GraphQL string interpolation for injection paths.
+
+**Deliverables:**
+- Spot-check every `client.query()` / `client.mutate()` call site for user-controlled string concatenation into GraphQL bodies (Octokit parameterizes variables, but template-literal patterns can sneak past)
+- Verify Zod schemas reject unexpected types at every public tool entry
+- Fixes inline; findings doc only if patterns warrant
+
+**Verification:** Review checklist completed; any fixes ship in one PR.
+
+---
+
+## Dependencies and Ordering
+
+```
+S1 (Dependabot) ──┐
+S2 (CodeQL) ──────┼──> S10 (triage) ──┐
+S3 (SECURITY.md) ─┤                   │
+S4 (branch prot) ─┘                   │
+                                       ├──> Done
+S5 (permissions) ──> S6 (pin SHAs) ──> S7 (actionlint) ──┤
+                                                          │
+S8 (npm OIDC) ────────────────────────────────────────────┤
+S9 (App research) ────────────────────────────────────────┤
+                                                          │
+S11 (hook audit) ─────────────────────────────────────────┤
+S12 (MCP audit) ──────────────────────────────────────────┘
+```
+
+S1-S4 can ship in parallel. S5 must precede S6 (permissions explicit before pinning surfaces blast-radius questions). S6 must precede S7 (actionlint will flag unpinned actions). S10 is gated by S2.
+
+## Splittability Notes for the Split Agent
+
+Each S-numbered section is a candidate atomic issue:
+- **Estimate:** S1, S3, S4, S5, S6, S7, S8 are XS-S; S2 is XS (default setup is one toggle); S9, S11 are S-M (research-heavy); S10, S12 are M (depends on findings volume)
+- **File ownership is disjoint** across S1-S8 — they can run in parallel waves without merge conflicts
+- **Parent epic** should track completion; close when S1-S12 are all Done or have explicit deferral rationale
+
+## Out of Scope / Explicit Deferrals
+
+- OpenSSF Scorecard workflow — useful but redundant once S1-S7 land; revisit after baseline is in place
+- SLSA Level 3+ provenance — npm provenance from S8 gets us SLSA L2; L3 needs reusable workflows, deferred
+- Sigstore / cosign signing of release artifacts — npm provenance covers the npm artifact; binary signing not relevant (no binaries shipped)
+- Signed commits requirement — possible quality-of-life add but not security-critical for a public repo with PR-only merges
+
+## Prior Work
+
+Bridged from original superpowers spec: `thoughts/shared/specs/2026-05-05-security-hardening-design.md`

--- a/thoughts/shared/specs/2026-05-05-security-hardening-design.md
+++ b/thoughts/shared/specs/2026-05-05-security-hardening-design.md
@@ -1,0 +1,243 @@
+---
+date: 2026-05-05
+status: draft
+type: spec
+tags: [security, hardening, github-actions, dependabot, codeql, supply-chain]
+github_issues: []
+---
+
+# Security Hardening Design
+
+Lift the ralph-hero repo to a strong baseline for a public, npm-publishing, multi-plugin codebase by leaning on GitHub-native automation wherever possible. Prefer configuration over custom code; defer hand-rolled solutions only when GitHub does not offer one.
+
+This spec is intentionally structured as **independent sections that map 1:1 to splittable sub-issues**. The split agent should be able to slice this into 9-12 atomic tickets without rewriting requirements.
+
+## Goals
+
+- Establish a documented security posture (vuln reporting, branch protection, dependency policy)
+- Eliminate floating-tag and over-scoped-token risks in CI/CD
+- Replace long-lived publish secrets with OIDC where supported
+- Add automated detection for vulnerable deps, insecure code patterns, and unsafe workflow configs
+- Audit the two custom-code surfaces (Bash hooks, MCP tool inputs) once, then rely on automation going forward
+
+## Non-Goals
+
+- Rewriting the MCP tool layer or hook architecture
+- Migrating off `ROUTING_PAT` if a viable GitHub App path doesn't exist for Projects V2
+- Securing downstream consumer projects (`thoughts/`, `gemma-lab`, etc.)
+- Runtime sandbox redesign for the worktree/hook system
+
+## Current State (verified 2026-05-05)
+
+| Surface | Status |
+|---|---|
+| Secret scanning | enabled |
+| Push protection | enabled |
+| Dependabot security updates | **disabled** |
+| Dependabot version updates | **no `dependabot.yml`** |
+| CodeQL | **not configured** |
+| `SECURITY.md` / private vuln reporting | **missing** |
+| Workflow `permissions:` blocks | only `release.yml` and `release-knowledge.yml` |
+| Action pinning | floating major tags (`@v4`, `@v2`) across all workflows |
+| npm publish auth | classic `NPM_TOKEN` secret |
+| Projects V2 PAT (`ROUTING_PAT`) | used by 5 workflows; no rotation policy documented |
+| Branch protection on `main` | **not yet audited** |
+| Bash hook input handling | **never security-reviewed** |
+
+## Design
+
+The work breaks into four tiers. Each section is self-contained: title, scope, deliverables, verification. Sections are ordered by leverage (Tier 1 = highest leverage / lowest effort).
+
+---
+
+### Tier 1 — Free GitHub-native baseline
+
+#### S1. Enable Dependabot version + security updates
+
+**Scope:** Add `.github/dependabot.yml` covering all 5 npm ecosystems and GitHub Actions.
+
+**Deliverables:**
+- `.github/dependabot.yml` with package-ecosystem entries for:
+  - `plugin/ralph-hero/mcp-server` (npm)
+  - `plugin/ralph-knowledge` (npm)
+  - `plugin/ralph-demo/remotion` (npm, pnpm-aware)
+  - `.github/scripts/sync` (npm)
+  - `scripts/routing` (npm)
+  - `github-actions` at repo root
+- Weekly schedule, grouped minor/patch updates, security updates ungrouped (immediate)
+- Enable "Dependabot security updates" toggle in repo settings (verify via API)
+
+**Verification:** `gh api repos/:owner/:repo --jq '.security_and_analysis.dependabot_security_updates.status'` returns `enabled`. First Dependabot PR opens within one week.
+
+#### S2. Enable CodeQL default setup
+
+**Scope:** Turn on GitHub-managed CodeQL for JavaScript/TypeScript.
+
+**Deliverables:**
+- Enable "default setup" via repo Security tab (no custom workflow file unless default setup misses paths — re-evaluate after first scan)
+- Document any path exclusions in `SECURITY.md`
+- Triage initial findings into one tracking issue per finding category
+
+**Verification:** CodeQL workflow runs on PR + weekly cron. First scan completes; findings visible under Security → Code scanning.
+
+#### S3. Add `SECURITY.md` and enable private vulnerability reporting
+
+**Scope:** Document supported versions, reporting channel, response SLA.
+
+**Deliverables:**
+- `SECURITY.md` at repo root: supported versions table (current major only — npm packages auto-released), report via GitHub's "Report a vulnerability" button, 7-day acknowledgement SLA
+- Enable "Private vulnerability reporting" in repo settings
+- Reference `SECURITY.md` from `README.md`
+
+**Verification:** "Report a vulnerability" button appears under repo Security tab. `gh api` shows the feature enabled.
+
+#### S4. Audit and document `main` branch protection
+
+**Scope:** Verify protections match intent; document the policy.
+
+**Deliverables:**
+- Required: PR review (≥1), required status checks (CI matrix jobs from `ci.yml`), dismiss stale reviews on push, require linear history, require conversation resolution, restrict force-push and deletion, include admins
+- Document the ruleset in `SECURITY.md` ("Branch protection" section)
+- Capture the current ruleset to `thoughts/shared/research/` for change tracking
+
+**Verification:** `gh api repos/:owner/:repo/branches/main/protection` matches documented ruleset.
+
+---
+
+### Tier 2 — Workflow hardening
+
+#### S5. Add least-privilege `permissions:` blocks to every workflow
+
+**Scope:** Top-level `permissions:` block in every `.github/workflows/*.yml`, set to `contents: read` by default; widen per-job only where required.
+
+**Deliverables:**
+- Edit each workflow file. Audit existing scopes:
+  - `ci.yml` → `contents: read`
+  - `route-issues.yml` → `contents: read, issues: read` (PAT does the writes)
+  - `sync-issue-state.yml`, `sync-pr-merge.yml`, `sync-project-state.yml`, `advance-parent.yml` → `contents: read` (PAT does writes)
+  - `release.yml`, `release-knowledge.yml` → keep existing job-level `permissions:` block (already explicit)
+- Confirm no workflow silently relied on the default `write-all` token
+
+**Verification:** All workflows still pass on a test PR. `gh api` workflow runs show no permission-denied errors.
+
+#### S6. Pin GitHub Actions to commit SHAs
+
+**Scope:** Replace floating tags (`@v4`, `@v2`, `@2.0.0`) with full commit SHAs + version comment.
+
+**Deliverables:**
+- Pin: `actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, `extractions/setup-just`, `bats-core/bats-action` (and any added later)
+- Format: `uses: actions/checkout@<sha> # v4.2.2`
+- Dependabot will keep these updated (S1 covers `package-ecosystem: github-actions`)
+
+**Verification:** `grep -E '@v[0-9]' .github/workflows/*.yml` returns no results. CI passes on PR.
+
+#### S7. Add `actionlint` and `zizmor` to CI
+
+**Scope:** Static analysis for workflow files — catches script-injection, missing permissions, unsafe `pull_request_target` patterns.
+
+**Deliverables:**
+- New job in `ci.yml` that runs `rhysd/actionlint` and `woodruffw/zizmor` against `.github/workflows/`
+- Required check on `main`
+- Resolve any findings inline before merge
+
+**Verification:** New CI job runs and is green on the same PR that introduces it.
+
+---
+
+### Tier 3 — Token reduction
+
+#### S8. Migrate npm publish to OIDC trusted publishing
+
+**Scope:** Replace `NPM_TOKEN` secret with npm's OIDC trusted-publisher flow for both `ralph-hero-mcp-server` and the ralph-knowledge package.
+
+**Deliverables:**
+- Configure trusted publisher on npmjs.com for both packages, scoped to this repo + `release.yml` / `release-knowledge.yml`
+- Update workflows: drop `NODE_AUTH_TOKEN`, add `id-token: write` permission, ensure `npm publish --provenance` continues to work (it does — provenance + OIDC are bundled)
+- After successful publish, **remove** `NPM_TOKEN` from repo secrets
+- Document the rotation/revocation flow in `SECURITY.md`
+
+**Verification:** Next auto-release publishes successfully. `npm view <pkg>` shows provenance attestation linked to the workflow run. `NPM_TOKEN` no longer in `gh secret list`.
+
+#### S9. Evaluate GitHub App alternative for `ROUTING_PAT`
+
+**Scope:** **Research-only ticket** — produce a recommendation, not necessarily a migration.
+
+**Deliverables:**
+- Research doc in `thoughts/shared/research/` covering:
+  - Whether a GitHub App can write to Projects V2 (it can, with `organization_projects: write` or `projects: write` on user scope)
+  - Comparison of App vs PAT: rotation, blast radius, audit trail, friction for self-hosters
+  - Recommendation: migrate / keep PAT with documented rotation / hybrid
+- If recommendation is "keep PAT": add a documented rotation cadence + calendar reminder; otherwise spawn a follow-up implementation issue
+
+**Verification:** Research doc merged. Follow-up issue created (or rotation policy documented), whichever the recommendation calls for.
+
+---
+
+### Tier 4 — Targeted code-level audits
+
+#### S10. CodeQL findings triage pass
+
+**Scope:** First-pass review of CodeQL output from S2.
+
+**Deliverables:**
+- Per finding category: fix, suppress with justification, or convert to tracking issue
+- One summary comment on the parent epic listing what was done
+
+**Verification:** All initial CodeQL alerts are either resolved or have a documented disposition.
+
+#### S11. Bash hook security audit
+
+**Scope:** One-time review of all 50+ scripts under `plugin/ralph-hero/hooks/` for command injection, unquoted expansions, and unsafe handling of tool-input JSON.
+
+**Deliverables:**
+- Audit findings doc in `thoughts/shared/research/`
+- Add `shellcheck` to `ci.yml` against `plugin/ralph-hero/hooks/**/*.sh` (covers regressions going forward — this is the GitHub-automation lean)
+- Fix any high-severity findings inline; file follow-up issues for low/medium
+
+**Verification:** `shellcheck` job green in CI. Audit doc merged.
+
+#### S12. MCP tool input validation review
+
+**Scope:** Audit `plugin/ralph-hero/mcp-server/src/tools/` Zod schemas + GraphQL string interpolation for injection paths.
+
+**Deliverables:**
+- Spot-check every `client.query()` / `client.mutate()` call site for user-controlled string concatenation into GraphQL bodies (Octokit parameterizes variables, but template-literal patterns can sneak past)
+- Verify Zod schemas reject unexpected types at every public tool entry
+- Fixes inline; findings doc only if patterns warrant
+
+**Verification:** Review checklist completed; any fixes ship in one PR.
+
+---
+
+## Dependencies and Ordering
+
+```
+S1 (Dependabot) ──┐
+S2 (CodeQL) ──────┼──> S10 (triage) ──┐
+S3 (SECURITY.md) ─┤                   │
+S4 (branch prot) ─┘                   │
+                                       ├──> Done
+S5 (permissions) ──> S6 (pin SHAs) ──> S7 (actionlint) ──┤
+                                                          │
+S8 (npm OIDC) ────────────────────────────────────────────┤
+S9 (App research) ────────────────────────────────────────┤
+                                                          │
+S11 (hook audit) ─────────────────────────────────────────┤
+S12 (MCP audit) ──────────────────────────────────────────┘
+```
+
+S1-S4 can ship in parallel. S5 must precede S6 (permissions explicit before pinning surfaces blast-radius questions). S6 must precede S7 (actionlint will flag unpinned actions). S10 is gated by S2.
+
+## Splittability Notes for the Split Agent
+
+Each S-numbered section is a candidate atomic issue:
+- **Estimate:** S1, S3, S4, S5, S6, S7, S8 are XS-S; S2 is XS (default setup is one toggle); S9, S11 are S-M (research-heavy); S10, S12 are M (depends on findings volume)
+- **File ownership is disjoint** across S1-S8 — they can run in parallel waves without merge conflicts
+- **Parent epic** should track completion; close when S1-S12 are all Done or have explicit deferral rationale
+
+## Out of Scope / Explicit Deferrals
+
+- OpenSSF Scorecard workflow — useful but redundant once S1-S7 land; revisit after baseline is in place
+- SLSA Level 3+ provenance — npm provenance from S8 gets us SLSA L2; L3 needs reusable workflows, deferred
+- Sigstore / cosign signing of release artifacts — npm provenance covers the npm artifact; binary signing not relevant (no binaries shipped)
+- Signed commits requirement — possible quality-of-life add but not security-critical for a public repo with PR-only merges


### PR DESCRIPTION
## Summary

- Audited every GraphQL call site in `plugin/ralph-hero/mcp-server/src/` (33 query, 13 mutate, 17 projectQuery, 16 projectMutate + 4 dynamically-built mutations) for injection paths.
- Verified all 33 tool registrations have well-typed Zod schemas: zero `z.any()` / `z.unknown()` in production source.
- Confirmed every dynamic GraphQL builder (`buildBatchMutationQuery`, `buildBatchArchiveMutation`, `buildBatchFieldValueQuery`) interpolates only server-controlled counters/aliases; user input always flows through Octokit's `variables` argument.
- One LOW-severity finding (`planPath` accepts arbitrary paths in `sync_plan_graph`) accepted as risk pending broader sandbox work; tool does not exfiltrate file contents in responses.

**No high-severity findings. No code changes ship in this PR — audit doc only.**

Full writeup: `thoughts/shared/research/2026-05-05-GH-1039-mcp-input-validation-audit.md`.

Closes #1039.

## Test plan

- [ ] Spot-check the call-site inventory table in the doc against `git grep "client\.\(query\|mutate\|projectQuery\|projectMutate\)" plugin/ralph-hero/mcp-server/src/`
- [ ] Confirm dispositions are reasonable for the project's threat model