### PR TITLE
feat(security): GH-1034 add actionlint and zizmor to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,54 @@ jobs:
         with:
           support-path: plugin/ralph-hero/scripts/__tests__
           tests-path: plugin/ralph-hero/scripts/__tests__
+
+  lint-workflows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
+          # shellcheck disabled: many existing scripts use single-quoted jq
+          # filters (intentional). Re-enable after a follow-up cleanup pass.
+          # The routing_pat ignore is a false positive — actionlint infers the
+          # secrets schema from the first dash-spelled usage and then flags the
+          # uppercase fallback. Both spellings are valid GitHub secret names.
+          /tmp/actionlint \
+            -color \
+            -shellcheck= \
+            -ignore 'property "routing_pat" is not defined'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Run zizmor
+        env:
+          ZIZMOR_VERSION: 1.24.1
+        run: |
+          set -euo pipefail
+          # Inline zizmor config. unpinned-uses is fully addressed by
+          # GH-1033 (S6); artipacked findings are low-confidence and tracked
+          # for follow-up. We disable both here so this job is green on its
+          # introducing PR. Remove these once S6 lands and the artipacked
+          # cleanup is done.
+          {
+            echo 'rules:'
+            echo '  unpinned-uses:'
+            echo '    disable: true'
+            echo '  artipacked:'
+            echo '    disable: true'
+          } > /tmp/zizmor.yml
+          uvx --from "zizmor==${ZIZMOR_VERSION}" zizmor \
+            --config /tmp/zizmor.yml \
+            .github/workflows/


### PR DESCRIPTION
## Summary

Adds a new `lint-workflows` job to `.github/workflows/ci.yml` that runs `actionlint` (v1.7.12, sha256-verified binary) and `zizmor` (v1.24.1 via `uvx`) against `.github/workflows/`. Closes #1034.

- `actionlint` binary is downloaded and integrity-checked via sha256 before execution
- `zizmor` is installed via `uvx` with `astral-sh/setup-uv` pinned to commit `08807647...` (v8.1.0)
- Both tools run on the same triggers as the rest of CI (push to `main`, PRs targeting `main`)

## Inline ignores (scoped + documented)

- **actionlint**
  - `-shellcheck=` disables shellcheck integration. Many existing scripts use single-quoted `jq` filters that shellcheck flags as `SC2016` (intentional pattern). Re-enable in a follow-up cleanup.
  - `-ignore 'property "routing_pat" is not defined'` — false positive. actionlint infers the secrets schema from the first dash-spelled usage in `route-issues.yml` and then flags the uppercase fallback. Both spellings reference the same GitHub secret.

- **zizmor** (inline `/tmp/zizmor.yml` written from the run step)
  - `unpinned-uses: disable: true` — fully addressed by GH-1033 (S6). Remove after S6 merges.
  - `artipacked: disable: true` — low-confidence findings about `persist-credentials: false` on `actions/checkout`. Tracked for follow-up.

## Verification

- [x] `actionlint -shellcheck= -ignore 'property "routing_pat" is not defined'` → exit 0 locally
- [x] `uvx --from zizmor==1.24.1 zizmor --config /tmp/zizmor.yml .github/workflows/` → exit 0 locally
- [ ] CI run on this PR is green
- [ ] After merge: add `lint-workflows` to required status checks on `main` (manual repo settings change)

## Follow-ups

- Re-enable shellcheck integration after a single-quoted `jq` cleanup pass
- Remove `unpinned-uses` suppression once GH-1033 (S6) is merged
- Resolve `artipacked` findings (set `persist-credentials: false` on workflow checkouts)