### PR TITLE
feat(skills): resolve depth-2 dispatch conflict (Path B) + ralph-pr → Agent

### DIFF
--- a/plugin/ralph-hero/skills/finish/SKILL.md
+++ b/plugin/ralph-hero/skills/finish/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Validate, merge, and watch CI for a completed implementation. Chains ralph-val → ralph-merge → CI watch into one command. Code review is handled by ralph-merge's built-in gate; when RALPH_REVIEW_MODE=auto and code review flags issues, dispatches impl-agent to fix them.
+description: Validate, run code review, merge, and watch CI for a completed implementation. Owns the code review gate (preserves depth-0 fan-out for the code-review:code-review plugin); when RALPH_REVIEW_MODE=auto and code review flags issues, dispatches impl-agent to fix them then re-runs code review (max 1 fix cycle). Once review resolves, dispatches ralph-merge for merge mechanics only.
 user-invocable: true
 argument-hint: <issue-number> [--pr-url url] [--plan-doc path]
 context: inline
@@ -34,12 +34,13 @@ allowed-tools:
 - Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
 - Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
 - Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+- Review mode: !`echo ${RALPH_REVIEW_MODE:-interactive}`
 
 Use these resolved values when constructing GitHub URLs or referencing the repository.
 
 # Ralph Finish
 
