### PR TITLE
test(ralph-knowledge): add knowledge_search retrieval eval as CI regression guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
           cache: npm
           cache-dependency-path: plugin/ralph-knowledge/package-lock.json
 
+      - name: Cache HuggingFace models (GH-920)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: ${{ runner.os }}-hf-${{ hashFiles('plugin/ralph-knowledge/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-hf-
+
       - name: Install dependencies
         run: npm ci
 
@@ -96,6 +104,10 @@ jobs:
       - name: Heap regression bench (GH-913)
         run: npm run bench:heap -- --assert
         timeout-minutes: 5
+
+      - name: Retrieval eval (GH-920)
+        run: npm run eval:retrieval -- --assert
+        timeout-minutes: 10
 
   test-cli:
     runs-on: ubuntu-latest

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop.md
@@ -1,0 +1,887 @@
+---
+date: 2026-04-16
+status: draft
+type: plan
+tags: [ralph-knowledge, chunking, embeddings, mcp, dream-loop, local-llm, contextual-retrieval, memory-layer, gemma-4, launchd]
+github_issue: 761
+github_issues: [761]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/761
+primary_issue: 761
+---
+
+# ralph-knowledge Chunked Embeddings + Contextual Retrieval + Dream-Loop Foundation
+
+## Prior Work
+
+- builds_on:: [[2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory]]
+- builds_on:: [[2026-03-28-ralph-knowledge-multi-project-architecture]]
+- builds_on:: [[2026-03-26-ralph-knowledge-architecture-for-engine-parity]]
+- builds_on:: [[2026-03-24-knowledge-graph-plugin-comparison]]
+- builds_on:: [[2026-03-27-group-GH-247-knowledge-persistence-parity]]
+
+## Overview
+
+Three coupled improvements to `ralph-hero/plugin/ralph-knowledge`, plus a new dream-loop that uses the improved substrate:
+
+1. **Chunked embeddings** — replace 500-char prefix truncation with recursive 512-token chunks (+64 overlap), enabling full-document semantic search over 3–8K char research corpus.
+2. **Contextual Retrieval** — prepend 50–100 token Gemma-4-generated context to each chunk before embedding, flag-on by default with graceful fallback when the local LLM is unreachable.
+3. **Multi-root ergonomics** — add `.ralphignore` support and a standard config pattern so the three project `thoughts/` roots index cleanly without per-session env var juggling.
+4. **Dream-loop** — nightly Python job pulls raw memories (gemma-lab sessions, git commits, existing corpus), clusters with HDBSCAN, asks Gemma 4 26B for per-cluster reflections, writes them back as `memory_tier=reflection` documents. Scheduled via launchd.
+
+This is a single plan because the dream-loop is the acceptance test for the chunking + MCP extensions: reflections are multi-paragraph, the corpus is long-form, and retrieval has to work end-to-end from Claude Code.
+
+## Current State Analysis
+
+Canonical implementation lives at `/Users/dubiel/projects/ralph-hero/plugin/ralph-knowledge/` (not ralph-engine — that is a downstream port).
+
+### What works today
+
+- **MCP server**: `index.ts:3,179` wires `StdioServerTransport` with `@modelcontextprotocol/sdk ^1.26.0`. 11 tools registered: `knowledge_search`, `knowledge_traverse`, `knowledge_record_outcome`, `knowledge_query_outcomes`, plus 7 graph tools (`graph-tools.ts:176,326,452,568,637,722,799`). Exposed as `mcp__plugin_ralph-knowledge_*` in Claude Code.
+- **Hybrid search**: `hybrid-search.ts:8,35-45` with RRF K=60. Document-level results only.
+- **Vector store**: `vector-search.ts:26-33` declares `documents_vec` as `vec0(id TEXT PRIMARY KEY, embedding float[384] distance_metric=cosine)`.
+- **Schema + migrations**: `db.ts:103-163` `createSchema()`. Migration pattern via `meta.schema_version` key (`reindex.ts:22-30, 151-153`). Current version: `"2"`.
+- **Multi-root via env var**: `reindex.ts:185-206` `resolveDirs()` accepts `RALPH_KNOWLEDGE_DIRS` (comma-split) OR CLI positional args, falls back to `../../thoughts` relative to cwd. **This already works** — it is just undiscoverable.
+- **Mtime incremental**: `reindex.ts:66-73` skips unchanged files. Stale deletion at `reindex.ts:44-55` drops `documents` / FTS / `documents_vec` / `sync` rows when a file disappears.
+- **Tests**: 13 vitest files under `src/__tests__/` cover every major module.
+- **Typed wikilinks**: `parser.ts:32,58-89` extracts `builds_on::`, `tensions::`, `post_mortem::` plus untyped `[[link]]` with paragraph context.
+
+### Gaps that break the research corpus
+
+1. **500-char prefix truncation** (`embedder.ts:7,24`): `prepareTextForEmbedding` (`embedder.ts:32-43`) concatenates `title + tagLine + firstParagraph` and slices at 500 chars. For 3–8K char research docs, everything past the first paragraph is invisible to vector search.
+2. **No chunk support in schema** (`db.ts:103-163`): one row per document in `documents`, one row per doc in `documents_vec`, one row per doc in `documents_fts`. No way to store multiple embeddings per document.
+3. **No `.ralphignore` / gitignore awareness** (`file-scanner.ts:4-18`): only skips `.`/`_`-prefixed entries. Ephemeral agent worktrees under `ralph-hero/.claude/worktrees/agent-*` would be indexed if the user added that root.
+4. **No `memory_tier` column**: dream-loop reflections need to be distinguishable from raw memories so the LLM can query "show me only reflections about X" or weigh them differently.
+5. **No config file**: only `RALPH_KNOWLEDGE_DIRS` env var (`reindex.ts:196-203`) — invisible at session start, lost if shell is reset.
+
+### Key discoveries
+
+- `meta` table with `schema_version` gives us clean forward migrations (`reindex.ts:22-30`). Bumping to `"3"` triggers full reindex automatically.
+- `outcome_events` table (`db.ts:130-145`) is a template for how auxiliary tables are structured — but reflection telemetry should go in its own `reflection_runs` table, not blend with outcome events.
+- `embed()` returns raw `Float32Array` (`embedder.ts:29`) — no hard-coded 384. Dim lives only in `vector-search.ts:29`. Future embedder swap (BGE-small same dim, or Nomic 768-dim with migration) is narrow in scope.
+- Gemma 4 26B MoE is live at `http://localhost:8000` (`gemma-lab/.env`, `scripts/start-server.sh`) with OpenAI-compatible `/v1/chat/completions`. 262K context, ~75 tok/s. Fast enough for per-chunk context generation.
+- `gemma-lab/sessions/YYYY-MM-DD.jsonl` already logs every `ask.sh` call — free dream-loop source with zero instrumentation.
+- `~/.llm/logs.db` is available if we install `simonw/llm` (not currently installed).
+
+## Desired End State
+
+After this plan:
+
+1. `knowledge_search "reflection loop HDBSCAN"` returns snippets from chunk-level matches inside research docs, not just title/first-paragraph matches.
+2. Schema version is `"3"`; `chunks` table populated with ~6–16 chunks per long document; every chunk has a `context_prefix` if `RALPH_LLM_URL` is reachable, empty string if not.
+3. `~/.ralph/knowledge.config.json` documents scan roots and ignore patterns. `.ralphignore` files at root dirs override for path-local exclusions.
+4. `scripts/dream-ingest.py` runs on demand and during the nightly job; pulls 24h of gemma-lab sessions, git commits, and optionally `llm` CLI logs into ralph-knowledge as `memory_tier=raw` documents.
+5. `scripts/dream-reflect.py` clusters the last 24h of raw memories, asks Gemma 4 26B for one reflection per cluster, stores them as `memory_tier=reflection` documents with `builds_on::` links to source raw memories.
+6. `~/Library/LaunchAgents/com.dubiel.dream-loop.plist` runs the ingester + reflector at 3 AM daily with `StartCalendarInterval` (survives sleep).
+7. From Claude Code, `knowledge_search "what did I work on this week" --memory_tier reflection` returns reflections covering last 7 days.
+
+### Verification
+
+- `npm run build && npm test` in `plugin/ralph-knowledge` passes.
+- `npm run reindex -- ~/.ralph-hero/knowledge.db /Users/dubiel/projects/thoughts` completes; `sqlite3 knowledge.db "SELECT COUNT(*) FROM chunks"` is > 3× `SELECT COUNT(*) FROM documents`.
+- Manual query from Claude Code via MCP returns chunk-level snippets from a known long research doc.
+- After one manual dream-loop run, `SELECT id, title FROM documents WHERE memory_tier='reflection' ORDER BY date DESC LIMIT 5` returns 1–5 reflections with source links.
+- `launchctl list | grep com.dubiel.dream-loop` shows the agent loaded; next fire timestamp is tomorrow at 03:00.
+
+## What We're NOT Doing
+
+Explicitly out of scope:
+
+- **Embedding model swap** (BGE-small-en-v1.5 / Nomic / EmbeddingGemma). Keep `Xenova/all-MiniLM-L6-v2` 384-dim. Model swap is a separate follow-up plan — trivial once chunks exist.
+- **Per-project DB isolation**. Global `~/.ralph-hero/knowledge.db` stays. Open question #2 from the research doc is deferred.
+- **Git `worktree list --porcelain` auto-discovery**. Multi-root is already supported; `.ralphignore` + config file is the complete ergonomic fix. Git shell-outs add fragility and risk indexing ephemeral agent worktrees.
+- **FTS5 incremental upsert optimization**. `reindex.ts` already handles per-document FTS inserts (`reindex.ts:151-153` full rebuild only on schema version bump). Current behavior is acceptable for the corpus size.
+- **Screenpipe ambient capture**. Not installed, out of scope. Optional Phase-later.
+- **`llm` CLI adoption as default prompt logger**. Install is optional in Phase 5; gemma-lab sessions are the canonical source.
+- **Reflection-of-reflections** (tier 2+ consolidation). Single pass: raw → reflection. Higher-order consolidation is future work.
+- **Cognee / Mem0 / Graphiti integration**. We extend ralph-knowledge instead.
+- **OAuth / ACL**. Single-user local stack. OAuth 2.1 OBO is Prototype C (team-memory) scope.
+- **Cross-repo issue coordination**. Tracking issue in `cdubiel08/ralph-hero`, all code PRs in same repo.
+
+## Implementation Approach
+
+Six phases. Phases 1–4 are plugin-side (TypeScript, `plugin/ralph-knowledge/src/`). Phases 5–6 add the dream-loop (Python, `scripts/dream/`, launchd plist). Phase 1 is a hard prerequisite for everything else; Phases 2–4 can run in parallel after Phase 1; Phase 5 depends on Phase 4; Phase 6 depends on Phase 5.
+
+---
+
+## Phase 1: Chunk-level embeddings + schema v3
+
+### Overview
+
+Introduce a `chunks` table and migrate `documents_vec` to chunk-level rows. Replace `prepareTextForEmbedding`'s single-slice truncation with a `RecursiveCharacterTextSplitter` that emits 512-token chunks with 64-token overlap. `HybridSearch` deduplicates by `document_id` and returns the best-scoring chunk's content as `snippet`.
+
+### Changes Required
+
+#### 1. Schema migration (v2 → v3)
+
+**File**: `plugin/ralph-knowledge/src/db.ts`
+
+In `createSchema()` after the `meta` table (around line 163), add:
+
+```sql
+CREATE TABLE IF NOT EXISTS chunks (
+  id TEXT PRIMARY KEY,              -- "{doc_id}#c{index}"
+  document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  chunk_index INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  char_start INTEGER NOT NULL,
+  char_end INTEGER NOT NULL,
+  context_prefix TEXT NOT NULL DEFAULT '',  -- filled by Phase 2
+  UNIQUE(document_id, chunk_index)
+);
+CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id);
+```
+
+Add `memory_tier` column to `documents`:
+
+```sql
+ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc'
+  CHECK(memory_tier IN ('doc','raw','reflection'));
+CREATE INDEX IF NOT EXISTS idx_documents_memory_tier ON documents(memory_tier);
+```
+
+Update `schema_version` bump in `reindex.ts:22-30` to target `"3"`. The existing logic already triggers full FTS + vec rebuild on version change; no new migration code path needed, just the SQL.
+
+#### 2. Chunker
+
+**File**: `plugin/ralph-knowledge/src/chunker.ts` (new)
+
+Port `RecursiveCharacterTextSplitter` semantics. Signature:
+
+```typescript
+export interface Chunk {
+  index: number;
+  content: string;
+  charStart: number;
+  charEnd: number;
+}
+
+export interface ChunkerOptions {
+  chunkSize?: number;   // default 2048 chars (~512 tokens for English)
+  chunkOverlap?: number; // default 256 chars (~64 tokens)
+  separators?: string[]; // default ["\n\n","\n",". "," ",""]
+}
+
+export function chunkText(text: string, opts?: ChunkerOptions): Chunk[];
+```
+
+Algorithm: try each separator in order; if split pieces fit `chunkSize`, join with overlap; else recurse into the largest piece with the next separator. Preserve `charStart`/`charEnd` byte offsets into the original string.
+
+Short documents (≤ `chunkSize`) yield a single chunk covering the whole text — so every document has at least one row in `chunks`.
+
+#### 3. Embedder API change
+
+**File**: `plugin/ralph-knowledge/src/embedder.ts`
+
+Replace `prepareTextForEmbedding` (lines 32-43) and the single-slice in `embed()` (line 24) with a chunk-aware flow.
+
+Keep the existing `embed(text: string): Promise<Float32Array>` for backward compat in tests. Add:
+
+```typescript
+export interface DocumentChunk extends Chunk {
+  embedding: Float32Array;
+  contextPrefix?: string; // added in Phase 2
+}
+
+export async function embedDocument(
+  title: string,
+  tags: string[],
+  content: string,
+  opts?: ChunkerOptions
+): Promise<DocumentChunk[]>;
+```
+
+Each chunk is embedded from `${title}\n${tagLine}\n${chunk.content}` (title and tags prepended to every chunk so the semantic anchor travels). No hard slice; the transformer's internal 512-token window handles overflow via its own truncation — acceptable since chunks are sized to fit.
+
+Remove `MAX_CHARS = 500`. Remove the `.slice(0, MAX_CHARS)` at line 24.
+
+#### 4. Reindex wiring
+
+**File**: `plugin/ralph-knowledge/src/reindex.ts`
+
+Around lines 100–140 where a document's content is written, replace the single `documents_vec` upsert with:
+
+```typescript
+// Delete all existing chunks for this document
+db.prepare('DELETE FROM chunks WHERE document_id = ?').run(doc.id);
+db.prepare('DELETE FROM documents_vec WHERE id GLOB ?').run(`${doc.id}#c*`);
+
+// Produce and insert chunks
+const docChunks = await embedDocument(doc.title, doc.tags, doc.content);
+const insertChunk = db.prepare(
+  'INSERT INTO chunks (id, document_id, chunk_index, content, char_start, char_end) VALUES (?,?,?,?,?,?)'
+);
+const insertVec = db.prepare(
+  'INSERT INTO documents_vec (id, embedding) VALUES (?, ?)'
+);
+for (const chunk of docChunks) {
+  const chunkId = `${doc.id}#c${chunk.index}`;
+  insertChunk.run(chunkId, doc.id, chunk.index, chunk.content, chunk.charStart, chunk.charEnd);
+  insertVec.run(chunkId, Buffer.from(chunk.embedding.buffer));
+}
+```
+
+Stale deletion (lines 44-55) stays as-is since `ON DELETE CASCADE` on `chunks.document_id` will clean children, and the `documents_vec` `GLOB` pattern works for the chunk id scheme.
+
+#### 5. HybridSearch: chunk-level match with doc-level dedupe
+
+**File**: `plugin/ralph-knowledge/src/hybrid-search.ts`
+
+Two changes:
+
+1. **Extract document_id from chunk id**: when reading vector search results, split on `#c` to get `doc_id`.
+2. **Deduplicate by doc_id, keep best chunk**: fuse RRF scores across chunk matches per document; return `{ doc_id, best_chunk_id, best_chunk_content, score }`.
+
+Pseudocode at lines 35-45 region:
+
+```typescript
+// Vector hits now reference chunks; convert to doc-level buckets
+const docBuckets = new Map<string, { bestChunkId: string; bestChunkRank: number; bestChunkContent: string }>();
+for (const hit of vectorResults) {
+  const docId = hit.id.split('#c')[0];
+  if (!docBuckets.has(docId) || hit.rank < docBuckets.get(docId)!.bestChunkRank) {
+    docBuckets.set(docId, { bestChunkId: hit.id, bestChunkRank: hit.rank, bestChunkContent: hit.content });
+  }
+}
+// Then RRF-fuse bucket ranks with FTS ranks (FTS is still doc-level)
+```
+
+The `snippet` field in `SearchResult` (`search.ts:11-19`) becomes the matching chunk's content (truncated to ~300 chars for readability), not the document's first paragraph.
+
+#### 6. Vector search join
+
+**File**: `plugin/ralph-knowledge/src/vector-search.ts`
+
+At lines 62-68, the MATCH query returns chunk ids; add a LEFT JOIN to `chunks` to return `content` alongside `distance` for the snippet.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npm run build` passes (TypeScript strict)
+- [ ] `npm test` passes (all 13 existing test files)
+- [ ] New file `src/__tests__/chunker.test.ts` covers: short docs (single chunk), long docs (multiple chunks), overlap boundaries, unicode, code fences preserved
+- [ ] Updated `src/__tests__/embedder.test.ts` covers `embedDocument` returning ≥1 chunk, chunk count scaling with document length
+- [ ] Updated `src/__tests__/hybrid-search.test.ts` covers dedup-by-document_id and best-chunk snippet selection
+- [ ] `npm run reindex` against a fixture with one 8K-char markdown file produces ≥4 `chunks` rows for that doc
+
+#### Manual Verification
+- [ ] After reindex against `/Users/dubiel/projects/thoughts`, `SELECT COUNT(*) FROM chunks` is at least 3× `SELECT COUNT(*) FROM documents`
+- [ ] `mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search` from Claude Code with query "chunking strategies recursive character" returns a research doc with a snippet drawn from the *body* of the doc, not just the title/first paragraph
+- [ ] Existing search results for simple title-matching queries are still at least as good (no regression)
+
+**Implementation Note**: Pause here for manual confirmation. Bump schema to `"3"` forces a full reindex of the corpus — verify elapsed time and disk size before proceeding to Phase 2.
+
+---
+
+## Phase 2: Contextual Retrieval pre-embedding
+
+### Overview
+
+For each chunk, generate 50–100 token context via Gemma 4 26B at `http://localhost:8000` and prepend it to the chunk content before embedding. Store the context prefix in `chunks.context_prefix` so it survives reindexes without regeneration (unless the document mtime changes). Feature-flagged on by default with graceful fallback when the LLM endpoint is unreachable.
+
+### Changes Required
+
+#### 1. LLM client
+
+**File**: `plugin/ralph-knowledge/src/llm-client.ts` (new)
+
+Minimal OpenAI-compatible client (no SDK dep):
+
+```typescript
+export interface LlmClientOptions {
+  baseUrl?: string;  // default http://localhost:8000
+  model?: string;    // default env RALPH_LLM_MODEL or mlx-community/gemma-4-26b-a4b-it-mxfp8
+  timeoutMs?: number; // default 30000
+}
+
+export interface LlmClient {
+  available(): Promise<boolean>;
+  contextualize(fullDocument: string, chunkContent: string): Promise<string>;
+}
+
+export function createLlmClient(opts?: LlmClientOptions): LlmClient;
+```
+
+`available()` probes `${baseUrl}/v1/models` with a 2s timeout.
+
+`contextualize()` uses the Anthropic Contextual Retrieval prompt verbatim:
+
+```
+<document>
+{fullDocument}
+</document>
+
+Here is the chunk we want to situate within the whole document:
+
+<chunk>
+{chunkContent}
+</chunk>
+
+Please give a short succinct context to situate this chunk within the overall
+document for the purposes of improving search retrieval of the chunk. Answer only
+with the succinct context and nothing else.
+```
+
+Response target: ≤ 100 tokens. On error or timeout: return empty string (fail-open).
+
+#### 2. Feature flag + env vars
+
+Env vars (documented in README):
+
+- `RALPH_LLM_URL` (default `http://localhost:8000`) — LLM endpoint
+- `RALPH_LLM_MODEL` (default `mlx-community/gemma-4-26b-a4b-it-mxfp8`)
+- `RALPH_CONTEXTUAL_RETRIEVAL` (default `1`) — set to `0` to disable entirely
+
+At reindex start, if flag is on, probe `available()`. If unreachable, log a single warning ("LLM endpoint unreachable at $URL, contextual retrieval disabled for this run") and proceed with empty context prefixes.
+
+#### 3. Wire into embedder
+
+**File**: `plugin/ralph-knowledge/src/embedder.ts`
+
+Extend `embedDocument` signature:
+
+```typescript
+export async function embedDocument(
+  title: string,
+  tags: string[],
+  content: string,
+  opts?: ChunkerOptions & { llm?: LlmClient }
+): Promise<DocumentChunk[]>;
+```
+
+When `opts.llm` is provided, for each chunk:
+1. Check `chunks` table for existing `context_prefix` keyed on `doc_id + chunk_index + content hash`. If present and doc mtime unchanged, reuse.
+2. Otherwise call `llm.contextualize(content, chunk.content)`.
+3. Embed `${context}\n${title}\n${tagLine}\n${chunk.content}`.
+
+The content hash check prevents regenerating context when chunking boundaries shift but the text itself is stable — reduces backfill cost on re-runs.
+
+#### 4. Reindex integration
+
+**File**: `plugin/ralph-knowledge/src/reindex.ts`
+
+At the top of `main()` (near line 30), construct an LLM client if flag is on; pass to `embedDocument` calls.
+
+Backfill note: one-time cost for 429 docs × ~8 chunks × ~15s ≈ 14 hours. User should run this overnight or in segments. Add a progress log every 50 chunks.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npm run build` passes
+- [ ] `src/__tests__/llm-client.test.ts` covers `available()` success + failure paths with mock fetch
+- [ ] `src/__tests__/embedder.test.ts` covers `embedDocument` with a mock LLM client, verifies `context_prefix` is stored
+- [ ] With `RALPH_CONTEXTUAL_RETRIEVAL=0`, reindex completes without any LLM calls (verify via mock client call count)
+- [ ] With flag on and a mock-unreachable endpoint, reindex completes with empty context prefixes and logs one warning
+
+#### Manual Verification
+- [ ] With gemma-lab running (`./scripts/status.sh` shows active), a reindex of a 10-doc fixture produces non-empty `context_prefix` for every chunk
+- [ ] With gemma-lab stopped, reindex still completes (fail-open) with empty `context_prefix` and one log line
+- [ ] Search quality improves for a hand-picked set of 5 queries where the first paragraph does not mention the query term — compare results before/after contextualization
+
+**Implementation Note**: Pause for manual confirmation. Kick off full-corpus backfill asynchronously before proceeding to Phase 3.
+
+---
+
+## Phase 3: Multi-root ergonomics (`.ralphignore` + config)
+
+### Overview
+
+Multi-root via `RALPH_KNOWLEDGE_DIRS` already works (`reindex.ts:196-203`). The real gaps are: no ignore-pattern support, no persistent config, and no discoverable way to see what roots are being indexed. Adds `.ralphignore` (gitignore syntax) per-root plus an optional `~/.ralph/knowledge.config.json` that lists roots and global ignore patterns.
+
+### Changes Required
+
+#### 1. Ignore-pattern matcher
+
+**File**: `plugin/ralph-knowledge/src/ignore.ts` (new)
+
+Thin wrapper around the `ignore` npm package (already a common dep in the TS ecosystem; add to `package.json` dependencies). Signature:
+
+```typescript
+export interface IgnoreMatcher {
+  isIgnored(relativePath: string): boolean;
+}
+
+export function loadIgnoreForRoot(rootDir: string, globalPatterns?: string[]): IgnoreMatcher;
+```
+
+Reads `${rootDir}/.ralphignore` if present, combines with `globalPatterns`, returns a matcher. Default global patterns (applied even with no config): `.claude/`, `node_modules/`, `dist/`, `.git/`, `*.log`.
+
+#### 2. Config file support
+
+**File**: `plugin/ralph-knowledge/src/config.ts` (new)
+
+```typescript
+export interface KnowledgeConfig {
+  roots?: string[];                // absolute paths; expanded tildes
+  ignorePatterns?: string[];       // gitignore syntax, applied to every root
+  dbPath?: string;
+}
+
+export function loadConfig(): KnowledgeConfig;
+```
+
+Reads `$RALPH_KNOWLEDGE_CONFIG` env var path OR `~/.ralph/knowledge.config.json` OR returns empty.
+
+#### 3. Precedence update in `resolveDirs`
+
+**File**: `plugin/ralph-knowledge/src/reindex.ts`
+
+At lines 185-206, update precedence:
+
+```
+1. CLI positional args (explicit override)
+2. RALPH_KNOWLEDGE_DIRS env var
+3. Config file roots
+4. Fallback: cwd/thoughts
+```
+
+If multiple sources conflict, the higher-priority wins (CLI > env > config > fallback). Log which source was selected.
+
+#### 4. Wire ignore into scanner
+
+**File**: `plugin/ralph-knowledge/src/file-scanner.ts`
+
+Extend signature:
+
+```typescript
+export function findMarkdownFiles(dir: string, matcher?: IgnoreMatcher): string[];
+```
+
+In the walk (lines 4-18), test each path against `matcher.isIgnored(relativeToRoot)` before descending or including. Keeps existing `.`/`_`-prefix skip as a fast-path.
+
+In `reindex.ts`, build a matcher per root via `loadIgnoreForRoot(root, config.ignorePatterns)` and pass it in.
+
+#### 5. User-facing config template
+
+**File**: `plugin/ralph-knowledge/README.md` (update)
+
+Document the config file with example:
+
+```json
+{
+  "roots": [
+    "/Users/dubiel/projects/thoughts",
+    "/Users/dubiel/projects/ralph-engine/thoughts",
+    "/Users/dubiel/projects/ralph-hero/thoughts"
+  ],
+  "ignorePatterns": [
+    ".claude/worktrees/**",
+    "**/node_modules/**"
+  ]
+}
+```
+
+Document that `.ralphignore` files at root dirs augment global ignore patterns.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npm run build` passes
+- [ ] `src/__tests__/ignore.test.ts` covers gitignore syntax (globs, negation, directory-only patterns)
+- [ ] `src/__tests__/config.test.ts` covers missing file, malformed JSON, tilde expansion, env var override
+- [ ] Updated `src/__tests__/reindex.test.ts` covers precedence (CLI > env > config > fallback)
+- [ ] `src/__tests__/file-scanner.test.ts` updated to verify `.ralphignore` exclusions on a temp directory
+
+#### Manual Verification
+- [ ] Write `~/.ralph/knowledge.config.json` with three roots; run `npm run reindex`; observe all three roots scanned (check log output)
+- [ ] Drop `.ralphignore` with `.claude/worktrees/**` into `ralph-hero/`; observe no `documents` rows from agent worktrees after reindex
+- [ ] `npm run reindex -- /Users/dubiel/projects/thoughts` still works (CLI override)
+
+---
+
+## Phase 4: MCP tool extensions
+
+### Overview
+
+Extend `knowledge_search` to accept a `memory_tier` filter and surface chunk-level snippet metadata (chunk index, char offsets) so agents can cite specific passages. Add a new `knowledge_memory_stats` tool so the dream-loop can check "did reflections get written today?" without shelling into sqlite.
+
+### Changes Required
+
+#### 1. `knowledge_search` schema extension
+
+**File**: `plugin/ralph-knowledge/src/index.ts` (lines 33-43)
+
+Add to Zod schema:
+
+```typescript
+memory_tier: z.enum(['doc','raw','reflection','any']).optional().default('any'),
+return_chunk_meta: z.boolean().optional().default(false),
+```
+
+When `memory_tier !== 'any'`, filter `documents.memory_tier` in the SQL joins. When `return_chunk_meta` is true, include `chunk_index`, `char_start`, `char_end`, and `context_prefix` in the result payload.
+
+#### 2. `knowledge_memory_stats` (new tool)
+
+**File**: `plugin/ralph-knowledge/src/index.ts`
+
+```typescript
+server.tool(
+  'knowledge_memory_stats',
+  {
+    since: z.string().optional(), // ISO date; defaults to 24h ago
+  },
+  async ({ since }) => { ... }
+);
+```
+
+Returns:
+
+```json
+{
+  "total_documents": 1234,
+  "by_tier": { "doc": 1200, "raw": 28, "reflection": 6 },
+  "new_since": { "doc": 3, "raw": 28, "reflection": 6 },
+  "chunks_per_doc_p50": 4,
+  "chunks_per_doc_p90": 11,
+  "last_reflection_at": "2026-04-16T03:12:47Z"
+}
+```
+
+Used by the dream-loop to confirm ingest + reflection completed.
+
+#### 3. `knowledge_traverse` memory_tier filter
+
+**File**: `plugin/ralph-knowledge/src/index.ts` (lines 70-79)
+
+Add `memory_tier` optional filter. Useful for "traverse reflections only" queries.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `npm run build` passes
+- [ ] `src/__tests__/index.test.ts` covers `knowledge_search` with `memory_tier=reflection` returns only reflection docs
+- [ ] New `src/__tests__/memory-stats.test.ts` covers `knowledge_memory_stats` tool on a fixture DB
+- [ ] `return_chunk_meta=true` results include `chunk_index` and `char_start`
+
+#### Manual Verification
+- [ ] From Claude Code: `knowledge_search` with `memory_tier=raw` returns only raw memories after Phase 5 runs
+- [ ] `knowledge_memory_stats` returns expected JSON shape
+
+---
+
+## Phase 5: Dream-loop ingester (Python)
+
+### Overview
+
+Python script `scripts/dream/ingest.py` that pulls the last 24 hours of raw memories from three sources and writes them to ralph-knowledge as `memory_tier=raw` markdown files in a dedicated `dream-memories/` directory, then triggers a reindex. Uses `uv` per user convention.
+
+### Changes Required
+
+#### 1. Directory + source conventions
+
+**Path**: `/Users/dubiel/projects/thoughts/dream-memories/YYYY/MM/DD/<source>-<hash>.md`
+
+Example: `thoughts/dream-memories/2026/04/16/gemma-lab-a3f2e1.md`
+
+Each file carries frontmatter:
+
+```yaml
+---
+date: 2026-04-16T14:32:07-07:00
+memory_tier: raw
+source: gemma-lab     # gemma-lab | llm-cli | git-commit
+source_id: a3f2e1...   # hash or line number for idempotency
+tags: [dream, raw]
+---
+```
+
+Body contains the raw memory content (prompt+response for LLM sessions, diff summary for commits).
+
+Add `thoughts/dream-memories/` to the config roots (Phase 3 already reads it).
+
+#### 2. Python project
+
+**File**: `ralph-hero/scripts/dream/pyproject.toml` (new)
+
+```toml
+[project]
+name = "ralph-dream"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "httpx>=0.27",
+  "hdbscan>=0.8.38",
+  "umap-learn>=0.5.6",
+  "numpy>=2.0",
+  "pyyaml>=6.0",
+]
+```
+
+Use `uv` for install: `uv sync` in `scripts/dream/`.
+
+#### 3. Ingester
+
+**File**: `ralph-hero/scripts/dream/ingest.py` (new)
+
+```python
+def ingest_gemma_lab_sessions(since: datetime) -> list[RawMemory]:
+    # Read gemma-lab/sessions/*.jsonl, filter by ts >= since
+    # Emit RawMemory per prompt/response pair
+
+def ingest_llm_cli_logs(since: datetime) -> list[RawMemory]:
+    # If ~/.llm/logs.db exists, read responses table, filter by datetime_utc >= since
+    # Emit RawMemory per response row
+
+def ingest_git_commits(since: datetime, repos: list[Path]) -> list[RawMemory]:
+    # For each repo, run `git log --since=... --format=... --patch`
+    # Emit RawMemory per commit with short patch summary
+
+def write_memory(m: RawMemory, base_dir: Path) -> Path:
+    # Hash source+id for idempotent filename
+    # Write .md with frontmatter to dream-memories/YYYY/MM/DD/
+```
+
+Idempotency: filename includes stable hash of `(source, source_id)`. Re-running the same day is safe — overwrites existing files with same content (no-op if mtime unchanged, so reindex skips).
+
+CLI:
+
+```bash
+uv run ingest.py --since 24h --base-dir /Users/dubiel/projects/thoughts/dream-memories \
+  --repos /Users/dubiel/projects/ralph-hero /Users/dubiel/projects/ralph-engine
+```
+
+#### 4. Config
+
+**File**: `ralph-hero/scripts/dream/config.yaml` (new)
+
+```yaml
+base_dir: /Users/dubiel/projects/thoughts/dream-memories
+gemma_lab_sessions: /Users/dubiel/projects/gemma-lab/sessions
+llm_cli_db: ~/.llm/logs.db   # optional; skipped if missing
+git_repos:
+  - /Users/dubiel/projects/ralph-hero
+  - /Users/dubiel/projects/ralph-engine
+  - /Users/dubiel/projects/gemma-lab
+```
+
+#### 5. Reindex hook
+
+At end of ingest, invoke:
+
+```bash
+npm --prefix /Users/dubiel/projects/ralph-hero/plugin/ralph-knowledge run reindex
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `uv sync` in `scripts/dream/` succeeds
+- [ ] `pytest` (add `tests/test_ingest.py`) covers:
+  - Gemma-lab JSONL parsing (fixture with 5 entries)
+  - Git commit extraction (fixture repo)
+  - Idempotency: running ingest twice produces same files with same content
+  - `llm` CLI absent is handled gracefully
+
+#### Manual Verification
+- [ ] Run `uv run ingest.py --since 24h` — `ls thoughts/dream-memories/YYYY/MM/DD/` shows expected files
+- [ ] Reindex triggered; `knowledge_memory_stats` returns `by_tier.raw > 0`
+- [ ] Running ingest again immediately does not duplicate files
+
+---
+
+## Phase 6: Nightly reflection loop + launchd scheduling
+
+### Overview
+
+`scripts/dream/reflect.py` runs after ingest. It queries ralph-knowledge for the last 24h of `memory_tier=raw` documents, clusters them with HDBSCAN on UMAP-reduced embeddings, asks Gemma 4 26B for one reflection per cluster, and writes reflections as `memory_tier=reflection` markdown files with `builds_on::` links to source raw memory ids. A launchd plist schedules both ingest + reflect at 3 AM daily.
+
+### Changes Required
+
+#### 1. Reflection clusterer
+
+**File**: `ralph-hero/scripts/dream/reflect.py` (new)
+
+```python
+def fetch_recent_raw_memories(mcp_url: str, since: datetime) -> list[Memory]:
+    # Call knowledge_search via MCP stdio (or direct sqlite if simpler)
+    # memory_tier=raw, since=..., limit=500
+
+def cluster_memories(memories: list[Memory]) -> list[Cluster]:
+    # Stack embeddings (Nx384)
+    # UMAP to 50 dims (n_neighbors=15, min_dist=0.1)
+    # HDBSCAN (min_cluster_size=5, min_samples=3)
+    # Return clusters; discard noise (label = -1)
+
+def synthesize_reflection(cluster: Cluster, llm: LlmClient) -> Reflection:
+    # Prompt template (A-Mem-inspired)
+
+def write_reflection(r: Reflection, base_dir: Path) -> Path:
+    # thoughts/dream-memories/reflections/YYYY/MM/DD/<theme-slug>.md
+```
+
+Embeddings: read directly from `knowledge.db` `documents_vec` for the raw memory chunks. For cluster assignment, use the mean chunk embedding per document.
+
+#### 2. Reflection prompt (A-Mem-inspired)
+
+```
+You are consolidating short-term memories into a single reflection note.
+
+Below are {N} related memories from the last 24 hours:
+
+{for each memory:
+---
+source: {source}
+timestamp: {ts}
+content: {content[:800]}
+---
+}
+
+Produce a reflection with:
+1. A 3-7 word title capturing the theme
+2. A 2-3 sentence summary of what the memories have in common
+3. 3-5 bullet points of specific insights, decisions, or unresolved questions
+4. A list of the memory ids this reflection links to
+
+Format as YAML frontmatter followed by markdown body.
+```
+
+Parse LLM output; write as `memory_tier=reflection` with `builds_on:: [[source-memory-id]]` for each linked memory.
+
+#### 3. Reflection storage convention
+
+**Path**: `/Users/dubiel/projects/thoughts/dream-memories/reflections/YYYY/MM/DD/<theme-slug>.md`
+
+Frontmatter:
+
+```yaml
+---
+date: 2026-04-17T03:12:47-07:00
+memory_tier: reflection
+source: dream-loop
+cluster_size: 7
+source_ids: [abc123, def456, ...]
+tags: [dream, reflection]
+---
+
+# Theme title
+
+## Summary
+...
+
+## Insights
+- ...
+
+## Links
+- builds_on:: [[dream-memory-abc123]]
+- builds_on:: [[dream-memory-def456]]
+```
+
+#### 4. launchd plist
+
+**File**: `~/Library/LaunchAgents/com.dubiel.dream-loop.plist` (new; not committed to repo — lives in `$HOME`)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.dubiel.dream-loop</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>cd /Users/dubiel/projects/ralph-hero/scripts/dream && uv run ingest.py --since 24h && uv run reflect.py --since 24h</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>3</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/dream-loop.out</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/dream-loop.err</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <key>RALPH_KNOWLEDGE_CONFIG</key>
+    <string>/Users/dubiel/.ralph/knowledge.config.json</string>
+    <key>RALPH_LLM_URL</key>
+    <string>http://localhost:8000</string>
+  </dict>
+</dict>
+</plist>
+```
+
+Commit a **template** at `ralph-hero/scripts/dream/launchd/com.dubiel.dream-loop.plist.template` and document the copy-and-load step:
+
+```bash
+cp scripts/dream/launchd/com.dubiel.dream-loop.plist.template \
+   ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
+launchctl load ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
+```
+
+#### 5. Log rotation
+
+Keep `/tmp/dream-loop.out` and `.err` bounded; add a `scripts/dream/logrotate.sh` that tails to 1000 lines post-run, called from the launchd job.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `pytest scripts/dream/tests/` passes; new `test_reflect.py` covers:
+  - Clustering on fixture embeddings (expect 2-3 clusters from a crafted fixture)
+  - Reflection parsing (well-formed LLM output fixture)
+  - LLM output malformed — fails gracefully with one warning, writes no reflection
+- [ ] `uv run reflect.py --since 24h --dry-run` on a seeded fixture produces the expected cluster count
+
+#### Manual Verification
+- [ ] Manually run `uv run ingest.py --since 24h && uv run reflect.py --since 24h` — at least 1 reflection written
+- [ ] Read the reflection — the theme is recognizable, insights are specific, links resolve
+- [ ] `knowledge_search` from Claude Code with `memory_tier=reflection` returns the new reflection
+- [ ] `launchctl load ~/Library/LaunchAgents/com.dubiel.dream-loop.plist` succeeds
+- [ ] `launchctl list | grep dream-loop` shows the agent with next-fire timestamp
+- [ ] Set system clock forward ~1 min past 03:00 OR use `launchctl start com.dubiel.dream-loop` — job runs; `/tmp/dream-loop.out` shows success
+- [ ] Next day at 03:00 real fire — reflections written (verify via `knowledge_memory_stats.last_reflection_at`)
+
+---
+
+## Testing Strategy
+
+### Unit tests (plugin/ralph-knowledge)
+- Chunker boundary cases (empty, short, unicode, code fences)
+- Embedder chunk generation count
+- HybridSearch dedupe-by-document
+- Ignore pattern matching
+- Config file precedence
+- LLM client fail-open
+
+### Integration tests (plugin/ralph-knowledge)
+- Full reindex of a 10-doc fixture corpus with varied lengths — verify chunk counts, context prefixes, search results
+- Reindex with contextual retrieval OFF then ON — verify context_prefix population differs
+
+### End-to-end (dream-loop)
+- Seed fixture: 20 gemma-lab sessions, 5 git commits, 3 llm-cli entries
+- Run ingest → verify raw memories created
+- Run reflect → verify reflections created with correct links
+- Query via MCP → verify reflections are retrievable
+
+### Manual acceptance
+- One week of real use: daily reflections written, reflections are actually useful for "what did I work on this week" queries
+
+## Performance Considerations
+
+- **Backfill**: ~429 docs × ~8 chunks × ~15s contextualization = ~14 hours one-time cost. Run overnight in a single pass; `reindex.ts` already supports resumption via mtime check.
+- **Incremental**: new docs in `thoughts/` trigger only their own chunks' contextualization (~2 min per new doc).
+- **Chunk table size**: 429 docs × 8 chunks × ~2KB content ≈ 7 MB. Current DB is 5.1 MB. Post-Phase-1 DB size estimate: 15–20 MB. Fine.
+- **Search latency**: chunk-level join adds one INDEX lookup per vector hit. Expected overhead: <5ms per query at corpus size.
+- **HDBSCAN on 100–500 memories**: <1s on M5 Pro. No concern.
+- **Gemma 4 26B reflection per cluster**: ~5–15 clusters/night × ~500 token output × ~75 tok/s = ~1–2 min total LLM time per night.
+
+## Migration Notes
+
+- **Schema v2 → v3**: bumping `meta.schema_version` forces full reindex via existing pattern at `reindex.ts:22-30`. No manual intervention needed.
+- **Existing `documents` rows preserved**: `memory_tier` defaults to `'doc'` for all current records. Dream-loop writes new rows with `raw`/`reflection`.
+- **Backward compat**: `knowledge_search` tool schema stays backward compatible (new fields are optional). Existing Claude Code invocations without `memory_tier` get `'any'` behavior (same as today).
+- **Rollback path**: if Phase 1 reindex produces worse search quality, revert schema to v2 and re-run reindex — chunks table is dropped by the downgrade.
+
+## References
+
+- Research: `thoughts/shared/research/2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory.md`
+- Contextual Retrieval (Anthropic, Sept 2024): https://www.anthropic.com/news/contextual-retrieval
+- A-Mem (NeurIPS 2025): https://arxiv.org/abs/2502.12110
+- sqlite-vec chunk pattern: https://github.com/asg017/sqlite-vec
+- `simonw/llm` schema: https://llm.datasette.io/en/stable/logging.html
+- launchd `StartCalendarInterval`: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/ScheduledJobs.html
+- Canonical code paths: `plugin/ralph-knowledge/src/{embedder,db,reindex,hybrid-search,vector-search,file-scanner,index}.ts`

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-22-context-handoff-topology.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-22-context-handoff-topology.md
@@ -1,0 +1,483 @@
+---
+date: 2026-04-22
+topic: "Context-handoff topology of the ralph-hero pipeline"
+tags: [research, architecture, context-windows, agent-dispatch, hooks, orchestration, consolidation]
+status: complete
+type: research
+git_commit: 8e6bb53
+---
+
+# Research: Context-handoff topology of the ralph-hero pipeline
+
+## Prior Work
+
+- builds_on:: [[2026-04-04-hero-dispatch-architecture-single-vs-team]]
+- builds_on:: [[2026-04-04-GH-0732-hero-skill-dispatch-migration]]
+- builds_on:: [[2026-04-06-haiku-skill-to-agent-dispatch]]
+- builds_on:: [[2026-04-01-GH-0674-agent-per-phase-still-needed]]
+- builds_on:: [[2026-03-24-GH-0674-agent-per-phase-architecture]]
+- builds_on:: [[2026-03-24-agent-env-propagation-token-scope]]
+- builds_on:: [[2026-03-20-skill-dispatch-inventory]]
+- builds_on:: [[2026-03-19-GH-0637-hero-dispatch-model]]
+- builds_on:: [[2026-02-22-ralph-workflow-v4-architecture-spec]]
+- builds_on:: [[2026-02-20-GH-0231-skill-subagent-team-context-pollution]]
+- builds_on:: [[2026-04-05-hero-pipeline-handoff-ux-inventory]]
+
+## Research Question
+
+Map every point in the ralph-hero pipeline where a fresh agent context starts vs. where state carries forward. For each handoff, document:
+
+1. What persists to disk (thoughts/, GitHub, worktree, plan docs) vs. what is discarded.
+2. The rationale for the split, if discoverable.
+3. Whether the split is structural (required for resumability/observability) or incidental.
+
+Enumerate (1) phase-to-phase handoffs in the hero orchestrator, (2) agent-to-subagent fan-outs inside each phase, (3) interactive vs. autonomous skill variants, and (4) hook-enforced constraints and their dependency on fresh-context attribution.
+
+## Summary
+
+Ralph-hero already consolidates context aggressively. The hero orchestrator dispatches the three highest-context phases (research, plan, review) as `Skill()` calls that run inline in hero's context; only impl, pr, merge, val, and cross-repo decomposition use `Agent()` fresh-context dispatch. This hybrid is the product of two deliberate migrations in early April 2026: GH-0732 moved Agent-per-phase → Skill() inline for analyst/builder phases; a follow-up (2026-04-06) moved pr/merge haiku phases back to Agent() because a haiku model cannot execute cleanly inside hero's Opus 1M context. Every current split exists for a specific reason documented in prior plans.
+
+Inside each phase, the remaining context-splits are the utility-agent fan-outs — `ralph-research` spawns 5–6 small specialist agents in parallel (codebase-locator, codebase-analyzer, codebase-pattern-finder, thoughts-locator, thoughts-analyzer, web-search-researcher), `ralph-plan` spawns 4, `ralph-plan-epic` spawns 2, `ralph-impl` spawns an implementer + reviewer pair per task plus a phase reviewer. The phase agents in `plugin/ralph-hero/agents/` are thin wrappers (a `skills:` preload); the utility agents are substantial and single-purpose.
+
+Hook enforcement is structured around `$RALPH_COMMAND` (set by each skill's own `SessionStart` hook via `set-skill-env.sh`), not `.agent_type` from the hook JSON payload. Only four scripts read `.agent_type`, and three use it as a fallback when `$RALPH_COMMAND` is empty. This is what made the GH-0732 migration safe — the same enforcement fires whether a phase runs via `Skill()` inline or `Agent()` fresh-context. The one enforcement tier that is unambiguously scoped to a fresh-context agent is the impl worktree gate (`impl-worktree-gate.sh`, `impl-staging-gate.sh`, `impl-plan-required.sh`) — these live in `ralph-impl/SKILL.md` frontmatter and activate whenever that skill is active, regardless of dispatch mode.
+
+Interactive and autonomous skill variants differ along seven dimensions: `context: fork`, `user-invocable: false`, absence of `AskUserQuestion`/`Edit`/`WebSearch`, full hook stack (6–10 hooks) vs. 0–1 hooks, `!cat` fragment loading, model override (only on `ralph-research`), and addition of state-mutation tools (`save_issue`, `sync_plan_graph`, `add_dependency`). The autonomous variants are deliberately narrower, not copy-pasted from the interactive ones.
+
+## Detailed Findings
+
+### 1. Phase-to-phase handoffs in the hero orchestrator
+
+#### 1.1 Dispatch matrix
+
+Source: [`plugin/ralph-hero/skills/hero/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/hero/SKILL.md) (Execution Loop, Step 3, lines 261–464).
+
+| Phase | Dispatch | Model | Inline or fresh? | File:line |
+|---|---|---|---|---|
+| SPLIT | `Skill("ralph-hero:ralph-split")` | opus | inline | hero/SKILL.md:278 |
+| RESEARCH | `Skill("ralph-hero:ralph-research")` | sonnet | inline | hero/SKILL.md:341 |
+| PLAN | `Skill("ralph-hero:ralph-plan")` or `ralph-plan-epic` | opus | inline | hero/SKILL.md:357–370 |
+| PLAN REVIEW | `Skill("ralph-hero:ralph-review")` | opus | inline | hero/SKILL.md:380 |
+| IMPLEMENT | `Agent(subagent_type="ralph-hero:impl-agent")` | opus | **fresh context** | hero/SKILL.md:418 |
+| PR | `Skill("ralph-hero:ralph-pr")` — marked for conversion to `Agent()` per 2026-04-06 plan | haiku | currently inline but flagged | hero/SKILL.md:443 |
+| FINISH | `Skill("ralph-hero:finish")` | sonnet | inline (orchestrator) | hero/SKILL.md:462 |
+| Inside FINISH — VAL | `Agent(subagent_type="ralph-hero:val-agent")` | haiku | **fresh context** | finish/SKILL.md (Step 3) |
+| Inside FINISH — MERGE | `Skill("ralph-hero:ralph-merge")` — marked for conversion to `Agent()` per 2026-04-06 plan | haiku | currently inline but flagged | finish/SKILL.md:119 |
+| Cross-repo decompose | `Agent(subagent_type="general-purpose")` × 2 (dry-run + create) | (unspecified) | **fresh context** | hero/SKILL.md:291–316 |
+
+Dispatch Architecture section: hero/SKILL.md:425–437 describes the hybrid explicitly. Quote at line 429: "Skills run inline in hero's context window and CAN dispatch sub-agents via `Agent()`."
+
+#### 1.2 What persists across handoffs
+
+| Artifact | Storage | Created by | Consumed by | Self-healing lookup |
+|---|---|---|---|---|
+| Workflow state | GitHub Project V2 field | Each phase via `save_issue` | `get_issue` in the next phase | Pipeline detection (`get_issue(includePipeline=true)`) |
+| Research doc | `thoughts/shared/research/YYYY-MM-DD-GH-NNNN-*.md` | ralph-research | ralph-plan | Artifact Comment Protocol → knowledge search → glob |
+| Plan doc | `thoughts/shared/plans/YYYY-MM-DD-GH-NNNN-*.md` | ralph-plan / ralph-plan-epic | ralph-review, ralph-impl, ralph-val, finish | Same as above |
+| Critique doc | `thoughts/shared/reviews/YYYY-MM-DD-GH-NNNN-critique.md` | ralph-review (auto) | hero orchestrator (verdict routing) | In-session only |
+| Artifact comment | GitHub issue comment with `## Research Document` / `## Implementation Plan` / `## Plan Critique` header | Each artifact-producing phase | Any subsequent phase | `ralph_hero__get_issue` returns comments |
+| Worktree | `worktrees/GH-NNN/` under repo | ralph-impl | ralph-pr, finish | Filesystem + `git worktree list` |
+| TaskList state | In-session via TaskCreate/Update | Hero at startup | Hero's execution loop | Rebuild from current phase on new session |
+| Drift log | Accumulated in commit messages (`DRIFT:` entries) | ralph-impl | ralph-val | `git log` |
+| Session env vars | `$CLAUDE_ENV_FILE` (written by `set-skill-env.sh`) | Each skill's SessionStart hook | Phase-specific hooks | Re-set on skill load |
+
+#### 1.3 Direct file-path handoffs (hero → next phase)
+
+The one place hero short-circuits re-fetching is the `--research-doc {path}` and `--plan-doc {path}` flags:
+
+- `Skill("ralph-hero:ralph-plan", args="NNN --review-plan auto --research-doc thoughts/shared/research/...")` — hero/SKILL.md:362
+- `Agent(subagent_type="ralph-hero:impl-agent", prompt="Implement GH-NNN. Plan doc: thoughts/shared/plans/...")` — hero/SKILL.md:418
+- `Skill("ralph-hero:ralph-review", args="NNN --review-plan auto --plan-doc thoughts/shared/plans/...")` — hero/SKILL.md:380
+
+Hero reads `artifact_path` from the upstream task's `TaskGet` metadata (hero/SKILL.md:349, 415) and injects it into the downstream phase's args/prompt. Absent the flag, each phase falls back to the Artifact Comment Protocol → knowledge search → glob chain. This means the file-path handoff is an optimization, not the system of record — the system of record is GitHub comments + workflow state.
+
+#### 1.4 Rationale for each dispatch choice
+
+From the plan docs:
+
+- **Skill() inline for research/plan/review**: "opus/sonnet and benefit from context sharing" (2026-04-06 plan, line 80). Also: "Agent()-spawned sub-agents cannot dispatch further sub-agents (empirically confirmed 2026-04-04), making all sub-agent dispatch instructions inside autonomous skills dead code in single-session mode. Skill() runs inline and preserves Agent() access" (GH-0732 plan, lines 20–22).
+- **Agent() for impl**: worktree isolation is the defining concern — `ralph-impl`'s frontmatter declares a full worktree-enforcement hook stack that is easiest to reason about when the whole phase runs in its own session. CLAUDE.md line 87: "Plugin-level hooks in `hooks.json` discriminate by `agent_type` (e.g., `impl-agent` triggers worktree gates)."
+- **Agent() for haiku phases (pr, merge, val)**: "when hero (running in Opus 1M context) invokes `Skill("ralph-hero:ralph-pr")`, the skill content loads into the current context window — then the haiku model tries to execute within a context that was built for 1M tokens, causing context crashes" (2026-04-06 plan, line 12). Val is already on `Agent()`; the 2026-04-06 plan converts pr and merge.
+
+### 2. Agent-to-subagent fan-outs inside each phase
+
+#### 2.1 Per-skill fan-out inventory
+
+Source files under [`plugin/ralph-hero/skills/`](https://github.com/cdubiel08/ralph-hero/tree/8e6bb53/plugin/ralph-hero/skills).
+
+**ralph-research** (Step 4, lines 151–156):
+1. `Agent(subagent_type="ralph-hero:codebase-locator", ...)`
+2. `Agent(subagent_type="ralph-hero:codebase-analyzer", ...)`
+3. `Agent(subagent_type="ralph-hero:codebase-pattern-finder", ...)`
+4. `Agent(subagent_type="ralph-hero:thoughts-locator", ...)`
+5. `Agent(subagent_type="ralph-hero:thoughts-analyzer", ...)` (after locators)
+6. `Agent(subagent_type="ralph-hero:web-search-researcher", ...)` (conditional)
+7. `Agent(subagent_type="ralph-playwright:explorer-agent", ...)` (UI baseline, Step 7.5)
+
+Fan-out pattern: parallel dispatch of 1–4 in a single message; thoughts-analyzer serial after locators; playwright conditional.
+
+**ralph-plan** (Step 3, lines 189–197):
+1. `Agent(subagent_type="ralph-hero:codebase-pattern-finder", ...)`
+2. `Agent(subagent_type="ralph-hero:codebase-analyzer", ...)`
+3. `Agent(subagent_type="ralph-hero:thoughts-locator", ...)`
+4. `Agent(subagent_type="ralph-hero:thoughts-analyzer", ...)` (serial after locators)
+
+Plus: `Skill("ralph-hero:ralph-split", "GH-NNN")` (line 515) — conditional on M-estimate issues.
+
+**ralph-plan-epic** (Step 2, lines 115–118):
+1. `Agent(subagent_type="ralph-hero:codebase-pattern-finder", ...)`
+2. `Agent(subagent_type="ralph-hero:codebase-analyzer", ...)`
+
+Plus: `Skill("ralph-hero:ralph-plan", ...)` per feature wave (Step 7, lines 233–256) — sequential per wave, parallel within waves.
+
+**ralph-review (auto mode)** (Step 4B, lines 224–263):
+1. `Agent(subagent_type="general-purpose", prompt="[critique instructions]")` — which internally dispatches:
+   - `Agent(subagent_type="ralph-hero:codebase-analyzer", prompt="Verify files mentioned in plan exist")`
+
+Nested one level.
+
+**ralph-impl** (Step 7, lines 297–336):
+1. Per task: `Agent(subagent_type="general-purpose", model=low→haiku|medium→sonnet|high→opus, prompt=implementer-prompt.md)` — parallel across independent tasks
+2. Per task: `Agent(subagent_type="general-purpose", model="haiku", prompt=task-reviewer-prompt.md)` — serial after implementer
+3. Per phase: `Agent(subagent_type="general-purpose", model="opus", prompt=phase-reviewer-prompt.md)` — after all tasks complete
+
+Total per phase: `(N_tasks × 2) + 1` dispatches. Max 3 retries per task.
+
+**ralph-split** (lines 72–120):
+1. `Agent(subagent_type="ralph-hero:codebase-locator", ...)` — find M/L/XL issues
+2. `Agent(subagent_type="ralph-hero:codebase-locator", ...)` — find related files
+3. `Agent(subagent_type="ralph-hero:codebase-analyzer", ...)` — analyze primary component
+
+**ralph-triage** (Step 3, lines 102–110):
+1. `Agent(subagent_type="ralph-hero:codebase-locator", ...)` — duplication check
+
+**ralph-pr, ralph-val**: no `Agent()` dispatches — pure CLI/git/verification operations.
+
+**ralph-merge** (Step 4, lines 108–177):
+- Conditional `Skill("code-review:code-review", ...)` — not an internal sub-agent fan-out.
+
+**finish** (Steps 3–4a, lines 93–127):
+1. `Agent(subagent_type="ralph-hero:val-agent", ...)` — Step 3
+2. `Agent(subagent_type="ralph-hero:impl-agent", ...)` — Step 4a, conditional on review feedback
+3. `Skill("ralph-hero:ralph-merge", args="NNN --pr-url PR_URL")` — Step 4
+
+#### 2.2 Utility agent inventory
+
+Source: [`plugin/ralph-hero/agents/`](https://github.com/cdubiel08/ralph-hero/tree/8e6bb53/plugin/ralph-hero/agents).
+
+| Agent | Model | Skill preload | Tools | Role |
+|---|---|---|---|---|
+| `research-agent` | sonnet | ralph-research | full | phase wrapper |
+| `plan-agent` | opus | ralph-plan | full | phase wrapper |
+| `plan-epic-agent` | opus | ralph-plan-epic | full | phase wrapper |
+| `review-agent` | opus | ralph-review | full | phase wrapper |
+| `impl-agent` | opus | ralph-impl | full | phase wrapper |
+| `split-agent` | opus | ralph-split | full | phase wrapper |
+| `triage-agent` | sonnet | ralph-triage | full | phase wrapper |
+| `pr-agent` | haiku | ralph-pr | minimal | phase wrapper |
+| `val-agent` | haiku | ralph-val | minimal | phase wrapper |
+| `merge-agent` | haiku | ralph-merge | minimal | phase wrapper |
+| `codebase-locator` | haiku | (none) | Grep, Glob, Bash | utility — finds files |
+| `codebase-analyzer` | sonnet | (none) | Read, Grep, Glob, Bash | utility — explains how code works |
+| `codebase-pattern-finder` | haiku | (none) | Grep, Glob, Read, Bash | utility — finds pattern examples |
+| `thoughts-locator` | haiku | (none) | Grep, Glob, Bash, knowledge-mcp | utility — finds docs |
+| `thoughts-analyzer` | sonnet | (none) | Read, Grep, Glob, Bash, knowledge-mcp | utility — extracts decisions |
+| `web-search-researcher` | sonnet | (none) | WebSearch, WebFetch, Read, Grep, Glob, Bash | utility — external research |
+
+Phase agents (first 10 rows) are thin wrappers — `skills: [ralph-hero:ralph-*]` preloads the skill content into the agent context. Example: [`agents/research-agent.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/research-agent.md) is 11 lines total.
+
+Utility agents (last 6 rows) have no skill preload — their full behavior is in the agent markdown itself. They are standalone specialists.
+
+#### 2.3 Frequency of utility-agent use
+
+| Utility agent | Dispatched by |
+|---|---|
+| codebase-locator | ralph-research, ralph-split (×2), ralph-triage, research (interactive), plan (interactive) |
+| codebase-analyzer | ralph-research, ralph-plan, ralph-plan-epic, ralph-split, ralph-review (nested), research, plan |
+| codebase-pattern-finder | ralph-research, ralph-plan, ralph-plan-epic, research |
+| thoughts-locator | ralph-research, ralph-plan, research, plan |
+| thoughts-analyzer | ralph-research, ralph-plan, research, plan |
+| web-search-researcher | ralph-research, research (conditional) |
+
+`codebase-analyzer` and `codebase-locator` are the most-dispatched utilities. `thoughts-locator` and `thoughts-analyzer` always appear together — thoughts-analyzer consumes the output of thoughts-locator in every call site.
+
+Pairing patterns observable in the skills:
+- Every skill that calls `thoughts-locator` also calls `thoughts-analyzer` (serial).
+- `codebase-locator` + `codebase-analyzer` frequently appear in parallel in the same research wave.
+- `codebase-pattern-finder` is only used in analyst-phase skills (research, plan, plan-epic) and their interactive counterparts.
+
+### 3. Interactive vs. autonomous skill variants
+
+Three pairs exist: research / ralph-research, plan / ralph-plan, impl / ralph-impl. Source paths:
+
+- Autonomous: [`plugin/ralph-hero/skills/ralph-research/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/ralph-research/SKILL.md), [`ralph-plan/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/ralph-plan/SKILL.md), [`ralph-impl/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/ralph-impl/SKILL.md).
+- Interactive: [`research/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/research/SKILL.md), [`plan/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/plan/SKILL.md), [`impl/SKILL.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/impl/SKILL.md).
+
+#### 3.1 Frontmatter deltas
+
+| Field | Autonomous | Interactive |
+|---|---|---|
+| `context: fork` | present (all 3) | absent (all 3) |
+| `user-invocable: false` | present (all 3) | absent (defaults true) |
+| `model:` | sonnet (research) / opus (plan, impl) | opus (all 3) |
+| `!cat` fragments | yes (knowledge-metadata, escalation-steps) | no |
+
+Only `ralph-research` downgrades the model relative to its interactive sibling.
+
+#### 3.2 Tool allowlist deltas
+
+**ralph-research** vs **research**:
+- Autonomous adds: `ralph_hero__save_issue`, `ralph_hero__add_dependency`, `ralph_hero__remove_dependency` (state mutation)
+- Interactive adds: `Edit`, `AskUserQuestion`
+
+**ralph-plan** vs **plan**:
+- Autonomous adds: `ralph_hero__sync_plan_graph` (sync `depends_on` → GitHub `blockedBy`)
+- Interactive adds: `Edit`, `WebSearch`, `WebFetch`, `AskUserQuestion`, `ralph_hero__create_issue`
+
+**ralph-impl** vs **impl**:
+- Autonomous adds: `ralph_hero__list_sub_issues` (group discovery)
+- Interactive adds: `WebSearch`, `WebFetch`, `AskUserQuestion`
+
+Pattern: autonomous variants add state-mutation tools the pipeline needs to advance workflows without human confirmation; interactive variants keep `AskUserQuestion` and add `Edit`/`WebSearch` for human-guided exploration.
+
+#### 3.3 Hook stacks
+
+`ralph-research` frontmatter hooks (lines 7–29):
+- SessionStart: `set-skill-env.sh RALPH_COMMAND=research RALPH_REQUIRED_BRANCH=main`
+- PreToolUse(Bash): `branch-gate.sh`
+- PostToolUse(get_issue): `research-state-gate.sh`
+- Stop: `research-postcondition.sh`, `doc-structure-validator.sh`, `lock-release-on-failure.sh`
+
+`ralph-plan` frontmatter hooks (lines 6–41):
+- SessionStart: `set-skill-env.sh RALPH_COMMAND=plan RALPH_REQUIRED_BRANCH=main RALPH_REQUIRES_RESEARCH=true RALPH_PLAN_TYPE=plan`
+- PreToolUse(Bash): `branch-gate.sh`
+- PreToolUse(Write): `plan-research-required.sh`
+- PreToolUse(save_issue): `plan-tier-validator.sh`
+- PreToolUse(AskUserQuestion): `review-plan-gate.sh`
+- PostToolUse(save_issue): `plan-state-gate.sh`
+- Stop: `plan-postcondition.sh`, `doc-structure-validator.sh`, `lock-release-on-failure.sh`
+
+`ralph-impl` frontmatter hooks (lines 6–43):
+- SessionStart: `set-skill-env.sh RALPH_COMMAND=impl RALPH_VALID_OUTPUT_STATES='In Progress,In Review,Human Needed' RALPH_REQUIRES_PLAN=true`
+- PreToolUse(Write|Edit): `impl-plan-required.sh`, `impl-worktree-gate.sh`
+- PreToolUse(save_issue): `impl-state-gate.sh`
+- PreToolUse(Bash): `impl-staging-gate.sh`, `impl-branch-gate.sh`
+- PostToolUse(Write|Edit): `drift-tracker.sh`
+- PostToolUse(Bash): `impl-verify-commit.sh`
+- Stop: `impl-postcondition.sh`, `lock-release-on-failure.sh`
+
+Interactive `research`: no hooks.
+Interactive `plan`: one hook — `PreToolUse(AskUserQuestion)` runs `review-plan-gate.sh`.
+Interactive `impl`: no hooks.
+
+The autonomous variants are where enforcement lives.
+
+#### 3.4 Sub-agent fan-out differences
+
+- Interactive `plan` runs **two** research waves (Step 1 initial, Step 2 deeper after user clarification); autonomous `ralph-plan` runs **one** wave.
+- Both `research` and `ralph-research` call the same 5–6 utility agents.
+- Interactive `impl` mentions sub-agents only "sparingly — mainly for targeted exploration of unfamiliar areas" (impl/SKILL.md:129). No structured sub-agent dispatch protocol. Autonomous `ralph-impl` has the structured implementer/reviewer/phase-reviewer pattern.
+- Interactive `impl` suggests worktree as optional ("Would you like me to set up an isolated worktree?" impl/SKILL.md:78–97). Autonomous `ralph-impl` requires it, hook-enforced.
+
+### 4. Hook-enforced constraints and their dependency on fresh-context attribution
+
+#### 4.1 Plugin-wide hooks
+
+Source: [`plugin/ralph-hero/hooks/hooks.json`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/hooks.json).
+
+| Matcher | Script(s) | Depends on `agent_type`? | Primary signal |
+|---|---|---|---|
+| SessionStart | `prune-merged-worktrees.sh`, `superpowers-bridge-session.sh` | no | none |
+| PreToolUse(save_issue) | `pre-github-validator.sh`, `artifact-discovery.sh`, `human-needed-outbound-block.sh` | no | `$RALPH_COMMAND`, tool args |
+| PreToolUse(get_issue) | `pre-ticket-lock-validator.sh`, `skill-precondition.sh` | yes (fallback only) | `$RALPH_COMMAND` primary |
+| PreToolUse(list_issues) | `skill-precondition.sh` | yes (fallback only) | `$RALPH_COMMAND` primary |
+| PreToolUse(Write\|Edit\|Bash) | `agent-phase-gate.sh` | **yes (for routing)** | `$RALPH_COMMAND` short-circuits |
+| PreToolUse(Write) | `gitignore-enforcement.sh`, `pre-artifact-validator.sh` | no | tool args, filesystem |
+| PreToolUse(Bash) | `pre-worktree-validator.sh` | no | tool args |
+| PostToolUse(save_issue) | `post-github-validator.sh`, `outcome-collector.sh` | no | tool args |
+| PostToolUse(create_comment) | `artifact-comment-validator.sh` | no | tool args |
+| PostToolUse(get_issue) | `post-blocker-reminder.sh` | no | tool args |
+| PostToolUse(Write) | `superpowers-bridge.sh`, `outcome-collector.sh` | no | env + tool args |
+| PostToolUse(Bash) | `post-git-validator.sh` | no | tool args |
+
+#### 4.2 The two identity signals
+
+- **`.agent_type`** is runtime-injected into the hook JSON payload. `hook-utils.sh:36–40` defines `get_agent_type()` which strips the plugin prefix (`ralph-hero:impl-agent` → `impl-agent`).
+- **`$RALPH_COMMAND`** is a shell env var written to `$CLAUDE_ENV_FILE` by `set-skill-env.sh`, invoked from each autonomous skill's `SessionStart` hook.
+
+In normal Agent() dispatch, both fire — the agent preloads the skill, the skill's SessionStart sets `$RALPH_COMMAND`, and the runtime also injects `.agent_type`. In Skill() inline dispatch, only `$RALPH_COMMAND` fires (the skill's SessionStart still runs on skill load). `.agent_type` is empty because there's no agent — the skill is just running in the caller's session.
+
+#### 4.3 Scripts that read `.agent_type`
+
+Only four:
+
+1. **`agent-phase-gate.sh`** (plugin-wide, Write|Edit|Bash):
+   - Line 20: if `$RALPH_COMMAND` is set → `allow` (short-circuit).
+   - Line 23: if `agent_type` is empty → `allow`.
+   - Lines 27–38: route to phase-specific sub-scripts based on agent name.
+   - Hook-compatibility analysis (GH-0732 plan, lines 60–62): "Checks `RALPH_COMMAND` first; if set, skips and defers to skill's own hooks. The `agent_type` routing is a fallback for team mode only."
+
+2. **`impl-branch-gate.sh`** (declared in ralph-impl frontmatter, Bash):
+   - Lines 18–22: primary check `$RALPH_COMMAND == "impl"`; fallback on `agent_type == "impl-agent"`.
+
+3. **`skill-precondition.sh`** (plugin-wide, get_issue|list_issues):
+   - Line 25: primary check `$RALPH_COMMAND`.
+   - Lines 28–30: if `$RALPH_COMMAND` empty but `agent_type` non-empty → allow.
+
+4. **`hook-utils.sh`**: defines `get_agent_type()` helper used by the above.
+
+#### 4.4 Scripts that do NOT read `agent_type`
+
+`pre-worktree-validator.sh`, `hero-dispatch-gate.sh`, `pre-github-validator.sh`, `human-needed-outbound-block.sh`, `gitignore-enforcement.sh`, `pre-artifact-validator.sh`, `artifact-comment-validator.sh`, `superpowers-bridge.sh`, `branch-gate.sh`, `impl-worktree-gate.sh`, `impl-plan-required.sh`, `impl-staging-gate.sh`, all postcondition scripts, `drift-tracker.sh`, `impl-verify-commit.sh`.
+
+These fire identically regardless of dispatch mode.
+
+#### 4.5 Impl-specific enforcement
+
+The worktree-isolation tier is declared in `ralph-impl/SKILL.md` frontmatter (not in `hooks.json`):
+
+- `impl-worktree-gate.sh` — blocks `Write`/`Edit` outside `$RALPH_WORKTREE_PATHS`; checks `$RALPH_COMMAND == "impl"`.
+- `impl-staging-gate.sh` — blocks `git add -A`/`git add .`/`git add --all`.
+- `impl-plan-required.sh` — blocks `Write`/`Edit` with no plan loaded.
+- `impl-state-gate.sh` — validates state transitions against `RALPH_VALID_OUTPUT_STATES`.
+- `impl-verify-commit.sh` — verifies commit conventions.
+- `drift-tracker.sh` — records file changes for drift log.
+- `impl-postcondition.sh`, `lock-release-on-failure.sh` — session-end checks.
+
+Because these are declared in ralph-impl's frontmatter, they activate when ralph-impl loads — whether via `Agent("impl-agent")` (which preloads ralph-impl) or via `Skill("ralph-impl")` inline. The skill's own `set-skill-env.sh` sets `RALPH_COMMAND=impl`, and the hooks key off that. Per the GH-0732 hook-compatibility analysis, none of these hooks requires fresh-context agent attribution — they require the skill to be active.
+
+#### 4.6 Hero-specific hook
+
+`hero/SKILL.md:10–14` declares:
+- `PreToolUse(matcher: Skill)`: `hero-dispatch-gate.sh` — guards that ralph-plan, ralph-plan-epic, and ralph-review are always called with `--review-plan` in their args.
+
+This hook checks `$RALPH_COMMAND == "hero"` (line 17). It fires only inside a hero session.
+
+## Code References
+
+### Orchestrators and skills
+- [`plugin/ralph-hero/skills/hero/SKILL.md:261-464`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/hero/SKILL.md#L261-L464) — execution loop and phase dispatch
+- [`plugin/ralph-hero/skills/hero/SKILL.md:425-437`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/hero/SKILL.md#L425-L437) — Dispatch Architecture section
+- [`plugin/ralph-hero/skills/ralph-research/SKILL.md:151-156`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/ralph-research/SKILL.md#L151-L156) — 5-agent fan-out
+- [`plugin/ralph-hero/skills/ralph-plan/SKILL.md:189-197`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/ralph-plan/SKILL.md#L189-L197) — 4-agent fan-out
+- [`plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md:115-118`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md#L115-L118) — 2-agent fan-out
+- [`plugin/ralph-hero/skills/ralph-impl/SKILL.md:297-336`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/ralph-impl/SKILL.md#L297-L336) — implementer/reviewer/phase-reviewer pattern
+- [`plugin/ralph-hero/skills/finish/SKILL.md:93-127`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/skills/finish/SKILL.md#L93-L127) — val → optional impl fix → merge chain
+
+### Phase agent wrappers (thin)
+- [`plugin/ralph-hero/agents/research-agent.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/research-agent.md) — 11 lines total
+- [`plugin/ralph-hero/agents/plan-agent.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/plan-agent.md)
+- [`plugin/ralph-hero/agents/impl-agent.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/impl-agent.md)
+
+### Utility agent definitions
+- [`plugin/ralph-hero/agents/codebase-locator.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/codebase-locator.md)
+- [`plugin/ralph-hero/agents/codebase-analyzer.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/codebase-analyzer.md)
+- [`plugin/ralph-hero/agents/codebase-pattern-finder.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/codebase-pattern-finder.md)
+- [`plugin/ralph-hero/agents/thoughts-locator.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/thoughts-locator.md)
+- [`plugin/ralph-hero/agents/thoughts-analyzer.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/thoughts-analyzer.md)
+- [`plugin/ralph-hero/agents/web-search-researcher.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/agents/web-search-researcher.md)
+
+### Hook infrastructure
+- [`plugin/ralph-hero/hooks/hooks.json`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/hooks.json) — plugin-wide hook registration
+- [`plugin/ralph-hero/hooks/scripts/hook-utils.sh:36-40`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/scripts/hook-utils.sh#L36-L40) — `get_agent_type()`
+- [`plugin/ralph-hero/hooks/scripts/agent-phase-gate.sh:17-38`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/scripts/agent-phase-gate.sh#L17-L38) — dual-signal routing
+- [`plugin/ralph-hero/hooks/scripts/skill-precondition.sh:25-31`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/scripts/skill-precondition.sh#L25-L31) — agent_type fallback
+- [`plugin/ralph-hero/hooks/scripts/set-skill-env.sh`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/scripts/set-skill-env.sh) — writes `$RALPH_COMMAND` into `$CLAUDE_ENV_FILE`
+- [`plugin/ralph-hero/hooks/scripts/hero-dispatch-gate.sh:17`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/scripts/hero-dispatch-gate.sh#L17) — `$RALPH_COMMAND == "hero"` guard
+- [`plugin/ralph-hero/hooks/scripts/impl-worktree-gate.sh`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/scripts/impl-worktree-gate.sh)
+- [`plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/plugin/ralph-hero/hooks/scripts/impl-staging-gate.sh)
+
+## Architecture Documentation
+
+### Dispatch primitives in current use
+
+1. **`Skill("name", args="...")`** — inline dispatch. Skill content loads into caller's context. Skill's SessionStart hooks fire. Skill's frontmatter `model:` is honored. The skill can dispatch further sub-agents via `Agent()`. Used for analyst/builder opus/sonnet phases.
+
+2. **`Agent(subagent_type="plugin:agent-name", prompt=..., description=...)`** — fresh-context dispatch. Agent preloads its `skills:` field (if present). Agent gets its own context window. Agent cannot dispatch further sub-agents (empirically confirmed 2026-04-04). Used for impl, haiku integrator phases, cross-repo decompose.
+
+3. **`Agent(subagent_type="general-purpose", ...)`** — used by ralph-impl for per-task implementers and reviewers, and by hero for cross-repo `decompose_feature` calls.
+
+### Two-axis taxonomy
+
+Skills in ralph-hero classify along two axes:
+
+**Axis 1: Dispatch level**
+- Orchestrators: `hero`, `team` (deprecated), `finish`
+- Phase skills: `ralph-split`, `ralph-research`, `ralph-plan`, `ralph-plan-epic`, `ralph-review`, `ralph-impl`, `ralph-pr`, `ralph-val`, `ralph-merge`, `ralph-triage`
+- Interactive siblings: `research`, `plan`, `impl`, `iterate`
+- Utility skills: `draft`, `form`, `hello`, `status`, `report`, `hygiene`, `prove-claim`, `bridge-artifact`, `idea-hunt`, `record-demo`, `setup*`, `gdrive-*`
+
+**Axis 2: Invocation style**
+- User-invocable (runs inline in the calling session)
+- Non-user-invocable (runs via orchestrator, declares `user-invocable: false`, requires `context: fork` for team mode)
+
+Autonomous phase skills are always non-user-invocable. Interactive siblings are user-invocable.
+
+### Artifact Comment Protocol
+
+Every artifact-producing phase writes a GitHub issue comment with a canonical header:
+- `## Research Document`
+- `## Implementation Plan`
+- `## Plan Critique`
+
+The comment body contains a permalink to the disk artifact. `artifact-comment-validator.sh` enforces this at PostToolUse on `create_comment` — if the header is present but a URL does not follow within 3 lines, the comment is rejected.
+
+This protocol is the **primary** handoff mechanism between phases. The `--research-doc`/`--plan-doc` flags are optimizations that short-circuit comment lookup when hero has the path in TaskList metadata.
+
+## Historical Context (from thoughts/)
+
+Key decisions driving the current state:
+
+**GH-0637 (2026-03-19) — Hero Dispatch Model**: Original problem statement. Identified that "each ralph-research, ralph-plan, and ralph-impl invocation consumes tokens in hero's context window, making long pipelines increasingly fragile." Proposed Agent() dispatch for all phases.
+
+**GH-0674 (2026-03-24) — Agent-Per-Phase Architecture**: Identified three root causes that motivated dedicated per-phase agents: (1) sub-agents cannot spawn sub-agents, (2) `$VAR` references are unexpandable by LLMs in skill markdown, (3) plugin sub-agent hooks are silently ignored. Implemented `get_agent_type()` and agent_type fallback in `skill-precondition.sh` (Phase 1, ~50% complete).
+
+**2026-04-01 — Agent-Per-Phase Reassessment**: Confirmed all three root causes still active; documented that Claude Code platform changes had not resolved any of them. `context: fork` in plugin-scoped skills still fails inconsistently (GitHub issue #16803 remains OPEN).
+
+**2026-04-04 — Single vs Team Dispatch Research**: Empirically confirmed that `Agent()`-spawned sub-agents lose `Agent` tool access. This meant that in the Agent-per-phase architecture, all the sub-agent dispatch logic inside `ralph-research`, `ralph-plan`, and `ralph-impl` was dead code. Led to GH-0732.
+
+**GH-0732 (2026-04-04) — Hero Skill Dispatch Migration**: Reversed direction. Hero now dispatches analyst/builder phases via `Skill()` inline (not `Agent()`), preserving sub-agent dispatch capability within those skills. Per-phase agents preserved for team mode. Hook-compatibility analysis confirmed all enforcement hooks use `$RALPH_COMMAND` as primary signal and `agent_type` as fallback — making the migration safe. Status: implemented-awaiting-manual-test.
+
+**2026-04-06 — Haiku Skill-to-Agent Dispatch**: Follow-up that found haiku phases (pr, merge, val) crash when invoked as `Skill()` inline in hero's Opus 1M context — the haiku model cannot execute cleanly in that context envelope. Converted pr/merge back to `Agent()` dispatch. Val was already on `Agent()`. Analyst phases (research/plan/review) remain `Skill()` inline because they run on opus/sonnet and benefit from context sharing.
+
+**2026-04-05 — Hero Pipeline Handoff UX Inventory**: Catalogued 8 handoff points between phases; documented AskUserQuestion usage and cost implications of alternative closing UX patterns.
+
+**2026-02-22 — Ralph Workflow v4 Architecture Spec**: Foundational spec defining Claude Code primitive taxonomy (skills/agents/hooks/MCP), concern separation, and dispatch patterns for both hero and team modes. Establishes the Analyst → Builder → Integrator phase groupings.
+
+**2026-02-20 (GH-0231) — Skill/Sub-agent/Team Context Pollution**: Identified that when skills spawn Task() sub-agents inside team context, phantom teammates appear in the roster. Contributed to the decision to keep sub-agent dispatch strictly via `Agent()` without `team_name`.
+
+## Related Research
+
+- [[2026-04-05-hero-pipeline-handoff-ux-inventory]] — 8-handoff inventory, AskUserQuestion usage
+- [[2026-03-20-skill-dispatch-inventory]] — classification of all 29 ralph-hero skills by dispatch mode
+- [[2026-02-21-debug-mode-observability-spec]] — JSONL session logging and collation MCP tools
+- [[2026-02-23-GH-0361-v4-phase-7b-collation-stats-mcp-tools]] — Phase 7b observability metrics
+- [[2026-02-17-GH-0044-worker-scope-boundaries]] — worker scope definition
+- [[2026-02-17-GH-0045-analyst-worker-agent]] — analyst worker boundaries
+- [[2026-02-17-GH-0046-builder-worker-agent]] — builder worker boundaries
+- [[2026-02-17-GH-0050-hero-orchestrator-worker-update]] — hero/worker architectural alignment
+- [[2026-02-17-GH-0053-teammate-inline-work-vs-skill-invocation]] — HOP (Higher-Order Prompt) pattern
+
+Spec documents (read-only reference):
+- [`specs/agent-permissions.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/specs/agent-permissions.md)
+- [`specs/skill-io-contracts.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/specs/skill-io-contracts.md)
+- [`specs/skill-permissions.md`](https://github.com/cdubiel08/ralph-hero/blob/8e6bb53/specs/skill-permissions.md)
+
+## Open Questions
+
+Surface-level observations that a consolidation analysis will need to resolve:
+
+1. **thoughts-locator + thoughts-analyzer always pair**. Every call site dispatches them sequentially (locator first, analyzer after). Is the separation structural (different tool allowlists, knowledge-mcp access) or incidental (easier to reason about in isolation)?
+
+2. **codebase-locator + codebase-pattern-finder overlap**. Both take haiku, both use Grep/Glob/Read/Bash. Pattern-finder returns examples; locator returns file paths. Could one haiku agent serve both needs?
+
+3. **Research wave count asymmetry**. Interactive `plan` runs two research waves; autonomous `ralph-plan` runs one. Was this a deliberate narrowing (autonomy assumes good prior research) or a copy-paste artifact?
+
+4. **`ralph-pr` and `ralph-merge` current vs. target dispatch**. The 2026-04-06 plan converts both from `Skill()` to `Agent()`. Is this migration complete at `8e6bb53`? (Verification: `grep -n 'Skill.*ralph-pr' plugin/ralph-hero/skills/*/SKILL.md` should return zero matches per the plan's verification steps.)
+
+5. **Per-task implementer/reviewer/phase-reviewer nesting in ralph-impl**. Three dispatch tiers per phase (implementer → task reviewer → phase reviewer). Is each tier observably required by the enforcement stack, or could the task-reviewer collapse into the implementer under a single guard?
+
+6. **`$RALPH_COMMAND` env var persistence across Skill() calls**. When hero calls `Skill("ralph-plan")`, ralph-plan's SessionStart sets `RALPH_COMMAND=plan`. When that skill returns to hero, does the env var revert to `hero` automatically, or does it linger? Answer determines whether adjacent inline skill calls can collide on env state.
+
+7. **Interactive variants' hook-less posture**. Interactive `research`, `impl` have zero hooks. Interactive `plan` has one. Was this a deliberate choice to avoid interrupting human flow, or was it just that the autonomous path drove the enforcement investment?
+
+8. **Web-search-researcher and Playwright explorer conditional dispatch**. Both utility agents are conditional. Are the conditions centrally checked, or duplicated across skill call sites?

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-24-landcrawler-backend-hardening-postmortem.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-24-landcrawler-backend-hardening-postmortem.md
@@ -1,0 +1,218 @@
+---
+date: 2026-04-24
+researcher: claude
+source_repository: landcrawler-ai
+host_repository: ralph-hero
+topic: "Why LandCrawler backend hardening is struggling — a post-mortem of 14 days of fire-fighting"
+tags: [postmortem, ralph-hero, autonomous-loop, hardening, observability, firefighting, xs-constraint, plan-iteration, landcrawler]
+status: complete
+type: research
+last_updated: 2026-04-24
+last_updated_by: claude
+---
+
+# Post-mortem: Why LandCrawler backend hardening is struggling
+
+## Why this lives in ralph-hero/thoughts
+
+The subject matter is LandCrawler's ELT pipeline, but the **root cause** is a structural property of the ralph-hero autonomous loop — specifically, the XS/Small ticket constraint biases the system against the medium-effort, multi-file infrastructure work that prevents whole classes of bug. This doc is preserved here so it can inform future ralph-hero design decisions (loop sizing, plan iteration cadence, firebreak scheduling).
+
+## Context
+
+Triggered by a user prompt in landcrawler-ai on 2026-04-24 after ~7 days of intensive backend hardening work that the user described as "still struggling." The investigation spanned:
+
+- Six in-flight or recent plan/research docs in `thoughts/shared/plans|research/` covering ELT pipeline reliability (GH-496, GH-527, GH-547, GH-552, GH-578, GH-582, GH-584)
+- 14 days of git history (~70 commits) across `src/elt/`, `src/extractors/texas/`, `terraform/pipeline/`, `terraform/monitoring/`, `alembic/versions/`
+- Direct verification of monitoring/observability state (e.g., `src/elt/main.py:25` still uses `logging.basicConfig`)
+- Four parallel subagent investigations (MFT scraper history, observability adoption gap, shallow-vs-deep fix classification, plan-to-impl velocity)
+
+The `gh` CLI was unauthorized in this session (`401 Bad credentials`), so issue/PR state was reconstructed from `git log` and `thoughts/` artifacts.
+
+## TL;DR / Verdict
+
+**The team is shipping fast and diagnosing well, but it keeps deferring the one structural fix that would prevent the entire class of bug — and the autonomous loop's preference for XS/S tickets is the reason.**
+
+- 27 merged PRs in 14 days. Individual fixes are well-diagnosed (the MFT chain GH-555→GH-571→GH-582→GH-584 shows each fix correctly identifying the prior one's miss).
+- But **0 of those PRs add a firebreak**: no Docker smoke test, no Cloud-Run-parity Playwright job, no contract tests pinning external schemas, and most critically — no adoption of structured logging in the ELT service.
+- The Apr 12 audit named ELT observability adoption (W2.1) the *"single most impactful structural gap."* Twelve days later it remains unimplemented; **6 of 8 monitoring gaps are still open** as a direct consequence.
+
+## The single most important finding
+
+`src/elt/main.py:25` reads:
+
+```python
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+```
+
+This is plain text. The two log-based metrics in `terraform/monitoring/metrics.tf` filter on `jsonPayload.records_extracted > 0` and `jsonPayload.status="failed"`, which never match plain-text logs. Therefore:
+
+- `pipeline_failure` alert policy (`terraform/monitoring/alerts.tf`) is structurally dead.
+- The `records_extracted` log-based metric never increments.
+- The `pipeline_failures` log-based metric never fires.
+- The two Tier-1 alerts that *do* work (DLQ backlog at `alerts.tf:149`, Cloud Run Job failure) shipped in GH-564 only because they don't depend on structured logs.
+
+This was named the highest-leverage gap on **2026-04-12** (`thoughts/shared/research/2026-04-12-elt-pipeline-quality-audit-monitoring.md`) and reaffirmed as critical-path on **2026-04-13** (`thoughts/shared/plans/2026-04-13-group-GH-0547-data-platform-quality-remediation.md` § Workstream 2). Yet:
+
+- No GH-### ticket exists with both research + plan for W2.1 specifically.
+- The plan-of-plans references it as "GH-560" but no research doc, plan doc, or commit references that number.
+- Every other W-series sub-ticket has been decomposed (GH-557, 558, 559, 561, 562, 564) — W2.1 alone slipped.
+
+**The team built around the gap rather than closing it.** GH-543 / GH-576 (`mv_refresh_metadata` UPSERT + structured-log sidecar) are explicitly described in their own plans as *"a stopgap until W2.1 lands."*
+
+### Status of the 8 monitoring gaps from the Apr 12 audit
+
+| # | Gap | Status as of 2026-04-24 |
+|---|---|---|
+| 1 | No raw table freshness alerts | OPEN — depends on W2.1 → W2.6 |
+| 2 | No DLQ alerting | **CLOSED** (GH-564, 2026-04-15) |
+| 3 | Log-based metrics don't match ELT logs | OPEN — `src/elt/main.py:25` still `basicConfig` |
+| 4 | No Cloud Run Job monitoring | **CLOSED** (GH-564, 2026-04-15) |
+| 5 | No per-pipeline alerting | OPEN — depends on W2.1 → W2.5 |
+| 6 | No MV-to-raw reconciliation | OPEN — depends on W2.1 + W2.2 |
+| 7 | No schema drift detection | OPEN — no plan filed |
+| 8 | No end-to-end freshness SLO | OPEN — depends on W2.6 |
+
+2 closed. 6 open. **All 6 of the open gaps depend on W2.1**, which has no ticket.
+
+## The systemic pattern: firefighting > firebreaks
+
+Classification of the last ~25 fix commits touching ELT/extractors/terraform/alembic:
+
+| Type | Count | Pct | Examples |
+|---|---|---|---|
+| A — root-cause fix for one pipeline | ~7 | 36% | GH-555 wait_until, GH-535 dedicated CRJ, GH-505 per-MV refresh, GH-498 P-5 content-type guard |
+| B — symptom patch | ~3 | 16% | GH-543/576 `mv_refresh_metadata` UPSERT (sidecar around W2.1), GH-534 dangling import |
+| C — config/infra tweak | ~9 | 48% | GH-527 TEXT widening, 6× Docker COPY lines, GH-578 Cloud SQL `?host=`, terraform field add |
+
+This is healthy diagnosis discipline at the *individual ticket* level. **But zero commits in the 14-day window add a firebreak.** None landed:
+
+- A Docker image build/import smoke test (would have caught all 6 Docker fixes — `816efb42`, `f829df68`, `c075ef9d`, `43af5c5d`, `aa6df399`, `db7f599a`)
+- A Cloud-Run-parity Playwright job in CI (would have caught GH-555 and GH-571 before merge)
+- A contract test pinning the GoAnywhere envelope or gzip magic bytes (would have caught GH-584's portal change before prod)
+- W2.1 itself (would close 6 monitoring gaps)
+
+## Case study 1: the MFT scraper chain
+
+Four consecutive PRs in 7 days hardening one daily scheduler (`tx-operators-daily`):
+
+| Fix | Date | Symptom | Diagnosis quality | LOC |
+|---|---|---|---|---|
+| GH-555 (#556) | 04-15 | `page.goto` times out at 30s; portal never reaches `networkidle` | **High** — explicit code review of MFT XHR keep-alive pattern | ~120 |
+| GH-570 (#580) | 04-20 | `orf850.txt` frozen since 2021-09-22 | **High** — confirmed via portal check + git history | ~20 |
+| GH-571 (#581) | 04-20 | Cloud Run reaches MFT in 120s+ vs laptop 783ms; bot-flagged | Medium — curl-from-laptop evidence rules out DNS/TLS, but in-cloud curl never run | ~15 |
+| GH-582 (#583) | 04-21 | Locator timeout despite GH-555/571; no failure artifacts | **High** — Playwright debug dump shows row resolved-but-budget-exceeded | ~80 |
+| GH-584 (#586) | 04-22 | RRC GoAnywhere now wraps `.gz` in `documents_<date>.zip` | **High** — manually reproduced via Playwright MCP | ~25 |
+
+**Diagnosis quality is improving and fixes are getting smaller.** Each subsequent fix correctly identified the prior one's miss rather than re-running the same hypothesis. This is the system working well at the ticket level.
+
+But the meta-pattern is concerning: `src/extractors/texas/p5_downloader.py` today has **2 nested retry layers, 4 timeout escalations, stealth UA, networkidle wait, full-flow retry, trace+screenshot upload to GCS, and ZIP envelope detection**. The code is hardened by *adding layers* rather than by *upstream contract testing*. The next portal change will require another layer.
+
+`tests/unit/extractors/texas/` has only mocked Playwright tests. **No integration tests against live or sandboxed MFT exist. No contract test asserts the response shape.** No plan in `thoughts/shared/plans/` proposes either.
+
+## Case study 2: the Docker fix sequence
+
+Six fixes in mid-April, all caused by missing `src/` directories, base image misalignment, or venv path issues:
+
+| Commit | Issue | What broke |
+|---|---|---|
+| `aa6df399` | — | venv python path broken between builder/runtime stages |
+| `43af5c5d` | — | Playwright reinstall failed because venv symlink broken |
+| `c075ef9d` | — | Base image mismatch broke venv symlinks |
+| `f829df68` | — | Missing `src/models`, `src/services`, `src/pipelines` → import failures at runtime |
+| `816efb42` | — | Missing `src/landcrawler_crawlers` defeated lazy import fallback |
+| `db7f599a` | GH-497 | Chromium not in image |
+
+**Each fix is individually surgical. Collectively they reveal one architectural gap**: the Dockerfile drifted for 3 months without validation. A single CI step (`docker build ... && docker run <image> python -c "from src.extractors.texas.p5_downloader import *; from src.elt.services.pipeline_dispatcher import *"`) would have caught all six. No ticket proposes one.
+
+## Case study 3: the doc-to-code ratio
+
+| Metric | Count (14 days, since 2026-04-10) |
+|---|---|
+| Research docs | 31 |
+| Plan docs | 22 |
+| Merged PRs (with GH-###) | 27 |
+| Unique tickets with research+plan+merged-PR | 8 |
+| Plans needing 1 review→iterate cycle | 5 of 9 shipped |
+| Plans shipped without iteration | 3 of 9 shipped |
+| Avg iter cycles per plan | 0.6 |
+
+The 31:22:27 ratio shows research is generating ~40% more documents than plans consume. Combined with average 0.6 iter cycles per plan, a meaningful share of cycles is going to *documenting fires already understood* rather than *building infrastructure to detect the next class of fire*.
+
+## Root cause: XS/S constraint structurally biases against firebreaks
+
+LandCrawler's `CLAUDE.md` documents the autonomous loop with this constraint:
+
+> **Constraints**: XS/Small tickets only, Linear as source of truth.
+
+W2.1 is a Medium at minimum:
+
+- Touches `src/elt/main.py` (one import, one function call)
+- Likely touches the dispatcher to emit structured fields
+- Requires updating `terraform/monitoring/alerts.tf` and validating each policy
+- Should add an integration test asserting `jsonPayload.*` fields are present
+- Probably needs a synthetic-failure smoke test
+
+**The autonomous loop cannot pick this up.** Each ralph-loop iteration scans the backlog and reaches for the freshest XS ticket — which is always the freshest fire (today: GH-578 alembic Cloud SQL `?host=`; yesterday: GH-584 GoAnywhere ZIP; the day before: GH-582 MFT reliability). The system is locally optimal at every step and globally stuck.
+
+This is a **ralph-hero design feedback signal**, not a LandCrawler-only issue. Other portfolios will hit the same wall when their structural-fix work doesn't fit the slot.
+
+## What IS working — preserve this
+
+- The research → plan → review → iterate → impl flow produces high-quality individual fixes. The MFT chain is a tight, converging feedback loop.
+- GH-535 (dedicated `tx-pdq-download` Cloud Run Job for /tmp exhaustion) and GH-505 (per-MV refresh isolation) are real architectural improvements, not patches.
+- GH-558 (W4.1 API latency instrumentation) shipped clean — proof the team *can* land observability work when it has a single clear owner.
+- The plan-iteration discipline (review-agent → iterate-agent → re-review) catches real issues. The 5/9 iteration rate is healthy, not pathological.
+- Each MFT fix correctly diagnoses the previous one's failure. No flailing at the ticket level.
+
+## Recommendations (priority order)
+
+1. **Stop deferring W2.1.** File research → plan → impl for "Adopt observability package in ELT service" today. Until it lands, the team is paying for monitoring infrastructure that does nothing. This single ticket re-arms `pipeline_failures` + `records_extracted` and unblocks W2.5/W2.6/W2.8. Estimated as Medium but mostly mechanical: import + init call + dispatcher field emission + test.
+
+2. **Add a Docker smoke test gate to CI.** One workflow step: `docker build -f docker/Dockerfile.elt . && docker run --rm <image> python -c "..."`. Prevents the entire Docker-fix class.
+
+3. **Loosen the XS/Small autonomous-loop constraint for W-series (workstream / structural) tickets** — or carve them out as human-driven work. The loop is structurally biased against the work that prevents the work the loop does. Possible mitigations to evaluate in ralph-hero:
+   - Tag tickets as `firebreak` and let the loop pick them up at a higher-priority weight despite size
+   - Reserve N% of loop cycles for Medium structural tickets
+   - Add a `loop-skip-xs` mode for periodic firebreak sprints
+
+4. **Add a contract test for the MFT response shape** (GoAnywhere ZIP envelope, gzip magic bytes, file count cardinality). Pin in `tests/integration/extractors/texas/`. Two more portal-side changes will happen this year.
+
+5. **Consider a weekly firebreak day**: no fire-fix tickets, only one of {test infrastructure, monitoring adoption, contract tests, smoke tests}.
+
+## References
+
+### LandCrawler files cited
+- `src/elt/main.py:25` — `logging.basicConfig`, no `init_fastapi`
+- `src/observability/instrumentation/fastapi.py` — exports `instrument_fastapi`, unused by ELT
+- `terraform/monitoring/metrics.tf` — log-based metrics filtering on `jsonPayload.*` that never exists
+- `terraform/monitoring/alerts.tf:149` — DLQ alert (functional)
+- `src/extractors/texas/p5_downloader.py` — current state: 2 nested retry layers, 4 timeout escalations, ZIP detection
+- `src/elt/CLAUDE.md` — ELT architecture docs
+
+### LandCrawler thoughts cited
+- `thoughts/shared/research/2026-04-12-elt-pipeline-quality-audit-monitoring.md` — names W2.1 as highest-leverage gap
+- `thoughts/shared/plans/2026-04-13-group-GH-0547-data-platform-quality-remediation.md` — plan-of-plans, W2.1 critical-path
+- `thoughts/shared/plans/2026-04-13-GH-0552-retrigger-stale-pipelines.md` — operational re-trigger
+- `thoughts/shared/plans/2026-04-12-GH-0527-fix-elt-verification-gaps.md` — UIC TEXT widening + freshness SQL
+- `thoughts/shared/plans/2026-04-21-GH-0582-mft-scraper-reliability-patch.md` — MFT defense-in-depth
+
+### Commits referenced (LandCrawler main, since 2026-04-10)
+- MFT chain: `0b45b667` (GH-555), `d5e3a45e` (GH-570), `a495cb79` (GH-571), `7fd14be9` (GH-582), `b0705dc8` (GH-584)
+- Docker fixes: `aa6df399`, `43af5c5d`, `c075ef9d`, `f829df68`, `816efb42`, `db7f599a` (GH-497)
+- ELT structural: `197470de` (GH-535 CRJ), `860ae2bd` (GH-505 per-MV), `3931f6b1` (GH-539 background ack)
+- Sidecar around missing W2.1: `f05c9295` (GH-543), `af7fb806` (GH-576)
+- Tier-1 alerts that work without structured logs: `1c5d2c78` (GH-564)
+
+## Open questions for ralph-hero
+
+1. Should ralph-hero introduce a `firebreak` label that elevates Medium tickets above the XS/S queue under defined conditions (e.g., when N consecutive symptom patches have shipped in the same area)?
+2. Is there a metric ralph-hero could surface — "consecutive symptom-patch commits in area X" — to flag when a portfolio is firefighting without firebreak progress?
+3. Should the plan-review gate check for "is this work a stopgap around an unimplemented W-series ticket?" and surface that explicitly?
+4. Could ralph-hero detect the doc-to-code ratio drift (research generating faster than plans consume) and pause research generation when it exceeds a threshold?
+
+## Methodology notes
+
+- Subagent investigations: 4 parallel `Explore` subagents covering MFT history, observability adoption, shallow-vs-deep fix classification, and plan-to-impl velocity.
+- All factual claims about file state were verified by direct read or grep, not delegated.
+- `gh` CLI unavailable (auth failure) — issue/PR state reconstructed from `git log` and `thoughts/` artifacts. State of issues marked as in-flight may be inaccurate by ±2 days.
+- Time-bounded to commits/docs from 2026-04-10 through 2026-04-24.

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-GH-0899-rrf-calibration-observability.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-GH-0899-rrf-calibration-observability.md
@@ -1,0 +1,165 @@
+---
+date: 2026-04-26
+github_issue: 899
+github_url: https://github.com/cdubiel08/ralph-hero/issues/899
+status: complete
+type: research
+tags: [calibration, rrf, hybrid-search, observability, retrieval, ralph-knowledge]
+---
+
+# Research: RRF Score Calibration & Observability (GH-899)
+
+## Prior Work
+
+- builds_on:: [[2026-04-26-softmax-and-rerank-calibration]]
+- builds_on:: [[2026-04-03-knowledge-implementation-comparison-obra-vs-ralph]]
+- builds_on:: [[2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop]]
+
+## Problem Statement
+
+`knowledge_search` returns RRF scores in the range `[0.010, 0.033]` with no interpretable threshold between relevant and incidental hits. The issue asks whether post-hoc calibration (Platt scaling, isotonic regression, beta calibration) can produce more meaningful scores — either applied to the fused RRF output or to per-retriever scores before fusion. This research answers: (a) what raw inputs are available at each stage, (b) whether those inputs are sufficient for post-hoc calibration, and (c) what observability hooks currently exist.
+
+## Current Implementation Analysis
+
+### RRF Fusion (`hybrid-search.ts`)
+
+The core fusion loop is at `plugin/ralph-knowledge/src/hybrid-search.ts:115-133`.
+
+The RRF constant is `K = 60` (line 35). For each document, the fused score is:
+
+```
+RRF(d) = Σ  1 / (K + rank_r(d))
+         r
+```
+
+With `limit * 2 = 40` candidates per retriever, the actual score range is:
+
+| Configuration | Score |
+|---|---|
+| Rank 0 in both retrievers | 0.032787 (1/61 + 1/61) |
+| Rank 0 in one retriever only | 0.016393 (1/61) |
+| Rank 39 in one retriever only | 0.010000 (1/100) |
+| Rank 39 in both retrievers | 0.020000 |
+
+The full observed range is `[0.010, 0.033]` — a compressed band of width ~0.023. This is exactly the compression described in the issue: `Σ 1/(k+rank)` discards score magnitude by design.
+
+### FTS5 Score (`search.ts`)
+
+`FtsSearch.search()` returns SQLite FTS5's built-in `rank` column as `score` (line 163). FTS5 `rank` is a **negative BM25 score** — more negative means higher relevance. The query uses `ORDER BY rank ASC` (line 169) so the most-negative value is the best match. This BM25 score is a real-valued, unbounded-negative number. Its magnitude varies per query and corpus.
+
+Critically: `ftsResults[i].score` (the BM25 value) is **never used in RRF**. Only the ordinal rank `i` enters the RRF formula at line 121: `1 / (HybridSearch.RRF_K + i + 1)`. The BM25 score is discarded after ordering.
+
+### Vector Search Score (`vector-search.ts`)
+
+`VectorSearch.search()` returns `distance` (cosine distance from sqlite-vec) per result (line 6, returned at line 88). The index uses `distance_metric=cosine` (line 36). sqlite-vec returns distances in `[0, 2]` for cosine (0 = identical, 2 = opposite). After L2-normalization (embedder uses `normalize: true` at line 27 of `embedder.ts`), practical distances sit in `[0, 1]`.
+
+The cosine distance is stored in `VectorResult.distance`. In `hybrid-search.ts`, the vector results are processed at line 104-113: the loop uses only ordinal position `i` (as `bucket.bestRank`) — the distance value is never used in RRF. Distances are not passed forward.
+
+### Score Availability Summary
+
+| Signal | Where available | Passed to RRF | Exposed to caller |
+|---|---|---|---|
+| FTS5 BM25 `rank` | `ftsResults[i].score` | No — only rank index | No |
+| Cosine `distance` | `vecResults[i].distance` | No — only rank index | No |
+| Bucketed vec rank | `bucket.bestRank` | Yes (as ordinal) | No |
+| FTS ordinal | loop var `i` | Yes (as ordinal) | No |
+| Fused RRF score | `scores` Map | — | Yes, via `SearchResult.score` |
+
+Neither the BM25 score nor the cosine distance is currently accessible outside the `search()` method. They are local variables consumed and discarded during fusion.
+
+## Calibration Feasibility Analysis
+
+### Question 1: Do post-hoc methods work on RRF output?
+
+**Platt scaling** fits a sigmoid `f(s) = 1 / (1 + exp(A*s + B))` on labeled (score, binary_label) pairs. It is strictly monotonic, so it preserves rank order while rescaling to `[0, 1]`.
+
+Applying Platt to RRF output is **mathematically valid but practically constrained**:
+
+1. The input range `[0.010, 0.033]` is narrow. A sigmoid fit over this range is numerically well-conditioned (no overflow risk, bounded derivative). The sigmoid can still provide a meaningful rescaling to a wider `[0, 1]` band.
+2. The sigmoid functional form may or may not match the true score-to-relevance relationship for RRF outputs. RRF has a hyperbolic-sum shape, not inherently sigmoidal. Platt will fit the sigmoid to whatever shape exists in the labeled sample — if the true shape is sufficiently S-curved within the observed range, fit quality will be good.
+3. Small labeled samples are viable for Platt. The parent survey document notes `<500 labels` as the appropriate range. With a ~75-doc corpus and ~30-50 representative queries, 100-150 labeled query-doc pairs are feasible.
+
+**Isotonic regression** requires `>= 1000 samples` to avoid overfitting (per the parent survey). With a 75-doc corpus and realistic query diversity, reaching 1000 labeled pairs would require 13+ labels per document per query, which is not feasible. Isotonic regression on RRF output is **not viable at this corpus scale**.
+
+**Beta calibration** extends Platt to handle scores clustered near boundaries (0 or 1). RRF scores are clustered near 0 (range `[0.010, 0.033]`), which is exactly the use case beta calibration addresses. It is viable on small samples. However, the implementation surface is higher than Platt, and the marginal benefit over Platt for this score distribution is unclear without empirical testing.
+
+**Temperature scaling** does not apply to RRF scores. Temperature scaling is defined for softmax logits and produces `exp(logit/T) / Σ exp(logit_j/T)`. RRF scores are not logits; there is no natural denominator to sum over for a single query result list. The parent survey correctly excludes temperature scaling for non-softmax signals.
+
+### Question 2: Are calibration methods better applied to per-retriever scores before fusion?
+
+Yes, in principle — but **the current code makes this impossible without modification**.
+
+The BM25 score (`ftsResults[i].score`) and cosine distance (`vecResults[i].distance`) are both discarded before the caller can observe them. To apply calibration upstream, the code would need to:
+
+1. Expose raw BM25 scores (already present in `ftsResults` as `SearchResult.score` at the point of line 88)
+2. Expose raw cosine distances (present in `vecResults[i].distance` at line 95)
+3. Apply calibration transforms to each signal separately before or instead of rank-based RRF
+
+Calibrating per-retriever scores before fusion has a theoretical advantage: each retriever's score distribution can be calibrated on its own training signal. BM25 scores for short documents cluster near 0 (a case beta calibration handles well); cosine distances from a normalized embedding model have a narrower, more Gaussian-like distribution. Calibrating each separately before a convex combination (`α * calibrated_dense + (1-α) * calibrated_sparse`) would require labeled data for tuning `α` as well, moving toward the "learned fusion" category.
+
+### Question 3: How much of the observability problem is corpus-size artifact?
+
+RRF score compression is **intrinsic to RRF, not a corpus-size artifact**. The formula `Σ 1/(60 + rank)` produces the same `[0.010, 0.033]` band regardless of corpus size, as long as the pool sizes are fixed. A corpus of 750 documents would produce identical score ranges.
+
+The corpus-size effect is on **calibration feasibility**, not on score interpretation: with only ~75 documents, even the best-case labeled dataset at 30-50 queries is approximately 100-200 query-doc pairs — sufficient for Platt but not isotonic.
+
+## Observability Hooks (Current State)
+
+### What exists
+
+1. `knowledge_record_outcome` and `knowledge_query_outcomes` tools in `index.ts` (lines 289-365) provide a structured outcome event store. These are designed for pipeline events (issue phases, verdicts), not query-level retrieval diagnostics.
+2. `SearchResult.score` is surfaced through the MCP tool as a numeric field, so callers can observe the fused RRF score.
+3. `SearchResult.bestChunkId`, `chunkIndex`, `charStart`, `charEnd` are returned when `return_chunk_meta=true`.
+4. No per-retriever scores (BM25 or cosine distance) are returned in any code path.
+5. No query latency, retriever hit count, or per-retriever result count is logged anywhere in the retrieval path.
+
+### What is missing
+
+- FTS5 BM25 score per result (currently discarded at `hybrid-search.ts:119-122`)
+- Cosine distance per result (currently discarded at `hybrid-search.ts:104-113`)
+- Whether a result came from FTS-only, vector-only, or both retrievers ("hit source" metadata)
+- Retriever hit counts (how many FTS results vs. vector results contributed)
+- A diagnostic mode that returns the above in extended result fields
+
+## Recommendation for Planning
+
+The issue is scoped to investigation. The plan should be structured around two distinct tracks:
+
+### Track A: RRF-output calibration experiment (viable immediately)
+
+Platt scaling on RRF output can be attempted without any code changes to the retrieval path. The experiment requires:
+
+1. A query sampling harness that calls `knowledge_search` on 30-50 queries and captures the returned `score` field.
+2. A hand-labeling step on ~100-150 query-doc pairs (binary: relevant/not relevant).
+3. A Python notebook under `plugin/ralph-knowledge/` fitting `sklearn.calibration.CalibratedClassifierCV` (with `method="sigmoid"` for Platt) on the RRF scores and producing a reliability diagram.
+4. Assessment: if calibrated probabilities are meaningfully better-separated than raw RRF scores (lower Brier score, tighter reliability diagram), the parameters `(A, B)` can be hardcoded or stored in config.
+
+This track does not require changes to `hybrid-search.ts`, `search.ts`, or `vector-search.ts`.
+
+### Track B: Per-retriever score observability (requires code change)
+
+To enable calibration upstream of RRF (or to decide definitively between the two approaches), `hybrid-search.ts` should expose per-retriever scores in the `SearchResult` interface as optional diagnostic fields:
+
+- `ftsScore?: number` — the raw FTS5 BM25 rank value
+- `vecDistance?: number` — the raw cosine distance
+- `hitSources?: string[]` — `["fts", "vec"]` or subset thereof
+
+These would be populated only when a new `diagnosticMode?: boolean` option is passed to `HybridSearch.search()`, avoiding payload bloat in production callers. The MCP tool can surface them under `return_diagnostics` alongside the existing `return_chunk_meta` flag.
+
+### Sequencing
+
+Track A should run first because it has no implementation cost and will produce empirical data about whether Platt on RRF output is useful. Track B is only necessary if Track A results show that RRF-output calibration is insufficient and per-retriever calibration is warranted.
+
+The followup issue referenced in #899 (#900 — labeling effort scope) should be planned before or in parallel with Track A, since both depend on the same labeled dataset.
+
+## Files Affected
+
+### Will Modify
+- `plugin/ralph-knowledge/src/hybrid-search.ts` — add optional `diagnosticMode` flag; surface `ftsScore`, `vecDistance`, `hitSources` as optional fields (Track B)
+- `plugin/ralph-knowledge/src/search.ts` — no change required for Track A; potentially expose `score` (BM25 rank) in return type for Track B diagnostic path (already present in `SearchResult.score`, just needs to survive into hybrid result)
+- `plugin/ralph-knowledge/src/index.ts` — add `return_diagnostics` boolean param to `knowledge_search` tool (Track B)
+
+### Will Read (Dependencies)
+- `plugin/ralph-knowledge/src/vector-search.ts` — `VectorResult.distance` field is the cosine distance source; no changes needed
+- `plugin/ralph-knowledge/src/format.ts` — `BriefSearchResult` will need new optional fields if brief mode is also to surface diagnostics
+- `plugin/ralph-knowledge/src/__tests__/hybrid-search.test.ts` — reference for test patterns when adding diagnostic field tests

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-GH-0902-mmr-diversity-reranking-ralph-knowledge.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-GH-0902-mmr-diversity-reranking-ralph-knowledge.md
@@ -1,0 +1,224 @@
+---
+date: 2026-04-26
+github_issue: 902
+github_url: https://github.com/cdubiel08/ralph-hero/issues/902
+status: complete
+type: research
+tags: [ralph-knowledge, mmr, diversity-reranking, hybrid-search, sqlite-vec, retrieval]
+---
+
+# Research: Label-Free MMR Diversity Reranking for ralph-knowledge (GH-902)
+
+## Prior Work
+
+- builds_on:: [[2026-04-26-softmax-and-rerank-calibration]]
+- builds_on:: [[2026-04-03-knowledge-implementation-comparison-obra-vs-ralph]]
+- builds_on:: [[2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop]]
+
+## Problem Statement
+
+The `knowledge_search` MCP tool returns up to K ranked documents fused by Reciprocal Rank Fusion over FTS5 and sqlite-vec. When the corpus contains near-duplicate topic clusters (research doc + plan doc for the same issue, or a group plan + multiple sub-issue plans), a single query can surface redundant documents occupying several of the top-K slots, crowding out genuinely different perspectives. The question is: (1) does the ralph-knowledge corpus exhibit enough near-duplicate clustering to make MMR worthwhile, and (2) if yes, how should a label-free MMR stage be designed?
+
+## Corpus Near-Duplicate Analysis
+
+### Corpus Scale
+
+The `thoughts/` tree contains 918 documents: 265 in `thoughts/shared/research/`, 274 in `thoughts/shared/plans/`, 87 in `thoughts/shared/reviews/`, plus ideas and raw memories. This is not a web-scale corpus where MMR is most often benchmarked, but it has a structural property that amplifies near-duplicate risk: the ralph-hero pipeline produces a research document and a plan document for every implemented issue.
+
+### Structural Near-Duplicate Clusters
+
+Four types of near-duplicate clusters are present and quantifiable:
+
+**Type 1: Research + Plan pairs on the same issue.** 221 research documents and 233 plan documents carry GH issue references. Of these, 116 issues have both a research doc and a plan doc. For any query that hits the research doc by topic, the plan doc almost certainly ranks in the top-20 candidate set too, since they share the same title keywords, tags, and vocabulary. A query for "chunked embeddings" would return both `2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop.md` (research) and `2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop.md` (plan) as top candidates, conveying overlapping information.
+
+**Type 2: Group plans + sub-issue plans.** There are 42 group plans (`group-GH-NNNN`) covering the same epic topic, alongside the individual sub-issue plans. The 2026-04-20 sprint produced 17 plans all tagged `ralph-playwright` on a single day. The group plan is a superset document; the sub-issue plans are subsets. All share the same terminology cluster. A user searching for "playwright visual diff" would see the group plan, the semantic diff plan, the regression emitter plan, and the noise floor pilot — all within the top-5 RRF results.
+
+**Type 3: Sprint cohort plans.** On 2026-02-20, 38 plans were produced for 38 different GH issues, all from the same pipeline/routing sprint. They each target a different GH issue but share the same background vocabulary (GraphQL, project board, MCP tool names). These are less strongly near-duplicate than Types 1/2 — they are parallel work-streams — but they do exhibit moderate BM25-level overlap on pipeline terms.
+
+**Type 4: Knowledge GH-055x cluster.** Six research documents from 2026-03-09 (GH-550 through GH-555) all describe "adding knowledge metadata to skill templates." They share the same 8,584-word vocabulary pool (total across 6 docs, individually 980–1,976 words each). A user asking "how do skills attach metadata for knowledge indexing" would get all six in the top-6 results.
+
+### Redundancy Assessment: Is It Worthwhile?
+
+**Yes, with a qualified justification.** The corpus is not a web-scale FAQ corpus where exact-duplicate URL variations flood results. Instead, it exhibits structured topic clustering from the sprint-group workflow. The redundancy is predictable and systematic: for any implemented feature, at minimum two documents (research + plan) cover the same topic with ~70% vocabulary overlap.
+
+Without MMR: a top-10 search for "ralph-knowledge hybrid search" would likely surface 3-4 plan+research pairs for the same issues, consuming 6-8 slots with overlapping content. With MMR at lambda=0.7, once the first research or plan doc for an issue is selected, the other's MMR score is penalized by `(1-0.7) * max_similarity_to_selected`, reducing its chance of occupying an adjacent slot.
+
+The corpus has enough near-duplicate clustering: estimated 30-40% of top-10 results on topic-specific queries are from type-1 or type-2 redundant clusters. MMR would reclaim these slots for genuinely different documents.
+
+## Current Search Pipeline and Integration Point
+
+### Pipeline Flow
+
+```
+query
+  → FTS5 BM25 top-40 candidates (limit*2=20 in HybridSearch, default limit=20 at HybridSearch level)
+  → sqlite-vec cosine top-40 candidates
+  → Bucketed by doc_id (best chunk per doc)
+  → RRF score fusion (k=60)
+  → Sort by RRF score descending
+  → Post-filters (superseded, type, tags, memory_tier)
+  → .slice(0, limit)  ← MMR replaces this truncation
+```
+
+**MMR slot in the pipeline:** post-RRF sort, pre-`slice(0, limit)`. The candidates entering MMR are the post-filter array, already ranked by RRF score. MMR reorders them greedily to maximize `lambda * rrfScore - (1-lambda) * max_cos_similarity_to_selected`.
+
+This is exactly the integration point described in the parent issue and the natural extension of the existing pipeline.
+
+### Embedding Availability for MMR
+
+The doc-doc similarity term in MMR (`max_similarity(d, selected)`) requires access to embeddings of the candidate documents. Two retrieval methods are viable:
+
+**Method A: sqlite-vec POINT queries (recommended).** The `documents_vec` virtual table supports three query plans: KNN (MATCH), POINT (rowid = ?), and FULLSCAN. The vec0 C implementation confirms this: `vec0Column_point()` and `vec0Column_fullscan()` both return the raw embedding BLOB via `sqlite3_result_blob`. The existing schema maps chunk ids (`doc_id#cN`) to embeddings; the doc-level best chunk id is already tracked in `bestChunkByDoc` inside `HybridSearch.search()`.
+
+Query pattern:
+```sql
+SELECT id, embedding FROM documents_vec WHERE id = ?
+```
+
+This is a POINT query (rowid equality on the TEXT primary key column), returns the float32 BLOB, and does not require a new MATCH pass. For 20-40 candidates, this is 20-40 point lookups in a single transaction.
+
+**Method B: Re-embed on demand.** Call `embedFn(candidate.title + snippet)` for each candidate. This costs one model inference per candidate (~5-10ms each on M5 Pro, totaling 100-400ms for 20-40 candidates). This is significantly more expensive and semantically slightly wrong (the stored embedding was computed from the full chunk content + contextual prefix, not from the truncated snippet). Not recommended.
+
+**Conclusion:** Method A is correct and cheap. Fetch raw float32 BLOBs via POINT queries on `documents_vec`. Deserialize as `new Float32Array(Buffer.from(blob).buffer)` (the same pattern used during upsert in `float32ToBuffer`).
+
+### Cosine Similarity Computation
+
+The `all-MiniLM-L6-v2` model produces L2-normalized embeddings (confirmed: `pooling: "mean", normalize: true` in `embedder.ts:26-29`). For normalized vectors, cosine similarity equals the dot product. The stored `distance` in the KNN search is `1 - cosine_similarity` (distance_metric=cosine in the vec0 definition). Therefore:
+
+```
+cosine_similarity(a, b) = 1 - cosine_distance(a, b)
+```
+
+For MMR we need cosine similarity in [0,1]. The dot product of two 384-dim L2-normalized Float32Arrays, computed in JavaScript, is O(384) per pair — approximately 1 microsecond per pair on modern hardware. For 20 candidates, the MMR loop involves at most 20*10 = 200 dot products = ~200 microseconds. This is negligible relative to SQLite query latency.
+
+## MMR Algorithm and Parameter Design
+
+### Standard MMR Formula
+
+```
+MMR(d) = lambda * score_rrf(d) - (1 - lambda) * max_{d' in S} cosine_similarity(d, d')
+```
+
+where `S` is the set of already-selected documents. `score_rrf(d)` is the RRF score from the fusion phase, normalized to [0, 1] via min-max over the candidate set (since raw RRF scores are in ~0.01-0.03 range and lambda needs to be a weight between comparable terms).
+
+### Lambda Justification for This Corpus
+
+The corpus characteristics that inform lambda selection:
+- Documents are long-form markdown (500-3000 words), not short web snippets
+- Near-duplicates are structural (same issue, same sprint), not exact copies
+- The primary use case is agent-side retrieval for planning and research — diversity matters but the query is usually specific
+- Users are not browsing; they want the most relevant doc, then a structurally different second perspective
+
+**Recommended lambda: 0.7.** At lambda=0.7:
+- A document with RRF score 0.9 (top relevance) will beat a document with RRF score 0.5 even if the latter is maximally diverse (similarity=0 to selected set): 0.7*0.9=0.63 vs 0.7*0.5=0.35, so high relevance still dominates.
+- A near-duplicate with RRF score 0.85 (plan doc alongside a research doc at 0.9) that has cosine similarity 0.80 to the selected research doc scores: 0.7*0.85 - 0.3*0.80 = 0.595 - 0.24 = 0.355. It drops below a genuinely different document with RRF score 0.65 and similarity 0.20: 0.7*0.65 - 0.3*0.20 = 0.455 - 0.06 = 0.395. MMR surface the different document first.
+- Lambda=0.7 matches the Elasticsearch default for their MMR implementation and the original Carbonell & Goldstein recommendation for information retrieval (as opposed to text summarization where lambda=0.5 is common).
+
+This corpus should NOT use lambda below 0.5 (too diversity-heavy) or above 0.85 (near-identity with pure relevance ranking, MMR has no effect). Lambda=0.7 is the right default for a research/planning corpus accessed by a reasoning agent.
+
+### DPP vs MMR Comparison
+
+**Determinantal Point Processes (DPPs)** compute set-level diversity as proportional to the determinant of the kernel matrix. For k selected items from N candidates, greedy MAP DPP is O(Nk³) versus MMR's O(Nk). At N=20, k=10, the difference is 200 vs 20,000 operations — DPP is 100x more expensive.
+
+DPP has better theoretical guarantees (global diversity vs MMR's local greedy view) and would in principle select a better diverse subset. However:
+- The corpus exhibits structured clusters (plan+research pairs) where greedy selection is already optimal: once the research doc is selected, the plan doc's similarity to the selected set is high, and MMR correctly penalizes it.
+- For retrieval queries (not recommendation), the user-specified query provides strong relevance signal, and greedy MMR's local choices are adequate.
+- The additional complexity of DPP (kernel matrix construction, determinant computation with numerical stability concerns) is disproportionate to the benefit for a 20-40 candidate set.
+
+**Recommendation: implement MMR, not DPP.** If diversity quality proves insufficient post-deployment (measured by user or agent feedback), DPP can replace MMR without changing the external API since the interface is lambda + candidates.
+
+Sampled MMR (SMMR from SIGIR 2025) adds randomness for better relevance-diversity tradeoff with logarithmic speedup — worth considering if MMR lambda tuning proves brittle, but not for the initial implementation.
+
+## Proposed Implementation
+
+### Changes to `plugin/ralph-knowledge/src/vector-search.ts`
+
+Add a `getEmbedding(id: string)` method that does a POINT query:
+
+```typescript
+getEmbedding(id: string): Float32Array | null {
+  this.ensureVecLoaded();
+  const row = this.knowledgeDb.db
+    .prepare("SELECT embedding FROM documents_vec WHERE id = ?")
+    .get(id) as { embedding: Buffer } | undefined;
+  if (!row) return null;
+  return new Float32Array(row.embedding.buffer, row.embedding.byteOffset, row.embedding.byteLength / 4);
+}
+```
+
+This works via the sqlite-vec POINT query plan (equality on primary key `id`), returning the float32 BLOB.
+
+### Changes to `plugin/ralph-knowledge/src/hybrid-search.ts`
+
+Add an MMR stage post-filter, pre-slice:
+
+```typescript
+// After all post-filters and before filtered.slice(0, limit)
+if (lambda !== undefined && lambda < 1.0) {
+  filtered = this.applyMMR(filtered, lambda, limit);
+} else {
+  filtered = filtered.slice(0, limit);
+}
+```
+
+The `applyMMR` method implements greedy selection, fetching embeddings via `this.vec.getEmbedding()` lazily (only for candidates that make it into the greedy selection process).
+
+### Changes to `plugin/ralph-knowledge/src/index.ts` (knowledge_search tool)
+
+Add an optional `lambda` parameter:
+
+```typescript
+lambda: z.number().min(0).max(1).optional().describe(
+  "MMR diversity trade-off: 1.0 = pure relevance (default), 0.7 = balanced, 0.0 = max diversity"
+),
+```
+
+The parameter is off by default (undefined = pure RRF, no MMR). Callers must opt in by passing `lambda: 0.7` until MMR is validated.
+
+### Test Coverage
+
+- `lambda=1.0` (or undefined): results identical to current sort-by-RRF behavior
+- `lambda=0.0`: first result is highest RRF, subsequent results are maximally dissimilar from selected
+- `lambda=0.7` with a planted near-duplicate pair: verify the near-duplicate ranks below a less-similar alternative
+
+## RRF Score Normalization Note
+
+The RRF score range (~0.01-0.03) and cosine similarity range ([0,1]) differ by an order of magnitude. Before applying the MMR formula, the `score_rrf` term must be normalized to [0,1] over the candidate set using min-max normalization:
+
+```
+score_norm(d) = (rrf(d) - min_rrf) / (max_rrf - min_rrf)
+```
+
+This is a 1-pass O(N) operation over the candidate set. Without normalization, the lambda term would not meaningfully balance relevance and diversity.
+
+## Risks
+
+1. **sqlite-vec POINT query on TEXT primary key**: The `documents_vec` table declares `id TEXT PRIMARY KEY` per the `createIndex()` method. sqlite-vec vec0 POINT query plan is triggered by `EQ` on the rowid column. When the primary key is TEXT (not INTEGER), the POINT plan may fall back to FULLSCAN for some sqlite-vec versions. This needs a quick test during implementation. Fallback: if POINT queries don't work, store a separate `embedding_cache` table (plain SQLite, not virtual) as a lookup.
+
+2. **Chunk-level vs doc-level embeddings**: The vector table stores chunk-level embeddings (`doc_id#cN`) not doc-level. The best chunk id for each candidate is tracked in `bestChunkByDoc`. MMR should use the best chunk's embedding (the one that contributed to the RRF score) as the representative for that document. If `bestChunkByDoc` doesn't have an entry for a candidate (FTS-only hit with no vector contribution), fall back to re-embedding or skip the similarity term for that candidate.
+
+3. **Cold start with no embeddings**: Documents with no vec entry (rare, possible if reindex was interrupted) would cause `getEmbedding` to return null. The MMR implementation should treat null embeddings as similarity=0 (maximally diverse) to maintain graceful degradation.
+
+## Files Affected
+
+### Will Modify
+- `plugin/ralph-knowledge/src/hybrid-search.ts` - Add `applyMMR()` method and `lambda` parameter to `search()` options
+- `plugin/ralph-knowledge/src/vector-search.ts` - Add `getEmbedding(id: string): Float32Array | null` method
+- `plugin/ralph-knowledge/src/index.ts` - Add optional `lambda` parameter to `knowledge_search` MCP tool
+- `plugin/ralph-knowledge/src/search.ts` - No changes needed (FTS output is already in RRF input format)
+
+### Will Read (Dependencies)
+- `plugin/ralph-knowledge/src/db.ts` - KnowledgeDB + schema reference (documents_vec table)
+- `plugin/ralph-knowledge/src/__tests__/hybrid-search.test.ts` - Existing test patterns to follow
+
+## Conclusion
+
+The ralph-knowledge corpus exhibits substantial near-duplicate clustering: 116 research+plan pairs, 42 group plan supersets, and sprint-cohort plan clusters that share 60-80% of their vocabulary. MMR at lambda=0.7 is warranted and will measurably improve result diversity for topically specific queries.
+
+The implementation is low-risk and self-contained:
+- sqlite-vec POINT queries expose raw float32 embeddings without re-embedding
+- The MMR math (dot products on 384-dim L2-normalized vectors) costs ~200 microseconds for a 20-candidate set
+- The feature is opt-in via the `lambda` parameter, defaulting off until validated
+- DPP is not necessary: the corpus's structured clustering is handled well by greedy MMR, and the 100x compute cost increase is not justified
+
+Recommended lambda: **0.7** (balanced), defaulting to off (lambda=1.0 or undefined). The lambda value should be exposed as a tunable parameter in the MCP tool to allow per-query experimentation.

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-dreaming-research-trail-and-self-containment.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-dreaming-research-trail-and-self-containment.md
@@ -1,0 +1,381 @@
+---
+date: 2026-04-26
+git_commit: 257a3db0651d3059b23aa4d1c439ff38eae66cfb
+branch: main
+topic: "Did we create research/docs about 'dreaming', and is the dream-loop implementation self-contained inside ralph-hero?"
+tags: [research, ralph-knowledge, dream-loop, dreaming, memory-tier, self-containment, audit, gemma, hdbscan, contextual-retrieval]
+status: complete
+type: research
+github_issues:
+  - 906  # bug(ralph-knowledge): parser drops memory_tier frontmatter
+  - 907  # bug(ralph-knowledge): reindex OOMs Node heap on ~1.7k-doc corpus
+  - 908  # bug(dream-loop): ingest.py auto-reindex hook surfaces OOM as silent warning
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/906
+  - https://github.com/cdubiel08/ralph-hero/issues/907
+  - https://github.com/cdubiel08/ralph-hero/issues/908
+---
+
+# Research: Dreaming Research Trail and Self-Containment Audit
+
+## Prior Work
+
+- builds_on:: [[2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory]]
+- builds_on:: [[2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop]]
+- builds_on:: [[2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop]]
+- builds_on:: [[2026-04-19-GH-762-critique]]
+- builds_on:: [[2026-04-26-softmax-and-rerank-calibration]]
+- builds_on:: [[2026-04-26-ralph-knowledge-wikilink-extractor]]
+
+## Research Question
+
+Did we create a doc / research / thought about *dreaming*? It seems like we didn't fully implement it and the implementation is not fully self-contained.
+
+Two-part question:
+1. **Document trail** — what writing exists about the dreaming concept, and where does it live?
+2. **Self-containment audit** — does the implementation run from a clean clone of `ralph-hero` alone, or does it depend on machine-local state, external repos, and out-of-band manual setup?
+
+## Summary
+
+**Documentation trail: yes, the writing exists — but the seed research lives in another repo, not in ralph-hero.** The foundational research doc (`2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory.md`) was moved to `/Users/dubiel/projects/thoughts/shared/research/`, the user's *global* thoughts repo. Two ralph-hero documents (`thoughts/shared/plans/2026-04-16-GH-0761-...md` and `thoughts/shared/research/2026-04-26-softmax-and-rerank-calibration.md`) `builds_on::` link to that filename, so from inside ralph-hero those wikilinks resolve to phantom nodes — the ralph-knowledge graph would treat them as unresolved targets unless the global thoughts root is added to the indexer's roots config.
+
+The seed research (now reachable at the global path) explicitly frames dreaming as one of three converging consumers of a shared retrieval substrate: *delivery truth* (day-job ADO/GitHub reconciliation), *personal dreams* (nightly memory consolidation loop), and *team memory* (governance-wrapped MCP retrieval service). Prototype A in the research doc — the personal dream loop — is what got built.
+
+**Implementation: shipped and merged to `main`, but only the *plugin* code is self-contained.** The TypeScript ralph-knowledge plugin (`plugin/ralph-knowledge/src/`) has zero hard-coded `/Users/` paths and degrades to safe defaults (cwd-relative `../../thoughts` fallback, `~/.ralph/knowledge.config.json` via `homedir()`, `http://localhost:8000` for the LLM with fail-open semantics). The Python dream-loop scripts and launchd template are not self-contained — they hard-code five absolute paths in `scripts/dream/config.yaml` and three in the launchd plist template, and assume sibling repos (`gemma-lab`, `ralph-engine`) plus a global `thoughts/dream-memories/` directory that lives outside ralph-hero entirely.
+
+**Runtime state: the dream-loop has never executed against this configuration.** The launchd agent is not loaded; the user-level `~/.ralph/knowledge.config.json` does not exist; the Gemma server at `http://localhost:8000` is not currently running; and `/Users/dubiel/projects/thoughts/dream-memories/` (the configured `base_dir`) has not been created. The code exists and tests pass — but no nightly memory has been ingested and no reflection has been synthesized on this machine.
+
+## Detailed Findings
+
+### Document Trail
+
+#### Foundational research (lives outside ralph-hero)
+
+The plans cite `[[2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory]]` as the seed. This doc was *moved* to:
+
+- `/Users/dubiel/projects/thoughts/shared/research/2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory.md`
+
+It is a complete, status-`complete` 423-line research document that frames three threads converging on one substrate:
+
+1. **Delivery truth** — local LLM diff classification + EmbeddingGemma PR↔ticket semantic matching, on top of Apache DevLake, to surface "ADO Done with no merged PR" gaps. Ties into the day-job utility architect role.
+2. **Personal dreams** — nightly clustering of last-24h memories with HDBSCAN, Gemma 4 26B writes one reflection per cluster, reflection embedded back as higher-tier memory. Source list: gemma-lab session JSONL, git commits, optional `simonw/llm` SQLite log, screenpipe events. Cites A-Mem (NeurIPS 2025, arxiv 2502.12110) and Anthropic's documented [Claude Code AutoDream pattern](https://claudefa.st/blog/guide/mechanics/auto-dream).
+3. **Team memory** — same retrieval substrate exposed via MCP with OAuth 2.1 + PKCE + RFC 8707 resource binding (OBO), framed as "institutional knowledge service" for regulated-utility deployment.
+
+The doc explicitly identifies four prerequisite gaps in ralph-knowledge that the dream-loop plan addresses: global singleton DB, worktree blindness, FTS5 rebuild, and 500-char embedding truncation.
+
+#### Plans inside ralph-hero
+
+- `thoughts/shared/plans/2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop.md` (887 lines, `status: draft`) — the plan-of-plans. Six phases: chunked embeddings + schema v3, contextual retrieval pre-embedding, multi-root ergonomics + `.ralphignore`, MCP tool extensions, dream-loop ingester (Python), nightly reflection loop + launchd. Frontmatter `github_issue: 761`, `primary_issue: 761`. Currently in git as untracked; staged neither for commit nor committed.
+- `thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md` (1,144 lines, `status: draft`) — atomic decomposition into 11 child issues (GH-762 through GH-772), each with file ownership, success criteria, and verification steps.
+
+#### Review
+
+- `thoughts/shared/reviews/2026-04-19-GH-762-critique.md` — `status: approved`. Verifies all technical claims against the codebase; flags discovery notes for implementers (e.g., `clearAll()` migration, vector table id scheme); confirms phase dependencies. Plan was approved as "well-researched and decomposed correctly."
+
+#### Tangentially related research (cite the dream-loop)
+
+- `thoughts/shared/research/2026-04-26-softmax-and-rerank-calibration.md` — `builds_on::` the missing seed; line 192 says "dream-loop seed, also cites RRF as the substrate."
+- `thoughts/shared/research/2026-04-26-ralph-knowledge-wikilink-extractor.md` — documents the wikilink extraction pathway that the dream-loop reflections will use to write `builds_on::` edges back to source raw memories.
+- `thoughts/shared/research/2026-04-22-context-handoff-topology.md` — context-flow architecture, indirect background.
+
+#### Wikilink graph health
+
+The dangling reference to `[[2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory]]` from inside ralph-hero is exactly the "phantom node" condition documented in `2026-04-26-ralph-knowledge-wikilink-extractor.md` — the parser extracts the target id from prose, but no document with that id exists in any indexed root *unless the user has added* `/Users/dubiel/projects/thoughts` *to their roots config*.
+
+### Implementation Trail (what merged, in commit order)
+
+All commits are on `main`. PR numbers come from merge-commit messages.
+
+| Commit | Phase | What landed |
+|---|---|---|
+| `f95d958` (PR #774) | 1 | `feat(ralph-knowledge): schema v3 migration — chunks table + memory_tier` |
+| `e535c98` (PR #775) | 1 | `feat(knowledge): add RecursiveCharacterTextSplitter chunker module` |
+| `0633afa` (PR #776 reuse) | 1 | `feat(ralph-knowledge): chunk-aware embedder + reindex persistence` |
+| `66cd9f0` (PR #779 / merge `d9c690d`) | 1 | `feat(ralph-knowledge): HybridSearch chunk-to-doc dedup + snippet` |
+| `b28d757` (PR #777 / merge `9b2c540`) | 4 | `feat(ralph-knowledge): memory_tier filter + knowledge_memory_stats tool` |
+| `b05b7c6` (PR #778) | 5 | `feat(dream-loop): Python uv ingester for gemma-lab + git + llm-cli` |
+| `52b2226` (PR #782) | 6 | `feat(dream-loop): reflection synthesis via UMAP+HDBSCAN+Gemma` |
+| `35ec45d` (PR #783) | 6 | `feat(dream-loop): launchd plist template + log rotation` |
+| `c50c393` (PR #835 / merge `9f5582a`) | follow-up | `fix(ralph-knowledge): remove redundant ALTER TABLE in memory_tier tests` |
+
+Phases 2 (contextual retrieval pre-embedding) and 3 (`.ralphignore` + config file) are also present in the codebase as `llm-client.ts`, `ignore.ts`, and `config.ts`, though their merge commits are not separately identified in this listing.
+
+### Code Layout
+
+#### TypeScript plugin (`plugin/ralph-knowledge/src/`)
+
+- `db.ts` — `createSchema()` declares `documents.memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))` plus the `chunks` table with `(id, document_id, chunk_index, content, char_start, char_end, context_prefix)` and `idx_chunks_document_id`.
+- `chunker.ts` (279 lines) — `RecursiveCharacterTextSplitter`-style algorithm; emits `DocumentChunk[]` with `content`, `charStart`, `charEnd`, `contextPrefix` fields.
+- `embedder.ts` — chunk-aware `embedDocument(title, tags, content, opts)`; calls `opts.llm?.contextualize()` per chunk when the LLM client is provided; embeds `${context}\n${title}\n${tagLine}\n${chunk.content}`.
+- `llm-client.ts:45` — `DEFAULT_BASE_URL = "http://localhost:8000"`. Probes `${baseUrl}/v1/models` with 2s timeout; `contextualize()` uses `/v1/chat/completions`. Fail-open: any error returns empty string and logs one warning.
+- `vector-search.ts` — chunk ids of the form `{doc_id}#c{index}` stored in `documents_vec`, one row per chunk.
+- `hybrid-search.ts` — splits chunk-id on `#c` to recover `doc_id`, deduplicates by document, returns best-scoring chunk's content as `snippet`.
+- `search.ts` — accepts optional `memoryTier` filter; adds `WHERE d.memory_tier = @memoryTier` when not `'any'`; silent fallback when reading a v2 DB without the column.
+- `config.ts` — `loadConfig()` reads `$RALPH_KNOWLEDGE_CONFIG` env var path or `~/.ralph/knowledge.config.json` via `homedir()`, returns empty config if missing. `expandHome()` handles tilde paths.
+- `ignore.ts` (82 lines) — `loadIgnoreForRoot(rootDir, globalPatterns?)` reads `${rootDir}/.ralphignore` and combines with global patterns.
+- `reindex.ts:286-367` — precedence chain `cli → env (RALPH_KNOWLEDGE_DIRS) → config → fallback (../../thoughts)`. Logs which source was selected.
+- `index.ts` — MCP tools: `knowledge_search` accepts `memory_tier: 'doc'|'raw'|'reflection'|'any'` (default `'any'`) and `return_chunk_meta: boolean`; `knowledge_traverse` accepts `memory_tier` filter; new `knowledge_memory_stats` tool returns tier counts, chunk percentiles, last-reflection timestamp.
+
+#### Python dream-loop (`scripts/dream/`)
+
+- `ingest.py` (603 lines) — three sources: gemma-lab JSONL sessions, git commits across configured repos, optional `~/.llm/logs.db`. Idempotent filenames via SHA-1 of `(source, source_id)`. `GIT_PATCH_CHAR_LIMIT = 4000`. Writes markdown with `memory_tier=raw` frontmatter under `<base_dir>/YYYY/MM/DD/<source>-<hash12>.md`.
+- `reflect.py` (767 lines) — reads embeddings directly from `knowledge.db` `documents_vec`, mean-pools chunk embeddings per document, UMAP to 50 dims (`n_neighbors=15, min_dist=0.1`), HDBSCAN (`min_cluster_size=5, min_samples=3`), discards noise. `_PROMPT_HEADER` + `_PROMPT_FOOTER` use the verbatim A-Mem-inspired prompt from the plan. `DEFAULT_LLM_URL = "http://localhost:8000"`, `DEFAULT_LLM_MODEL = "mlx-community/gemma-4-26b-a4b-it-mxfp8"`. Writes under `<base_dir>/reflections/YYYY/MM/DD/<slug>.md`.
+- `logrotate.sh` — caps `/tmp/dream-loop.out` and `/tmp/dream-loop.err` at 1000 lines via `tail -n 1000` + atomic rename.
+- `pyproject.toml` — `requires-python = ">=3.11"`; deps: `httpx`, `hdbscan`, `umap-learn`, `numpy`, `pyyaml`, `sqlite-vec`. Managed via `uv`.
+- `tests/test_ingest.py` (14 KB) and `tests/test_reflect.py` (21 KB) with fixture `sessions/2026-04-19.jsonl`.
+- `README.md` — manual run, install, verify, uninstall, env var documentation.
+
+### Self-Containment Audit
+
+This is the part the user flagged. Auditing every external coupling.
+
+#### Layer 1: TypeScript plugin — self-contained ✓
+
+- Zero `/Users/` paths in `plugin/ralph-knowledge/src/` (verified by `grep -rn "/Users/" src/`).
+- Zero `/Users/` paths in `plugin/ralph-knowledge/src/__tests__/`.
+- Defaults via `os.homedir()` for `~/.ralph/knowledge.config.json`.
+- Final fallback: `"../../thoughts"` cwd-relative (`reindex.ts:362-367`) — works on any machine if a sibling `thoughts/` exists.
+- LLM endpoint default: `http://localhost:8000`, fail-open on unreachability — does not crash a reindex if Gemma isn't running.
+- Tests use `:memory:` SQLite (per CLAUDE.md convention) — no machine-local state.
+
+**Verdict**: the plugin alone is portable. A user with no Gemma server, no config file, and no special directories can clone, `npm install && npm test`, and the system works.
+
+#### Layer 2: `scripts/dream/config.yaml` — five hard-coded absolute paths
+
+```yaml
+base_dir: /Users/dubiel/projects/thoughts/dream-memories         # outside ralph-hero
+gemma_lab_sessions: /Users/dubiel/projects/gemma-lab/sessions    # separate repo
+llm_cli_db: ~/.llm/logs.db                                       # tilde-expanded; OK
+git_repos:
+  - /Users/dubiel/projects/ralph-hero                            # this repo
+  - /Users/dubiel/projects/ralph-engine                          # separate repo
+  - /Users/dubiel/projects/gemma-lab                             # separate repo
+reindex_cmd: npm --prefix /Users/dubiel/projects/ralph-hero/plugin/ralph-knowledge run reindex
+```
+
+Five of the six configured paths bake in the user's specific `/Users/dubiel/projects/...` layout. Only `llm_cli_db` is portable (tilde-relative).
+
+#### Layer 3: `scripts/dream/launchd/com.dubiel.dream-loop.plist.template` — three hard-coded paths
+
+```xml
+<string>cd /Users/dubiel/projects/ralph-hero/scripts/dream && uv run ingest.py ...</string>
+<string>/Users/dubiel/projects/ralph-hero/scripts/dream/logrotate.sh</string>
+...
+<key>RALPH_KNOWLEDGE_CONFIG</key>
+<string>/Users/dubiel/.ralph/knowledge.config.json</string>
+```
+
+Calling this a "template" is generous — no placeholder syntax (no `__HOME__`, `${USER}`, etc.). Each new user must hand-edit before `cp` into `~/Library/LaunchAgents/`.
+
+#### Layer 4: cross-repo dependencies
+
+The dream-loop, as configured, requires four repositories on disk in specific sibling paths:
+
+| Path | Status today | Required for |
+|---|---|---|
+| `/Users/dubiel/projects/ralph-hero/` | exists | this repo (host) |
+| `/Users/dubiel/projects/thoughts/` | exists | `base_dir`, foundational research, knowledge corpus |
+| `/Users/dubiel/projects/gemma-lab/` | exists (1 jsonl) | gemma-lab sessions source, Gemma server runner |
+| `/Users/dubiel/projects/ralph-engine/` | exists | git_repos source for ingest |
+
+The dream-loop is fundamentally a **multi-repo** feature presented as a sub-directory of ralph-hero. The foundational research that the plans `builds_on::` lives in `/Users/dubiel/projects/thoughts/`, not in this repo.
+
+#### Layer 5: machine-local state required, but not bootstrapped by this repo
+
+| Resource | Required | Current state |
+|---|---|---|
+| `~/.ralph/knowledge.config.json` | Yes — referenced by launchd's `RALPH_KNOWLEDGE_CONFIG`; declares which roots to index, must include `/Users/dubiel/projects/thoughts/dream-memories/` for reflections to be searchable | **Missing** |
+| `~/Library/LaunchAgents/com.dubiel.dream-loop.plist` | For nightly automation | **Not loaded** (`launchctl list | grep dream-loop` empty) |
+| Gemma server on `http://localhost:8000` | For contextual retrieval pre-embedding (Phase 2) and reflection synthesis (Phase 6) | **Not running** today (curl failed) |
+| `/Users/dubiel/projects/thoughts/dream-memories/` | Output directory for `ingest.py` and `reflect.py` | **Does not exist** — auto-created on first run |
+| `~/.llm/logs.db` | Optional source for `simonw/llm` CLI logs | **Missing** — gracefully skipped per docs |
+| `/Users/dubiel/projects/gemma-lab/sessions/*.jsonl` | Primary memory source | Exists with one file: `2026-04-13.jsonl` |
+| `~/.ralph-hero/knowledge.db` | The chunked-embedding store the reflector reads from | Plugin auto-creates on first reindex |
+
+#### Layer 6: undocumented manual setup steps
+
+To go from a clean machine clone to a working nightly dream-loop, a user must (none of this is automated by `ralph-hero`):
+
+1. Clone `ralph-hero`, `gemma-lab`, `ralph-engine`, and have a `thoughts/` corpus at `/Users/dubiel/projects/thoughts/`.
+2. Install `uv`. Run `uv sync` in `scripts/dream/`.
+3. Edit `scripts/dream/config.yaml` to match your machine's paths (or rely on the user-specific defaults).
+4. Author `~/.ralph/knowledge.config.json` with roots that include `dream-memories/` so reflections become indexable.
+5. Run `npm install && npm run build` in `plugin/ralph-knowledge/`.
+6. Run `npm run reindex` (or trigger via the configured `reindex_cmd`).
+7. Start a local OpenAI-compatible server on `http://localhost:8000` serving Gemma 4 26B (via `gemma-lab/scripts/start-server.sh`).
+8. Hand-edit the launchd plist template to match your `$HOME` and project path.
+9. `cp` the edited plist into `~/Library/LaunchAgents/`.
+10. `launchctl load` it. Verify with `launchctl list | grep dream-loop`.
+
+The README documents steps 8–10 only. Steps 1–7 are not consolidated into any setup script.
+
+### Implementation Completeness vs Plan Acceptance Criteria
+
+The 2026-04-16 plan listed seven success criteria. Status today:
+
+| Plan criterion | Status | Evidence |
+|---|---|---|
+| 1. Chunk-level snippets returned by `knowledge_search` | Code merged | `hybrid-search.ts` chunk-id splitting; not verified against the corpus on this machine |
+| 2. Schema version `"3"` with `chunks` table populated > 3× docs after reindex | Code merged | `db.ts` declares schema; corpus reindex with v3 not verified to have run |
+| 3. `~/.ralph/knowledge.config.json` exists with roots + ignore patterns | Not done | File missing |
+| 4. `scripts/dream-ingest.py` runs (gemma-lab + git + llm-cli) | Code merged | Script exists; never executed against this machine's sources |
+| 5. `scripts/dream-reflect.py` clusters and writes reflections | Code merged | Script exists; `dream-memories/reflections/` does not exist |
+| 6. `~/Library/LaunchAgents/com.dubiel.dream-loop.plist` registered with next-fire | Not done | launchctl shows nothing |
+| 7. `knowledge_search ... --memory_tier reflection` returns reflections | Latent | Tool accepts the parameter; no reflections to find yet |
+
+**Net**: criteria 1, 2, 4, 5, and 7 are *latently satisfied* (code shipped) but **not empirically verified on this machine** because the dream-loop has never run end-to-end. Criteria 3 and 6 are concretely unmet — the user-side configuration files don't exist.
+
+## Code References
+
+- `/Users/dubiel/projects/thoughts/shared/research/2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory.md:1-423` — foundational research; lives in the global thoughts repo, not in ralph-hero
+- `thoughts/shared/plans/2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop.md:17` — the dangling `builds_on::` link to the seed research
+- `thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md` — atomic decomposition into GH-762 through GH-772
+- `thoughts/shared/reviews/2026-04-19-GH-762-critique.md` — approved plan review
+- `plugin/ralph-knowledge/src/db.ts` — schema v3 with `chunks` table and `memory_tier` column
+- `plugin/ralph-knowledge/src/chunker.ts` — RecursiveCharacterTextSplitter
+- `plugin/ralph-knowledge/src/llm-client.ts:45` — `DEFAULT_BASE_URL = "http://localhost:8000"`
+- `plugin/ralph-knowledge/src/config.ts:44` — `~/.ralph/knowledge.config.json` lookup via `homedir()`
+- `plugin/ralph-knowledge/src/reindex.ts:286-367` — roots precedence chain ending in `"../../thoughts"` fallback
+- `plugin/ralph-knowledge/src/index.ts` — `knowledge_search` `memory_tier`, `knowledge_memory_stats` tool registration
+- `scripts/dream/ingest.py:1-60` — three-source ingester, idempotent SHA-1 filenames
+- `scripts/dream/reflect.py:50-51` — `DEFAULT_LLM_URL` + `DEFAULT_LLM_MODEL` constants
+- `scripts/dream/config.yaml:7-18` — five hard-coded `/Users/dubiel/projects/...` paths
+- `scripts/dream/launchd/com.dubiel.dream-loop.plist.template:11,29` — three hard-coded `/Users/dubiel/...` paths
+- `scripts/dream/README.md:29-43` — install/load/verify steps
+
+## Architecture Documentation
+
+The dreaming system as designed:
+
+```
+Sources (three repos + machine-local state)
+─────────
+gemma-lab/sessions/*.jsonl (24h)
+git log --since=24h (ralph-hero, ralph-engine, gemma-lab)
+~/.llm/logs.db (optional)
+                                                                      
+        │                                                             
+        ▼                                                             
+ingest.py (uv) ── markdown frontmatter (memory_tier=raw) ─►  thoughts/dream-memories/YYYY/MM/DD/
+                                                              │
+                                                              ▼
+                                          npm run reindex (configured roots)
+                                                              │
+                                                              ▼
+                          knowledge.db: documents (memory_tier=raw)
+                                       chunks (one row per chunk)
+                                       documents_vec (per-chunk embedding)
+                                                              │
+                                                              ▼
+reflect.py (uv) ─ HDBSCAN on UMAP(embeddings) ─ Gemma per cluster ─►  dream-memories/reflections/YYYY/MM/DD/
+                                                              │
+                                                              ▼
+                                          npm run reindex (next time)
+                                                              │
+                                                              ▼
+                          knowledge.db: documents (memory_tier=reflection)
+                                       builds_on:: ─► raw memories
+                                                              │
+                                                              ▼
+                          knowledge_search (memory_tier=reflection) from Claude Code
+                                                              │
+                                                              ▼
+                                            launchd: 03:00 daily, RunAtLoad=false
+```
+
+Three layers of "outside the repo":
+1. The seed *research* lives in `/Users/dubiel/projects/thoughts/`.
+2. The *output* (raw + reflections) writes to `/Users/dubiel/projects/thoughts/dream-memories/`.
+3. The *user-specific config* (`~/.ralph/knowledge.config.json`, the loaded launchd plist) lives in `$HOME`, not anywhere this repo can author for you.
+
+The plugin (Layer 1) is the only piece that runs from a clone alone.
+
+## Historical Context (from thoughts/)
+
+- `thoughts/shared/plans/2026-04-16-GH-0761-...md` "What We're NOT Doing" section explicitly defers per-project DB isolation, embedding model swap, screenpipe ambient capture, reflection-of-reflections, and OAuth/ACL — keeping the dream-loop scoped to single-user, single-machine, local stack.
+- The 2026-04-19 critique flagged the `clearAll()` migration concern and the `documents_vec` GLOB pattern as discovery notes for implementers — both addressed in the merged code.
+- The companion research at `thoughts/shared/research/2026-04-26-softmax-and-rerank-calibration.md:192` notes that the dream-loop "cites RRF as the substrate" — the same Reciprocal Rank Fusion (K=60) that hybrid-search uses for chunk-level results.
+- The wikilink-extractor research (`2026-04-26-ralph-knowledge-wikilink-extractor.md`) documents that *typed* edges like `builds_on::` are extracted from prose and become graph edges; reflections will use this exact mechanism to link back to source raw memories.
+
+## Bootstrap Findings (2026-04-26)
+
+A live end-to-end bootstrap of the dream-loop on this machine surfaced three additional implementation bugs that the static audit did not predict. These are documented here because they directly impact the user's "not fully implemented" intuition.
+
+### Bug 1: Parser ignores `memory_tier` frontmatter
+
+The schema migration adds `documents.memory_tier TEXT NOT NULL DEFAULT 'doc'` and `getMemoryTier()` was added to `db.ts:481-483` to read it. But:
+
+- `parser.ts` does not extract `memory_tier` from frontmatter (only `date`, `type`, `status`, `github_issue`, `tags`, `superseded_by`)
+- `db.ts:upsertDocument()` SQL does not include the `memory_tier` column in either INSERT or UPDATE clauses
+
+Result: every indexed document — including all 14 raw-memory markdown files written by `ingest.py` with explicit `memory_tier: raw` in their frontmatter — gets the column default `'doc'`. The promised tier-filtered retrieval (`knowledge_search memory_tier=raw|reflection`) returns zero results because the data was never written that way.
+
+Empirical proof:
+
+```
+$ sqlite3 ~/.ralph-hero/knowledge.db "SELECT memory_tier, COUNT(*) FROM documents GROUP BY memory_tier"
+doc|1685
+```
+
+All 1,685 indexed documents have `memory_tier='doc'`, including the 2 dream-memory files that did get indexed before the reindex OOM'd.
+
+### Bug 2: Reindex OOMs the JS heap
+
+`npm run reindex` exhausts the Node JS heap on a 1,668-document corpus. Default Node heap (~4 GB on macOS) hits `FATAL ERROR: Reached heap limit`. Even with `NODE_OPTIONS="--max-old-space-size=8192"` (8 GB), the same OOM occurs partway through processing. Of 14 raw-memory files written by ingest.py, only 2 made it into the DB before OOM.
+
+Stack trace points at the embedder's chunk processing (Builtins_AsyncFunctionAwaitResolveClosure → PromiseFulfillReactionJob → microtask queue exhaustion). Likely root cause: the transformer model holding embedding tensors in JS heap across the full corpus without batching/release between docs, possibly compounded by sqlite-vec buffer accumulation. Not investigated to root cause in this audit.
+
+### Bug 3: ingest.py auto-reindex inherits the OOM
+
+`scripts/dream/config.yaml` declares `reindex_cmd: npm --prefix .../ralph-knowledge run reindex`, which `ingest.py` invokes at the end of a successful ingest. That subprocess hits the same OOM as a manual `npm run reindex`, exits with code -6 (SIGABRT), and the ingester logs:
+
+```
+WARNING ralph.dream.ingest: Reindex exited with code -6
+```
+
+The ingest itself completed successfully (14 raw-memory files on disk). The reindex hook does not.
+
+### End-to-End Consequence
+
+The dream-loop pipeline cannot complete on this machine in its current state:
+
+```
+ingest.py        ✓ wrote 14 git-commit raw memories
+                ↓
+auto-reindex     ✗ OOM at 4GB heap; -6 exit
+manual reindex   ✗ OOM at 8GB heap; only 2/14 memories indexed
+                ↓
+parser           ✗ even the 2 indexed memories got memory_tier='doc' (frontmatter ignored)
+                ↓
+reflect.py       ✗ "Loaded 0 raw memories. No raw memories in window; nothing to reflect."
+                  (correct query, empty result set due to upstream bugs)
+```
+
+Six of the plan's seven success criteria cannot be empirically verified until the parser and OOM are fixed. The plugin tests pass because tests use `:memory:` SQLite with hand-crafted `memory_tier='raw'` rows — they verify the *filter* works, not the *write path*.
+
+### Bootstrap state on this machine after the audit
+
+- `~/.ralph/knowledge.config.json` — **authored** with three thoughts roots + dream-memories root + global ignore patterns
+- `~/.zshrc` shortcuts — **added** `gemma-up`, `gemma-down`, `gemma-status`, `gemma-ask`, `dream-now`
+- Gemma server — **running** at `http://localhost:8000` (`mlx-community/gemma-4-26b-a4b-it-mxfp8`)
+- `scripts/dream/.venv/` — **populated** via `uv sync` (umap-learn 0.5.12, hdbscan, sqlite-vec, etc.)
+- `plugin/ralph-knowledge/dist/` — **built** (`npm run build` clean)
+- `/Users/dubiel/projects/thoughts/dream-memories/2026/04/26/` — **created**, contains 14 `git-commit-*.md` files
+- `~/.ralph-hero/knowledge.db` — schema v3, 1,685 documents, 11,743 chunks, **all `memory_tier='doc'`**
+- launchd plist — **not loaded** (intentionally deferred per user)
+- Reflections — **none** (blocked by Bugs 1+2)
+
+## Open Questions
+
+1. **Should the foundational research be copied/mirrored into `ralph-hero/thoughts/shared/research/`** so the `builds_on::` wikilinks resolve from inside this repo without depending on the global thoughts root being in the user's `~/.ralph/knowledge.config.json`?
+2. **Is the dream-loop intended to be a single-user, single-machine feature** (in which case the hard-coded paths are documentation, not bugs), **or a portable feature** (in which case `config.yaml` and the launchd template need placeholder substitution + a setup script)?
+3. **Should `~/.ralph/knowledge.config.json` authoring be automated** by `ralph-knowledge:setup` or a sibling skill, given that the launchd job depends on it but the README doesn't walk users through writing it?
+4. **Has any nightly run actually completed end-to-end on this machine** — the absence of `dream-memories/` and the empty `launchctl list` suggest no, but a one-shot manual run (`uv run ingest.py --since 24h && uv run reflect.py --since 24h`) might have been attempted and not produced output.
+5. **What is the intended host repo** for `dream-memories/`? Today it points at the global `/Users/dubiel/projects/thoughts/`, which is consistent with treating dreaming as a cross-project memory layer rather than a ralph-hero-internal concern.
+
+## Related Research
+
+- `thoughts/shared/research/2026-04-26-softmax-and-rerank-calibration.md` — chunk-level retrieval scoring
+- `thoughts/shared/research/2026-04-26-ralph-knowledge-wikilink-extractor.md` — typed edges, phantom nodes
+- `thoughts/shared/research/2026-04-22-context-handoff-topology.md` — context flow architecture
+- `/Users/dubiel/projects/thoughts/shared/research/2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory.md` — foundational seed (outside this repo)

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-ralph-knowledge-wikilink-extractor.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-ralph-knowledge-wikilink-extractor.md
@@ -1,0 +1,283 @@
+---
+date: 2026-04-26
+topic: "How the ralph-knowledge indexer extracts wikilinks and turns them into graph nodes/edges, including the source of 'phantom node' observations from knowledge_traverse"
+tags: [research, ralph-knowledge, indexer, parser, graph-builder, wikilinks, untyped-edges, stub-documents]
+status: complete
+type: research
+github_issue: 897
+github_url: https://github.com/cdubiel08/ralph-hero/issues/897
+---
+
+# Research: ralph-knowledge Wikilink Extractor — Indexer Pipeline and Phantom-Node Source
+
+## Prior Work
+
+- builds_on:: [[2026-03-24-GH-0664-capture-all-wiki-links-as-edges]]
+- builds_on:: [[2026-03-26-ralph-knowledge-architecture-for-engine-parity]]
+- builds_on:: [[2026-03-25-GH-0682-ralph-knowledge-three-bug-fix]]
+- builds_on:: [[2026-03-28-ralph-knowledge-multi-project-architecture]]
+- builds_on:: [[2026-04-03-knowledge-implementation-comparison-obra-vs-ralph]]
+
+## Research Question
+
+When `knowledge_traverse` was run from the seed dream-loop research doc, the result set included target IDs that look like literal placeholder text rather than real document IDs — `wikilink`, `wikilinks`, `doc-id`, `target`, `target-id`, `link`, `Alice`, `future-research-topic`, `<other surface docs that touch this one>`. Document how the current indexer extracts wikilinks, where these targets come from, and what filtering exists between extraction and the MCP traverse output.
+
+## Summary
+
+The phantom-target behavior is fully explained by the parser. `parser.ts:34` defines `WIKILINK_RE = /\[\[([^\]]+)\]\]/g` — any string between `[[` and `]]` that doesn't contain `]` is captured verbatim as a target ID. There is **no allowlist, no validation, no resolution step**. Code-fence blocks (triple backticks) are stripped before extraction; inline code, HTML comments, and block quotes are not. Each extracted target is persisted as both a stub document row (`is_stub = 1`, with the raw wikilink text used as `title`) and an untyped relationship row.
+
+A graph-layer filter does exist: `GraphBuilder.buildGraph()` loads only documents with `is_stub = 0 OR is_stub IS NULL` and skips relationships whose endpoints aren't in the node set. This means stub-target edges *should* be invisible to anything that goes through `GraphBuilder`. Since `knowledge_traverse` returned them anyway, the suspected cause is that `traverse.ts` queries the SQLite `relationships` table directly without applying the stub filter — but this was not confirmed in this research and is the open question below.
+
+The angle-bracket text `<other surface docs that touch this one>` is consistent with the regex: `[^\]]` accepts `<` and `>` freely, so a literal `[[<other surface docs that touch this one>]]` written inside a doc body would extract that exact string as a target ID.
+
+## Detailed Findings
+
+### Pipeline overview
+
+The indexer (`reindex.ts`) runs in three phases:
+
+1. **File discovery and stale cleanup.** `findMarkdownFiles` walks the configured root directories. Any previously synced file no longer on disk has its `documents`, FTS, and vector rows deleted from SQLite.
+2. **Parse and store changed files.** For each file whose `mtime` differs from the `sync` table record, `parseDocument` extracts frontmatter, typed relationships, and untyped wikilink edges. The document is upserted, relationships are deleted and re-inserted, and every target — including unknown ones — is materialized as a stub `documents` row to satisfy the foreign-key constraint.
+3. **FTS rebuild.** Full FTS rebuild only runs on schema-version change; per-document FTS is incremental during phase 2.
+
+The in-memory `GraphBuilder` is a read-only view built on demand from the persisted `documents` and `relationships` tables. It is not part of the indexer write path.
+
+### Wikilink extraction
+
+`plugin/ralph-knowledge/src/parser.ts:32-35` defines four regexes:
+
+```ts
+const WIKILINK_REL_RE = /^- (builds_on|tensions|post_mortem):: \[\[(.+?)\]\]/gm;
+const SUPERSEDED_BY_RE = /\[\[(.+?)\]\]/;
+const WIKILINK_RE      = /\[\[([^\]]+)\]\]/g;
+const FENCED_CODE_RE   = /```[\s\S]*?```/g;
+```
+
+- `WIKILINK_REL_RE` (line 32): typed relationship lines only (`- builds_on:: [[…]]`, `- tensions:: [[…]]`, `- post_mortem:: [[…]]`).
+- `SUPERSEDED_BY_RE` (line 33): non-global; applied only to the `superseded_by` frontmatter value.
+- `WIKILINK_RE` (line 34): the **untyped** extractor — anything `[[…]]` where `…` contains no `]`.
+- `FENCED_CODE_RE` (line 35): triple-backtick block stripper.
+
+`extractUntypedWikilinks` (around `parser.ts:70`) strips fenced code from each paragraph before scanning:
+
+```ts
+const stripped = paragraph.replace(FENCED_CODE_RE, "");
+```
+
+The test at `parser.test.ts:348-352` explicitly verifies that `[[should-be-skipped]]` inside a fenced block produces zero edges.
+
+#### Behavior on observed phantom targets
+
+| Source text in doc | Captured `targetId` | Why |
+|---|---|---|
+| `[[2026-04-16-real-doc]]` | `2026-04-16-real-doc` | Real wikilink, normal case |
+| `[[wikilink]]` | `wikilink` | No filtering on capture group |
+| `[[doc-id]]` | `doc-id` | Same |
+| `[[Alice]]` | `Alice` | Same |
+| `[[wikilinks]]`, `[[link]]`, `[[future-research-topic]]`, `[[target]]`, `[[target-id]]` | each captured verbatim | Same |
+| `[[<other surface docs that touch this one>]]` | `<other surface docs that touch this one>` | `[^\]]` admits `<` and `>` |
+| `<other surface docs…>` (no double brackets) | (nothing) | Angle brackets alone do not match any regex |
+
+The phantom targets observed in `knowledge_traverse` output match category 1 (someone writing example wikilinks like `[[wikilink]]` inside research-doc prose to illustrate the syntax).
+
+#### What is NOT stripped before extraction
+
+Frontmatter is stripped at `parser.ts:94` (`raw.slice(fmMatch[0].length).trim()`), and fenced code blocks are stripped per-paragraph. The following are **not** stripped:
+
+- **Inline code** (single backtick, e.g., `` `[[target]]` ``) — wikilinks inside are extracted as edges.
+- **HTML comments** (`<!-- … -->`) — wikilinks inside are extracted.
+- **Block quotes** (`> …`) — wikilinks inside are extracted.
+
+No tests cover any of these three cases.
+
+### Graph node/edge creation
+
+For every untyped edge returned by `parseDocument`, `reindex.ts:165-168` runs:
+
+```ts
+for (const edge of parsed.untypedEdges) {
+  db.upsertStubDocument(edge.targetId);
+  db.addRelationship(edge.sourceId, edge.targetId, "untyped", edge.context);
+}
+```
+
+`db.upsertStubDocument` (`db.ts:238-241`) executes:
+
+```sql
+INSERT OR IGNORE INTO documents
+  (id, path, title, date, type, status, github_issue, content, is_stub)
+VALUES (?, NULL, ?, NULL, NULL, NULL, NULL, '', 1)
+```
+
+For an unknown target, this creates a row with `is_stub = 1`, `path = NULL`, `title` set to the raw wikilink text, and all other metadata `NULL`. `INSERT OR IGNORE` makes it a no-op when the target is already a real document.
+
+`db.addRelationship` (`db.ts:261`):
+
+```sql
+INSERT OR IGNORE INTO relationships (source_id, target_id, type, context)
+VALUES (?, ?, ?, ?)
+```
+
+The primary key `(source_id, target_id, type)` on `db.ts:125` silently drops duplicate edges.
+
+Typed relationships follow the identical path at `reindex.ts:160-163` (no `context` value passed; column stored as `NULL`).
+
+#### Phase 3 stub sweep
+
+After all files are processed, `reindex.ts:257-270` runs:
+
+```ts
+const allTargetIds = new Set<string>(
+  (db.db.prepare("SELECT DISTINCT target_id FROM relationships").all() ...)
+    .map(r => r.target_id)
+);
+for (const targetId of allTargetIds) {
+  if (!db.documentExists(targetId)) {
+    db.upsertStubDocument(targetId);
+    stubCount++;
+  }
+}
+```
+
+This catches targets from prior runs whose referencing files were `mtime`-skipped in the current incremental run.
+
+### GraphBuilder filtering
+
+`GraphBuilder.buildGraph()` at `graph-builder.ts:33-34` loads only non-stub documents as graph nodes:
+
+```sql
+SELECT id, title, date, type, status FROM documents WHERE is_stub = 0 OR is_stub IS NULL
+```
+
+At `graph-builder.ts:63-64`, it then defensively skips any relationship row where either endpoint is missing from the node set:
+
+```ts
+if (!graph.hasNode(rel.source_id) || !graph.hasNode(rel.target_id)) {
+  continue;
+}
+```
+
+**Net effect**: stub-only targets are absent from the in-memory graphology graph. The `relationships` rows persist in SQLite, but `GraphBuilder` silently drops them during graph construction. Anything that consumes `GraphBuilder` (community detection, centrality, subgraph extraction) will not see them.
+
+### Allowlist, validation, resolution — none
+
+The captured `match[1]` from `WIKILINK_RE` is used verbatim as `targetId`. No date-prefix validation, no length check, no fuzzy match, no title-based resolution. The only deduplication:
+
+- `seenInParagraph` Set (`parser.ts:81`) — same target twice in one paragraph collapses to one edge per paragraph.
+- `typedTargets` Set (`parser.ts:79`) — a target appearing as a typed relationship is excluded from `untypedEdges`.
+- SQLite `PRIMARY KEY (source_id, target_id, type)` (`db.ts:125`) — exact duplicate triples dropped via `INSERT OR IGNORE`.
+
+### Test coverage
+
+Tests in `plugin/ralph-knowledge/src/__tests__/`.
+
+`parser.test.ts` — `extractUntypedWikilinks` block (lines 324-382):
+- Single wikilink in a simple paragraph (line 325)
+- Context returned as trimmed paragraph text (line 334)
+- Multiple wikilinks per paragraph each get an edge (line 340)
+- Wikilinks inside fenced code blocks skipped (line 348)
+- Wikilinks whose target is in `typedTargets` skipped (line 354)
+- Same target twice in one paragraph deduplicates (line 361)
+- Same target in two paragraphs produces two edges (line 368)
+- No wikilinks in body returns empty array (line 377)
+
+`parser.test.ts` — `parseDocument untyped edges` block (lines 384-435): full-integration coverage of the above.
+
+`reindex.test.ts`:
+- Scenario 6 (line 239): real-document target is not marked as stub when the target file exists.
+- Scenario 8 (line 289): stub document for unresolved wikilink `phantom` is created on first index and survives the next incremental run when the referencing file is `mtime`-skipped.
+
+`graph-builder.test.ts`:
+- FK constraint test (line 153): inserting a `relationships` row referencing a non-existent `documents.id` directly (bypassing `upsertStubDocument`) throws `FOREIGN KEY constraint failed`.
+- No test asserts that a stub-target edge present in SQLite is dropped during `buildGraph()`. The behavior is documented in code comments at `graph-builder.ts:63-64` only.
+
+**Gaps in test coverage:**
+- Inline code (single backtick).
+- HTML comments.
+- Block quotes.
+- Angle-bracket targets like `[[<...>]]`.
+- The graph-side stub-edge drop behavior.
+- Whether `knowledge_traverse` honors the stub filter.
+
+## Code References
+
+All references are at ralph-hero commit [`557f2a4`](https://github.com/cdubiel08/ralph-hero/tree/557f2a4389b0e37ce77d2da1d54cf698a6788e6e).
+
+- [`parser.ts:32-35`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/parser.ts#L32-L35) — Regex constants for typed, untyped, superseded-by, and fenced-code blocks.
+- [`parser.ts:70`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/parser.ts#L70) — Fenced-code stripping before untyped scan.
+- [`parser.ts:79-81`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/parser.ts#L79-L81) — `typedTargets` and `seenInParagraph` dedup sets.
+- [`parser.ts:94`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/parser.ts#L94) — Frontmatter stripped from `body`.
+- [`parser.ts:121`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/parser.ts#L121) — `extractUntypedWikilinks` invocation in `parseDocument`.
+- [`reindex.ts:160-163`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/reindex.ts#L160-L163) — Typed relationship persistence.
+- [`reindex.ts:165-168`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/reindex.ts#L165-L168) — Untyped edge persistence with stub creation.
+- [`reindex.ts:257-270`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/reindex.ts#L257-L270) — Phase 3 stub-target sweep across the relationships table.
+- [`db.ts:125`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/db.ts#L125) — `relationships` primary key.
+- [`db.ts:238-241`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/db.ts#L238-L241) — `upsertStubDocument` SQL.
+- [`db.ts:261`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/db.ts#L261) — `addRelationship` SQL.
+- [`graph-builder.ts:33-34`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/graph-builder.ts#L33-L34) — Graph node load with stub filter.
+- [`graph-builder.ts:63-64`](https://github.com/cdubiel08/ralph-hero/blob/557f2a4389b0e37ce77d2da1d54cf698a6788e6e/plugin/ralph-knowledge/src/graph-builder.ts#L63-L64) — Edge skip when endpoint missing.
+
+## Architecture Documentation
+
+The indexer is a single-pass, incremental, write-through pipeline. The graph layer is read-through and built on demand. Every wikilink target — real or placeholder — becomes a persistent edge in SQLite; the graph layer is the place where placeholders are filtered out. This design keeps the indexer permissive (it doesn't need to know which targets will eventually exist) while concentrating all "what counts as a real node" decisions in `GraphBuilder`. The tradeoff is that any consumer that bypasses `GraphBuilder` and queries the `relationships` table directly will see the unfiltered, stub-inclusive view.
+
+The frontmatter convention `builds_on:: [[…]]`, `tensions:: [[…]]`, and `post_mortem:: [[…]]` is the typed-edge surface; everything else inside `[[…]]` becomes an untyped edge with the surrounding paragraph stored as `context`.
+
+## Historical Context (from thoughts/)
+
+- `thoughts/shared/research/2026-03-24-GH-0664-capture-all-wiki-links-as-edges.md` — The research that introduced the current extraction behavior, including the paragraph-context capture and the explicit decision to capture *all* wikilinks (not only those resolving to real docs).
+- `thoughts/shared/plans/2026-03-25-GH-0682-ralph-knowledge-three-bug-fix.md` — Bug #3 in that plan addressed an earlier stub-creation timing issue where `knownIds` was built only from the current batch, missing targets referenced by `mtime`-skipped files. The Phase 3 sweep at `reindex.ts:257-270` is the fix.
+- `thoughts/shared/research/2026-03-26-ralph-knowledge-architecture-for-engine-parity.md` — Architecture overview describing the typed/untyped split and where each lives in the schema.
+- `thoughts/shared/research/2026-03-28-ralph-knowledge-multi-project-architecture.md` — Multi-project ingestion and FTS5 rebuild behavior.
+- `thoughts/shared/research/2026-04-03-knowledge-implementation-comparison-obra-vs-ralph.md` — Post-convergence scorecard noting "wikilinks as untyped edges now captured."
+
+## Open Questions
+
+1. **Does `knowledge_traverse` query SQLite directly or go through `GraphBuilder`?** Observed traverse output included stub targets (`wikilink`, `<other surface docs that touch this one>`, etc.) that `GraphBuilder` would have dropped. Tracing `traverse.ts` would confirm whether the MCP traverse path bypasses the stub filter, and if so, whether `knowledge_communities` and `knowledge_central` (which presumably do go through `GraphBuilder`) are unaffected.
+2. **Does the same bypass affect any other MCP tools?** `knowledge_subgraph` is a likely candidate — it returns nodes and edges around a root document. If it queries SQLite directly, the same phantom-node behavior would appear there.
+3. **What does the test for "stub edges are filtered at graph layer" look like?** Currently absent. Would need to set up a fixture with at least one stub target and assert it's not in `graph.nodes()` after `buildGraph()`.
+
+## Follow-up audit (2026-04-26)
+
+A direct trace of every MCP tool against the `is_stub` filter resolved the open questions above and surfaced two additional bypasses the original research missed. Tracked in [#897](https://github.com/cdubiel08/ralph-hero/issues/897).
+
+### Summary table
+
+| Tool | Path | `is_stub` filter? | Verdict |
+|---|---|---|---|
+| `knowledge_search` (FTS leg) | `search.ts:155-171` JOIN of `documents_fts` to `documents` | **NO** | **BYPASSES** |
+| `knowledge_search` (vector-only leg) | `hybrid-search.ts:158-162` explicit `doc.isStub` guard | YES | HONORS |
+| `knowledge_traverse` | `traverse.ts:24,81` recursive CTE + `LEFT JOIN documents` | **NO** | **BYPASSES** |
+| `knowledge_subgraph` | `graph-tools.ts:799-916` → `GraphBuilder.buildGraph()` | YES | HONORS |
+| `knowledge_communities` | `graph-tools.ts:176-321` → `GraphBuilder` | YES | HONORS |
+| `knowledge_community` | `graph-tools.ts:326-447` → `GraphBuilder` | YES | HONORS |
+| `knowledge_central` | `graph-tools.ts:452-563` → `GraphBuilder` | YES | HONORS |
+| `knowledge_paths` | `graph-tools.ts:637-717` → `GraphBuilder` | YES | HONORS |
+| `knowledge_bridges` | `graph-tools.ts:568-632` → `GraphBuilder` | YES | HONORS |
+| `knowledge_common` | `graph-tools.ts:722-793` → `GraphBuilder` | YES | HONORS |
+| `knowledge_memory_stats` | `index.ts:196,213,224` direct `SELECT COUNT(*)` on `documents` | **NO** | **BYPASSES** |
+| `knowledge_query_outcomes` | `outcome_events` only | N/A | N/A |
+| `knowledge_record_outcome` | `outcome_events` only | N/A | N/A |
+
+### Confirmed answers
+
+1. **`knowledge_traverse` does query SQLite directly.** Both `traverse()` and `traverseIncoming()` walk `relationships` with a `LEFT JOIN documents` and no `is_stub` clause. Stubs surface as hops with `doc.title = stubId` (because `upsertStubDocument` at `db.ts:241` sets `title = id`).
+2. **`knowledge_subgraph` is NOT affected.** It calls `GraphBuilder.buildGraph()` at `graph-tools.ts:822`, so stubs are filtered.
+3. **Two additional bypasses surfaced** (not on the original list):
+   - **`knowledge_search` FTS leg.** `FtsSearch.rebuildIndex()` (`search.ts:90-104`) runs an unfiltered `INSERT INTO documents_fts ... SELECT rowid, title, path, content FROM documents`. After any schema-version bump, stubs are in the FTS index. Stub `content = ''` and `title = id`, so they match by title/path with empty snippets. The vector-only path at `hybrid-search.ts:161` already has a guard; the FTS path does not.
+   - **`knowledge_memory_stats`.** All three count queries against `documents` (`index.ts:196`, `:213`, `:224`) lack the filter. `total_documents` and `by_tier` are inflated by every stub. `new_since` is incidentally clean only because stubs have `date = NULL` and the query filters on `date IS NOT NULL`.
+
+### New side-effect findings
+
+- **Typed relationships also create stubs.** `reindex.ts:160-168` calls `db.upsertStubDocument(rel.targetId)` for every typed relationship target (`builds_on`, `tensions`, `post_mortem`, `superseded_by`) before inserting the row. The fix must cover stubs created by typed edges, not just untyped wikilinks.
+- **Vector index is clean.** `vec.upsertEmbedding` is only called inside the real-document chunk loop at `reindex.ts:230`; `upsertStubDocument` never embeds. Stubs have no rows in `documents_vec`, which is why the vector leg of search is naturally clean — the `hybrid-search.ts:161` guard is defense-in-depth, not the only thing protecting it.
+- **FTS rebuild is conditional.** A full `rebuildIndex()` only runs on schema-version change (`reindex.ts:253`). Per-document FTS in Phase 2 is incremental and only touches real documents (stubs are never passed to `fts.upsertFtsEntry`). So stub-pollution of FTS is a *post-schema-bump* phenomenon, not continuous — but once present, it persists until the next schema bump.
+
+### Test-coverage gaps confirmed
+
+No test asserts:
+- Stub edges are dropped during `GraphBuilder.buildGraph()`.
+- `knowledge_traverse` excludes stub hops.
+- `knowledge_search` FTS does not return stub documents.
+- `knowledge_memory_stats` excludes stubs from totals.
+- Typed relationships do not produce visible stubs.

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-softmax-and-rerank-calibration.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-26-softmax-and-rerank-calibration.md
@@ -1,0 +1,243 @@
+---
+date: 2026-04-26
+topic: "The softmax function from first principles, and the broader landscape of techniques for calibrating and re-ranking search results beyond softmax/temperature scaling"
+tags: [research, softmax, calibration, reranking, retrieval, hybrid-search, rrf, cross-encoders, learning-to-rank, llm-rerank, ralph-knowledge]
+status: complete
+type: research
+github_issue: 898
+github_url: https://github.com/cdubiel08/ralph-hero/issues/898
+---
+
+# Research: Softmax + Re-Rank Calibration Landscape
+
+## Prior Work
+
+- builds_on:: [[2026-04-03-knowledge-implementation-comparison-obra-vs-ralph]]
+- builds_on:: [[2026-03-28-ralph-knowledge-multi-project-architecture]]
+- builds_on:: [[2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop]]
+- builds_on:: [[2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop]]
+- builds_on:: [[2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory]]
+
+## Research Question
+
+Two parts:
+
+1. Document the softmax function — its formula, the temperature parameter, where it appears in machine learning, where it appears (and doesn't) in retrieval/ranking, and its known calibration pitfalls.
+2. Survey other production-grade and research-grade techniques for improving the calibration and quality of search re-ranking, beyond softmax + temperature scaling. Pay particular attention to techniques compatible with a hybrid BM25 + dense-vector pipeline, since `ralph-knowledge` already uses RRF over FTS5 + sqlite-vec.
+
+## Summary
+
+Softmax converts an arbitrary real-valued vector of "logits" into a probability distribution over K classes. It is the dominant choice for multi-class classifier output layers, transformer attention, RL policy heads, and language-model token sampling. In retrieval, softmax is the underlying loss for several listwise learning-to-rank formulations, but **it is not the dominant production choice for combining or normalizing hybrid-retrieval scores** — RRF (Reciprocal Rank Fusion, k=60) holds that role across Elasticsearch, OpenSearch, Weaviate, Qdrant, and Azure AI Search. The broader landscape of re-rank quality improvements falls into seven categories: cross-encoder rerankers, LLM-as-reranker, post-hoc score calibration (Platt, isotonic, beta), learned linear/GBDT fusion, query-side techniques (HyDE, LLM rewriting), diversity reranking (MMR, DPP), and a handful of newer specialty techniques (LiPO, Lost-in-the-Middle mitigations, multi-stage cross-encoder fine-tuning).
+
+A practical decision heuristic at the end of this document maps common scenarios (small-corpus cold start, large-corpus with click logs, regulated domain, latency-sensitive, batch quality) to a first-line technique to consider.
+
+## Part 1 — The Softmax Function
+
+### Definition
+
+Given a vector **z** of K real numbers (logits):
+
+```
+σ(z)_i = exp(z_i) / Σ_j exp(z_j)
+```
+
+Outputs lie strictly in (0, 1) and sum to exactly 1, yielding a valid probability distribution over K categories. The exponential maps arbitrary real inputs to positive values (required before normalization) and amplifies differences between logits — larger logits get disproportionately more probability mass, the source of softmax's "soft argmax" character.
+
+**Numerical stability.** The raw formula overflows for large logits since `exp(800)` exceeds float64 range. The standard fix subtracts the maximum logit before exponentiating:
+
+```
+σ(z)_i = exp(z_i − max(z)) / Σ_j exp(z_j − max(z))
+```
+
+Mathematically identical, but all exponentials are bounded by 1. See [Softmax — Wikipedia](https://en.wikipedia.org/wiki/Softmax_function).
+
+The function was named and given its probabilistic interpretation by John S. Bridle in 1990 ([Springer chapter](https://link.springer.com/chapter/10.1007/978-3-642-76153-9_28)). The standard textbook treatment is Goodfellow et al., *Deep Learning*, [Section 6.2](https://www.deeplearningbook.org/contents/mlp.html).
+
+### Temperature parameter
+
+Dividing logits by a scalar T before softmax controls distributional sharpness:
+
+```
+σ(z/T)_i = exp(z_i / T) / Σ_j exp(z_j / T)
+```
+
+- T → 0 collapses onto the highest-logit class (argmax), deterministic.
+- T = 1 uses the trained distribution as-is.
+- T → ∞ approaches uniform.
+
+Three contexts where temperature is load-bearing:
+
+- **Reinforcement learning** (Boltzmann policy): T controls exploration vs. exploitation.
+- **Language-model sampling**: T = 0.7–0.9 typical for creative generation, T < 0.5 for factual tasks.
+- **Calibration**: Guo et al. (ICML 2017) showed post-hoc temperature scaling — fitting a single scalar T on a held-out set — is one of the simplest and most effective recalibration methods for modern neural networks. [On Calibration of Modern Neural Networks — arXiv:1706.04599](https://arxiv.org/abs/1706.04599) | [AWS Prescriptive Guidance — Temperature Scaling](https://docs.aws.amazon.com/prescriptive-guidance/latest/ml-quantifying-uncertainty/temp-scaling.html).
+
+### Common uses in ML
+
+- **Multi-class classification.** Canonical final-layer activation when classes are mutually exclusive; pairs with cross-entropy loss. Softmax enforces inter-class competition that sigmoid does not.
+- **Transformer attention.** [Vaswani et al. 2017](https://arxiv.org/abs/1706.03762) define `Attention(Q, K, V) = softmax(QKᵀ / √d_k) · V`. The `√d_k` divisor is itself a temperature-like stabilization.
+- **RL policy heads.** Softmax converts Q-values or advantage estimates into action probabilities.
+- **LM token sampling.** Logit vector over vocabulary → softmax (with temperature) → sample. Top-k and top-p truncate before/after.
+
+### Use in retrieval, ranking, and score normalization
+
+**Listwise learning-to-rank.** Softmax cross-entropy serves as a listwise loss in ListNet (Cao et al. 2007) and successors. A SIGIR 2019 paper, ["An Analysis of the Softmax Cross Entropy Loss for Learning-to-Rank"](https://dl.acm.org/doi/10.1145/3341981.3344221), shows the softmax CE loss analytically bounds MRR and NDCG.
+
+**Hybrid search (BM25 + dense vectors): the score-normalization problem.** BM25 scores are unbounded non-negative reals; cosine similarity sits in [−1, 1] (typically [0, 1] after L2 normalization). Distributions differ in range, shape, and per-query spread. Naive options have known failure modes:
+
+- **Min-max normalization**: outlier-sensitive. One anomalous high BM25 score compresses the rest into a narrow band, letting that retriever dominate regardless of mixing weight α. See [Avchauzov on hybrid retrieval](https://avchauzov.github.io/blog/2025/hybrid-retrieval-rrf-rank-fusion/).
+- **Z-score normalization**: addresses outliers but still produces query-dependent distributions that don't necessarily match across retrievers.
+- **Softmax as normalization**: forces outputs into (0,1) summing to 1, but inherits min-max's outlier sensitivity (one high logit produces a near-degenerate distribution) and adds query-dependent scaling. Not standard in any documented production hybrid pipeline.
+- **Convex combination after normalization**: [Macdonald et al. 2023, arXiv:2210.11934](https://arxiv.org/abs/2210.11934) shows weighted sum outperforms RRF in-domain and out-of-domain when even a small labeled set exists for tuning α.
+- **Reciprocal Rank Fusion (RRF, k=60)**: [Cormack, Clarke, Büttcher, SIGIR 2009](https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf): `RRF_score(d) = Σ_r 1 / (k + rank_r(d))`. Score-agnostic, no tuning required, robust across LETOR 3. The tradeoff: discards score magnitude — a 0.99 cosine and a 0.52 cosine at the same rank are treated identically.
+
+The literature has converged on RRF as the robust no-tuning default and convex combination as the higher-ceiling option when labeled data exists. Softmax-based score normalization remains research-level rather than production-standard for hybrid retrieval.
+
+### Pitfalls
+
+- **Overconfidence.** Modern deep networks trained with softmax + cross-entropy routinely emit probabilities of 0.99+ on inputs that are ambiguous or out-of-distribution. Guo et al. document this systematically across ResNets, DenseNets, LSTMs.
+- **No epistemic uncertainty.** Softmax models *aleatoric* uncertainty (inherent class overlap) but cannot express *epistemic* uncertainty (input outside training domain). [Ulmer et al. 2021 — Understanding Softmax Confidence](https://ar5iv.labs.arxiv.org/html/2106.04972): "there is no reason to trust them outside of the training distribution."
+- **Probabilities are relative, not absolute.** Outputs sum to 1 across the K candidate classes seen during training. Adding/removing a class changes all probabilities; outputs are not portable as standalone confidence scores.
+- **Calibration is fixable but not automatic.** Temperature scaling is the simplest remedy; Platt, isotonic, and Dirichlet calibration exist for cases where T alone is insufficient.
+
+## Part 2 — Re-Rank Calibration and Quality Beyond Softmax
+
+### Cross-encoder rerankers (the dominant production cascade)
+
+**Why the cascade exists.** Bi-encoders (dense retrievers) embed query and document independently, enabling ANN search but losing token-level interaction. Cross-encoders concatenate (query, document) and run them through a full transformer — much more accurate but O(n) forward passes per candidate. The standard production answer: bi-encoder retrieves ~100–500 candidates, cross-encoder reranks the shortlist.
+
+- **MonoBERT, MonoT5, DuoT5.** MonoBERT scores via BERT `[CLS]` head as binary classification. MonoT5 ([Nogueira et al. 2020](https://arxiv.org/pdf/2101.05667)) reframes ranking as seq2seq: feed `"Query: … Document: … Relevant:"` and score the log-prob of `true`. DuoT5 does pairwise comparisons (O(n²), used only on top ~50). The Castorini *Expando-Mono-Duo* pipeline is canonical.
+- **ColBERT / ColBERTv2 (late interaction).** Retains per-token embeddings for query and document; scores via MaxSim (each query token's nearest document token, summed). Sits between bi-encoder and cross-encoder in compute and quality. ColBERTv2 adds residual compression; PLAID adds centroid-based pruning (7× faster GPU, 45× faster CPU). [ColBERT explainer](https://medium.com/@2nick2patel2/colbert-and-friends-re-ranking-that-feels-instant-6c09102b7526).
+- **Commercial offerings (2024–2026).** All API-accessible, send (query, documents[]) → ranked list:
+  - [Cohere Rerank v3/v4](https://cohere.com/rerank) — multilingual, strong BEIR, ~600ms p50.
+  - [Voyage AI Rerank-2/2.5](https://blog.voyageai.com/2024/09/30/rerank-2/) — instruction-following, 13.9% NDCG lift over Cohere v3 on their eval set.
+  - [Jina Reranker v3](https://jina.ai/models/jina-reranker-v3/) — open-weight, 61.94 nDCG@10 on BEIR, sub-200ms.
+  - BGE-Reranker-v2-m3 (BAAI) — open-source, self-hostable, competitive on MTEB.
+  - [AnswerAI/rerankers](https://github.com/AnswerDotAI/rerankers) — unified Python API across the above.
+
+*Use when:* quality matters more than marginal API cost and 200ms–2s rerank latency on top-100 is acceptable. For sub-50ms SLAs, prefer ColBERT late interaction.
+
+### LLM-as-reranker
+
+**Three prompting paradigms.** *Pointwise* (rate each doc independently — cheap, scale-biased), *pairwise* ("which is more relevant?" — better signal, O(n²)), *listwise* (rank a window of K, output a permutation — highest fidelity).
+
+- **RankGPT (Sun et al. 2023).** Sliding window of ~20 docs, GPT outputs numbered permutation, window slides bottom-up. Zero-shot.
+- **RankZephyr / RankVicuna.** Open-source 7B fine-tuned variants. Toolkit: [castorini/rank_llm](https://github.com/castorini/rank_llm).
+- **Failure mode — Lost in the Middle.** [Liu et al. 2023, arXiv:2307.03172](https://arxiv.org/abs/2307.03172): LLMs preferentially attend to start/end of context. Mitigations: interleave window orderings, multi-pass aggregation, or use position-robust architectures like ListT5.
+- **Cost reality.** Adds 4–6s latency vs cross-encoders, 10–100× cost per query at GPT-4o prices. Open-source models on vLLM/SGLang reach ~1–2s.
+
+*Use when:* batch reranking (offline), domain-specific corpora with subtle relevance signals, no labeled data for cross-encoder fine-tuning.
+
+### Score calibration techniques (post-hoc)
+
+These adjust raw scores to produce well-calibrated probabilities. Goal isn't to change ranking order — it's to make scores meaningful across queries and systems for fusion or thresholding.
+
+- **Platt scaling.** Logistic regression (sigmoid with parameters A, B) fit on validation (raw_score, binary_label) pairs. Strictly monotonic — preserves AUC exactly. *Use when:* small labeled set (<500), score is roughly sigmoidal, must preserve exact rank metrics. [scikit-learn calibration docs](https://scikit-learn.org/stable/modules/calibration.html) | [Platt scaling — Wikipedia](https://en.wikipedia.org/wiki/Platt_scaling).
+- **Isotonic regression.** Piecewise-constant monotonic non-decreasing function. More powerful than Platt for non-sigmoid curves, requires ≥1000 samples to avoid overfitting. May introduce ties (flat steps). *Use when:* ample labeled data, calibration accuracy is the priority, downstream is thresholding/display rather than fine-grained ranking within ties.
+- **Beta calibration.** Generalizes Platt to handle scores that cluster near 0 or 1 (common for BM25 on short docs). [abzu.ai calibration intro](https://www.abzu.ai/data-science/calibration-introduction-part-2/).
+- **Histogram / equal-frequency binning.** Partition score range into K bins, assign each bin the mean observed relevance rate. Interpretable, audit-friendly. Needs even more data than isotonic. *Use when:* regulated domain where "show your work" is required.
+
+**Comparison to temperature scaling.** Temperature only sharpens or flattens an existing softmax; it cannot fix a badly-shaped calibration curve. For non-softmax outputs (BM25, raw cosine), Platt or isotonic generally outperform temperature scaling because they're not constrained to the softmax functional form.
+
+### Learned fusion / weighted combination
+
+- **Weighted convex combination.** `score = α·score_dense + (1−α)·score_sparse` with α tuned on a labeled dev set. Simple, interpretable. Vulnerable to query-type distribution shift.
+- **LambdaMART / GBDT on retrieval scores as features.** Treat each retrieval signal — BM25, dense score, field-weighted TF-IDF, CTR, document age — as a feature; gradient-boosted trees with the LambdaRank objective directly optimize NDCG. [LambdaMART explained — Shaped](https://www.shaped.ai/blog/lambdamart-explained-the-workhorse-of-learning-to-rank) | [XGBoost LTR tutorial](https://xgboost.readthedocs.io/en/stable/tutorials/learning_to_rank.html) | [LightGBM LGBMRanker](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html). Elasticsearch ships a native LTR plugin. *Use when:* thousands+ of click logs or judgments, heterogeneous signals with non-linear interactions, can afford periodic retraining. Remains a strong baseline against neural models in e-commerce and web search.
+- **DPR + cross-encoder distillation.** Train the bi-encoder using soft labels from a cross-encoder teacher; the retriever learns to mimic the cross-encoder's score distribution. PairDistill (2024) extends to pairwise signals. [arXiv:2410.01383](https://arxiv.org/html/2410.01383). *Use when:* you want to bake reranker quality into retrieval and reduce reranker invocations at inference.
+
+### Pseudo-relevance feedback and query-side techniques
+
+- **RM3 / Rocchio.** Classic PRF: top-K docs → expand query with top-M terms. Rarely used in classical form today.
+- **HyDE — Hypothetical Document Embeddings ([Gao et al. 2022, arXiv:2212.10496](https://arxiv.org/abs/2212.10496)).** Prompt LLM for a hypothetical ideal document, encode that, retrieve by similarity to the hypothetical embedding. nDCG@10 of 61.3 on TREC-DL20 vs 44.5 for Contriever — ~38% relative improvement, no labels needed. [Haystack HyDE docs](https://docs.haystack.deepset.ai/docs/hypothetical-document-embeddings-hyde). *Use when:* zero-shot/cold-start, short ambiguous queries, vocabulary mismatch between query and corpus. Adds 25–60% latency.
+- **LLM query rewriting.** Generate paraphrases / entity expansions / sub-question decompositions, retrieve for each, fuse. Stays in query space — easier to audit than HyDE.
+
+### Diversity / MMR re-ranking
+
+- **Maximal Marginal Relevance (Carbonell & Goldstein 1998).** Greedy iterative: pick doc maximizing `λ·relevance − (1−λ)·max_similarity_to_already_selected`. Native in [Elasticsearch](https://www.elastic.co/search-labs/blog/maximum-marginal-relevance-diversify-results) and [OpenSearch](https://docs.opensearch.org/latest/vector-search/specialized-operations/vector-search-mmr/). *Use when:* near-duplicate clustering, or diversity is a stated product goal.
+- **Determinantal Point Processes (DPPs).** Probabilistic model where set probability ∝ determinant of a kernel matrix encoding pairwise similarity. Greedy MAP is O(Nk³). Joint reasoning over global diversity, vs MMR's local greedy view. *Use when:* you can afford the compute and need set-level diversity guarantees.
+- **Sampled MMR (SIGIR 2025).** Adds randomness for better relevance-diversity tradeoff with logarithmic speedup. [ACM DL — SMMR](https://dl.acm.org/doi/10.1145/3726302.3730250).
+
+### Newer / specialty techniques (2024–2026)
+
+- **ColBERT as a reranker substrate (mid-cascade).** Late interaction between bi-encoder retrieval and full cross-encoder; better quality than bi-encoder, lower cost than cross-encoder. PLAID makes it production-feasible.
+- **LiPO — Listwise Preference Optimization ([NAACL 2025](https://aclanthology.org/2025.naacl-long.121.pdf)).** Applies LambdaLoss as a fine-tuning objective for LLMs, directly optimizing DCG. RLPO ([arXiv:2601.07449](https://arxiv.org/html/2601.07449v1)) adds a lightweight set-encoder for list-conditioned residuals.
+- **Lost-in-the-Middle mitigations.** For listwise LLM rerankers: place high-relevance candidates at window boundaries, multi-permuted-pass aggregation, or position-robust architectures like ListT5.
+- **CombSUM / CombMNZ / weighted RRF.** Beyond plain RRF: CombSUM sums normalized scores; CombMNZ multiplies by the count of systems retrieving the doc (rewards consensus); weighted RRF allows per-list weights. Both score-based variants need normalization first. [OpenSearch RRF intro](https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/) | [Risk-reward in rank fusion (Benham)](https://rodgerbenham.github.io/bc17-adcs.pdf).
+- **Multi-stage cross-encoder fine-tuning ([arXiv:2503.22672](https://arxiv.org/html/2503.22672v1)).** Pretraining on a general corpus then domain-adapting consistently outperforms single-stage fine-tuning across retrieval benchmarks.
+
+### Decision rubric
+
+| Scenario | First technique to consider |
+|---|---|
+| Small corpus, no labels, cold start | HyDE + cross-encoder via API (Cohere/Jina), no training |
+| Large corpus + click logs | LambdaMART with BM25/dense + click features; bi-encoder distilled from cross-encoder |
+| Regulated domain, interpretable calibration required | Platt scaling or equal-frequency histogram on reranker outputs; MMR for diversity; avoid opaque LLM reranking |
+| Latency-sensitive (< 200ms SLA) | ColBERT late interaction or Jina Reranker v3 (sub-200ms); avoid LLM-as-reranker |
+| Batch / offline quality, latency unconstrained | LLM listwise reranking (RankGPT/RankZephyr) with Lost-in-the-Middle mitigation; DPP for diversity |
+| Fusion calibration across heterogeneous retrievers | Platt-scale each retriever on a labeled dev set before fusing; weighted RRF or LambdaMART-fusion over raw CombSUM |
+
+## Code References
+
+No softmax or post-hoc calibration code currently lives in `ralph-knowledge`. Hybrid ranking goes through `hybrid-search.ts` using RRF over FTS5 (`search.ts`) and sqlite-vec (`vector-search.ts`) outputs. This research surveys techniques external to the current implementation.
+
+## Architecture Documentation
+
+`ralph-knowledge` currently sits at "Stage 1" of the cascade — bi-encoder + BM25 fused via RRF, with no reranker stage. Adopting any technique from Part 2 above would mean inserting a Stage 2 reranker between RRF and the MCP tool surface, or replacing RRF with a learned fusion. Both are architectural changes; both require a labeled dev set or click signal that doesn't currently exist in this corpus.
+
+## Historical Context (from thoughts/)
+
+- `thoughts/shared/research/2026-04-03-knowledge-implementation-comparison-obra-vs-ralph.md` — confirms RRF is the current ranker ("ralph-knowledge is ahead: Hybrid search with Reciprocal Rank Fusion").
+- `thoughts/shared/research/2026-03-28-ralph-knowledge-multi-project-architecture.md` — MCP tool surface table marking `knowledge_search` as "FTS5 + sqlite-vec RRF."
+- `thoughts/shared/plans/2026-04-19-group-GH-762-ralph-knowledge-chunked-embeddings-dream-loop.md` — Task 4.3 modifies hybrid search to bucket by `doc_id` for chunk-level dedup; doesn't change ranker math.
+- `thoughts/shared/plans/2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop.md` — vector search join logic and chunk-to-document aggregation, including snippet generation.
+- `thoughts/shared/research/2026-04-16-local-llm-delivery-truth-personal-dreams-team-memory.md` — dream-loop seed, also cites RRF as the substrate.
+- No prior thoughts mention softmax, Platt scaling, isotonic regression, cross-encoders, ColBERT, RankGPT, HyDE, MMR, or LambdaMART. Net-new territory for this corpus.
+
+## Open Questions
+
+1. **Score-magnitude observability.** The current `knowledge_search` returns RRF scores in the 0.01–0.03 range with no obvious cutoff between relevant and incidental hits. Would any of the post-hoc calibration techniques (Platt, isotonic) work well on RRF output, or do they require the underlying retriever scores instead?
+2. **Labeled data feasibility.** Most learned-fusion and calibration approaches need a labeled dev set (clicks, judgments, or self-annotations). What's the minimum-viable labeling effort that would unlock LambdaMART or convex-combination-with-tuned-α for this corpus size (~75+ docs and growing)?
+3. **Local cross-encoder feasibility.** A local cross-encoder rerank stage (e.g., BGE-Reranker-v2-m3 or a small Qwen-based reranker) on M5 Pro hardware could complement the existing local-LLM stack. Latency and quality at the corpus scale would need a small benchmark.
+4. **Diversity without labels.** MMR is label-free and could be added immediately as a Stage 2. Whether the current corpus exhibits enough near-duplicate clustering to make this worthwhile would need a quick measurement.
+
+## Sources
+
+- [Softmax function — Wikipedia](https://en.wikipedia.org/wiki/Softmax_function)
+- [Bridle 1990 — Springer](https://link.springer.com/chapter/10.1007/978-3-642-76153-9_28)
+- [Goodfellow et al., Deep Learning, Ch. 6](https://www.deeplearningbook.org/contents/mlp.html)
+- [Vaswani et al. 2017, Attention Is All You Need](https://arxiv.org/abs/1706.03762)
+- [Guo et al. 2017, On Calibration of Modern Neural Networks](https://arxiv.org/abs/1706.04599)
+- [Ulmer et al. 2021, Understanding Softmax Confidence](https://ar5iv.labs.arxiv.org/html/2106.04972)
+- [Cormack et al. 2009, RRF (SIGIR)](https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf)
+- [Macdonald et al. 2023, Fusion Functions for Hybrid Retrieval](https://arxiv.org/abs/2210.11934)
+- [Softmax Cross-Entropy Loss for Learning-to-Rank — SIGIR 2019](https://dl.acm.org/doi/10.1145/3341981.3344221)
+- [Avchauzov on hybrid retrieval and RRF](https://avchauzov.github.io/blog/2025/hybrid-retrieval-rrf-rank-fusion/)
+- [Baeldung — Softmax temperature](https://www.baeldung.com/cs/softmax-temperature)
+- [AWS — Temperature scaling](https://docs.aws.amazon.com/prescriptive-guidance/latest/ml-quantifying-uncertainty/temp-scaling.html)
+- [Pradeep, Nogueira et al. — Expando-Mono-Duo](https://arxiv.org/pdf/2101.05667)
+- [ColBERT and Friends — Re-ranking that feels instant](https://medium.com/@2nick2patel2/colbert-and-friends-re-ranking-that-feels-instant-6c09102b7526)
+- [Cohere Rerank](https://cohere.com/rerank)
+- [Voyage AI Rerank-2](https://blog.voyageai.com/2024/09/30/rerank-2/)
+- [Jina Reranker v3](https://jina.ai/models/jina-reranker-v3/)
+- [AnswerAI/rerankers — unified API](https://github.com/AnswerDotAI/rerankers)
+- [LLMs as Pairwise Rankers](https://arxiv.org/html/2306.17563v2)
+- [castorini/rank_llm — RankGPT/Zephyr/Vicuna toolkit](https://github.com/castorini/rank_llm)
+- [Lost in the Middle (Liu et al. 2023)](https://arxiv.org/abs/2307.03172)
+- [ListT5 — Listwise Reranking with Fusion-in-Decoder](https://arxiv.org/html/2402.15838v2)
+- [scikit-learn — Probability Calibration](https://scikit-learn.org/stable/modules/calibration.html)
+- [Platt scaling — Wikipedia](https://en.wikipedia.org/wiki/Platt_scaling)
+- [Beta calibration — abzu.ai](https://www.abzu.ai/data-science/calibration-introduction-part-2/)
+- [LambdaMART — Shaped](https://www.shaped.ai/blog/lambdamart-explained-the-workhorse-of-learning-to-rank)
+- [XGBoost — Learning to Rank](https://xgboost.readthedocs.io/en/stable/tutorials/learning_to_rank.html)
+- [LightGBM — LGBMRanker](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html)
+- [PairDistill](https://arxiv.org/html/2410.01383)
+- [HyDE — arXiv:2212.10496](https://arxiv.org/abs/2212.10496)
+- [HyDE — Haystack docs](https://docs.haystack.deepset.ai/docs/hypothetical-document-embeddings-hyde)
+- [MMR — Elasticsearch Labs](https://www.elastic.co/search-labs/blog/maximum-marginal-relevance-diversify-results)
+- [MMR — OpenSearch](https://docs.opensearch.org/latest/vector-search/specialized-operations/vector-search-mmr/)
+- [DPP for diversity — Medium](https://medium.com/data-science-collective/diversity-in-recommendations-determinantal-point-processes-dpp-2427bf1b6324)
+- [SMMR — SIGIR 2025](https://dl.acm.org/doi/10.1145/3726302.3730250)
+- [LiPO — NAACL 2025](https://aclanthology.org/2025.naacl-long.121.pdf)
+- [RLPO](https://arxiv.org/html/2601.07449v1)
+- [Multi-stage cross-encoder fine-tuning](https://arxiv.org/html/2503.22672v1)
+- [Introducing RRF — OpenSearch](https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/)
+- [Risk-Reward Tradeoffs in Rank Fusion (Benham)](https://rodgerbenham.github.io/bc17-adcs.pdf)

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-29-GH-911-release-embedder-tensors.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-29-GH-911-release-embedder-tensors.md
@@ -1,0 +1,328 @@
+---
+date: 2026-04-29
+status: draft
+type: plan
+github_issue: 911
+github_issues: [911]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/911
+primary_issue: 911
+tags: [ralph-knowledge, performance, memory-profiling, reindex, embedder, oom]
+---
+
+# Release Embedder Tensors and Drop parsedDocs Accumulator - Atomic Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-04-29-reindex-memory-profile]]
+- builds_on:: [[2026-04-29-GH-910-reindex-memory-profile]]
+- builds_on:: [[2026-04-26-dreaming-research-trail-and-self-containment]]
+
+## Overview
+
+Single-issue plan with three sequential phases. The dominant retainer driving the OOM at ~150 chunks is per-call `@huggingface/transformers` Tensor allocation pressure inside `embed()` — the pipeline returns a Tensor wrapping ONNX-runtime native data buffers that V8 cannot reclaim quickly enough across the per-chunk `await` loop. Profile evidence (4 GB and 8 GB heap runs both OOM at iter=15 / 150 chunks with identical `ArrayPrototypeSlice → AsyncFunctionAwaitResolveClosure → PromiseFulfillReactionJob` stack) rules out `parsedDocs[]`, sqlite-vec, microtask buildup, and the LLM contextualize path.
+
+| Phase | Issue | Title | Estimate |
+|-------|-------|-------|----------|
+| 1 | GH-911 | Dispose transformer Tensor outputs after copying embedding data | S |
+| 2 | GH-911 | Skip parsedDocs[] accumulator when generate=false | S |
+| 3 | GH-911 | Verify on full corpus and re-run heap profile | S |
+
+**Why phased**: Phase 1 is the OOM-blocking fix (1-line change at `embedder.ts:23-31`). Phase 2 is a correctness improvement that lands alongside since the issue body bundles them. Phase 3 is empirical confirmation against the live 1,626-doc corpus, mirroring the GH-910 profile run.
+
+## Shared Constraints
+
+- **Embedder singleton must NOT be destroyed** — `embedderInstance` at [embedder.ts:10](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/embedder.ts#L10) is a fixed-cost module-level cache. The leak is per-`embed()`-call, not the model itself. Do not add `embedderInstance = null` anywhere.
+- **Embedding semantics must not change** — the returned `Float32Array` shape (length 384), values, and call surface (`embed(text: string)`) are part of the public API consumed by `embedDocument()` and contract-tested in `embedder.test.ts`. Phase 1 only adds tensor cleanup AFTER the data copy; the returned vector must be byte-identical.
+- **No new runtime dependencies** — `Tensor.dispose()` already exists in `@huggingface/transformers@^3.0.0` at `node_modules/@huggingface/transformers/src/utils/tensor.js:121`. No new packages.
+- **No `--expose-gc`** — the issue body explicitly cautions against forcing GC. The fix must be structural (release native buffers eagerly), not heuristic.
+- **`RALPH_CONTEXTUAL_RETRIEVAL=0` is a workaround, not a fix** — Phase 3 verification must run with the default contextual flag (or `=0` consistent with the GH-910 baseline) and confirm the OOM is gone with default 4 GB heap.
+- **Test environment uses mocked transformers** — `embedder.test.ts` mocks `@huggingface/transformers` to avoid loading the real ONNX model. The mock returns `{ data: new Float32Array(384) }` (no `dispose()` method). Phase 1's call to `output.dispose()` must be safe when `dispose` is absent on the mock — check for the method's existence before invoking it.
+
+## Current State Analysis
+
+### Per-call leak in `embed()`
+
+The current implementation at [plugin/ralph-knowledge/src/embedder.ts:23-31](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/embedder.ts#L23-L31):
+
+```typescript
+export async function embed(text: string): Promise<Float32Array> {
+  const embedder = await getEmbedder();
+  const output = await embedder(text, {
+    pooling: "mean",
+    normalize: true,
+  });
+  return new Float32Array(output.data as ArrayLike<number>);
+}
+```
+
+`output` is a `Tensor` wrapping an ONNX-runtime `ort_tensor` whose `.data` is a `TypedArray` view onto a native `ArrayBuffer`. Constructing `new Float32Array(output.data)` *copies* the data (the constructor's `ArrayLike<number>` overload iterates and assigns), so the returned Float32Array is independent of the source buffer.
+
+However, the `output` reference itself stays in scope until the function returns and the closure is collected. Across 150 sequential awaits in `embedDocument()`, V8's incremental Mark-Compact cannot reclaim them fast enough. The native ONNX-allocated `last_hidden_state` buffers (sequence_length × 384 × 4 bytes ≈ 786 KB per call at 512 tokens) accumulate in OldSpace until heap_limit is reached.
+
+`Tensor.dispose()` at `node_modules/@huggingface/transformers/src/utils/tensor.js:121-124` calls `this.ort_tensor.dispose()`, releasing the native buffer immediately rather than waiting for V8 GC.
+
+### Unbounded `parsedDocs[]` accumulator
+
+[plugin/ralph-knowledge/src/reindex.ts:97](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L97):
+
+```typescript
+const parsedDocs: ParsedDocument[] = [];
+// ... per-file loop pushes parsed docs ...
+parsedDocs.push(parsed);  // line 120
+// ... at end of reindex, line 274:
+if (generate && dirs.length > 0) {
+  generateIndexes(dirs[0], parsedDocs);
+}
+```
+
+The accumulator pins every parsed document's full content + relationships in memory across the entire run, but `generateIndexes()` is the only consumer and only runs when `generate=true`. On the live corpus (24.6 MB raw markdown), this pins ~125 MB worst-case — not OOM-causing on its own but a footgun on a 10x corpus.
+
+### Files Affected (from research)
+
+**Will Modify**:
+- [plugin/ralph-knowledge/src/embedder.ts](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/embedder.ts) — Phase 1: add `output.dispose()` in `embed()`
+- [plugin/ralph-knowledge/src/reindex.ts](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts) — Phase 2: gate `parsedDocs.push(parsed)` on `generate=true`
+- [plugin/ralph-knowledge/src/__tests__/embedder.test.ts](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/__tests__/embedder.test.ts) — Phase 1: add a test asserting `dispose()` is called and the mock supports its absence
+- [plugin/ralph-knowledge/src/__tests__/reindex.test.ts](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/__tests__/reindex.test.ts) — Phase 2: add a test that confirms `generateIndexes` still works when `generate=true` and is unaffected by the accumulator gating
+
+**Will Read**:
+- [plugin/ralph-knowledge/src/__tests__/reindex.test.ts](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/__tests__/reindex.test.ts) — confirm mock `embedDocument` shape
+- [plugin/ralph-knowledge/package.json](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/package.json) — discover build/test commands
+
+## Desired End State
+
+### Verification
+
+- [~] `npm run reindex` on the full corpus completes successfully with default 4 GB Node heap. **PARTIAL**: GH-911's fix verified working end-to-end on a synthetic 400-doc / 2,800-chunk corpus (steady-state heap, peak heap_used 39.6 MB). The full live corpus run is blocked by a **pre-existing chunker bug** in `chunker.chunkText()` that OOMs on multiple real-world markdown docs (verified to reproduce on `main` pre-911) — out of scope for #911, needs separate issue.
+- [x] Peak heap during the verification run stays ≤ 600 MB. **VERIFIED**: peak heap_used = 39.6 MB on the synthetic 400-doc corpus (well under the 600 MB ceiling).
+- [x] Indexing throughput (docs/sec) is within 20% of pre-fix baseline. **VERIFIED** indirectly: 36.7 chunks/sec on synthetic corpus. No pre-fix baseline exists since pre-fix runs OOMed before completing measurable work; this 36.7 chunks/sec figure is the new baseline.
+- [x] All existing tests in `embedder.test.ts` (32 tests) and `reindex.test.ts` (incremental scenarios) still pass. **VERIFIED**: 455 tests pass (32 embedder + 33 reindex + others).
+- [x] New test asserts `output.dispose()` is invoked once per `embed()` call. **VERIFIED**: 3 new tests in `describe("embed (tensor disposal)")`.
+- [x] New test confirms `parsedDocs` is empty (or skipped) when `generate=false` and populated only when `generate=true`. **VERIFIED**: 3 new scenarios (28-30) in reindex tests.
+
+## What We're NOT Doing
+
+- **Not collapsing the embedder singleton** — `embedderInstance` remains module-level. Per profile, it's a 200-300 MB fixed cost, not the leak.
+- **Not adding `--expose-gc` or manual `global.gc()` calls** — the fix is structural (eager native release), not heuristic.
+- **Not switching transformer libraries** — per the research's "Open Questions", evaluating onnxruntime-node directly is a future optimization, out of scope.
+- **Not changing `DEFAULT_CHUNK_SIZE`** — chunker constants stay; this changes embedding semantics.
+- **Not implementing sqlite-vec batching** — that's #912, deprioritized to throughput-only after the GH-910 profile.
+- **Not adding the heap regression bench** — that's #913.
+- **Not addressing LLM contextualize retainers** — `RALPH_CONTEXTUAL_RETRIEVAL=0` ruled out the LLM path; out of scope.
+- **Not refactoring `generateIndexes()` to stream** — Phase 2 only gates the accumulator; `generateIndexes` continues to receive the full `ParsedDocument[]` when `generate=true`. Streaming refactor is a future correctness/scalability improvement.
+
+## Implementation Approach
+
+Phase 1 ships the OOM-blocking fix (the smallest possible structural change). Phase 2 lands alongside as a correctness fix because the issue body bundles both. Phase 3 is the empirical confirmation that mirrors the GH-910 profile methodology — without it, we can't claim the OOM is fixed.
+
+**Phase dependency annotations**:
+- Phase 1: no dependency (independent surgical fix)
+- Phase 2: no dependency on Phase 1 (different file, independent change), but ordered second by convention
+- Phase 3: depends on Phase 1 + Phase 2 (verifies both are present)
+
+---
+
+## Phase 1: Dispose transformer Tensor outputs after copying embedding data
+
+- **depends_on**: null
+
+### Overview
+
+Add `output.dispose()` after copying `output.data` into the returned `Float32Array` in `embed()`. Guard the call so the existing test mock (which returns `{ data: Float32Array }` without a `dispose` method) keeps passing. Add a unit test asserting the dispose call is made.
+
+### Tasks
+
+#### Task 1.1: Add tensor disposal in `embed()`
+
+- **files**: `plugin/ralph-knowledge/src/embedder.ts` (modify)
+- **tdd**: true
+- **complexity**: low
+- **depends_on**: null
+- **acceptance**:
+  - [ ] After `new Float32Array(output.data as ArrayLike<number>)` copies the data, `embed()` calls `output.dispose()` if the method exists.
+  - [ ] The dispose call is wrapped in a `typeof output.dispose === "function"` guard so the mock (which lacks the method) still works.
+  - [ ] The returned `Float32Array` is byte-identical to the pre-fix output (constructor copies; `dispose()` only affects the source `Tensor`).
+  - [ ] No change to the function signature: `export async function embed(text: string): Promise<Float32Array>`.
+  - [ ] No reassignment to `embedderInstance` anywhere.
+
+#### Task 1.2: Update mock and add disposal test
+
+- **files**: `plugin/ralph-knowledge/src/__tests__/embedder.test.ts` (modify)
+- **tdd**: true
+- **complexity**: low
+- **depends_on**: [1.1]
+- **acceptance**:
+  - [ ] Mock `fakePipeline` at `embedder.test.ts:8-11` returns an object with both `data: Float32Array` and a `dispose: vi.fn()` mock.
+  - [ ] New test in the existing `describe("prepareTextForEmbedding")` or a new `describe("embed")` block that calls `embed("hello")` and asserts `fakePipelineOutput.dispose` was called exactly once.
+  - [ ] Existing 32 tests in `embedder.test.ts` continue to pass (the mock-update is backward-compatible because the guard at Task 1.1 tolerates `dispose: undefined`).
+
+### Phase Success Criteria
+
+#### Automated Verification:
+- [x] `npm run build` (from `plugin/ralph-knowledge/`) — no TypeScript errors
+- [x] `npm test` (from `plugin/ralph-knowledge/`) — all tests pass, including new disposal test
+- [x] `npx vitest run src/__tests__/embedder.test.ts` — embedder suite green
+
+#### Manual Verification:
+- [x] Diff inspection: only `embed()` body and one mock object are touched. No changes to `getEmbedder()`, `embedDocument()`, or `prepareTextForEmbedding()`.
+
+**Creates for next phase**: A guarded `output.dispose()` call in `embed()` that releases native ONNX buffers eagerly, eliminating the per-call retention pressure that currently OOMs the corpus reindex at ~150 chunks.
+
+---
+
+## Phase 2: Skip parsedDocs[] accumulator when generate=false
+
+- **depends_on**: null
+
+### Overview
+
+Stop unconditionally pushing every `ParsedDocument` into the corpus-wide `parsedDocs[]` array. Push only when `generate=true` (the rare case where `generateIndexes()` runs at end of reindex). On a 10x larger corpus this avoids pinning hundreds of MB of parsed-doc state for no gain.
+
+### Tasks
+
+#### Task 2.1: Gate `parsedDocs.push(parsed)` on the `generate` flag
+
+- **files**: `plugin/ralph-knowledge/src/reindex.ts` (modify)
+- **tdd**: true
+- **complexity**: low
+- **depends_on**: null
+- **acceptance**:
+  - [ ] At [reindex.ts:120](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L120), `parsedDocs.push(parsed)` is wrapped in `if (generate) { ... }`.
+  - [ ] At [reindex.ts:97](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L97), `const parsedDocs: ParsedDocument[] = [];` remains so the variable is in scope for the post-loop `generateIndexes` call (when `generate=true`).
+  - [ ] At [reindex.ts:274-277](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L274-L277), the existing `if (generate && dirs.length > 0) { generateIndexes(dirs[0], parsedDocs); }` block is unchanged — same call site, same arguments.
+  - [ ] No other reference to `parsedDocs` is added or removed.
+
+#### Task 2.2: Add reindex test verifying accumulator gating
+
+- **files**: `plugin/ralph-knowledge/src/__tests__/reindex.test.ts` (modify)
+- **tdd**: true
+- **complexity**: medium
+- **depends_on**: [2.1]
+- **acceptance**:
+  - [ ] New test scenario in the `describe("incremental reindex")` block titled along the lines of "scenario N: generateIndexes is invoked only when generate=true".
+  - [ ] Test calls `reindex([dir], dbPath, false)` (generate=false), confirms `generateIndexes` is NOT called by spying on the mocked module (or asserting no `index.md` is produced).
+  - [ ] Second test call: `reindex([dir], dbPath, true)` (generate=true), confirms `generateIndexes` IS called with a non-empty `ParsedDocument[]` matching the on-disk fixtures.
+  - [ ] All existing 17+ scenarios in `reindex.test.ts` continue to pass.
+
+### Phase Success Criteria
+
+#### Automated Verification:
+- [x] `npm run build` — no errors
+- [x] `npx vitest run src/__tests__/reindex.test.ts` — all reindex scenarios pass, including new gating test
+- [x] `npm test` — full suite green
+
+#### Manual Verification:
+- [x] Diff shows only one conditional wrap and one new test scenario; no other reindex behavior changed.
+
+**Creates for next phase**: A reindex run with `generate=false` (the default for the production CLI invocation) no longer pins `ParsedDocument[]` for the full corpus. Combined with Phase 1, this leaves zero unbounded accumulators in the per-document hot path.
+
+---
+
+## Phase 3: Verify on full corpus and re-run heap profile
+
+- **depends_on**: [phase-1, phase-2]
+
+### Overview
+
+Run `npm run reindex` against the full live corpus (`~/projects/thoughts`, `~/projects/ralph-hero/thoughts`, `~/projects/ralph-engine/thoughts`, `~/projects/landcrawler-ai/thoughts`) at default 4 GB heap and confirm: (a) it completes without OOM, (b) peak heap stays ≤ 600 MB per the GH-910 recommendation, (c) throughput is within 20% of a pre-fix baseline. Append findings to the existing GH-910 research document or create a short verification note.
+
+### Tasks
+
+#### Task 3.1: Backup pre-existing knowledge.db
+
+- **files**: `~/.ralph-hero/knowledge.db` (read; no source-code change)
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: null
+- **acceptance**:
+  - [ ] If `~/.ralph-hero/knowledge.db` exists, rename it to `~/.ralph-hero/knowledge.db.pre-911-backup`. If it does not exist, log "no pre-existing DB" and continue.
+  - [ ] Backup file is restorable via `mv` if the run aborts.
+
+#### Task 3.2: Build the plugin with the Phase 1 + Phase 2 fixes
+
+- **files**: `plugin/ralph-knowledge/package.json` (read)
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: [3.1]
+- **acceptance**:
+  - [ ] `cd plugin/ralph-knowledge && npm run build` exits 0 with no TypeScript errors.
+  - [ ] `dist/embedder.js` exists and `grep "dispose" dist/embedder.js` shows the disposal call is in the compiled output.
+  - [ ] `dist/reindex.js` exists and `grep -A1 "if (generate)" dist/reindex.js` shows the accumulator gating is in the compiled output.
+
+#### Task 3.3: Run reindex at default 4 GB heap with `--heap-prof`
+
+- **files**: `plugin/ralph-knowledge/dist/reindex.js` (read)
+- **tdd**: false
+- **complexity**: medium
+- **depends_on**: [3.2]
+- **acceptance**:
+  - [ ] Command run from `plugin/ralph-knowledge/`: `RALPH_CONTEXTUAL_RETRIEVAL=0 node --heap-prof --heap-prof-dir=/tmp/heap-prof-gh911 dist/reindex.js`
+  - [ ] Run completes with exit code 0 (NOT 134 / SIGABRT).
+  - [ ] Final stdout shows "Done. N documents indexed, M skipped (unchanged)." with N + M ≥ 1,600.
+  - [ ] At least one `.heapprofile` file is produced under `/tmp/heap-prof-gh911/`.
+
+#### Task 3.4: Capture peak heap and throughput metrics
+
+- **files**: `/tmp/heap-prof-gh911/*` (read), `/tmp/reindex-911-stdout.log` (create)
+- **tdd**: false
+- **complexity**: medium
+- **depends_on**: [3.3]
+- **acceptance**:
+  - [ ] Run a second invocation with `process.memoryUsage()` snapshots logged every 50 chunks (modify a temporary copy of `dist/reindex.js` or use a wrapping probe — do NOT commit any probe).
+  - [ ] Capture peak `rss` and peak `heapUsed`. Peak `heapUsed` ≤ 600 MB.
+  - [ ] Capture wall-clock duration and chunks-per-second. Document these in the verification note.
+
+#### Task 3.5: Append verification findings to the research document
+
+- **files**: `thoughts/shared/research/2026-04-29-reindex-memory-profile.md` (modify)
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: [3.4]
+- **acceptance**:
+  - [ ] Append a new section `## Verification (post-#911 fix)` to the research document with: date of run, plugin commit hash, peak heap (rss + heapUsed), wall-clock duration, doc/chunk count, exit code.
+  - [ ] Section includes a short paragraph confirming the OOM is fixed and noting any remaining concerns (e.g., RSS still inflates due to ONNX baseline, but heapUsed is bounded).
+  - [ ] No re-derivation of the original profile findings — only append; do not edit prior sections.
+
+#### Task 3.6: Restore (or accept new) knowledge.db
+
+- **files**: `~/.ralph-hero/knowledge.db.pre-911-backup` (read)
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: [3.5]
+- **acceptance**:
+  - [ ] If the verification run produced a fresh `~/.ralph-hero/knowledge.db` that is healthy (sqlite3 check passes, document count matches files-on-disk), keep the new DB and remove the backup.
+  - [ ] Otherwise restore the backup via `mv ~/.ralph-hero/knowledge.db.pre-911-backup ~/.ralph-hero/knowledge.db`.
+
+### Phase Success Criteria
+
+#### Automated Verification:
+- [x] `npm run build` — clean
+- [x] `npm test` — green (455 tests pass)
+- [~] `node dist/reindex.js` against full corpus exits 0 (not 134) — **BLOCKED by pre-existing chunker OOM**: synthetic 400-doc / 2,800-chunk corpus exits 0 with steady-state heap; live corpus blocked on out-of-scope `chunkText()` bug (verified pre-existing on `main`).
+- [~] `sqlite3 ~/.ralph-hero/knowledge.db "SELECT COUNT(*) FROM documents WHERE is_stub=0"` returns ≥ 1,600 — **BLOCKED by chunker bug**, see above.
+
+#### Manual Verification:
+- [x] Verification section appended to `2026-04-29-reindex-memory-profile.md` with peak heap ≤ 600 MB (39.6 MB measured), wall-clock duration (76.2 s for 400 docs / 2,800 chunks), throughput (36.7 chunks/sec).
+- [x] Stack trace in stderr from synthetic-corpus run does NOT contain `JS Allocation failed` or `Mark-Compact (reduce)` near heap_limit messages — synthetic run completes cleanly.
+
+**Creates for next phase**: Empirical proof that Phase 1 + Phase 2 fix the per-call native-buffer retention pressure that drove the original 150-chunk OOM. Sibling issue #913 can now calibrate its regression bench against the measured 600 MB ceiling. A new follow-up issue should be filed for the chunker `chunkText()` OOM discovered during verification (pre-existing on `main`, blocks full-corpus reindex).
+
+---
+
+## Integration Testing
+
+- [ ] Full `npm test` from `plugin/ralph-knowledge/` passes (covers embedder, reindex, hybrid-search, vector-search, parser, all interactive tests).
+- [ ] Manual smoke test: `knowledge_search` MCP tool returns sensible results against the freshly indexed DB (verifies the embedder fix didn't change embedding values).
+- [ ] `knowledge_memory_stats` returns non-zero `total_chunks` matching the indexed corpus.
+
+## References
+
+- Issue: https://github.com/cdubiel08/ralph-hero/issues/911
+- Parent issue: https://github.com/cdubiel08/ralph-hero/issues/907
+- Sibling profile (closed): https://github.com/cdubiel08/ralph-hero/issues/910
+- Sibling regression bench (open): https://github.com/cdubiel08/ralph-hero/issues/913
+- Sibling sqlite-vec batching (open, deprioritized): https://github.com/cdubiel08/ralph-hero/issues/912
+- Research: [thoughts/shared/research/2026-04-29-reindex-memory-profile.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-04-29-reindex-memory-profile.md)
+- transformers.js Tensor source: `node_modules/@huggingface/transformers/src/utils/tensor.js:121-124` (`dispose()` impl)
+- transformers.js FeatureExtractionPipeline: `node_modules/@huggingface/transformers/src/pipelines.js:1305-1357`

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-29-GH-916-chunker-no-progress-fix.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-29-GH-916-chunker-no-progress-fix.md
@@ -1,0 +1,362 @@
+---
+date: 2026-04-29
+status: draft
+type: plan
+tags: [ralph-knowledge, chunker, oom, dream-loop]
+github_issue: 916
+github_issues: [916]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/916
+primary_issue: 916
+---
+
+# GH-916: Fix chunker.chunkText() infinite loop on single-atom chunks shorter than chunkOverlap
+
+## Prior Work
+
+- builds_on:: [[2026-04-29-reindex-memory-profile]]
+- builds_on:: [[2026-04-29-GH-911-release-embedder-tensors]]
+
+## Overview
+
+`chunkText()` enters an infinite loop and OOMs the JS heap when a chunk consists of a single atom whose length is less than `chunkOverlap` (256). This is the **remaining blocker** for end-to-end dream-loop reindex on the live 1,668-doc corpus — combined with the #911 embedder fix, fixing this enables `npm run reindex` to complete on the full corpus at default 4 GB Node heap.
+
+## Current State Analysis
+
+### Reproduced
+
+Minimal repro: `chunkText(raw)` on the first 18,630 bytes of `landcrawler-ai/thoughts/shared/plans/2025-12-31-oklahoma-permit-raw-migration.md` OOMs at any heap size. Bisection narrowed to slice (0, 18630) — a single byte less (18620) succeeds. The doc is plain markdown with embedded Python code blocks; longest line is 239 chars and longest paragraph is 1933 chars (both well under `chunkSize=2048`).
+
+### Root cause (instrumented trace)
+
+After `flattenToAtoms` produces 74 atoms (correctly), the chunking loop in [`chunkText` chunker.ts:244-276](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/chunker.ts#L244-L276) packs atoms greedily up to `chunkSize`. When it reaches:
+
+- Atom 72: a 230-char paragraph
+- Atom 73: an 1,827-char paragraph
+- Combined: 230 + 1827 = 2,057 > chunkSize (2048)
+
+The packing loop (line 252) breaks before including atom 73, producing a single-atom chunk for atom 72 alone. Then `findOverlapStartIndex(atoms, 72, 16805, 256)` is called:
+
+- `targetStart = 16805 - 256 = 16549`
+- `atoms[72].start = 16575`, which is `>= 16549` → `overlapAtomIdx = 72`
+- The walk continues backward to k=71, but `atoms[71].start < 16549` → break
+- The guard at [chunker.ts:192-194](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/chunker.ts#L192-L194) checks `overlapAtomIdx > lastEndAtomIndex` (`72 > 72` is false) → guard does not trigger
+- Return `overlapAtomIdx = 72`
+
+The caller sets `i = 72` (its previous value). Loop iteration N+1 produces an identical single-atom chunk for atom 72. **Infinite loop.** Each iteration appends a new `Chunk` object to `chunks[]`; the array grows until heap exhausts.
+
+### Why existing tests miss this
+
+The 16 test cases in [`chunker.test.ts`](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/__tests__/chunker.test.ts) cover empty/short inputs, long documents, overlap behavior, unicode, and separator priority. None construct an input where a chunk would consist of a single atom shorter than `chunkOverlap`. The two long-doc tests use synthetic 8K+ inputs where atoms are uniform-sized, so the packing always produces multi-atom chunks.
+
+### Trigger condition (general)
+
+The bug fires whenever a chunk contains a single atom whose `text.length < chunkOverlap` (default: 256). This happens when:
+- Atom N is "short" (< 256 chars; common: a few-line code block, a short sentence, a 1–2 line list item)
+- Atom N+1 is "long" enough that `len(N) + len(N+1) > chunkSize` (i.e., len(N+1) > chunkSize - len(N))
+- Result: the packer takes only atom N for the current chunk, then `findOverlapStartIndex` returns N → infinite loop
+
+This pattern is common in real markdown (heading → paragraph, short fenced block → long fenced block, short list item → long list item).
+
+### Key Discoveries
+
+- The bug is **algorithmic**, not memory-related. The OOM is a downstream symptom of unbounded loop iterations producing chunk objects.
+- `flattenToAtoms` is correct — atoms are produced as expected.
+- The infinite loop produces millions of identical chunk objects before the heap exhausts, which matches the `Builtins_StringSubstring → JSEntry` stack trace (each iteration runs `text.slice(charStart, charEnd)` in `buildChunk`).
+- The existing "no atoms found" guard ([line 192-194](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/chunker.ts#L192-L194)) is necessary but insufficient. It catches the case where overlap walks past all atoms; it doesn't catch the case where overlap walks back to the previous chunk's start.
+- The bug applies to `chunkOverlap > 0` runs only. Setting `chunkOverlap = 0` short-circuits at [line 177-179](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/chunker.ts#L177-L179) and returns `lastEndAtomIndex + 1`, which always makes progress.
+
+## Desired End State
+
+`chunkText()` makes forward progress on every loop iteration regardless of atom layout. Specifically: every call to `chunkText()` returns within bounded time and bounded memory proportional to `text.length`. The 1,668-doc live corpus reindexes successfully via `npm run reindex` at default 4 GB Node heap (combined with the #911 fix already in main).
+
+### Verification
+
+- The minimal repro fixture (a 230-char paragraph followed by an 1,827-char paragraph) chunks correctly with sensible overlap or no overlap.
+- The full failing input (`oklahoma-permit-raw-migration.md`, 45 KB) chunks in <1s and produces a sensible chunk count.
+- The live 1,668-doc corpus completes `npm run reindex` end-to-end at default 4 GB heap.
+
+## What We're NOT Doing
+
+- **Not changing `DEFAULT_CHUNK_SIZE` or `DEFAULT_CHUNK_OVERLAP`** — these affect embedding semantics; staying at 2048 / 256 preserves embedding compatibility with the existing index.
+- **Not refactoring `flattenToAtoms`** — the flatten phase is correct; only the chunking loop needs the fix.
+- **Not changing `chunkText`'s public signature** — the existing API contract (input → `Chunk[]` with charStart/charEnd invariants) stays intact.
+- **Not streaming the chunker output** — current API returns all chunks; a streaming refactor is a separate enhancement.
+- **Not addressing #912 (sqlite-vec batching)** — separate sibling, deprioritized per #910 findings.
+- **Not addressing #913 (regression microbenchmark)** — separate sibling that should run AFTER this fix lands so it can use a working full-corpus baseline.
+
+## Implementation Approach
+
+Add a forward-progress guard to the chunking loop. The simplest correct fix is at the call site of `findOverlapStartIndex`: ensure the next chunk's starting atom is strictly greater than the current chunk's starting atom. This preserves the existing overlap semantics whenever overlap is achievable, and falls through to "no overlap, advance to next atom" when the overlap calculation would not produce progress.
+
+Two equivalent fix locations were considered:
+
+1. **At the call site** ([`chunkText` line 275](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/chunker.ts#L275)): clamp `nextStart` to `>= i + 1`. Selected because it makes the progress invariant explicit at the loop control point and doesn't require changing the helper's signature.
+
+2. Inside `findOverlapStartIndex`: pass the previous chunk's first-atom index and clamp internally. Rejected — adds a parameter to a helper for one caller, and the loop control is the natural place to enforce progress.
+
+The fix is one line plus a clarifying comment. Tests for the new invariant cover the trigger pattern explicitly.
+
+## Phase 1: Fix the no-progress case in chunkText's loop
+
+### Overview
+
+Add a forward-progress clamp to the loop that advances `i` after each chunk is emitted. Update the helper's doc comment to clarify the new invariant. Add three regression tests covering the bug.
+
+### Changes Required
+
+#### 1. `plugin/ralph-knowledge/src/chunker.ts`
+
+**Change**: Clamp `nextStart` to ensure `i` strictly advances each iteration.
+
+Current code at lines 268-275:
+```typescript
+const lastEndAtomIdx = j - 1;
+const nextStart = findOverlapStartIndex(
+  atoms,
+  lastEndAtomIdx,
+  chunk.charEnd,
+  chunkOverlap,
+);
+i = nextStart;
+```
+
+New code:
+```typescript
+const lastEndAtomIdx = j - 1;
+const nextStart = findOverlapStartIndex(
+  atoms,
+  lastEndAtomIdx,
+  chunk.charEnd,
+  chunkOverlap,
+);
+// Ensure forward progress: when a chunk consists of a single atom shorter
+// than chunkOverlap, the overlap walk would land back on the same atom.
+// Clamp to i + 1 in that case so we always advance, accepting that the
+// resulting chunks will not overlap (this is the only correct option:
+// overlap requires that the next chunk start within the previous chunk's
+// span, but if the previous chunk has only one atom, there is no earlier
+// position within its span to start from).
+i = nextStart > i ? nextStart : i + 1;
+```
+
+Update the doc comment on `findOverlapStartIndex` (lines 165-170) to note the caller's progress responsibility:
+
+```typescript
+/**
+ * Compute the start position for the next chunk's atoms given the previous
+ * chunk ended at `prevEnd`. We walk backward through the atom list to find
+ * the atom whose start >= prevEnd - chunkOverlap; that atom begins the
+ * overlap region.
+ *
+ * NOTE: this function may return an index <= the previous chunk's first atom
+ * when the previous chunk consisted of a single atom shorter than chunkOverlap.
+ * The caller in chunkText clamps the result to ensure forward progress.
+ */
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `npm run build` in `plugin/ralph-knowledge/` exits 0
+- [x] `npm test` in `plugin/ralph-knowledge/` exits 0 (all 455+ tests still pass)
+- [x] New tests in `chunker.test.ts` pass (see Phase 2)
+
+#### Manual Verification
+
+- [x] Repro command from issue body OOMs pre-fix; succeeds post-fix:
+  ```bash
+  cd plugin/ralph-knowledge
+  node --max-old-space-size=512 -e "
+    const {chunkText} = require('./dist/chunker.js');
+    const fs = require('fs');
+    const raw = fs.readFileSync('/Users/dubiel/projects/landcrawler-ai/thoughts/shared/plans/2025-12-31-oklahoma-permit-raw-migration.md','utf-8');
+    console.log('chunks:', chunkText(raw).length);
+  "
+  ```
+
+**Implementation Note**: After Phase 1 + Phase 2 pass automated verification, pause for the manual repro confirmation before continuing to Phase 3.
+
+---
+
+## Phase 2: Add regression tests
+
+### Overview
+
+Add three test cases to `chunker.test.ts` that lock down the fix: the minimal trigger pattern, the post-fix progress invariant on the failing fixture, and a general "every input terminates" property.
+
+### Changes Required
+
+#### 1. `plugin/ralph-knowledge/src/__tests__/chunker.test.ts`
+
+Append a new `describe` block:
+
+```typescript
+describe("chunkText — forward progress invariant", () => {
+  // Regression test for GH-916. Pre-fix this OOMs.
+  it("terminates when a chunk would consist of a single atom shorter than chunkOverlap", () => {
+    // Trigger: atom N is short (< 256 chars), atom N+1 is large enough that
+    // packing them together would exceed chunkSize (2048).
+    const shortAtom = "short paragraph that is under 256 chars.\n\n";
+    const longAtom = "x".repeat(1900) + "\n\n";
+    const text = shortAtom + longAtom + "tail.";
+    const chunks = chunkText(text);
+    // We don't care about the exact count; we care that chunkText returns at
+    // all (pre-fix it loops forever) and that all chunks have non-empty content.
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.length).toBeLessThan(100); // sanity: no runaway
+    for (const c of chunks) {
+      expect(c.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("makes strict forward progress: chunk[i+1].charStart > chunk[i].charStart", () => {
+    // Build an input that triggers many single-atom chunks.
+    const blocks = [];
+    for (let i = 0; i < 20; i++) {
+      blocks.push("short " + i + ".\n\n");
+      blocks.push("x".repeat(1900) + "\n\n");
+    }
+    const chunks = chunkText(blocks.join(""));
+    expect(chunks.length).toBeGreaterThan(0);
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i]!.charStart).toBeGreaterThan(chunks[i - 1]!.charStart);
+    }
+  });
+
+  it("chunks the GH-916 fixture file in bounded time and memory", () => {
+    // Path-independent fixture: a markdown sample that mirrors the trigger
+    // pattern (short paragraphs interspersed with large code blocks).
+    const sample = [
+      "# Heading\n\n",
+      "Short intro paragraph.\n\n",
+      "```python\n" + "code line\n".repeat(180) + "```\n\n",
+      "Short follow-up.\n\n",
+      "```python\n" + "more code\n".repeat(180) + "```\n\n",
+      "End.",
+    ].join("");
+    const start = Date.now();
+    const chunks = chunkText(sample);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(1000); // pre-fix this would not return
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.length).toBeLessThan(50); // sanity: no runaway
+    // Spot-check the canonical invariant
+    for (const c of chunks) {
+      expect(sample.slice(c.charStart, c.charEnd)).toBe(c.content);
+    }
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `npx vitest run src/__tests__/chunker.test.ts` exits 0 with all 19+ tests passing (16 existing + 3 new)
+- [x] Pre-fix: confirm at least the first new test hangs/OOMs by reverting Phase 1 in a scratch branch (manual confirmation only, do not commit)
+
+---
+
+## Phase 3: End-to-end verification on the live corpus
+
+### Overview
+
+With #911 (already in main) and Phase 1+2 of this issue, run `npm run reindex` against the live 1,668-doc corpus at default 4 GB Node heap. Append a verification appendix to the existing memory profile research note documenting the result.
+
+### Changes Required
+
+#### 1. Run `npm run reindex` on the live corpus
+
+```bash
+# Backup the existing knowledge.db (rename, don't delete)
+mv ~/.ralph-hero/knowledge.db ~/.ralph-hero/knowledge.db.pre-916-bak
+
+# Run reindex at default heap with no override
+cd plugin/ralph-knowledge
+RALPH_CONTEXTUAL_RETRIEVAL=0 npm run reindex 2>&1 | tee /tmp/reindex-post-916.log
+
+# Capture final state
+sqlite3 ~/.ralph-hero/knowledge.db "SELECT COUNT(*) FROM documents"
+```
+
+Expected: exit 0, document count matches input file count (~1,668), no FATAL ERROR / SIGABRT.
+
+#### 2. Append to research note
+
+Append a new section to [`thoughts/shared/research/2026-04-29-reindex-memory-profile.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-04-29-reindex-memory-profile.md):
+
+```markdown
+## End-to-end verification (post-#911 + post-#916)
+
+**Date**: 2026-04-29
+**Plugin commit**: <commit sha after Phase 1 lands>
+**Node**: v22.22.1 (default 4 GB heap)
+**Flags**: `RALPH_CONTEXTUAL_RETRIEVAL=0`
+
+### Result
+
+| Metric | Value |
+|---|---|
+| Files on disk | 1,668 |
+| Documents indexed | <observed> |
+| Wall clock | <observed> |
+| Peak heap_used | <observed> |
+| Peak RSS | <observed> |
+| Exit code | 0 |
+
+### Conclusion
+
+The combined fixes from #911 (embedder Tensor disposal + parsedDocs accumulator gate) and #916 (chunker forward-progress guard) close out the parent #907. The dream-loop reindex now works end-to-end at default 4 GB Node heap.
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `npm run reindex` exits 0 (no SIGABRT, no FATAL ERROR)
+- [x] `sqlite3 ~/.ralph-hero/knowledge.db "SELECT COUNT(*) FROM documents"` returns >= 1,500 (allowing for some small delta from filesystem-level filtering) — observed: 1,710
+- [x] Peak `heap_used` observed during the run is < 600 MB (consistent with the #911 acceptance threshold) — observed: 81.1 MB
+
+#### Manual Verification
+
+- [ ] `dream-now` (the manual end-to-end shortcut from `~/projects/CLAUDE.md`) runs without error
+- [ ] `knowledge_search` returns results for a smoke-test query
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Three new test cases in `chunker.test.ts > "forward progress invariant"`:
+  1. Minimal trigger pattern: short atom + long atom causes single-atom chunk → must terminate
+  2. General progress invariant: `chunk[i+1].charStart > chunk[i].charStart` always holds
+  3. Realistic markdown sample (mirroring the GH-916 fixture pattern) — bounded time, bounded chunk count, content-offset invariant holds
+
+### Integration Tests
+
+- `reindex.test.ts` already exercises `chunkText` via `embedDocument` (existing 33 scenarios). All must continue to pass.
+
+### Manual Testing
+
+1. Run the issue body's repro command pre- and post- fix on a clean clone of `feature/GH-916`. Pre-fix OOMs; post-fix returns `chunks: <number>` quickly.
+2. Run the dream-loop end-to-end via `dream-now` from the user's `~/.zshrc`.
+
+## Performance Considerations
+
+The fix is one comparison and one assignment per chunk emitted. No measurable performance impact. The fix may produce slightly fewer chunks (no overlap on single-short-atom chunks vs. infinite chunks), but the change in chunk count is bounded by the number of trigger occurrences in the input — typically <1% of total chunks.
+
+## Migration Notes
+
+No data migration required. The chunker output format is unchanged. Documents that previously failed to chunk (and therefore weren't indexed) will be indexed on the next `reindex` run, naturally adding to the document count.
+
+## References
+
+- Original issue: https://github.com/cdubiel08/ralph-hero/issues/916
+- Parent: https://github.com/cdubiel08/ralph-hero/issues/907
+- Profile research: [thoughts/shared/research/2026-04-29-reindex-memory-profile.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-04-29-reindex-memory-profile.md)
+- #911 fix (prerequisite, already in main): [thoughts/shared/plans/2026-04-29-GH-911-release-embedder-tensors.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-29-GH-911-release-embedder-tensors.md)
+- Chunker source: [plugin/ralph-knowledge/src/chunker.ts](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/chunker.ts)
+- Failing fixture: `landcrawler-ai/thoughts/shared/plans/2025-12-31-oklahoma-permit-raw-migration.md` (45 KB markdown, lines 1-end; bisected fail point at first 18,630 bytes)

--- a/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-29-reindex-memory-profile.md
+++ b/plugin/ralph-knowledge/__tests__/eval-corpus/2026-04-29-reindex-memory-profile.md
@@ -1,0 +1,413 @@
+---
+date: 2026-04-29
+type: research
+status: complete
+github_issue: 910
+github_issues: [910, 907, 911, 912, 913]
+tags: [ralph-knowledge, performance, memory-profiling, reindex, embedder, oom]
+---
+
+# Reindex OOM Memory Profile
+
+## Prior Work
+
+- builds_on:: [[2026-04-26-dreaming-research-trail-and-self-containment]]
+- builds_on:: [[2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop]]
+
+## Summary
+
+Reproduced the `npm run reindex` OOM at default 4 GB heap and 8 GB heap on the live 1,626-doc corpus. Both runs OOM after embedding ~150 chunks (12-15 docs) with the **identical** failure stack — `Builtins_AsyncFunctionAwaitResolveClosure → PromiseFulfillReactionJob → RunMicrotasks → ArrayPrototypeSlice` — and at the V8 OldSpace ceiling (4056 MB at 4 GB cap, 8085 MB at 8 GB cap).
+
+The dominant retainer is the **`@huggingface/transformers` `FeatureExtractionPipeline` per-call allocation pressure** inside `embedDocument()`'s per-chunk `await embed(...)` loop. Each `embedder(text, ...)` call passes through `mean_pooling` → `result.normalize(2, -1)` → `result.clone().normalize_(...)` → `Array.prototype.slice` chains that allocate large intermediate Tensor objects (clone copies the `last_hidden_state` data buffer). V8's incremental Mark-Compact cannot keep up with the per-call allocation rate, so OldSpace climbs to the heap ceiling within ~16 seconds at default 4 GB.
+
+The leak is **NOT** in the `parsedDocs[]` accumulator (whole corpus = 24.6 MB raw text), **NOT** in sqlite-vec writes (probe with and without DB writes OOM identically), and **NOT** caused by microtask queue buildup (probes inserting `setImmediate` between chunks AND between docs OOM at the same iteration count).
+
+**Recommendation**: tighten #911 scope to "release transformer Tensor outputs after each `embed()` call (`output.dispose()` and/or copy `output.data` then null the reference) and remove the unbounded `parsedDocs` accumulator", collapse #912 to a *throughput-only* optimization that is no longer blocking the OOM fix, and calibrate #913's heap-regression bench threshold to 600 MB peak heap for a 50-doc / 200-chunk synthetic corpus.
+
+## Reproduction
+
+### Environment
+
+| Property | Value |
+|---|---|
+| Machine | M5 Pro MacBook (darwin 25.4.0) |
+| Node | v22.22.1 (mise-managed) |
+| Corpus roots | `~/projects/landcrawler-ai/thoughts` (641), `~/projects/ralph-hero/thoughts` (671), `~/projects/ralph-engine/thoughts` (250), `~/projects/thoughts` (64) |
+| Total markdown files indexed | 1,626 |
+| Total raw markdown content | 24,685,301 bytes (23.5 MB) |
+| Pre-existing DB | renamed to `~/.ralph-hero/knowledge.db.pre-profile-backup` (96 MB on disk) |
+| Plugin version | `ralph-hero-knowledge-index@0.1.29` (commit `de209d2`) |
+| `RALPH_CONTEXTUAL_RETRIEVAL` | `0` (LLM contextualize disabled) |
+| Other env | none |
+
+### Run 1: default 4 GB heap
+
+```bash
+cd plugin/ralph-knowledge
+RALPH_CONTEXTUAL_RETRIEVAL=0 \
+  node --heap-prof --heap-prof-dir=/tmp/heap-prof-gh910 dist/reindex.js
+```
+
+| Metric | Value |
+|---|---|
+| Wall clock to OOM | 16 seconds |
+| Last log line | `150 chunks embedded` |
+| Approx docs processed before OOM | ~12-15 (out of 1,626) |
+| Heap at OOM | `Mark-Compact (reduce) 4059.2 (4133.5) -> 4056.8 (4122.0) MB` |
+| Exit code | 134 (SIGABRT — V8 OOM) |
+| Stack frame triggering OOM | `Builtins_AsyncFunctionAwaitResolveClosure → PromiseFulfillReactionJob → RunMicrotasks` |
+
+### Run 2: extended 8 GB heap
+
+```bash
+cd plugin/ralph-knowledge
+RALPH_CONTEXTUAL_RETRIEVAL=0 NODE_OPTIONS="--max-old-space-size=8192" \
+  node --heap-prof --heap-prof-dir=/tmp/heap-prof-gh910 dist/reindex.js
+```
+
+| Metric | Value |
+|---|---|
+| Wall clock to OOM | 26 seconds |
+| Last log line | `150 chunks embedded` (same as 4 GB run) |
+| Heap at OOM | `Mark-Compact 8085.3 (8240.0) -> 8085.1 (8242.5) MB` |
+| Exit code | 134 |
+| Stack | identical to Run 1 |
+
+### Per-doc growth rate
+
+The two runs OOM at the same chunk count, so the 8 GB run does NOT walk further into the corpus. The "extra" 4 GB of heap is consumed by the same set of operations — each call leaves ~30 MB more allocation pressure on average.
+
+| Configuration | Doc count at OOM | Time to OOM | Peak heap |
+|---|---|---|---|
+| 4 GB heap | ~15 | 16 s | 4056 MB |
+| 8 GB heap | ~15 | 26 s | 8085 MB |
+
+Per-call allocation rate (V8-tracked):
+- 4 GB / 150 chunks ≈ 27 MB/chunk transient
+- 8 GB / 150 chunks ≈ 54 MB/chunk transient
+
+Per-call RSS growth (from controlled probe at varying input lengths):
+- 500-char input: 194 KB/call RSS
+- 2000-char input: 412 KB/call RSS
+- 4000-char input: 863 KB/call RSS
+
+The growth scales linearly with input length, consistent with Tensor `.slice()` and `.clone()` operations that depend on `last_hidden_state` size (which is `seq_length × 384 × 4 bytes`).
+
+## Heap Profile Findings
+
+### Limitation: OOM aborts before `--heap-prof` flushes
+
+Node's `--heap-prof` does NOT flush a profile on OOM crash — only on clean exit. Both reindex runs exited via `FATAL ERROR: Reached heap limit`, so neither produced a usable `.heapprofile` file. The only `.heapprofile` in `/tmp/heap-prof-gh910/` (`Heap.20260429.194811.51087.0.001.heapprofile`, 39 KB) is from an earlier failed-startup run with a stale DB; it is not OOM-relevant.
+
+### Workaround: explicit `writeHeapSnapshot()` at controlled iteration points
+
+A small probe (`/tmp/snapshot-probe.mjs`) reproduces the inner reindex loop, takes `v8.writeHeapSnapshot()` at iter=1, iter=6, iter=12 (just before OOM territory at iter=15+), and stops short of OOM. Three snapshots produced, each 19-21 MB, in `/tmp/heap-prof-gh910/`.
+
+### Top retainers by class (post-GC steady state)
+
+Aggregated via `node --expose-gc analyze-snapshot.mjs` over the saved `.heapsnapshot` files (script in `/tmp/analyze-snapshot.mjs`). Numbers are total `self_size` across all nodes in each class.
+
+| Class | iter=1 | iter=6 | iter=12 | Δ iter1→iter12 |
+|---|---|---|---|---|
+| `native::system / JSArrayBufferData` | ~0.5 MB | ~1.9 MB | **6.46 MB** (155 nodes) | **+5.9 MB** |
+| `string` | 6.03 MB | 6.11 MB | 6.27 MB | +0.24 MB |
+| `code` | 5.95 MB | 6.67 MB | 5.51 MB | -0.44 MB |
+| `array` | 4.12 MB | 4.12 MB | 4.09 MB | -0.03 MB |
+| `object shape` | 1.67 MB | 1.69 MB | 1.47 MB | -0.20 MB |
+| `closure` | 0.86 MB | 0.85 MB | 0.85 MB | 0 |
+| **Total self_size** | **20.86 MB** | **23.13 MB** | **26.20 MB** | **+5.34 MB** |
+
+**Steady-state V8 retention is small** (only +5.34 MB across 12 docs / 100 chunks, post-GC). The overwhelming majority of growth is **transient inside a single `embed()` call**, which is invisible to a snapshot taken between docs.
+
+### RSS vs. heap discrepancy
+
+`process.memoryUsage()` snapshots BETWEEN iterations (probe, no DB):
+
+| iter | chunks | content avg | rss | heapUsed | heapTotal | external |
+|---|---|---|---|---|---|---|
+| start | 0 | — | 91 MB | 15 MB | 24 MB | 2 MB |
+| 1 (load+1 doc) | 1 | 0 | 320 MB | 24 MB | 38 MB | 4 MB |
+| 5 | 28 | 8.7 KB | 375 MB | 23 MB | 39 MB | 7 MB |
+| 10 | 56 | 9.1 KB | 380 MB | 22 MB | 39 MB | 10 MB |
+| 12 | 100 | 14 KB | 395 MB | 26 MB | 39 MB | 16 MB |
+| 15 | 151 | 17 KB | 404 MB | 24 MB | 39 MB | 23 MB |
+| **OOM during iter 17** | — | — | **n/a** | **(reaches 4056 MB)** | — | — |
+
+Between iter=15 (RSS 404 MB, heap 24 MB) and the OOM, V8 OldSpace fills up by ~3,650 MB. **No iteration is logged after this point** — the OOM happens during a single call's microtask chain, before the iteration's `console.log` runs. The post-GC snapshot at iter=12 only captures the survivor set; the killer allocations are transient peaks during one `embedDocument()` call.
+
+### Drilling into the dominant retainer
+
+The OOM stack (both runs):
+
+```
+12: 0x10b9ada98
+13: 0x10b960a24
+14: 0x10b99b374    <- transformers.js JS frame
+15: Builtins_AsyncFunctionAwaitResolveClosure
+16: Builtins_PromiseFulfillReactionJob
+17: Builtins_RunMicrotasks
+18: Builtins_JSRunMicrotasksEntry
+```
+
+The 8 GB run's OOM stack adds an explicit `Builtins_ArrayPrototypeSlice` and `Builtins_ExtractFastJSArray` frame just before `AsyncFunctionAwaitResolveClosure`. This points squarely at `tensor.js:355`:
+
+```js
+// node_modules/@huggingface/transformers/src/utils/tensor.js:355
+clone() {
+    return new Tensor(this.type, this.data.slice(), this.dims.slice());
+}
+```
+
+`normalize()` at `tensor.js:590` calls `this.clone().normalize_(p, dim)`. In the embed pipeline (`pipelines.js:1348`), `result = result.normalize(2, -1)` runs AFTER `mean_pooling` so the data should be small (1×384 floats = 1.5 KB). This alone is not the leak.
+
+What IS the leak: `mean_pooling` (`tensor.js:1086-1126`) reads `last_hidden_state.data` (sequence_length × 384 × 4 bytes — up to 786 KB per call at 512 tokens). The `result` Tensor returned from the pipeline retains references to all the intermediate Tensor wrappers. **Without an explicit `.dispose()` call after each embedding, the underlying ONNX Tensor data buffers stay alive until V8 detects them collectible.** Across 150 chunks with 512-token inputs:
+
+- last_hidden_state buffers retained transiently: 150 × 786 KB ≈ 115 MB
+- ONNX runtime intermediate activations (attention scores, layer outputs) per call: tens of MB
+- These are allocated as TypedArrays / ArrayBuffers tracked by V8's external/native accounting
+
+V8's mark-compact scans these but cannot release them fast enough — the per-call allocation rate exceeds incremental GC throughput, OldSpace fills, and Mark-Compact reduces only ~6 MB per cycle ("Ineffective mark-compacts near heap limit").
+
+## Suspected Retainer Audit
+
+| Suspect from issue body | Status | Evidence |
+|---|---|---|
+| 1. transformer `FeatureExtractionPipeline` tensor cache | **CONFIRMED DOMINANT** | OOM stack ends at `ArrayPrototypeSlice → AsyncFunctionAwaitResolveClosure` matching `Tensor.clone()` in `tensor.js:355`. RSS scales linearly with input length (194 KB → 412 KB → 863 KB per call for 500/2000/4000-char inputs). Per-call ONNX ArrayBuffer allocations dominate. |
+| 2. `Float32Array` chunks accumulating in JS heap | **RULED OUT** | Per-chunk 384-float buffers = 1.5 KB × 11,743 chunks = 17.6 MB total — far below 4 GB. Snapshot at iter=12 shows only 6.46 MB in `JSArrayBufferData` total. |
+| 3. `parsedDocs: ParsedDocument[]` accumulator at `reindex.ts:84` | **RULED OUT** | Total raw corpus = 24.6 MB. Even with 5x parsing overhead = 125 MB. Snapshot at iter=12 with 12 parsedDocs in scope shows only 26 MB total V8 retention. *Worth fixing for correctness*, but not the OOM cause. |
+| 4. sqlite-vec per-chunk `INSERT` allocations | **RULED OUT** | Probe with DB writes (`probe-realistic.mjs`) and probe without DB writes (`probe-embed-doc.mjs`) BOTH OOM at iter=15 / 150 chunks. sqlite-vec is not on the critical path. *Worth batching for throughput* (#912 still has merit), but not for OOM. |
+| 5. LLM client `contextualize` response accumulation | **RULED OUT** | `RALPH_CONTEXTUAL_RETRIEVAL=0` for both runs — no LLM calls made. OOM still reproduces. |
+| 6. (added) microtask queue buildup from per-chunk awaits | **RULED OUT** | Probe inserting `await new Promise(r => setImmediate(r))` between every chunk AND between every doc still OOMs at iter=15 / 150 chunks (`probe-yield.mjs`, `probe-yield-chunks.mjs`). The microtask queue is not the dominant retainer; the leak is per-call inside `embed()`. |
+
+## Recommendation
+
+### #911: tighten scope to "release transformer Tensor data after each embed call"
+
+**Current scope** (per issue body): "release embedder tensors and stop accumulating parsedDocs in reindex".
+
+**Recommended scope after profile**:
+
+1. **Primary fix (blocks OOM)**: in `embedder.ts:12-19` (`embed()`), call `output.dispose()` after copying `output.data` into the returned `Float32Array`, OR explicitly assign `output = null` to break the closure reference before the next chunk's `await`. This forces ONNX to release the underlying tensor buffer at the end of each call rather than waiting for V8 GC.
+
+2. **Secondary fix (correctness, not OOM)**: drop the `parsedDocs[]` accumulator at `reindex.ts:84`. It only feeds `generateIndexes(dirs[0], parsedDocs)` at `reindex.ts:230` (gated on `generate=true`, which is rare). When `generate=false`, the accumulator pins ~25 MB unnecessarily — fine on this corpus, but a footgun on a 10x larger corpus. Either:
+   - Skip the accumulator when `generate=false`.
+   - Or stream-process: instead of `parsedDocs.push(parsed)`, write to disk and re-read in `generateIndexes`.
+
+3. **Out of scope** (do NOT include in #911): sqlite-vec batching, LLM contextualize fix, microtask yield. Those either have separate tickets (#912) or are ruled out as non-causes.
+
+**Estimate**: still S. The fix is targeted (1-2 lines in embedder.ts plus 1 conditional in reindex.ts).
+
+### #912: collapse to throughput optimization, no longer blocks OOM
+
+**Current scope**: "batch sqlite-vec chunk writes during reindex".
+
+**Recommended action**: keep the issue but de-prioritize from P1 to P2/P3. The probe shows sqlite-vec writes are NOT the OOM cause; per-chunk `INSERT` is fine for correctness and the per-chunk overhead is bounded (tens of microseconds per chunk). Batching is still worth doing for throughput (saves SQLite transaction overhead across 11,743 chunks → seconds of wall-clock), but it is no longer a fix for OOM.
+
+If the issue body asserts sqlite-vec as a leak source, **remove that claim**. Reframe as: "Batch chunk writes inside a single transaction to reduce per-chunk SQLite overhead during reindex of a 1.6k-doc / 11k-chunk corpus."
+
+### #913: calibrate heap-regression bench threshold
+
+**Current scope**: "add reindex heap regression microbenchmark".
+
+**Recommended threshold**: peak heap ≤ 600 MB for a 50-doc / 200-chunk synthetic corpus. Justification:
+
+- After #911 fix, per-call retention should drop to ~5-10 MB instead of ~30 MB.
+- 50 docs × 4 chunks/doc avg × 8 MB peak per call ≈ 200 MB transient + 200 MB ONNX baseline + 100 MB margin = 500 MB.
+- 600 MB gives comfortable headroom while still failing if a future regression reintroduces unbounded transient allocation.
+
+The bench should NOT use the live corpus (too slow for CI). Generate 50 synthetic markdown files, ~5-10 KB each, with realistic English text.
+
+### No new ticket needed
+
+All findings map cleanly to existing siblings #911-913. The "transformer tensor pressure" hypothesis is the dominant retainer #911 was already targeting, just with sharper specifics. **No follow-up ticket required.**
+
+## Code References
+
+- [plugin/ralph-knowledge/src/embedder.ts](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/embedder.ts) — singleton pipeline at line 10, per-call `embed()` at lines 12-19, per-chunk `embedDocument()` loop at lines 38-79
+- [plugin/ralph-knowledge/src/reindex.ts:84](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L84) — `parsedDocs: ParsedDocument[]` accumulator (correctness, not OOM)
+- [plugin/ralph-knowledge/src/reindex.ts:230](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L230) — only consumer of `parsedDocs`, gated on `generate=true`
+- [plugin/ralph-knowledge/src/reindex.ts:209-217](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/reindex.ts#L209-L217) — chunk insert loop (per-chunk `INSERT`, no transaction wrap)
+- [plugin/ralph-knowledge/src/vector-search.ts:29-38](https://github.com/cdubiel08/ralph-hero/blob/main/plugin/ralph-knowledge/src/vector-search.ts#L29-L38) — `upsertEmbedding` does DELETE + INSERT per call
+- `node_modules/@huggingface/transformers/src/utils/tensor.js:355` — `Tensor.clone()` does `data.slice()` (the `.slice` in the OOM stack)
+- `node_modules/@huggingface/transformers/src/utils/tensor.js:121-124` — `Tensor.dispose()` exists but is NEVER called by ralph-knowledge
+- `node_modules/@huggingface/transformers/src/pipelines.js:1305-1357` — `FeatureExtractionPipeline._call` chain: tokenize → model → mean_pooling → normalize
+
+## Heap Profile Artifacts
+
+All under `/tmp/heap-prof-gh910/` (NOT committed — too large at ~20 MB each, may contain corpus content fragments):
+
+- `/tmp/heap-prof-gh910/snapshot-iter1.heapsnapshot` (20 MB) — after embedder pipeline load + 1 doc
+- `/tmp/heap-prof-gh910/snapshot-iter6.heapsnapshot` (21 MB) — after 6 docs / 29 chunks
+- `/tmp/heap-prof-gh910/snapshot-iter12.heapsnapshot` (19 MB) — after 12 docs / 100 chunks (last clean snapshot before OOM territory)
+- `/tmp/heap-prof-gh910/snapshot-iter1-analysis.txt` — top-30 (type,name) by self_size
+- `/tmp/heap-prof-gh910/snapshot-iter6-analysis.txt` — top-30 (type,name) by self_size
+- `/tmp/heap-prof-gh910/snapshot-iter12-analysis.txt` — top-30 (type,name) by self_size
+- `/tmp/reindex-default-stdout.log`, `/tmp/reindex-default-stderr.log` — full 4 GB run output (incl. OOM stack)
+- `/tmp/reindex-8gb-stdout.log`, `/tmp/reindex-8gb-stderr.log` — full 8 GB run output (incl. OOM stack)
+
+Probe scripts (also kept under `/tmp/`):
+
+- `/tmp/memprobe.mjs` — minimal embedder-only probe (200 calls, short text → healthy)
+- `/tmp/memprobe-long.mjs` — embedder with 2000-char text (100 calls → healthy, 411 KB/call RSS growth)
+- `/tmp/memprobe-full.mjs` — full `parseDocument + embedDocument` loop (OOM at iter=15)
+- `/tmp/memprobe-embed-doc.mjs` — `embedDocument` only, no DB (OOM at iter=15)
+- `/tmp/probe-realistic.mjs` — `parse + embed + sqlite-vec write` (OOM at iter=15, same as without DB → confirms sqlite-vec is not on the critical path)
+- `/tmp/probe-yield.mjs` — `setImmediate` between docs (OOM at iter=15 → microtask yield doesn't help)
+- `/tmp/probe-yield-chunks.mjs` — `setImmediate` between every chunk (OOM at iter=15 → microtask yield even between chunks doesn't help)
+- `/tmp/probe-vary.mjs` — varying input length (500/2000/4000 chars) → confirms RSS scales linearly with input length
+- `/tmp/probe-tiny.mjs` — `--max-old-space-size=512` to force OOM at lower threshold; survives 16 iters before OOM at 510 MB
+- `/tmp/snapshot-probe.mjs` — controlled snapshot capture at iter=1/6/12
+- `/tmp/analyze-snapshot.mjs` — JSON parser for `.heapsnapshot` files; aggregates self_size by class
+
+## Verification Commands Run
+
+```bash
+# Confirm corpus size
+find ~/projects/thoughts ~/projects/ralph-hero/thoughts ~/projects/ralph-engine/thoughts \
+  ~/projects/landcrawler-ai/thoughts -name '*.md' | wc -l
+# -> 1626 (matches the audit's "1,668" within the same order of magnitude;
+#    delta is from .gitignore patterns and dream-memories absent on this machine)
+
+# Total raw bytes
+find ... -name '*.md' -exec wc -c {} + | tail -1
+# -> 24685301 total (23.5 MB)
+
+# Confirm pre-existing DB renamed
+ls -la ~/.ralph-hero/
+# -> knowledge.db.pre-profile-backup (96 MB), no live knowledge.db
+
+# Confirm RALPH_CONTEXTUAL_RETRIEVAL=0 reaches reindex.js
+grep -A2 'flagRaw !== "0"' plugin/ralph-knowledge/dist/reindex.js
+# -> contextualEnabled = flagRaw !== "0" && flagRaw !== "false"
+```
+
+## Open Questions / Follow-ups
+
+- Does calling `output.dispose()` in `embed()` actually fix the OOM? **Need experimental confirmation as part of #911.** The profile is consistent with this hypothesis but does not prove it. #911's acceptance criteria should include "rerun this profile after the fix and confirm peak heap ≤ 600 MB for a full 1,626-doc reindex."
+- Is `transformers.js` v3 the right transformer library? The `Pipeline` class does NOT auto-dispose tensors. Switching to a smaller / streaming-aware embedder (e.g., onnxruntime-node directly with manual tensor lifecycle) is out of scope for #911 but worth tracking as a future optimization.
+- The `DEFAULT_CHUNK_SIZE = 2048` chars in `chunker.ts` produces ~512-token inputs. Reducing to 1024 chars would halve `last_hidden_state.size` and reduce per-call retention by ~50%. **Not part of #911 fix** (changes embedding semantics) but a potential mitigation.
+
+## References
+
+- Issue: https://github.com/cdubiel08/ralph-hero/issues/910
+- Plan: https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-04-29-GH-910-reindex-memory-profile.md
+- Parent: https://github.com/cdubiel08/ralph-hero/issues/907
+- Sibling fixes: #911, #912, #913
+- Audit (Bug 2): https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-04-26-dreaming-research-trail-and-self-containment.md#bug-2-reindex-ooms-the-js-heap
+- Node `--heap-prof` docs: https://nodejs.org/api/cli.html#--heap-prof
+- transformers.js Tensor source: `node_modules/@huggingface/transformers/src/utils/tensor.js`
+- transformers.js FeatureExtractionPipeline: `node_modules/@huggingface/transformers/src/pipelines.js:1295-1358`
+
+## Verification (post-#911 fix)
+
+**Date of run**: 2026-04-29
+**Plugin commit**: 3888bebdd470c29dc1fdafa7fdc51fd04088fe5d (`feature/GH-911`)
+**Node**: v22.22.1 (default 4 GB heap, no `--max-old-space-size` override)
+**Flags**: `RALPH_CONTEXTUAL_RETRIEVAL=0` (matches GH-910 baseline)
+
+### Result summary
+
+| Test | Docs | Chunks | Wall clock | Peak heap_used | Peak RSS | Outcome |
+|------|------|--------|------------|----------------|----------|---------|
+| Isolated `embed()` loop, 200 calls of 2 KB texts | 1 (model warmup) | 200 | 1.5 s | 26 MB | 330 MB | OK |
+| Synthetic corpus, 50 docs / ~150 chunks | 50 | 150 | ~3 s | ~30 MB | ~370 MB | OK |
+| Synthetic corpus, 200 docs / ~1,000 chunks | 200 | 1,000 | ~28 s | ~35 MB | ~410 MB | OK |
+| Synthetic corpus, 400 docs / 2,800 chunks | 400 | 2,800 | 76.2 s | 39.6 MB | 467 MB | OK |
+| Live `~/projects/ralph-hero/thoughts` (674 files) | partial | ~150 | ~16 s | n/a (OOM) | n/a (OOM) | **OOM** |
+| Live `~/projects/ralph-engine/thoughts` (250 files) | partial | ~50 | ~11 s | n/a (OOM) | n/a (OOM) | **OOM** |
+| Live full corpus (1,633 files across 4 roots) | partial | 150 | ~16 s | n/a (OOM) | n/a (OOM) | **OOM** |
+
+### Steady-state behavior (synthetic 400-doc / 2,800-chunk run)
+
+`heap_used` snapshots taken every 250 ms across the 76 s run remain bounded between 25–40 MB throughout. No monotonic growth — V8 reaches a stable working set within 10 s and stays there for the rest of the run:
+
+```
+t=8s   heap_used=30.3 MB  rss=422 MB  external=43 MB
+t=16s  heap_used=26.2 MB  rss=439 MB  external=46 MB
+t=24s  heap_used=33.1 MB  rss=452 MB  external=65 MB
+t=31s  heap_used=34.1 MB  rss=423 MB  external=82 MB
+t=39s  heap_used=25.5 MB  rss=437 MB  external=92 MB
+t=47s  heap_used=28.1 MB  rss=439 MB  external=92 MB
+t=55s  heap_used=25.1 MB  rss=442 MB  external=93 MB
+t=62s  heap_used=28.1 MB  rss=444 MB  external=93 MB
+t=70s  heap_used=36.4 MB  rss=445 MB  external=94 MB
+```
+
+Peak `heap_used = 39.6 MB` (well under the 600 MB ceiling required by #910 / #911 acceptance). Peak `external = 94.8 MB` (sqlite-vec arrayBuffers). No OOM.
+
+### Conclusion: GH-911 fix is correct and effective
+
+The `output.dispose()` call in `embed()` and the `parsedDocs[]` accumulator gate both work as designed. On the synthetic 400-doc / 2,800-chunk corpus — which is **2x the live corpus's chunk count** — `heap_used` stays bounded under 40 MB indefinitely. The 200-call isolated `embed()` loop (proves the dispose contract end-to-end) showed identical steady-state behavior. The fix has eliminated the per-call native-buffer retention pressure that drove the original 150-chunk OOM.
+
+### Pre-existing chunker OOM (out of scope; new issue needed)
+
+While verifying on the live corpus, a **separate** OOM was discovered that is **not addressable by GH-911**: `chunker.chunkText()` itself OOMs deterministically on multiple real-world markdown documents in the corpus. Repro:
+
+```bash
+node --max-old-space-size=8192 -e "
+  import('plugin/ralph-knowledge/dist/chunker.js').then(({chunkText}) => {
+    const raw = require('fs').readFileSync('/Users/dubiel/projects/landcrawler-ai/thoughts/shared/plans/2025-12-31-oklahoma-permit-raw-migration.md','utf-8');
+    chunkText(raw);
+  });"
+# -> FATAL ERROR: Reached heap limit Allocation failed - JS heap out of memory
+```
+
+This OOMs on the **plain `chunker.chunkText()` call** before any embedding occurs. The doc is 45 KB of normal markdown. Verified the same OOM reproduces on `main` (pre-911) — this is a pre-existing bug, not introduced by GH-911. The OOM stack trace shows `Builtins_StringSubstring → JSEntry`, suggesting a runaway recursion in `flattenToAtoms()` / `splitOnSeparator()` for content patterns the existing tests don't cover.
+
+**Affected docs identified during verification**:
+- `landcrawler-ai/thoughts/shared/plans/2025-12-31-oklahoma-permit-raw-migration.md` (45 KB)
+- `ralph-engine/thoughts/...` (chunker OOMs at the 50-chunk mark on this corpus)
+- `ralph-hero/thoughts/...` (chunker OOMs at the 150-chunk mark on this corpus)
+
+**Implication for #911 acceptance**: The "1,626-doc corpus reindex completes successfully" criterion cannot be evaluated end-to-end until the chunker bug is fixed in a separate issue. However, all three acceptance criteria of GH-911 ARE met for the synthesizable subset of the corpus (steady-state heap, no monotonic growth, throughput within tolerance). The chunker bug is filed for follow-up; this research note documents it to spare future profiling sessions from chasing the same red herring.
+
+### Throughput
+
+| Configuration | docs/sec | chunks/sec |
+|---------------|----------|-----------|
+| Synthetic 400-doc corpus, post-#911 | 5.25 | 36.7 |
+
+Pre-fix baseline is unavailable (the original profile run didn't complete enough work to measure end-to-end throughput before OOM), so the "within 20%" comparison is not directly possible. The 36.7 chunks/sec figure is the new baseline against which #913's regression bench should calibrate.
+
+## End-to-end verification (post-#911 + post-#916)
+
+**Date**: 2026-04-29
+**Plugin commit**: feature/GH-916 (after Phase 1+2 of GH-916 land)
+**Node**: v22.22.1 (default 4 GB heap, no `--max-old-space-size` override)
+**Flags**: `RALPH_CONTEXTUAL_RETRIEVAL=0`
+
+### Result
+
+| Metric | Value |
+|---|---|
+| Files on disk | 1,668 |
+| Documents indexed | 1,636 (DB total: 1,710 incl. 14 raw + stub docs) |
+| Chunks indexed | 12,879 |
+| Wall clock (active reindex) | 478.7 s (~8 min) |
+| Peak heap_used | 81.1 MB |
+| Peak heap_total | 104.0 MB |
+| Peak RSS | 532.5 MB |
+| Peak external | 95.0 MB |
+| Exit code | 0 |
+
+Heap sampler trace (250 ms cadence, every 30th sample shown):
+
+```
+t=0.3s    heap_used=25.7 MB  rss=126 MB  external=7 MB
+t=21.7s   heap_used=37.0 MB  rss=430 MB  external=57 MB
+t=86.5s   heap_used=37.5 MB  rss=492 MB  external=7 MB   (model warm)
+t=151.7s  heap_used=48.8 MB  rss=496 MB  external=9 MB
+t=238.5s  heap_used=56.2 MB  rss=507 MB  external=7 MB
+t=325.3s  heap_used=70.9 MB  rss=517 MB  external=8 MB
+t=412.3s  heap_used=67.7 MB  rss=527 MB  external=6 MB
+t=474.5s  heap_used=65.5 MB  rss=532 MB  external=6 MB
+t=478.7s  heap_used=20.8 MB  rss=525 MB  external=6 MB   (Done. 1636 indexed)
+```
+
+Heap_used grew gradually from ~25 MB (cold) to a peak of 81.1 MB, then dropped to ~21 MB after `Done. 1636 documents indexed` printed. Growth was sub-linear and well below the 600 MB acceptance threshold.
+
+### Conclusion
+
+The combined fixes from #911 (embedder Tensor disposal + parsedDocs accumulator gate) and #916 (chunker forward-progress guard) close out the parent #907. The dream-loop reindex now works end-to-end at default 4 GB Node heap on the live 1,668-doc corpus.
+
+The chunker no-progress fix in #916 was specifically validated by the disappearance of the prior OOM at the ~150-chunk mark — the same fixture (`landcrawler-ai/.../oklahoma-permit-raw-migration.md`) that previously OOMed at 8 GB heap now chunks in <1 ms producing 28 chunks at a 512 MB heap cap. The full corpus run reached 12,879 chunks across 1,636 documents, ~85x the pre-fix progress threshold.

--- a/plugin/ralph-knowledge/benchmark/eval-rerank.mjs
+++ b/plugin/ralph-knowledge/benchmark/eval-rerank.mjs
@@ -11,9 +11,11 @@
  * The script imports the compiled `dist/` modules so it exercises the exact
  * code path `knowledge_search` runs in production.
  */
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 import { KnowledgeDB } from "../dist/db.js";
 import { FtsSearch } from "../dist/search.js";
 import { VectorSearch } from "../dist/vector-search.js";
@@ -28,60 +30,17 @@ const DB_PATH = process.env.RALPH_KNOWLEDGE_DB
  * The 8 golden queries from the 2026-04-29 baseline eval. `expectedSubstrings`
  * lists path-segment substrings any of which counts as a hit (some queries
  * have multiple legitimate primary docs per the baseline).
+ *
+ * Loaded from `evals/golden-queries.json` so this benchmark and the CI guard
+ * (`scripts/eval-retrieval.ts`) share a single source of truth (GH-920).
  */
-const QUERIES = [
-  {
-    n: 1,
-    query: "what causes the reindex to OOM in ralph-knowledge",
-    expectedSubstrings: ["2026-04-29-reindex-memory-profile"],
-    type: "specific-keyword",
-  },
-  {
-    n: 2,
-    query: "release transformer tensors after embedding to free memory",
-    expectedSubstrings: ["2026-04-29-GH-911-release-embedder-tensors"],
-    type: "specific-keyword",
-  },
-  {
-    n: 3,
-    query: "chunker forward progress infinite loop fix",
-    expectedSubstrings: ["2026-04-29-GH-916-chunker-no-progress-fix"],
-    type: "specific-keyword",
-  },
-  {
-    n: 4,
-    query: "dream-loop memory consolidation pipeline architecture",
-    expectedSubstrings: [
-      "2026-04-26-dreaming-research-trail-and-self-containment",
-      "2026-04-16-GH-0761",
-    ],
-    type: "mixed",
-  },
-  {
-    n: 5,
-    query: "cross-encoder reranker score calibration",
-    expectedSubstrings: ["2026-04-26-softmax-and-rerank-calibration"],
-    type: "mixed",
-  },
-  {
-    n: 6,
-    query: "wikilink extractor for markdown",
-    expectedSubstrings: ["2026-04-26-ralph-knowledge-wikilink-extractor"],
-    type: "specific-keyword",
-  },
-  {
-    n: 7,
-    query: "context handoff topology between agents",
-    expectedSubstrings: ["2026-04-22-context-handoff-topology"],
-    type: "mixed",
-  },
-  {
-    n: 8,
-    query: "landcrawler permit raw data migration hardening",
-    expectedSubstrings: ["2026-04-24-landcrawler-backend-hardening-postmortem"],
-    type: "specific-keyword",
-  },
-];
+const QUERIES_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "evals",
+  "golden-queries.json",
+);
+const QUERIES = JSON.parse(readFileSync(QUERIES_PATH, "utf8")).queries;
 
 function findRank(results, expectedSubstrings) {
   for (let i = 0; i < results.length; i++) {

--- a/plugin/ralph-knowledge/evals/golden-queries.json
+++ b/plugin/ralph-knowledge/evals/golden-queries.json
@@ -1,0 +1,55 @@
+{
+  "queries": [
+    {
+      "n": 1,
+      "query": "what causes the reindex to OOM in ralph-knowledge",
+      "expectedSubstrings": ["2026-04-29-reindex-memory-profile"],
+      "type": "specific-keyword"
+    },
+    {
+      "n": 2,
+      "query": "release transformer tensors after embedding to free memory",
+      "expectedSubstrings": ["2026-04-29-GH-911-release-embedder-tensors"],
+      "type": "specific-keyword"
+    },
+    {
+      "n": 3,
+      "query": "chunker forward progress infinite loop fix",
+      "expectedSubstrings": ["2026-04-29-GH-916-chunker-no-progress-fix"],
+      "type": "specific-keyword"
+    },
+    {
+      "n": 4,
+      "query": "dream-loop memory consolidation pipeline architecture",
+      "expectedSubstrings": [
+        "2026-04-26-dreaming-research-trail-and-self-containment",
+        "2026-04-16-GH-0761"
+      ],
+      "type": "mixed"
+    },
+    {
+      "n": 5,
+      "query": "cross-encoder reranker score calibration",
+      "expectedSubstrings": ["2026-04-26-softmax-and-rerank-calibration"],
+      "type": "mixed"
+    },
+    {
+      "n": 6,
+      "query": "wikilink extractor for markdown",
+      "expectedSubstrings": ["2026-04-26-ralph-knowledge-wikilink-extractor"],
+      "type": "specific-keyword"
+    },
+    {
+      "n": 7,
+      "query": "context handoff topology between agents",
+      "expectedSubstrings": ["2026-04-22-context-handoff-topology"],
+      "type": "mixed"
+    },
+    {
+      "n": 8,
+      "query": "landcrawler permit raw data migration hardening",
+      "expectedSubstrings": ["2026-04-24-landcrawler-backend-hardening-postmortem"],
+      "type": "specific-keyword"
+    }
+  ]
+}

--- a/plugin/ralph-knowledge/package.json
+++ b/plugin/ralph-knowledge/package.json
@@ -17,6 +17,7 @@
     "reindex": "node dist/reindex.js",
     "test": "vitest run",
     "bench:heap": "tsx benchmark/reindex-heap-bench.ts",
+    "eval:retrieval": "tsx scripts/eval-retrieval.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/plugin/ralph-knowledge/scripts/eval-retrieval.ts
+++ b/plugin/ralph-knowledge/scripts/eval-retrieval.ts
@@ -1,0 +1,244 @@
+/**
+ * GH-920 — knowledge_search retrieval-quality CI guard.
+ *
+ * Loads the 8 hand-curated golden queries from `evals/golden-queries.json`,
+ * reindexes the pinned `__tests__/eval-corpus/` fixture into a tmp-dir SQLite
+ * DB, runs each query through `HybridSearch.search()` with `rerank: false`
+ * (the default RRF-only path), and computes Hit@1, Hit@5, MRR.
+ *
+ * Modeled after `benchmark/reindex-heap-bench.ts` (GH-913): same `--assert`
+ * flag, same `process.exitCode = 1` (NOT `process.exit(1)`) discipline to
+ * avoid the libc++ abort during native ONNX teardown that otherwise turns
+ * a clean exit-1 into a SIGABRT exit-134.
+ *
+ * Run with:
+ *   # Always exits 0; just prints the summary:
+ *   npx tsx plugin/ralph-knowledge/scripts/eval-retrieval.ts
+ *
+ *   # Exits 1 if Hit@5 < 5/8 (62.5%):
+ *   npx tsx plugin/ralph-knowledge/scripts/eval-retrieval.ts --assert
+ */
+import { mkdtempSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { KnowledgeDB } from "../src/db.js";
+import { FtsSearch, type SearchResult } from "../src/search.js";
+import { VectorSearch } from "../src/vector-search.js";
+import { HybridSearch } from "../src/hybrid-search.js";
+import { embed } from "../src/embedder.js";
+import { reindex } from "../src/reindex.js";
+
+/**
+ * Hit@5 floor — raise to 6/8 (75%) once stable.
+ *
+ * Set conservatively below the verified 87.5% (7/8) post-reranker baseline so
+ * a slightly noisy CI run does not flake on the threshold even though the
+ * default RRF-only path consistently exceeds it. The threshold is in
+ * absolute query-count units (not a percentage) to match the `${n}/8`
+ * formatting convention from `benchmark/eval-rerank.mjs`.
+ */
+const HIT5_THRESHOLD = 5; // 5/8 = 62.5% — raise to 6/8 (75%) once stable
+
+interface GoldenQuery {
+  n: number;
+  query: string;
+  expectedSubstrings: string[];
+  type: string;
+}
+
+interface PerQueryResult {
+  n: number;
+  query: string;
+  type: string;
+  rank: number | null;
+  topPath: string | null;
+}
+
+interface EvalSummary {
+  perQuery: PerQueryResult[];
+  hit1: string;
+  hit5: string;
+  mrr: number;
+  hit1Count: number;
+  hit5Count: number;
+  total: number;
+}
+
+/**
+ * Load and parse the shared `evals/golden-queries.json`. Path is resolved
+ * relative to this script via `import.meta.url` so it works whether the
+ * script is invoked from the repo root, from `plugin/ralph-knowledge/`,
+ * or from any other cwd.
+ */
+function loadGoldenQueries(jsonPath: string): GoldenQuery[] {
+  let raw: string;
+  try {
+    raw = readFileSync(jsonPath, "utf8");
+  } catch (e) {
+    throw new Error(
+      `eval-retrieval: failed to read golden-queries.json at ${jsonPath}: ${(e as Error).message}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `eval-retrieval: failed to parse golden-queries.json at ${jsonPath}: ${(e as Error).message}`,
+    );
+  }
+  const queries = (parsed as { queries?: unknown }).queries;
+  if (!Array.isArray(queries)) {
+    throw new Error(
+      `eval-retrieval: golden-queries.json at ${jsonPath} missing top-level "queries" array`,
+    );
+  }
+  return queries as GoldenQuery[];
+}
+
+/**
+ * Substring-based rank lookup. Mirrors `findRank()` in
+ * `benchmark/eval-rerank.mjs` lines 86-95. Returns the 1-indexed position of
+ * the first result whose `path` or `id` contains ANY of the expected
+ * substrings; `null` when no result matches.
+ */
+function findRank(
+  results: SearchResult[],
+  expectedSubstrings: string[],
+): number | null {
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const haystack = (r.path ?? "") + (r.id ?? "");
+    for (const sub of expectedSubstrings) {
+      if (haystack.includes(sub)) return i + 1;
+    }
+  }
+  return null;
+}
+
+async function runEval(): Promise<EvalSummary> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const queriesPath = join(here, "..", "evals", "golden-queries.json");
+  const corpusDir = join(here, "..", "__tests__", "eval-corpus");
+
+  const queries = loadGoldenQueries(queriesPath);
+
+  // Mirror the heap-bench gate: disable contextual retrieval so the LLM probe
+  // doesn't try to reach localhost:8000 (which is unreachable in CI). MUST be
+  // set before `reindex()` reads the env var.
+  process.env.RALPH_CONTEXTUAL_RETRIEVAL = "0";
+
+  // Tmp-dir DB: `mkdtempSync(join(tmpdir(), "eval-retrieval-db-"))` creates a
+  // unique dir each run so concurrent CI jobs don't collide. NEVER write to
+  // the user's `~/.ralph-hero/knowledge.db` — the eval needs a clean,
+  // deterministic corpus.
+  const dbDir = mkdtempSync(join(tmpdir(), "eval-retrieval-db-"));
+  const dbPath = join(dbDir, "bench.db");
+
+  console.log(`eval-retrieval: corpus=${corpusDir}`);
+  console.log(`eval-retrieval: db=${dbPath}`);
+  console.log(`eval-retrieval: reindexing ${queries.length}-query corpus...`);
+
+  await reindex([corpusDir], dbPath, false);
+
+  const db = new KnowledgeDB(dbPath);
+  const fts = new FtsSearch(db);
+  const vec = new VectorSearch(db);
+  // No reranker — the CI guard tests the default RRF-only path. The cross-
+  // encoder reranker incurs a ~7s ONNX cold-start that would balloon CI time
+  // for marginal threshold-floor benefit.
+  const hybrid = new HybridSearch(db, fts, vec, embed, undefined);
+
+  // Warm the embedder once so the first per-query measurement isn't dominated
+  // by model load. Doesn't affect the rank metrics — just keeps the per-query
+  // log lines representative of the warm path.
+  await hybrid.search("warmup", { limit: 1, rerank: false });
+
+  const perQuery: PerQueryResult[] = [];
+  for (const q of queries) {
+    const results = await hybrid.search(q.query, { limit: 10, rerank: false });
+    const rank = findRank(results, q.expectedSubstrings);
+    const topPath = results[0]?.path ?? results[0]?.id ?? null;
+    perQuery.push({
+      n: q.n,
+      query: q.query,
+      type: q.type,
+      rank,
+      topPath,
+    });
+  }
+
+  db.close();
+
+  const total = queries.length;
+  const hit1Count = perQuery.filter((p) => p.rank !== null && p.rank === 1).length;
+  const hit5Count = perQuery.filter((p) => p.rank !== null && p.rank <= 5).length;
+  const mrr =
+    perQuery.reduce((acc, p) => acc + (p.rank === null ? 0 : 1 / p.rank), 0) /
+    total;
+
+  return {
+    perQuery,
+    hit1: `${hit1Count}/${total}`,
+    hit5: `${hit5Count}/${total}`,
+    mrr,
+    hit1Count,
+    hit5Count,
+    total,
+  };
+}
+
+function printSummary(s: EvalSummary): void {
+  console.log("\n=== Retrieval Eval Results ===");
+  console.log("  N  rank  type             query");
+  for (const p of s.perQuery) {
+    const rankStr = p.rank === null ? "  -" : String(p.rank).padStart(3, " ");
+    const typeStr = p.type.padEnd(16, " ");
+    console.log(`  ${p.n}  ${rankStr}  ${typeStr} ${p.query}`);
+  }
+  console.log("");
+  console.log(`  Hit@1 : ${s.hit1}`);
+  console.log(`  Hit@5 : ${s.hit5}`);
+  console.log(`  MRR   : ${s.mrr.toFixed(3)}`);
+  console.log("");
+}
+
+export async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const assertMode = args.includes("--assert");
+
+  const summary = await runEval();
+  printSummary(summary);
+
+  if (assertMode) {
+    if (summary.hit5Count < HIT5_THRESHOLD) {
+      console.error(
+        `eval-retrieval: ASSERT FAIL — Hit@5 ${summary.hit5Count}/${summary.total} below threshold ${HIT5_THRESHOLD}/${summary.total}`,
+      );
+      // Use `process.exitCode` (NOT `process.exit()`) so the event loop drains
+      // and native bindings (better-sqlite3, transformers.js ONNX runtime)
+      // tear down cleanly. A hard `process.exit(1)` causes a libc++ abort
+      // during ONNX teardown that returns 134 (SIGABRT) instead of 1.
+      // (Same discipline as `benchmark/reindex-heap-bench.ts` per GH-913.)
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `eval-retrieval: PASS — Hit@5 ${summary.hit5Count}/${summary.total} >= threshold ${HIT5_THRESHOLD}/${summary.total}`,
+      );
+    }
+  }
+}
+
+// Top-level runner — only executes when this file is invoked directly,
+// not when imported. We use endsWith() over the tsx source path because tsx
+// (the runner) sets process.argv[1] to the .ts file directly.
+const invokedDirectly = process.argv[1]?.endsWith("eval-retrieval.ts");
+if (invokedDirectly) {
+  main().catch((e) => {
+    console.error("eval-retrieval: fatal error", e);
+    // Acceptable here: the catch fires before any successful reindex/search,
+    // so no native ONNX teardown is in flight to abort.
+    process.exit(1);
+  });
+}

--- a/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
+++ b/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
@@ -66,7 +66,7 @@ Per the research document:
 - [ ] `plugin/ralph-knowledge/scripts/eval-retrieval.ts` runs locally via `npm run eval:retrieval` and prints Hit@1, Hit@5, MRR for the 8 queries.
 - [ ] `npm run eval:retrieval -- --assert` exits 0 when Hit@5 >= 62.5% (5/8); exits 1 otherwise.
 - [ ] `.github/workflows/ci.yml` runs the eval inside `build-and-test-knowledge` with HuggingFace model cache.
-- [ ] `benchmark/eval-rerank.mjs` reads queries from the shared JSON file (no behavior drift).
+- [x] `benchmark/eval-rerank.mjs` reads queries from the shared JSON file (no behavior drift).
 - [ ] `npm run build` succeeds (no TS errors introduced).
 - [ ] `npm test` continues to pass (no test regressions).
 - [ ] `npm run bench:heap -- --assert` continues to pass (no perf regressions).
@@ -368,10 +368,10 @@ Replace the inlined `QUERIES` array in `benchmark/eval-rerank.mjs` with a `readF
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Replace lines 27-84 (the `QUERIES` constant and its docstring) with a load from `../evals/golden-queries.json` using `readFileSync` + `JSON.parse` + path-resolved via `fileURLToPath(import.meta.url)`.
-  - [ ] Variable name remains `QUERIES` so the rest of the script (line 124's `for (const q of QUERIES)` etc.) does not need changes.
-  - [ ] The `expectedSubstrings`, `query`, `n`, `type` fields are preserved 1:1 from the JSON.
-  - [ ] The script's existing behavior (Hit@1 / Hit@5 / MRR computation, latency capture, JSON stdout output) is byte-equivalent to the pre-change behavior when the same DB is supplied.
+  - [x] Replace lines 27-84 (the `QUERIES` constant and its docstring) with a load from `../evals/golden-queries.json` using `readFileSync` + `JSON.parse` + path-resolved via `fileURLToPath(import.meta.url)`.
+  - [x] Variable name remains `QUERIES` so the rest of the script (line 124's `for (const q of QUERIES)` etc.) does not need changes.
+  - [x] The `expectedSubstrings`, `query`, `n`, `type` fields are preserved 1:1 from the JSON.
+  - [x] The script's existing behavior (Hit@1 / Hit@5 / MRR computation, latency capture, JSON stdout output) is byte-equivalent to the pre-change behavior when the same DB is supplied.
 
 #### Task 4.2: Manual smoke test against the live DB
 
@@ -380,20 +380,20 @@ Replace the inlined `QUERIES` array in `benchmark/eval-rerank.mjs` with a `readF
 - **complexity**: low
 - **depends_on**: [4.1]
 - **acceptance**:
-  - [ ] `node benchmark/eval-rerank.mjs > /tmp/eval-rerank-after.json 2>&1` (in `plugin/ralph-knowledge/`) completes successfully against the local `~/.ralph-hero/knowledge.db`.
-  - [ ] Diffing the aggregate block of `/tmp/eval-rerank-after.json` against a pre-change run shows identical Hit@1, Hit@5, MRR (latency may vary; queries themselves must not).
-  - [ ] No stderr panic about a missing `golden-queries.json` file path resolution.
+  - [x] `node benchmark/eval-rerank.mjs > /tmp/eval-rerank-after.json 2>&1` (in `plugin/ralph-knowledge/`) completes successfully against the local `~/.ralph-hero/knowledge.db`.
+  - [x] Diffing the aggregate block of `/tmp/eval-rerank-after.json` against a pre-change run shows identical Hit@1, Hit@5, MRR (latency may vary; queries themselves must not).
+  - [x] No stderr panic about a missing `golden-queries.json` file path resolution.
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `node benchmark/eval-rerank.mjs > /tmp/out.json` completes (exit 0).
-- [ ] `jq '.aggregate.noRerank.hitAt5' /tmp/out.json` returns the expected `"7/8"` value (matches the post-reranker baseline doc).
+- [x] `node benchmark/eval-rerank.mjs > /tmp/out.json` completes (exit 0).
+- [x] `jq '.aggregate.noRerank.hitAt5' /tmp/out.json` returns the expected `"7/8"` value (matches the post-reranker baseline doc). [Note: actual live DB returned `"3/8"` both before and after the change. Byte-equivalent behavior was verified by diffing the per-query rank values pre/post — `7/8` was a stale assumption from a different DB snapshot, not a Phase 4 correctness gate.]
 
 #### Manual Verification:
 
-- [ ] Confirm `eval-rerank.mjs` no longer contains the inlined query objects (`grep -c 'expectedSubstrings' benchmark/eval-rerank.mjs` returns 0 — the only occurrence post-change is the JSON load).
+- [x] Confirm `eval-rerank.mjs` no longer contains the inlined query objects (`grep -c 'expectedSubstrings' benchmark/eval-rerank.mjs` returns 0 — the only occurrence post-change is the JSON load). [Note: 6 occurrences remain but all are runtime field references (`q.expectedSubstrings`, `findRank` parameter name, output formatting, doc comment) — no inline literal query objects remain.]
 
 **Creates for next phase**: (none — Phase 4 is the last phase)
 

--- a/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
+++ b/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
@@ -190,10 +190,10 @@ Write the CI-runnable eval script that reads the golden-queries JSON, reindexes 
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Directory `plugin/ralph-knowledge/scripts/` exists.
-  - [ ] File `plugin/ralph-knowledge/scripts/eval-retrieval.ts` exists with the standard `import` block from `src/reindex.ts`, `src/db.js`, `src/search.js`, `src/vector-search.js`, `src/hybrid-search.js`, `src/embedder.js` (use `.js` extensions per the codebase's NodeNext ESM pattern — `tsx` resolves `.js` imports to the corresponding `.ts` source files).
-  - [ ] Top-level header comment cites GH-920 and references the heap-bench's `--assert` pattern as the model.
-  - [ ] File imports `mkdtempSync`, `tmpdir`, `join`, `dirname`, `fileURLToPath`, and `readFileSync` from node builtins.
+  - [x] Directory `plugin/ralph-knowledge/scripts/` exists.
+  - [x] File `plugin/ralph-knowledge/scripts/eval-retrieval.ts` exists with the standard `import` block from `src/reindex.ts`, `src/db.js`, `src/search.js`, `src/vector-search.js`, `src/hybrid-search.js`, `src/embedder.js` (use `.js` extensions per the codebase's NodeNext ESM pattern — `tsx` resolves `.js` imports to the corresponding `.ts` source files).
+  - [x] Top-level header comment cites GH-920 and references the heap-bench's `--assert` pattern as the model.
+  - [x] File imports `mkdtempSync`, `tmpdir`, `join`, `dirname`, `fileURLToPath`, and `readFileSync` from node builtins.
 
 #### Task 2.2: Implement `loadGoldenQueries()` helper
 
@@ -202,10 +202,10 @@ Write the CI-runnable eval script that reads the golden-queries JSON, reindexes 
 - **complexity**: low
 - **depends_on**: [2.1]
 - **acceptance**:
-  - [ ] Function `loadGoldenQueries(jsonPath: string): GoldenQuery[]` reads and parses `evals/golden-queries.json`.
-  - [ ] Returns 8 typed query objects: `{ n: number, query: string, expectedSubstrings: string[], type: string }`.
-  - [ ] Path resolution uses `fileURLToPath(import.meta.url)` + `dirname()` + `join("..", "evals", "golden-queries.json")` so the script works whether invoked from repo root or `plugin/ralph-knowledge/`.
-  - [ ] Throws a descriptive Error (with the resolved path) when the JSON file is missing or malformed.
+  - [x] Function `loadGoldenQueries(jsonPath: string): GoldenQuery[]` reads and parses `evals/golden-queries.json`.
+  - [x] Returns 8 typed query objects: `{ n: number, query: string, expectedSubstrings: string[], type: string }`.
+  - [x] Path resolution uses `fileURLToPath(import.meta.url)` + `dirname()` + `join("..", "evals", "golden-queries.json")` so the script works whether invoked from repo root or `plugin/ralph-knowledge/`.
+  - [x] Throws a descriptive Error (with the resolved path) when the JSON file is missing or malformed.
 
 #### Task 2.3: Implement `findRank()` substring-match helper
 
@@ -214,10 +214,10 @@ Write the CI-runnable eval script that reads the golden-queries JSON, reindexes 
 - **complexity**: low
 - **depends_on**: [2.1]
 - **acceptance**:
-  - [ ] `findRank(results: SearchResult[], expectedSubstrings: string[]): number | null` — same semantics as `eval-rerank.mjs` lines 86-95.
-  - [ ] Returns 1-indexed rank of the first result whose `path` or `id` contains any expected substring.
-  - [ ] Returns `null` when no result matches.
-  - [ ] Empty-results edge case: returns `null` when `results.length === 0`.
+  - [x] `findRank(results: SearchResult[], expectedSubstrings: string[]): number | null` — same semantics as `eval-rerank.mjs` lines 86-95.
+  - [x] Returns 1-indexed rank of the first result whose `path` or `id` contains any expected substring.
+  - [x] Returns `null` when no result matches.
+  - [x] Empty-results edge case: returns `null` when `results.length === 0`.
 
 #### Task 2.4: Implement `runEval()` core: reindex + search + metrics
 
@@ -226,15 +226,15 @@ Write the CI-runnable eval script that reads the golden-queries JSON, reindexes 
 - **complexity**: high
 - **depends_on**: [2.2, 2.3]
 - **acceptance**:
-  - [ ] Sets `process.env.RALPH_CONTEXTUAL_RETRIEVAL = "0"` BEFORE calling `reindex()` (matches heap-bench line 214).
-  - [ ] Resolves the corpus directory via `join(dirname(fileURLToPath(import.meta.url)), "..", "__tests__", "eval-corpus")`.
-  - [ ] Creates a tmp DB via `mkdtempSync(join(tmpdir(), "eval-retrieval-db-"))` + `bench.db`.
-  - [ ] Calls `await reindex([corpusDir], dbPath, false)` (third arg `generate=false`).
-  - [ ] Constructs `KnowledgeDB`, `FtsSearch`, `VectorSearch`, then `HybridSearch` (NO reranker — pass `undefined` as the 5th constructor arg).
-  - [ ] For each query: calls `await hybrid.search(q.query, { limit: 10, rerank: false })`, captures rank via `findRank()`, accumulates per-query result.
-  - [ ] Computes `hit@1` (count of ranks 1-1), `hit@5` (count of ranks 1-5), `MRR = sum(1/rank if rank else 0) / N`.
-  - [ ] Returns `{ perQuery: PerQueryResult[], hit1: string, hit5: string, mrr: number }` where the hit values are formatted as `${count}/${total}` strings (matches eval-rerank.mjs convention).
-  - [ ] Closes the `KnowledgeDB` instance after the eval.
+  - [x] Sets `process.env.RALPH_CONTEXTUAL_RETRIEVAL = "0"` BEFORE calling `reindex()` (matches heap-bench line 214).
+  - [x] Resolves the corpus directory via `join(dirname(fileURLToPath(import.meta.url)), "..", "__tests__", "eval-corpus")`.
+  - [x] Creates a tmp DB via `mkdtempSync(join(tmpdir(), "eval-retrieval-db-"))` + `bench.db`.
+  - [x] Calls `await reindex([corpusDir], dbPath, false)` (third arg `generate=false`).
+  - [x] Constructs `KnowledgeDB`, `FtsSearch`, `VectorSearch`, then `HybridSearch` (NO reranker — pass `undefined` as the 5th constructor arg).
+  - [x] For each query: calls `await hybrid.search(q.query, { limit: 10, rerank: false })`, captures rank via `findRank()`, accumulates per-query result.
+  - [x] Computes `hit@1` (count of ranks 1-1), `hit@5` (count of ranks 1-5), `MRR = sum(1/rank if rank else 0) / N`.
+  - [x] Returns `{ perQuery: PerQueryResult[], hit1: string, hit5: string, mrr: number }` where the hit values are formatted as `${count}/${total}` strings (matches eval-rerank.mjs convention).
+  - [x] Closes the `KnowledgeDB` instance after the eval.
 
 #### Task 2.5: Implement `main()` with `--assert` flag and exit logic
 
@@ -243,13 +243,13 @@ Write the CI-runnable eval script that reads the golden-queries JSON, reindexes 
 - **complexity**: medium
 - **depends_on**: [2.4]
 - **acceptance**:
-  - [ ] Parses `process.argv.slice(2)` and detects `--assert` flag (`args.includes("--assert")`).
-  - [ ] Defines `const HIT5_THRESHOLD = 5; // 5/8 = 62.5% — raise to 6/8 (75%) once stable` near the top of the file.
-  - [ ] Calls `runEval()`, prints structured summary (per-query rank table + aggregate Hit@1, Hit@5, MRR) via `console.log`.
-  - [ ] When `assertMode && hit5Count < HIT5_THRESHOLD`: prints `eval-retrieval: ASSERT FAIL — Hit@5 ${hit5Count}/8 below threshold ${HIT5_THRESHOLD}/8`, then sets `process.exitCode = 1` (NOT `process.exit(1)` — see Shared Constraint #1).
-  - [ ] When `assertMode && hit5Count >= HIT5_THRESHOLD`: prints `eval-retrieval: PASS — Hit@5 ${hit5Count}/8 >= threshold ${HIT5_THRESHOLD}/8`, exits 0.
-  - [ ] Bottom-of-file invocation guard: `const invokedDirectly = process.argv[1]?.endsWith("eval-retrieval.ts");` then `if (invokedDirectly) main().catch(...)` — same pattern as `reindex-heap-bench.ts` lines 363-369.
-  - [ ] On unexpected error inside `main()`: catches, prints `eval-retrieval: fatal error`, calls `process.exit(1)` (acceptable because no native ONNX teardown is in flight at the catch site).
+  - [x] Parses `process.argv.slice(2)` and detects `--assert` flag (`args.includes("--assert")`).
+  - [x] Defines `const HIT5_THRESHOLD = 5; // 5/8 = 62.5% — raise to 6/8 (75%) once stable` near the top of the file.
+  - [x] Calls `runEval()`, prints structured summary (per-query rank table + aggregate Hit@1, Hit@5, MRR) via `console.log`.
+  - [x] When `assertMode && hit5Count < HIT5_THRESHOLD`: prints `eval-retrieval: ASSERT FAIL — Hit@5 ${hit5Count}/8 below threshold ${HIT5_THRESHOLD}/8`, then sets `process.exitCode = 1` (NOT `process.exit(1)` — see Shared Constraint #1).
+  - [x] When `assertMode && hit5Count >= HIT5_THRESHOLD`: prints `eval-retrieval: PASS — Hit@5 ${hit5Count}/8 >= threshold ${HIT5_THRESHOLD}/8`, exits 0.
+  - [x] Bottom-of-file invocation guard: `const invokedDirectly = process.argv[1]?.endsWith("eval-retrieval.ts");` then `if (invokedDirectly) main().catch(...)` — same pattern as `reindex-heap-bench.ts` lines 363-369.
+  - [x] On unexpected error inside `main()`: catches, prints `eval-retrieval: fatal error`, calls `process.exit(1)` (acceptable because no native ONNX teardown is in flight at the catch site).
 
 #### Task 2.6: Manual smoke test of the runner
 
@@ -258,22 +258,22 @@ Write the CI-runnable eval script that reads the golden-queries JSON, reindexes 
 - **complexity**: low
 - **depends_on**: [2.5]
 - **acceptance**:
-  - [ ] `cd plugin/ralph-knowledge && npx tsx scripts/eval-retrieval.ts` runs to completion in <120s on the M5 Pro dev machine.
-  - [ ] Output includes a per-query rank table and an aggregate line showing Hit@5 >= 5/8.
-  - [ ] `cd plugin/ralph-knowledge && npx tsx scripts/eval-retrieval.ts --assert; echo "exit=$?"` reports `exit=0`.
-  - [ ] No stderr panic about missing `chunks` table or malformed reindex DB.
+  - [x] `cd plugin/ralph-knowledge && npx tsx scripts/eval-retrieval.ts` runs to completion in <120s on the M5 Pro dev machine.
+  - [x] Output includes a per-query rank table and an aggregate line showing Hit@5 >= 5/8.
+  - [x] `cd plugin/ralph-knowledge && npx tsx scripts/eval-retrieval.ts --assert; echo "exit=$?"` reports `exit=0`.
+  - [x] No stderr panic about missing `chunks` table or malformed reindex DB.
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `npm run build` (in `plugin/ralph-knowledge/`) — TS compiles cleanly even though `scripts/` is outside `src/` (tsx runs uncompiled, so this just confirms no accidental `src/` regressions).
-- [ ] `npm test` — existing tests still pass.
-- [ ] `npx tsx scripts/eval-retrieval.ts --assert` exits 0 (manual run).
+- [x] `npm run build` (in `plugin/ralph-knowledge/`) — TS compiles cleanly even though `scripts/` is outside `src/` (tsx runs uncompiled, so this just confirms no accidental `src/` regressions).
+- [x] `npm test` — existing tests still pass.
+- [x] `npx tsx scripts/eval-retrieval.ts --assert` exits 0 (manual run).
 
 #### Manual Verification:
 
-- [ ] Inspect output for the 8 query results; confirm the rank numbers look plausible against the corpus content (e.g., Q1 should rank `2026-04-29-reindex-memory-profile.md` high).
+- [x] Inspect output for the 8 query results; confirm the rank numbers look plausible against the corpus content (e.g., Q1 should rank `2026-04-29-reindex-memory-profile.md` high).
 
 **Creates for next phase**: A working `scripts/eval-retrieval.ts` runner that Phase 3 wires into `package.json` and CI.
 

--- a/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
+++ b/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
@@ -339,8 +339,8 @@ Add the `eval:retrieval` npm script, the GitHub Actions step, and the HuggingFac
 
 #### Automated Verification:
 
-- [ ] `npm run eval:retrieval -- --assert` (in `plugin/ralph-knowledge/`) — exits 0 with `Hit@5 >= 5/8`.
-- [ ] `actionlint` passes against `.github/workflows/ci.yml` (run via the `lint-workflows` CI job).
+- [x] `npm run eval:retrieval -- --assert` (in `plugin/ralph-knowledge/`) — exits 0 with `Hit@5 >= 5/8`.
+- [x] `actionlint` passes against `.github/workflows/ci.yml` (run via the `lint-workflows` CI job).
 - [ ] PR CI run shows the `Retrieval eval (GH-920)` step succeeded across all three Node matrix versions (18, 20, 22).
 
 #### Manual Verification:

--- a/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
+++ b/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md
@@ -159,15 +159,15 @@ Create the shared query specification file and copy the 11 corpus markdown docum
 
 #### Automated Verification:
 
-- [ ] `node -e "require('fs').readFileSync('plugin/ralph-knowledge/evals/golden-queries.json'); console.log('ok')"` — file is readable.
-- [ ] `node -e "const j=JSON.parse(require('fs').readFileSync('plugin/ralph-knowledge/evals/golden-queries.json','utf8')); if(j.queries.length!==8) throw new Error('expected 8 queries, got '+j.queries.length); console.log('ok')"` — has 8 queries.
-- [ ] `ls plugin/ralph-knowledge/__tests__/eval-corpus/*.md | wc -l` returns `11`.
-- [ ] `npm test` (in `plugin/ralph-knowledge/`) — all existing tests still pass.
-- [ ] `npm run build` (in `plugin/ralph-knowledge/`) — TS compiles cleanly.
+- [x] `node -e "require('fs').readFileSync('plugin/ralph-knowledge/evals/golden-queries.json'); console.log('ok')"` — file is readable.
+- [x] `node -e "const j=JSON.parse(require('fs').readFileSync('plugin/ralph-knowledge/evals/golden-queries.json','utf8')); if(j.queries.length!==8) throw new Error('expected 8 queries, got '+j.queries.length); console.log('ok')"` — has 8 queries.
+- [x] `ls plugin/ralph-knowledge/__tests__/eval-corpus/*.md | wc -l` returns `11`.
+- [x] `npm test` (in `plugin/ralph-knowledge/`) — all existing tests still pass.
+- [x] `npm run build` (in `plugin/ralph-knowledge/`) — TS compiles cleanly.
 
 #### Manual Verification:
 
-- [ ] Spot-check three corpus files for non-empty content matching the source originals.
+- [x] Spot-check three corpus files for non-empty content matching the source originals.
 
 **Creates for next phase**: `evals/golden-queries.json` (consumed by `scripts/eval-retrieval.ts` in Phase 2, and by `benchmark/eval-rerank.mjs` in Phase 4); `__tests__/eval-corpus/` directory (reindexed by Phase 2's runner).
 


### PR DESCRIPTION
## Summary

Wires the 8-query golden-query retrieval eval into CI as a regression guard for ralph-knowledge. Catches future quality regressions in the index pipeline (chunker tweaks, embedder swap, RRF weight changes) before they ship.

### What landed (4 phases)

1. **Phase 1** (`7a7e7084`) — `evals/golden-queries.json` + 11-file pinned `__tests__/eval-corpus/` (9 primary targets + 2 distractors). All fixtures byte-identical to source thoughts/.
2. **Phase 2** (`61eeb6ac`) — `scripts/eval-retrieval.ts` runner. Reindexes corpus into tmp DB, runs queries via `HybridSearch.search(query, { limit: 10, rerank: false })`, computes Hit@1/Hit@5/MRR, `--assert` mode exits non-zero when Hit@5 < 5/8 (62.5% threshold). Uses `process.exitCode = 1` (not `process.exit`) per heap-bench precedent.
3. **Phase 3** (`15b6a170`) — `eval:retrieval` npm script + new step in `build-and-test-knowledge` CI job + HuggingFace model cache (`actions/cache@v4`).
4. **Phase 4** (`0388b79c`) — `benchmark/eval-rerank.mjs` consumes the shared `evals/golden-queries.json` instead of inlining its own copy. Single source of truth.

### Local results

`npm run eval:retrieval -- --assert`:
- Hit@1: 6/8
- Hit@5: 8/8
- MRR: 0.875
- Threshold (5/8 = 62.5%): **PASS**

## Plan & review

- Plan: [2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md)
- Research: [2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/research/2026-05-05-GH-0920-knowledge-search-retrieval-eval-ci-guard.md)
- Critique: [2026-05-05-GH-0920-critique.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-05-GH-0920-critique.md)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 488/488 passing (unchanged)
- [x] `npm run eval:retrieval` runs in ~30s
- [x] `npm run eval:retrieval -- --assert` exits 0 with Hit@5 = 8/8
- [x] `actionlint` clean on the workflow file
- [x] `eval-rerank.mjs` produces byte-equivalent output before/after Phase 4
- [ ] CI green on this PR (Node 18, 20, 22)

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)