-Validate, merge, and watch CI for a completed implementation. Code review is handled by ralph-merge's built-in gate — when `RALPH_REVIEW_MODE=auto`, finish also orchestrates a code-review → impl-fix → re-merge cycle if the automated review flags issues (max 1 fix cycle).
+Validate, run code review, merge, and watch CI for a completed implementation. Finish owns the code review gate (so the `code-review:code-review` plugin's parallel-agent fan-out always runs at depth 0, depth-2 safe). When `RALPH_REVIEW_MODE=auto` and code review flags issues, finish dispatches impl-agent to fix them, then re-runs code review (max 1 fix cycle). Once review passes, finish dispatches `ralph-merge` for merge mechanics only.
 
 ## Step 1: Parse Arguments
 
@@ -104,23 +105,105 @@ Check the agent output for the verdict:
 - If output contains `VALIDATION FIX`: mechanical issues only (formatting, lint). Dispatch impl-agent to apply the listed fix commands in the worktree, commit, then re-run val-agent. Max 1 fix cycle — if it still fails after fixes, treat as FAIL.
 - If output contains `VALIDATION FAIL`: stop with the validation report. Substantive failures require implementation work.
 
-## Step 4: Merge (dispatch ralph-merge)
+## Step 4: Code Review Gate
 
-Build args for ralph-merge — always pass the PR URL to avoid redundant lookup:
+> **Why code review runs HERE (not inside ralph-merge):**
+>
+> The `code-review:code-review` plugin spawns 5 parallel Sonnet reviewers + N parallel Haiku scorers via the `Agent` tool. Those parallel agents land at depth 1 only when `code-review:code-review` itself is invoked from depth 0. By keeping the code review gate inline in finish (which runs at depth 0), we preserve the parallel-agent fan-out. If code review were dispatched from inside an agent context, the runtime's no-depth-2-Agent rule would silently break the parallel reviewers.
+
+Check whether the PR has received a code review:
+
+```bash
+gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
+```
+
+**If `reviewDecision` is `APPROVED`**: a code review has been performed and approved. Proceed to Step 5.
+
+**If `reviewDecision` is `CHANGES_REQUESTED`**: a human reviewer (not the automated code-review skill) requested changes. Output:
 
 ```
-Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")
+FINISH BLOCKED
+Issue: #NNN
+PR: #PR_NUMBER
+Reason: Human reviewer requested changes — address feedback before merging.
 ```
 
-ralph-merge handles: code review gate (including optional `code-review:code-review` dispatch), PR readiness check, merge via `merge-pr.sh`, worktree cleanup, state transition to Done, parent advancement, cross-repo unblock, and posting the Merged comment.
+And stop.
 
-Check the skill output:
+**If no review decision exists** (`reviewDecision` is null or empty), branch on `RALPH_REVIEW_MODE`:
 
-- If output contains `MERGE BLOCKED` or `MERGE NOT READY`: report the status and stop.
-- If output contains `MERGED`: continue to Step 5.
-- If output contains `CODE_REVIEW_FEEDBACK`: automated code review flagged issues. Proceed to Step 4a.
+### Auto mode (`RALPH_REVIEW_MODE=auto`)
+
+Run code review automatically — do NOT prompt the user:
+
+```
+Skill("code-review:code-review", "PR_NUMBER")
+```
+
+The `code-review:code-review` skill runs inline at depth 0; its parallel reviewer agents land at depth 1 (legal). After the review skill completes, re-check `reviewDecision`:
+
+```bash
+gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
+```
+
+- If `APPROVED`: continue to Step 5.
+- If `CHANGES_REQUESTED`: proceed to Step 4a (Code Review Fix Cycle).
+
+### Interactive mode (`RALPH_REVIEW_MODE=interactive`, default)
+
+Present a choice:
+
+!cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
+
+```
+AskUserQuestion(
+  questions=[{
+    "question": "This PR has no code review yet. Would you like to run one before merging?",
+    "header": "Code Review",
+    "options": [
+      {"label": "Run code review", "description": "Invoke /code-review:code-review on PR #PR_NUMBER before merging"},
+      {"label": "Merge without review", "description": "Skip code review and proceed to merge"}
+    ],
+    "multiSelect": false
+  }]
+)
+```
+
+- If user selects **"Run code review"**: invoke `Skill("code-review:code-review", "PR_NUMBER")`. After it completes, re-check `reviewDecision`. If `APPROVED`, continue to Step 5. If `CHANGES_REQUESTED`, proceed to Step 4a.
+- If user selects **"Merge without review"**: continue to Step 5.
+- If user selects **"Other"**: stop.
+
+### Skill not available
+
+If the `code-review:code-review` skill is NOT installed:
+
+```
+This PR has no code review. Consider installing the code-review plugin:
+  claude plugins install @anthropic/code-review
+```
+
+Then present:
+
+```
+AskUserQuestion(
+  questions=[{
+    "question": "Proceed without code review?",
+    "header": "No Code Review Plugin",
+    "options": [
+      {"label": "Merge without review", "description": "Skip code review and proceed to merge"},
+      {"label": "Stop", "description": "Stop here — install the code-review plugin first"}
+    ],
+    "multiSelect": false
+  }]
+)
+```
+
+- If user selects **"Merge without review"**: continue to Step 5.
+- If user selects **"Stop"** or **"Other"**: stop.
 
 ## Step 4a: Code Review Fix Cycle
+
+Triggered when the auto code review (or interactive "Run code review") returned `CHANGES_REQUESTED`.
 
 Dispatch impl-agent in Address Mode to fix the flagged issues. The issue is already "In Review" with an open PR that has review comments — impl-agent will auto-detect Address Mode.
 
@@ -128,18 +211,40 @@ Dispatch impl-agent in Address Mode to fix the flagged issues. The issue is alre
 Agent(subagent_type="ralph-hero:impl-agent", prompt="Address PR review feedback for GH-NNN. The automated code review flagged issues on PR #PR_NUMBER. Fix the MUST_FIX and SHOULD_FIX items, push, and reply to comments.")
 ```
 
-After impl-agent completes, re-run ralph-merge:
+After impl-agent completes, re-run code review once:
+
+```
+Skill("code-review:code-review", "PR_NUMBER")
+```
+
+Then re-check `reviewDecision`:
+
+- If `APPROVED`: continue to Step 5.
+- If `CHANGES_REQUESTED` again: stop. Max 1 fix cycle. Output:
+
+```
+FINISH BLOCKED
+Issue: #NNN
+PR: #PR_NUMBER
+Reason: Code review feedback unresolved after 1 fix cycle.
+```
+
+## Step 5: Merge (dispatch ralph-merge)
+
+Code review has resolved (approved, skipped by user, or no skill available). Dispatch ralph-merge for merge mechanics only — always pass the PR URL to avoid redundant lookup:
 
 ```
 Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")
 ```
 
-Check the output again:
+ralph-merge is now a leaf skill: it handles PR readiness check, merge via `merge-pr.sh`, worktree cleanup, state transition to Done, parent advancement, cross-repo unblock, and posting the Merged comment. It does NOT run code review (that's owned by Step 4 above).
 
-- If `MERGED`: continue to Step 5.
-- If `MERGE BLOCKED`, `MERGE NOT READY`, or `CODE_REVIEW_FEEDBACK` again: stop. Max 1 fix cycle — report the status and let the human intervene.
+Check the skill output:
 
-## Step 5: CI Watch
+- If output contains `MERGE BLOCKED` or `MERGE NOT READY`: report the status and stop.
+- If output contains `MERGED`: continue to Step 6.
+
+## Step 6: CI Watch
 
 After merge completes, watch CI checks on the merge commit.
 
@@ -161,7 +266,7 @@ Check the results:
 
 If no runs are found for the merge commit (e.g., no CI configured), report CI as skipped.
 
-## Step 6: Report Final Status
+## Step 7: Report Final Status
 
 ```
 FINISHED

--- a/plugin/ralph-hero/skills/hero/SKILL.md
+++ b/plugin/ralph-hero/skills/hero/SKILL.md
@@ -423,13 +423,20 @@ Agent(subagent_type="ralph-hero:impl-agent", prompt="Implement GH-NNN")
 
 Hero uses **two distinct dispatch modes** depending on session type:
 
-**Single-session mode (default)**: Hero dispatches pipeline phases via `Skill()`. Skills run inline in hero's context window and CAN dispatch sub-agents via `Agent()`. This is the dispatch mode described above.
+**Single-session mode (default)**: Hero mixes `Skill()` and `Agent()` dispatch by phase:
 
-- `model:` in skill frontmatter is honored — opus for planning/review/impl, sonnet for research/triage, haiku for PR
+- **Analyst phases (research, plan, review)**: `Skill()` inline — opus/sonnet models that benefit from context sharing in hero's window.
+- **Implementation**: `Agent(impl-agent)` — runs in isolated worktree, opus model.
+- **PR phase**: `Agent(pr-agent)` — haiku model in isolated context (haiku in Opus 1M envelope is wasteful, and pr-agent has no nested fan-out so it's depth-2 safe).
+- **Validate phase**: `Agent(val-agent)` — haiku model in isolated context.
+- **Merge phase**: `Skill(ralph-merge)` inline (called from `finish`) — preserves the `code-review:code-review` parallel-agent fan-out at depth 0. Hoisting code review into `finish` (per Path B in GH-895) means `ralph-merge` is now a leaf merge-mechanics skill; running it inline keeps the merge chain depth-2 safe.
+- **Finish phase**: `Skill(finish)` inline — orchestrator that owns the code review gate plus dispatches val/impl/merge as needed.
+
+Key properties:
+- `model:` in skill frontmatter is honored for inline `Skill()` calls
 - `hooks:` in skill frontmatter fire automatically — SessionStart sets `RALPH_COMMAND`, PreToolUse/PostToolUse enforce phase gates
 - Skills accept args via the `args` parameter matching their `argument-hint:` field
-- Sub-agent dispatch inside skills (codebase-locator, thoughts-locator, etc.) executes successfully
-- Skill output is visible in hero's context — artifact paths (research docs, plan docs) can be observed directly or via TaskUpdate metadata
+- `Agent()` dispatches use natural-language prompts and run in isolated context windows
 
 **Team mode**: Team spawns per-phase agents as teammates via Claude Code Agent Teams. Each agent is a full session with its own context window and CAN dispatch sub-agents. Per-phase agent definitions in `plugin/ralph-hero/agents/` serve this mode.
 
@@ -437,7 +444,7 @@ If any implementation fails, STOP immediately. Do NOT continue to next issue.
 
 #### PR tasks
 ```
-Skill("ralph-hero:ralph-pr", args="NNN")
+Agent(subagent_type="ralph-hero:pr-agent", prompt="Create PR for GH-NNN. Worktree: worktrees/GH-NNN", description="PR for GH-NNN")
 ```
 
 #### MERGE GATE

--- a/plugin/ralph-hero/skills/ralph-merge/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-merge/SKILL.md
@@ -1,8 +1,7 @@
 ---
-description: Merge a pull request after code review — handles review gate, merges, cleans up worktree, moves issues to Done. Use when you want to merge a PR for a completed issue.
+description: Merge an approved pull request — handles PR readiness, merges, cleans up worktree, moves issues to Done. Code review must be run by the caller (finish or ralph-code-review); ralph-merge refuses to merge a PR with no review decision.
 user-invocable: false
 argument-hint: <issue-number> [--pr-url url]
-context: fork
 model: haiku
 hooks:
   SessionStart:
@@ -18,8 +17,6 @@ allowed-tools:
   - Read
   - Glob
   - Bash
-  - AskUserQuestion
-  - Skill
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
@@ -33,13 +30,12 @@ allowed-tools:
 - Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
 - Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
 - Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
-- Review mode: !`echo ${RALPH_REVIEW_MODE:-interactive}`
 
 Use these resolved values when constructing GitHub URLs or referencing the repository.
 
 # Ralph Merge
 
-Merge an approved pull request and move issues to Done.
+Merge an approved pull request and move issues to Done. This is a leaf merge-mechanics skill — code review is the responsibility of the orchestrating caller (finish or ralph-code-review). Standalone callers (`just merge NNN`) that invoke this skill on an unreviewed PR will be rejected with `MERGE BLOCKED — review required` to preserve safety.
 
 ## Step 1: Parse Arguments
 
@@ -100,29 +96,28 @@ gh pr list --head feature/GH-NNN --json number,url,state --jq '.[0]'
 
 If no PR found, report and stop.
 
-## Step 4: Code Review Gate
+## Step 4: Review Decision Guard (Standalone Safety)
 
 > **Output contract for callers (orchestrators: ralph-finish, ralph-hero):**
 >
-> This step can produce three distinct stop statuses that callers MUST handle:
+> This step produces two stop statuses that callers MUST handle:
 >
 > | Status | Meaning | Caller action |
 > |--------|---------|---------------|
-> | `MERGE BLOCKED` | A human reviewer requested changes (manual `CHANGES_REQUESTED` review on GitHub). Hard block. | Stop. Surface to human; do NOT auto-fix. |
-> | `CODE_REVIEW_FEEDBACK` | Auto-mode code review (via `code-review:code-review` skill) requested changes. Soft block — fix cycle is appropriate. | Dispatch impl-agent to address review findings, then re-invoke ralph-merge. |
-> | `MERGE NOT READY` | PR is open but not mergeable (conflicts, draft, missing review). Transient. | Retry later or escalate. |
+> | `MERGE BLOCKED` | Either a human reviewer requested changes, OR no code review has been run on the PR. Hard block. | Run code review (via finish/ralph-code-review) or surface to human. |
+> | `MERGE NOT READY` | PR is open but not mergeable (conflicts, draft). Transient. | Retry later or escalate. |
 >
-> The distinction between `MERGE BLOCKED` and `CODE_REVIEW_FEEDBACK` matters: a caller that only handles `MERGE BLOCKED` will treat `CODE_REVIEW_FEEDBACK` as an unrecognized status and lose the auto-fix opportunity. Orchestrators MUST switch on all three statuses.
+> Code review is the responsibility of the orchestrating caller — this step only verifies that a review decision exists before letting merge proceed. This guard preserves safety for standalone `just merge NNN` callers that bypass the finish orchestrator.
 
-Check whether the PR has received a code review:
+Check the PR's review decision:
 
 ```bash
-gh pr view NNN --json reviewDecision
+gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
 ```
 
-**If `reviewDecision` is `APPROVED`**: a code review has been performed and approved. Proceed to Step 5.
+**If `reviewDecision` is `APPROVED`**: a code review has been performed and approved. Proceed to Step 4a.
 
-**If `reviewDecision` is `CHANGES_REQUESTED`**: a code review was performed but the reviewer requested changes. Output:
+**If `reviewDecision` is `CHANGES_REQUESTED`**: a reviewer requested changes. Output:
 
 ```
 MERGE BLOCKED
@@ -135,79 +130,21 @@ And stop.
 
 **If no review decision exists** (`reviewDecision` is null or empty):
 
-1. Check if the `code-review:code-review` skill is available by looking for it in the available skills list (it is an official Anthropic plugin).
+Check the XS-no-review exception. Use the issue's `estimate` field and the PR's comment count:
 
-2. **If the skill is available AND review mode is "auto":**
+```bash
+PR_COMMENT_COUNT=$(gh pr view PR_NUMBER --json comments --jq '.comments | length')
+```
 
-   Run code review automatically — do NOT prompt the user:
+- If the issue's estimate is `XS` AND `PR_COMMENT_COUNT == 0`: small unreviewed changes are permitted. Proceed to Step 4a (the autonomous merge gate also re-checks this exception when `RALPH_AUTO_MERGE=true`).
+- Otherwise: output and stop:
 
-   ```
-   Skill("code-review:code-review", "PR_NUMBER")
-   ```
-
-   After the review completes, re-check `reviewDecision` via `gh pr view`.
-
-   - If the PR was approved: continue to Step 5.
-   - If changes were requested: output the review findings with a distinct status so the caller (finish) can dispatch a fix cycle:
-
-   ```
-   CODE_REVIEW_FEEDBACK
-   Issue: #NNN
-   PR: #PR_NUMBER
-   Reason: Automated code review flagged issues — impl-agent fix cycle available.
-   ```
-
-   And stop. Do NOT output `MERGE BLOCKED` for automated review feedback — the `CODE_REVIEW_FEEDBACK` status signals that finish should attempt a fix cycle.
-
-3. **If the skill is available AND review mode is "interactive" (default):**
-
-   Present a choice:
-
-   !cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
-
-   ```
-   AskUserQuestion(
-     questions=[{
-       "question": "This PR has no code review yet. Would you like to run one before merging?",
-       "header": "Code Review",
-       "options": [
-         {"label": "Run code review", "description": "Invoke /code-review:code-review on PR #NNN before merging"},
-         {"label": "Merge without review", "description": "Skip code review and proceed to merge"}
-       ],
-       "multiSelect": false
-     }]
-   )
-   ```
-
-   - If user selects **"Run code review"**: invoke `Skill("code-review:code-review", "PR_NUMBER")` where PR_NUMBER is the PR number obtained in Step 3 (not the issue number). After the review completes, re-check `reviewDecision` via `gh pr view`. If the PR was approved, continue to Step 5. If changes were requested, output the review findings and stop — the user needs to address feedback first.
-   - If user selects **"Merge without review"**: proceed to Step 5.
-   - If user selects **"Other"**: stop.
-
-4. **If the skill is NOT available**, inform the user:
-
-   ```
-   This PR has no code review. Consider installing the code-review plugin:
-     claude plugins install @anthropic/code-review
-   ```
-
-   Then present:
-
-   ```
-   AskUserQuestion(
-     questions=[{
-       "question": "Proceed without code review?",
-       "header": "No Code Review Plugin",
-       "options": [
-         {"label": "Merge without review", "description": "Skip code review and proceed to merge"},
-         {"label": "Stop", "description": "Stop here — install the code-review plugin first"}
-       ],
-       "multiSelect": false
-     }]
-   )
-   ```
-
-   - If user selects **"Merge without review"**: proceed to Step 5.
-   - If user selects **"Stop"** or **"Other"**: stop.
+```
+MERGE BLOCKED
+Issue: #NNN
+PR: #PR_NUMBER
+Reason: Code review required — invoke /ralph-hero:finish or /ralph-hero:ralph-code-review first.
+```
 
 ## Step 4a: Autonomous Merge Gate
 

--- a/plugin/ralph-hero/skills/ralph-merge/eval-scenarios.md
+++ b/plugin/ralph-hero/skills/ralph-merge/eval-scenarios.md
@@ -2,14 +2,17 @@
 type: eval-scenarios
 skill: ralph-merge
 date: 2026-04-25
+last_updated: 2026-05-05
 status: defined
 ---
 
 # Ralph-Merge Eval Scenarios
 
-Three scenarios used to grade the ralph-merge skill on its primary code-review-gate paths: APPROVED merge, auto-mode CHANGES_REQUESTED → CODE_REVIEW_FEEDBACK, and interactive prompt for unreviewed PR. Manual or future-automated execution should produce structured outputs that can be checked against the assertions below.
+Three scenarios used to grade the ralph-merge skill on its primary review-decision-guard and merge-mechanics paths: APPROVED merge, standalone safety rejection of unreviewed PRs, and the XS-no-review exception. Manual or future-automated execution should produce structured outputs that can be checked against the assertions below.
 
-> **Execution note**: These scenarios are written but **not executed** by this audit. Manual eval runs are tracked outside the audit plan (see #566). When grading, dispatch the `merge-agent` against a test issue matching the Input column and compare the actual output blocks (`MERGED`, `CODE_REVIEW_FEEDBACK`, `MERGE BLOCKED`) and the issue comments to the Assertions.
+> **Architecture note (updated 2026-05-05 per GH-895):** ralph-merge is now a leaf merge-mechanics skill. Code review is the responsibility of the orchestrating caller (`finish` or `ralph-code-review`). Step 4 in ralph-merge is a small "Review Decision Guard" that rejects unreviewed PRs to preserve safety for standalone callers. Eval scenarios that previously exercised the in-merge code-review gate (auto-mode `CODE_REVIEW_FEEDBACK`, interactive `AskUserQuestion`) have been retired — those flows are now exercised by finish's eval scenarios.
+
+> **Execution note**: These scenarios are written but **not executed** by this audit. Manual eval runs are tracked outside the audit plan (see #566). When grading, dispatch the `merge-agent` against a test issue matching the Input column and compare the actual output blocks (`MERGED`, `MERGE BLOCKED`) and the issue comments to the Assertions.
 
 ---
 
@@ -23,19 +26,19 @@ An "In Review" issue with the following shape:
 - **Estimate**: S
 - **PR**: An open PR exists at `feature/GH-NNN`, `mergeable: MERGEABLE`, `reviewDecision: APPROVED` (a reviewer has explicitly approved on GitHub).
 - **Worktree**: `worktrees/GH-NNN` exists.
-- **Review mode**: any (review is already approved, so mode does not matter).
 
 ### Expected Behavior
 
 1. Skill parses args, fetches issue, confirms state is "In Review".
 2. Skill finds the PR via `gh pr list --head feature/GH-NNN`.
-3. Skill enters Step 4 Code Review Gate — `reviewDecision == APPROVED` — proceeds immediately to Step 5.
-4. Step 5 single `gh pr view` call returns `state: OPEN`, `mergeable: MERGEABLE`, `mergedAt: null`. Branch B (readiness) routes to Step 6.
-5. Skill runs `./scripts/merge-pr.sh PR_NUMBER GH-NNN` to merge and clean up the worktree.
-6. Skill calls `save_issue(number=NNN, workflowState="Done", command="ralph_merge")` to advance the standalone issue.
-7. Skill posts `## Merged` comment on the issue.
-8. Skill runs Step 9a cross-repo unblock check (informational; no cross-repo dependents in this scenario).
-9. Skill outputs `MERGED` block with PR URL.
+3. Skill enters Step 4 Review Decision Guard — `reviewDecision == APPROVED` — proceeds immediately to Step 4a.
+4. Step 4a Autonomous Merge Gate is skipped (`RALPH_AUTO_MERGE` unset). Falls through to Step 5.
+5. Step 5 single `gh pr view` call returns `state: OPEN`, `mergeable: MERGEABLE`, `mergedAt: null`. Branch B (readiness) routes to Step 6.
+6. Skill runs `./scripts/merge-pr.sh PR_NUMBER GH-NNN` to merge and clean up the worktree.
+7. Skill calls `save_issue(number=NNN, workflowState="Done", command="ralph_merge")` to advance the standalone issue.
+8. Skill posts `## Merged` comment on the issue.
+9. Skill runs Step 9a cross-repo unblock check (informational; no cross-repo dependents in this scenario).
+10. Skill outputs `MERGED` block with PR URL.
 
 ### Assertions
 
@@ -45,13 +48,12 @@ An "In Review" issue with the following shape:
 - [ ] State gate hook (`merge-state-gate.sh`) does NOT block the Done transition
 - [ ] `## Merged` comment posted on issue
 - [ ] `MERGED` output block emitted with PR URL
-- [ ] No `CODE_REVIEW_FEEDBACK` or `MERGE BLOCKED` output (PR was already approved)
-- [ ] No `Skill("code-review:code-review", ...)` invocation (review already exists)
+- [ ] No `MERGE BLOCKED` output (PR was approved)
 - [ ] Single `gh pr view` call in Step 5 (Step 9b detection consolidated per Phase 4 audit)
 
 ---
 
-## Scenario B: Auto-mode CHANGES_REQUESTED → CODE_REVIEW_FEEDBACK
+## Scenario B: Standalone unreviewed PR → MERGE BLOCKED
 
 ### Input
 
@@ -59,96 +61,82 @@ An "In Review" issue with the following shape:
 
 - **Title**: "Add cross-project dashboard aggregation to `pipeline_dashboard`"
 - **Estimate**: S
-- **PR**: An open PR at `feature/GH-NNN`, `mergeable: MERGEABLE`, `reviewDecision: null` (no human review yet).
+- **PR**: An open PR at `feature/GH-NNN`, `mergeable: MERGEABLE`, `reviewDecision: null` (no review yet), 0 PR comments.
 - **Worktree**: `worktrees/GH-NNN` exists.
-- **Review mode**: `RALPH_REVIEW_MODE=auto`.
-- **`code-review:code-review` skill**: available.
-- **Code-review outcome**: When invoked, the skill posts a CHANGES_REQUESTED review on the PR (it found a missing null-check that would crash on empty input).
+- **Invocation**: standalone `just merge NNN` (NOT through finish).
 
 ### Expected Behavior
 
 1. Skill parses args, fetches issue, confirms state is "In Review".
 2. Skill finds PR via `gh pr list`.
-3. Step 4: `reviewDecision == null`. Mode is `auto`, skill is available. Skill invokes `Skill("code-review:code-review", "PR_NUMBER")` without prompting (PR_NUMBER, not issue number).
-4. After review completes, skill re-checks `gh pr view --json reviewDecision` — now `CHANGES_REQUESTED`.
-5. Skill outputs `CODE_REVIEW_FEEDBACK` status block (NOT `MERGE BLOCKED`) with the PR number and "Automated code review flagged issues — impl-agent fix cycle available" reason.
-6. Skill stops — does NOT proceed to Step 5/6/7 (no merge, no Done transition).
-7. The contract block at the top of Step 4 documents this output for the orchestrator (ralph-finish/ralph-hero).
+3. Step 4 Review Decision Guard: `reviewDecision == null`. Estimate is `S` (not `XS`), so the XS exception does NOT apply.
+4. Skill outputs `MERGE BLOCKED` block with reason "Code review required — invoke /ralph-hero:finish or /ralph-hero:ralph-code-review first" and stops.
+5. Skill does NOT proceed to Step 4a/5/6/7 (no merge, no Done transition).
 
 ### Assertions
 
-- [ ] `Skill("code-review:code-review", "PR_NUMBER")` invoked exactly once (PR number, not issue number)
-- [ ] After invocation, `gh pr view --json reviewDecision` re-checked
-- [ ] Output block begins with `CODE_REVIEW_FEEDBACK` (NOT `MERGE BLOCKED`)
-- [ ] Reason text mentions "impl-agent fix cycle available" (or equivalent)
+- [ ] No `Skill(...)` call to any code-review skill from inside ralph-merge (the skill's `allowed-tools` no longer permits `Skill`)
+- [ ] Output block begins with `MERGE BLOCKED`
+- [ ] Reason text mentions "Code review required" and "/ralph-hero:finish"
 - [ ] PR NOT merged (`gh pr view --json state` still `OPEN`)
 - [ ] Issue workflow state NOT changed (still "In Review")
 - [ ] No `## Merged` comment posted
-- [ ] Caller-facing contract table at the top of Step 4 lists `CODE_REVIEW_FEEDBACK` as a distinct status from `MERGE BLOCKED` (Phase 4 audit fix)
 - [ ] State gate hook does NOT block (no `save_issue` call to gate)
 
 ---
 
-## Scenario C: Interactive prompt for unreviewed PR
+## Scenario C: XS-no-review exception → merge
 
 ### Input
 
 An "In Review" issue with the following shape:
 
-- **Title**: "Add markdown linter pre-commit hook to ralph-hero"
-- **Estimate**: S
-- **PR**: An open PR at `feature/GH-NNN`, `mergeable: MERGEABLE`, `reviewDecision: null` (no review yet).
+- **Title**: "Bump octokit-graphql to 9.1.0"
+- **Estimate**: XS
+- **PR**: An open PR at `feature/GH-NNN`, `mergeable: MERGEABLE`, `reviewDecision: null` (no review yet), 0 PR comments.
 - **Worktree**: `worktrees/GH-NNN` exists.
-- **Review mode**: `RALPH_REVIEW_MODE=interactive` (default).
-- **`code-review:code-review` skill**: available.
 
 ### Expected Behavior
 
-1. Skill detects no review and `interactive` mode.
-2. Step 4 case 3 fires: skill presents `AskUserQuestion` with three options:
-   - "Run code review" — invoke `Skill("code-review:code-review", "PR_NUMBER")`.
-   - "Merge without review" — skip review, proceed to Step 5.
-   - (default "Other" stop option provided by AskUserQuestion).
-3. **Test variant 1 — user picks "Run code review"**: skill invokes the code-review skill. If approved, flow continues to Step 5 → merge → Done. If changes requested, output stops the merge and surfaces the review (note: in INTERACTIVE this is a manual stop, not `CODE_REVIEW_FEEDBACK`).
-4. **Test variant 2 — user picks "Merge without review"**: skill skips Step 4 review, proceeds to Step 5 → merge → Done.
-5. **Test variant 3 — user picks "Other"**: skill stops with no merge.
+1. Skill parses args, fetches issue, confirms state is "In Review".
+2. Skill finds PR via `gh pr list`.
+3. Step 4 Review Decision Guard: `reviewDecision == null`. Estimate is `XS` AND PR comment count is 0 — XS exception applies. Proceed to Step 4a.
+4. Step 4a Autonomous Merge Gate is skipped (`RALPH_AUTO_MERGE` unset). Falls through to Step 5.
+5. Step 5 readiness check passes; merge proceeds normally.
+6. Skill outputs `MERGED` block with PR URL.
 
 ### Assertions
 
-- [ ] `AskUserQuestion` invoked at least once with the three documented options
-- [ ] Question header is "Code Review"
-- [ ] Question text includes "This PR has no code review yet"
-- [ ] **Variant 1 (run review)**: `Skill("code-review:code-review", "PR_NUMBER")` invoked with the PR number (not issue number)
-- [ ] **Variant 2 (merge without review)**: PR merged, issue → Done, `## Merged` comment posted
-- [ ] **Variant 3 (other/stop)**: PR NOT merged, issue stays in "In Review", no comment posted
-- [ ] Skill does NOT auto-invoke `Skill("code-review:code-review", ...)` without prompting (interactive mode contract)
-- [ ] State gate hook does NOT block any valid Done transition (Variant 2)
-- [ ] No `advance_parent` carve-out exercised (Phase 4 audit removed dead code from `merge-state-gate.sh`)
+- [ ] No `MERGE BLOCKED` output (XS exception bypassed the guard)
+- [ ] PR merged on GitHub
+- [ ] Issue workflow state advanced to "Done"
+- [ ] `## Merged` comment posted
+- [ ] `MERGED` output block emitted
 
 ---
 
 ## Grading Rubric
 
-| Dimension | A (APPROVED) | B (auto CHANGES_REQUESTED) | C (interactive) |
-|-----------|--------------|----------------------------|-----------------|
-| Review present | Yes (APPROVED) | None initially | None initially |
-| Mode | any | auto | interactive |
-| `code-review` skill invoked | No | Yes (auto, no prompt) | Variant 1 only |
-| AskUserQuestion invoked | No | No | Yes |
-| Output status | MERGED | CODE_REVIEW_FEEDBACK | MERGED (V1 approved, V2) / nothing (V1 reject, V3) |
-| PR merged | Yes | No | Variant-dependent |
-| Issue → Done | Yes | No | Variant-dependent |
-| Step 5 single gh pr view | Yes | N/A (stops at Step 4) | Variant-dependent |
-| Description match | Yes (post-Phase-4 desc covers approved PRs) | Yes (post-Phase-4 desc covers unapproved too) | Yes |
+| Dimension | A (APPROVED) | B (standalone unreviewed) | C (XS exception) |
+|-----------|--------------|---------------------------|------------------|
+| Review present | Yes (APPROVED) | No (null) | No (null) |
+| Estimate | S | S | XS |
+| PR comments | any | 0 | 0 |
+| `code-review` skill invoked | No | No | No |
+| AskUserQuestion invoked | No | No | No |
+| Output status | MERGED | MERGE BLOCKED | MERGED |
+| PR merged | Yes | No | Yes |
+| Issue → Done | Yes | No | Yes |
+| Step 5 single gh pr view | Yes | N/A (stops at Step 4) | Yes |
 
-A run is graded **PASS** if all `[ ]` assertions for its scenario hold. **FAIL** otherwise. Variant-specific assertions in Scenario C are graded independently per variant.
+A run is graded **PASS** if all `[ ]` assertions for its scenario hold. **FAIL** otherwise.
 
 ## Anti-Patterns to Watch For
 
-1. **`CODE_REVIEW_FEEDBACK` reported as `MERGE BLOCKED`**: Skill outputs the wrong status in auto mode + CHANGES_REQUESTED (Scenario B). Orchestrators handling only `MERGE BLOCKED` lose the auto-fix routing.
-2. **Issue-number passed instead of PR-number**: `Skill("code-review:code-review", "ISSUE_NUMBER")` invoked. Should always pass PR number.
-3. **Stale `advance_issue` invocation**: Skill body or agent attempts `advance_issue(...)` instead of `save_issue(workflowState=..., command="ralph_merge")`. Phase 4 removed `advance_issue` from `allowed-tools`.
-4. **Description misleads caller**: Description still says "Merge an approved pull request" implying pre-approval (Phase 4 audit fix replaced with "Merge a pull request after code review").
-5. **Duplicate `gh pr view` calls in Step 5 + Step 9b**: Phase 4 consolidated rejection detection into Step 5 single call. Multiple identical `gh pr view --json state,mergedAt` calls indicate the consolidation regressed.
-6. **`advance_parent` carve-out exercised**: Hook script branches on `tool_name == *advance_parent*`. Phase 4 removed this dead code from `merge-state-gate.sh` — any reference indicates the audit fix regressed.
-7. **Auto mode prompts user**: In auto mode, skill MUST NOT call `AskUserQuestion`. Any prompt invocation in auto + skill-available is a violation.
+1. **Code-review skill invoked from ralph-merge**: ralph-merge no longer runs code review (per GH-895 Path B). Any `Skill(...)` invocation from inside ralph-merge is a regression — the skill's `allowed-tools` no longer permits `Skill`.
+2. **AskUserQuestion in ralph-merge**: The interactive code-review prompt moved to finish. Any `AskUserQuestion` call from inside ralph-merge is a regression — the skill's `allowed-tools` no longer permits `AskUserQuestion`.
+3. **Standalone PR merged without review**: Skill bypasses Step 4 guard on a non-XS unreviewed PR (Scenario B). The standalone safety guard is the only line of defense for `just merge` callers — it MUST refuse.
+4. **XS exception applied to non-XS issue**: Skill applies the XS-no-review exception to an issue with estimate S/M/L/XL, allowing an unreviewed merge.
+5. **Stale `advance_issue` invocation**: Skill body or agent attempts `advance_issue(...)` instead of `save_issue(workflowState=..., command="ralph_merge")`. Phase 4 removed `advance_issue` from `allowed-tools`.
+6. **Duplicate `gh pr view` calls in Step 5 + Step 9b**: Phase 4 consolidated rejection detection into Step 5 single call. Multiple identical `gh pr view --json state,mergedAt` calls indicate the consolidation regressed.
+7. **`advance_parent` carve-out exercised**: Hook script branches on `tool_name == *advance_parent*`. Phase 4 removed this dead code from `merge-state-gate.sh` — any reference indicates the audit fix regressed.

--- a/thoughts/shared/plans/2026-04-06-auto-code-review-impl-fix-loop.md
+++ b/thoughts/shared/plans/2026-04-06-auto-code-review-impl-fix-loop.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-04-06
-status: draft
+status: superseded
 type: plan
 tags: [code-review, ralph-merge, finish, impl-agent, automation, plan-skill, auto-mode]
 github_issues: [756]
@@ -11,6 +11,12 @@ github_issue: 756
 ---
 
 # Auto Mode Pipeline Gaps — Implementation Plan
+
+## Superseded By
+
+[2026-05-05-GH-0895-depth-2-dispatch-resolution](2026-05-05-GH-0895-depth-2-dispatch-resolution.md)
+
+Phases 1 and 2 of this plan placed the auto code-review gate inside `ralph-merge` and built a `CODE_REVIEW_FEEDBACK` output contract that finish would interpret. The GH-895 depth-2 dispatch resolution plan (Path B) moved the code review gate up one level: `finish` now owns the code review gate directly (auto vs interactive branching, impl-agent fix cycle), and `ralph-merge` became a leaf merge-mechanics skill that no longer runs code review or emits `CODE_REVIEW_FEEDBACK`. The impl-agent fix-cycle pattern is preserved, but it is now triggered from finish's new Step 4a (post-review fix cycle) rather than from interpreting ralph-merge's output. Phases 3 and 4 of this plan (plan-skill auto mode + documentation updates) are not affected by GH-895 and may be revived independently if still desired.
 
 ## Prior Work
 

--- a/thoughts/shared/plans/2026-04-06-haiku-skill-to-agent-dispatch.md
+++ b/thoughts/shared/plans/2026-04-06-haiku-skill-to-agent-dispatch.md
@@ -1,11 +1,17 @@
 ---
 date: 2026-04-06
-status: draft
+status: superseded
 type: plan
 tags: [hero, dispatch, agents, context-window, haiku]
 ---
 
 # Haiku Skill-to-Agent Dispatch Fix
+
+## Superseded By
+
+[2026-05-05-GH-0895-depth-2-dispatch-resolution](2026-05-05-GH-0895-depth-2-dispatch-resolution.md)
+
+The ralph-pr conversion described in Phase 1 of this plan was absorbed into Phase 1 Task 1.3 of the GH-895 depth-2 dispatch resolution plan and shipped together with the code-review hoist. The ralph-merge conversion described in Phase 2 was rejected: research (`thoughts/shared/research/2026-05-05-GH-0895-depth-2-dispatch-resolution-path.md`) found that converting merge to Agent dispatch would push the `code-review:code-review` plugin's parallel-reviewer fan-out to depth 2 (forbidden by the Claude Code runtime). Path B was adopted instead — the code review gate moves from ralph-merge up to finish, which preserves the depth-0 fan-out without converting merge. ralph-merge remains a `Skill()` invoked inline by finish.
 
 ## Overview
 

--- a/thoughts/shared/plans/2026-05-05-GH-0895-depth-2-dispatch-resolution.md
+++ b/thoughts/shared/plans/2026-05-05-GH-0895-depth-2-dispatch-resolution.md
@@ -68,14 +68,14 @@ After this plan:
 
 ### Verification
 
-- [ ] `grep -n 'code-review:code-review' plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns zero matches
-- [ ] `grep -n 'code-review:code-review' plugin/ralph-hero/skills/finish/SKILL.md` returns at least one match (the new inline call)
-- [ ] `grep -n 'Skill.*ralph-pr' plugin/ralph-hero/skills/hero/SKILL.md` returns zero matches
-- [ ] `grep -n 'Agent.*pr-agent' plugin/ralph-hero/skills/hero/SKILL.md` returns at least one match
-- [ ] ralph-merge's `allowed-tools` does NOT include `Skill`
-- [ ] ralph-merge's frontmatter `context: fork` is removed (it became misleading — the skill is now a leaf and runs in caller context as a normal Skill())
-- [ ] Standalone `just merge NNN` on a PR with no review decision outputs `MERGE BLOCKED — review required` and stops
-- [ ] `RALPH_REVIEW_MODE=auto` finish run on a PR with auto-review feedback dispatches impl-agent and re-runs the merge path
+- [x] `grep -n 'code-review:code-review' plugin/ralph-hero/skills/ralph-merge/SKILL.md` returns zero matches
+- [x] `grep -n 'code-review:code-review' plugin/ralph-hero/skills/finish/SKILL.md` returns at least one match (the new inline call)
+- [x] `grep -n 'Skill.*ralph-pr' plugin/ralph-hero/skills/hero/SKILL.md` returns zero matches
+- [x] `grep -n 'Agent.*pr-agent' plugin/ralph-hero/skills/hero/SKILL.md` returns at least one match
+- [x] ralph-merge's `allowed-tools` does NOT include `Skill`
+- [x] ralph-merge's frontmatter `context: fork` is removed (it became misleading — the skill is now a leaf and runs in caller context as a normal Skill())
+- [ ] Standalone `just merge NNN` on a PR with no review decision outputs `MERGE BLOCKED — review required` and stops (manual)
+- [ ] `RALPH_REVIEW_MODE=auto` finish run on a PR with auto-review feedback dispatches impl-agent and re-runs the merge path (manual)
 
 ## What We're NOT Doing
 
@@ -114,19 +114,19 @@ Single phase implementing the full Path B resolution plus the independent ralph-
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] A new step (Step 3.5 or renamed Step 4 with merge dispatch becoming Step 5) runs the code-review gate BEFORE the merge-mechanics dispatch.
-  - [ ] The new step calls `gh pr view PR_NUMBER --json reviewDecision` and branches:
+  - [x] A new step (Step 3.5 or renamed Step 4 with merge dispatch becoming Step 5) runs the code-review gate BEFORE the merge-mechanics dispatch.
+  - [x] The new step calls `gh pr view PR_NUMBER --json reviewDecision` and branches:
     - If `APPROVED` → continue to merge dispatch.
     - If `CHANGES_REQUESTED` (human reviewer) → output `FINISH BLOCKED` with reason "Human reviewer requested changes" and stop.
     - If null/empty → check `RALPH_REVIEW_MODE`:
       - `auto` → dispatch `Skill("code-review:code-review", "PR_NUMBER")` directly inline (legal: finish runs at depth 0, code-review runs at depth 0, fan-out at depth 1).
       - `interactive` (default) → present the existing AskUserQuestion choice ("Run code review" / "Merge without review"), behavior matching the prior ralph-merge Step 4 interactive branch.
-  - [ ] After the auto code-review completes, re-check `reviewDecision`:
+  - [x] After the auto code-review completes, re-check `reviewDecision`:
     - `APPROVED` → continue to merge dispatch.
     - `CHANGES_REQUESTED` → dispatch impl-agent in Address Mode (the existing Step 4a logic, now repurposed as the post-review fix cycle). Max 1 fix cycle. Re-run code-review once after the fix; if still `CHANGES_REQUESTED`, output `FINISH BLOCKED — code review feedback unresolved` and stop.
-  - [ ] After the gate resolves, the merge dispatch step calls `Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")` (unchanged) and handles `MERGED`, `MERGE BLOCKED`, `MERGE NOT READY` as before.
-  - [ ] The `CODE_REVIEW_FEEDBACK` status path is removed from finish — the fix cycle is now driven from the new gate step, not from interpreting ralph-merge's output.
-  - [ ] Configuration section adds `- Review mode: !` `echo ${RALPH_REVIEW_MODE:-interactive}` `` resolution line.
+  - [x] After the gate resolves, the merge dispatch step calls `Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")` (unchanged) and handles `MERGED`, `MERGE BLOCKED`, `MERGE NOT READY` as before.
+  - [x] The `CODE_REVIEW_FEEDBACK` status path is removed from finish — the fix cycle is now driven from the new gate step, not from interpreting ralph-merge's output.
+  - [x] Configuration section adds `- Review mode: !` `echo ${RALPH_REVIEW_MODE:-interactive}` `` resolution line.
 
 #### Task 1.2: Strip code-review gate from ralph-merge/SKILL.md
 - **files**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md` (modify)
@@ -134,19 +134,19 @@ Single phase implementing the full Path B resolution plus the independent ralph-
 - **complexity**: medium
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] The entire Step 4 ("Code Review Gate", lines ~103-211) is replaced with a smaller "Step 4: Review Decision Guard":
+  - [x] The entire Step 4 ("Code Review Gate", lines ~103-211) is replaced with a smaller "Step 4: Review Decision Guard":
     - Calls `gh pr view PR_NUMBER --json reviewDecision`.
     - If `APPROVED` or null AND the issue's estimate is `XS` with zero PR comments → continue to Step 4a / Step 5 (preserves the existing XS-no-review exception in Step 4a).
     - If `null` (and not the XS exception) → output `MERGE BLOCKED` with reason "Code review required — invoke /ralph-hero:finish or /ralph-hero:ralph-code-review first" and stop.
     - If `CHANGES_REQUESTED` → output `MERGE BLOCKED` with reason "Reviewer requested changes — address feedback before merging" and stop.
-  - [ ] No `Skill("code-review:code-review", ...)` call remains anywhere in ralph-merge.
-  - [ ] No `AskUserQuestion` for code-review remains in ralph-merge (interactive prompt now lives in finish).
-  - [ ] The output-contract table at the top of Step 4 is updated: `CODE_REVIEW_FEEDBACK` row is removed (no longer emitted by ralph-merge).
-  - [ ] Step 4a (Autonomous Merge Gate, `RALPH_AUTO_MERGE=true`) is unchanged.
-  - [ ] Step 5 (Check PR Readiness) and all subsequent steps are unchanged.
-  - [ ] Frontmatter `allowed-tools` no longer contains `Skill` and no longer contains `AskUserQuestion`.
-  - [ ] Frontmatter `context: fork` is removed (the skill now runs inline as a leaf merge-mechanics skill; `context: fork` was misleading documentation and is not enforced anyway).
-  - [ ] The skill's description in frontmatter is updated to reflect the new scope (e.g., "Merge an approved pull request — handles PR readiness, merges, cleans up worktree, moves issues to Done. Code review must be run by the caller (finish or ralph-code-review).").
+  - [x] No `Skill("code-review:code-review", ...)` call remains anywhere in ralph-merge.
+  - [x] No `AskUserQuestion` for code-review remains in ralph-merge (interactive prompt now lives in finish).
+  - [x] The output-contract table at the top of Step 4 is updated: `CODE_REVIEW_FEEDBACK` row is removed (no longer emitted by ralph-merge).
+  - [x] Step 4a (Autonomous Merge Gate, `RALPH_AUTO_MERGE=true`) is unchanged.
+  - [x] Step 5 (Check PR Readiness) and all subsequent steps are unchanged.
+  - [x] Frontmatter `allowed-tools` no longer contains `Skill` and no longer contains `AskUserQuestion`.
+  - [x] Frontmatter `context: fork` is removed (the skill now runs inline as a leaf merge-mechanics skill; `context: fork` was misleading documentation and is not enforced anyway).
+  - [x] The skill's description in frontmatter is updated to reflect the new scope (e.g., "Merge an approved pull request — handles PR readiness, merges, cleans up worktree, moves issues to Done. Code review must be run by the caller (finish or ralph-code-review).").
 
 #### Task 1.3: Convert hero's PR dispatch from Skill to pr-agent
 - **files**: `plugin/ralph-hero/skills/hero/SKILL.md` (modify)
@@ -154,9 +154,9 @@ Single phase implementing the full Path B resolution plus the independent ralph-
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] The `Skill("ralph-hero:ralph-pr", args="NNN")` call is replaced with `Agent(subagent_type="ralph-hero:pr-agent", prompt="Create PR for GH-NNN. Worktree: worktrees/GH-NNN", description="PR for GH-NNN")`.
-  - [ ] The Dispatch Architecture explanation block is updated to document the new pattern: PR phase always uses `Agent()` (haiku in isolated context); merge phase remains `Skill()` inline (Path B preserves code-review fan-out).
-  - [ ] No other dispatch calls in hero/SKILL.md are changed.
+  - [x] The `Skill("ralph-hero:ralph-pr", args="NNN")` call is replaced with `Agent(subagent_type="ralph-hero:pr-agent", prompt="Create PR for GH-NNN. Worktree: worktrees/GH-NNN", description="PR for GH-NNN")`.
+  - [x] The Dispatch Architecture explanation block is updated to document the new pattern: PR phase always uses `Agent()` (haiku in isolated context); merge phase remains `Skill()` inline (Path B preserves code-review fan-out).
+  - [x] No other dispatch calls in hero/SKILL.md are changed.
 
 #### Task 1.4: Mark superseded draft plans
 - **files**:
@@ -166,9 +166,9 @@ Single phase implementing the full Path B resolution plus the independent ralph-
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `2026-04-06-haiku-skill-to-agent-dispatch.md`: front-matter `status` changed from `draft` to `superseded`. A `## Superseded By` section added near the top pointing to this plan with one-paragraph explanation: ralph-pr conversion was absorbed into Phase 1 Task 1.3 of this plan; ralph-merge conversion was rejected in favor of Path B (hoist code-review out of merge instead of converting merge to Agent).
-  - [ ] `2026-04-06-auto-code-review-impl-fix-loop.md`: front-matter `status` changed from `draft` to `superseded`. A `## Superseded By` section added pointing to this plan with one-paragraph explanation: the auto code-review gate moved up to finish (Task 1.1) instead of staying in ralph-merge; the impl-agent fix-cycle pattern is preserved but now keyed on the new finish-owned gate, not on ralph-merge's `CODE_REVIEW_FEEDBACK` output.
-  - [ ] Both files retain all existing content below the new header — no historical content is deleted.
+  - [x] `2026-04-06-haiku-skill-to-agent-dispatch.md`: front-matter `status` changed from `draft` to `superseded`. A `## Superseded By` section added near the top pointing to this plan with one-paragraph explanation: ralph-pr conversion was absorbed into Phase 1 Task 1.3 of this plan; ralph-merge conversion was rejected in favor of Path B (hoist code-review out of merge instead of converting merge to Agent).
+  - [x] `2026-04-06-auto-code-review-impl-fix-loop.md`: front-matter `status` changed from `draft` to `superseded`. A `## Superseded By` section added pointing to this plan with one-paragraph explanation: the auto code-review gate moved up to finish (Task 1.1) instead of staying in ralph-merge; the impl-agent fix-cycle pattern is preserved but now keyed on the new finish-owned gate, not on ralph-merge's `CODE_REVIEW_FEEDBACK` output.
+  - [x] Both files retain all existing content below the new header — no historical content is deleted.
 
 #### Task 1.5: Verify standalone safety + cross-skill consistency
 - **files**: read-only across the repo (no file edits)
@@ -176,22 +176,22 @@ Single phase implementing the full Path B resolution plus the independent ralph-
 - **complexity**: low
 - **depends_on**: [1.1, 1.2, 1.3]
 - **acceptance**:
-  - [ ] `grep -rn 'code-review:code-review' plugin/ralph-hero/skills/ralph-merge/` returns zero matches.
-  - [ ] `grep -rn 'code-review:code-review' plugin/ralph-hero/skills/finish/` returns at least one match.
-  - [ ] `grep -rn 'Skill.*ralph-pr' plugin/ralph-hero/skills/hero/SKILL.md` returns zero matches.
-  - [ ] `grep -rn 'Agent.*pr-agent' plugin/ralph-hero/skills/hero/SKILL.md` returns at least one match.
-  - [ ] ralph-merge's `allowed-tools` block does not contain `Skill` (mechanical inspection of frontmatter).
-  - [ ] ralph-code-review's `Skill("code-review:code-review", ...)` call is unchanged (this skill is the other depth-0 entry point — Path B does not affect it).
+  - [x] `grep -rn 'code-review:code-review' plugin/ralph-hero/skills/ralph-merge/` returns zero matches.
+  - [x] `grep -rn 'code-review:code-review' plugin/ralph-hero/skills/finish/` returns at least one match.
+  - [x] `grep -rn 'Skill.*ralph-pr' plugin/ralph-hero/skills/hero/SKILL.md` returns zero matches.
+  - [x] `grep -rn 'Agent.*pr-agent' plugin/ralph-hero/skills/hero/SKILL.md` returns at least one match.
+  - [x] ralph-merge's `allowed-tools` block does not contain `Skill` (mechanical inspection of frontmatter).
+  - [x] ralph-code-review's `Skill("code-review:code-review", ...)` call is unchanged (this skill is the other depth-0 entry point — Path B does not affect it).
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no TypeScript errors (the plan only edits markdown skill bodies, but the build catches accidental syntactic drift in the broader plugin).
-- [ ] `cd plugin/ralph-hero/mcp-server && npm test` — all existing tests pass (no behavior change in tools; the plan edits skill instructions only, not MCP tool implementations).
-- [ ] `grep -rn 'code-review:code-review' plugin/ralph-hero/skills/ralph-merge/` — zero matches.
-- [ ] `grep -rn 'CODE_REVIEW_FEEDBACK' plugin/ralph-hero/skills/ralph-merge/` — zero matches.
-- [ ] `grep -rn 'Skill.*ralph-pr' plugin/ralph-hero/skills/hero/SKILL.md` — zero matches.
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no TypeScript errors (the plan only edits markdown skill bodies, but the build catches accidental syntactic drift in the broader plugin).
+- [x] `cd plugin/ralph-hero/mcp-server && npm test` — all existing tests pass (no behavior change in tools; the plan edits skill instructions only, not MCP tool implementations).
+- [x] `grep -rn 'code-review:code-review' plugin/ralph-hero/skills/ralph-merge/` — zero matches.
+- [x] `grep -rn 'CODE_REVIEW_FEEDBACK' plugin/ralph-hero/skills/ralph-merge/` — zero matches.
+- [x] `grep -rn 'Skill.*ralph-pr' plugin/ralph-hero/skills/hero/SKILL.md` — zero matches.
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

Implements Path B from #895 to resolve the forward-looking depth-2 dispatch conflict, plus the independent ralph-pr → Agent conversion.

- **finish/SKILL.md**: Hoisted `code-review:code-review` gate from `ralph-merge` Step 4 into a new `finish` Step 4 (auto + interactive branches), with Step 4a fix cycle. Renumbered downstream steps. Now finish owns the gate at depth 0.
- **ralph-merge/SKILL.md**: Stripped Step 4 down to a small Review Decision Guard (APPROVED → continue; null + non-XS → MERGE BLOCKED; null + XS-no-comments → continue; CHANGES_REQUESTED → MERGE BLOCKED). Removed `Skill`, `AskUserQuestion`, and `context: fork` from frontmatter — merge is now a leaf skill.
- **ralph-merge/eval-scenarios.md**: Rewrote scenarios for guard-only behavior; retired the auto-mode `CODE_REVIEW_FEEDBACK` and interactive `AskUserQuestion` scenarios.
- **hero/SKILL.md**: Replaced `Skill("ralph-hero:ralph-pr")` with `Agent(subagent_type="ralph-hero:pr-agent")`. Updated Dispatch Architecture text.
- **2026-04-06-haiku-skill-to-agent-dispatch.md** + **2026-04-06-auto-code-review-impl-fix-loop.md**: marked `status: superseded` with `## Superseded By` paragraphs.

## Plan & review

- Plan: [2026-05-05-GH-0895-depth-2-dispatch-resolution.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-05-GH-0895-depth-2-dispatch-resolution.md)
- Research: [2026-05-05-GH-0895-depth-2-dispatch-resolution-path.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-05-05-GH-0895-depth-2-dispatch-resolution-path.md)
- Critique: [2026-05-05-GH-0895-critique.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-05-GH-0895-critique.md)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1100/1100 passing
- [x] `code-review:code-review` zero matches in `plugin/ralph-hero/skills/ralph-merge/`
- [x] `code-review:code-review` matches in `plugin/ralph-hero/skills/finish/`
- [x] `Skill.*ralph-pr` zero matches in hero/SKILL.md
- [x] `Agent.*pr-agent` matches in hero/SKILL.md
- [x] ralph-merge frontmatter no `Skill`, no `AskUserQuestion`, no `context: fork`
- [x] Both 2026-04-06 plans now `status: superseded`
- [ ] Manual: `just merge NNN` standalone safety end-to-end test
- [ ] Manual: `RALPH_REVIEW_MODE=auto` finish round-trip

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)