### PR TITLE
feat(hygiene): preserve repository field on HygieneItem

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/hygiene.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/hygiene.test.ts
@@ -543,3 +543,137 @@ describe("findDuplicateCandidates", () => {
     expect(report.summary.duplicateCandidateCount).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// repository field preservation (Phase 1)
+// ---------------------------------------------------------------------------
+
+describe("repository field preservation", () => {
+  it("findArchiveCandidates preserves repository on items", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Done",
+        closedAt: new Date(NOW - 20 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+    ];
+    const result = findArchiveCandidates(items, NOW, 14);
+    expect(result).toHaveLength(1);
+    expect(result[0].repository).toBe("owner/repo-a");
+  });
+
+  it("findStaleItems preserves repository on items", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-b",
+      }),
+    ];
+    const result = findStaleItems(items, NOW, 7);
+    expect(result).toHaveLength(1);
+    expect(result[0].repository).toBe("owner/repo-b");
+  });
+
+  it("findOrphanedItems preserves repository on items", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        assignees: [],
+        updatedAt: new Date(NOW - 20 * DAY_MS).toISOString(),
+        repository: "owner/repo-c",
+      }),
+    ];
+    const result = findOrphanedItems(items, NOW, 14);
+    expect(result).toHaveLength(1);
+    expect(result[0].repository).toBe("owner/repo-c");
+  });
+
+  it("findFieldGaps preserves repository on missingEstimate and missingPriority", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        estimate: null,
+        priority: "P1",
+        repository: "owner/repo-d",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        estimate: "S",
+        priority: null,
+        repository: "owner/repo-e",
+      }),
+    ];
+    const gaps = findFieldGaps(items, NOW);
+    expect(gaps.missingEstimate).toHaveLength(1);
+    expect(gaps.missingEstimate[0].repository).toBe("owner/repo-d");
+    expect(gaps.missingPriority).toHaveLength(1);
+    expect(gaps.missingPriority[0].repository).toBe("owner/repo-e");
+  });
+
+  it("findWipViolations preserves repository on items inside each violation", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "In Progress",
+        repository: "owner/repo-f",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "In Progress",
+        repository: "owner/repo-g",
+      }),
+      makeItem({
+        number: 3,
+        workflowState: "In Progress",
+        repository: "owner/repo-h",
+      }),
+    ];
+    const violations = findWipViolations(items, NOW, { "In Progress": 2 });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].items).toHaveLength(3);
+    expect(violations[0].items[0].repository).toBe("owner/repo-f");
+    expect(violations[0].items[1].repository).toBe("owner/repo-g");
+    expect(violations[0].items[2].repository).toBe("owner/repo-h");
+  });
+
+  it("findDuplicateCandidates preserves repository on both items in each pair", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        title: "Add caching to API layer",
+        workflowState: "Backlog",
+        repository: "owner/repo-i",
+      }),
+      makeItem({
+        number: 2,
+        title: "Add caching to API layers",
+        workflowState: "Backlog",
+        repository: "owner/repo-j",
+      }),
+    ];
+    const result = findDuplicateCandidates(items, NOW, 0.8);
+    expect(result).toHaveLength(1);
+    expect(result[0].items[0].repository).toBe("owner/repo-i");
+    expect(result[0].items[1].repository).toBe("owner/repo-j");
+  });
+
+  it("toHygieneItem omits repository key when source has none (no undefined value)", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Done",
+        closedAt: new Date(NOW - 20 * DAY_MS).toISOString(),
+        // no repository field
+      }),
+    ];
+    const result = findArchiveCandidates(items, NOW, 14);
+    expect(result).toHaveLength(1);
+    expect("repository" in result[0]).toBe(false);
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/lib/hygiene.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/hygiene.ts
@@ -33,6 +33,7 @@ export interface HygieneItem {
   title: string;
   workflowState: string | null;
   ageDays: number;
+  repository?: string; // "owner/repo" nameWithOwner format
 }
 
 export interface DuplicateCandidate {
@@ -81,6 +82,7 @@ function toHygieneItem(item: DashboardItem, now: number): HygieneItem {
     title: item.title,
     workflowState: item.workflowState,
     ageDays: Math.round(ageDays(item.updatedAt, now) * 10) / 10,
+    ...(item.repository ? { repository: item.repository } : {}),
   };
 }
 

--- a/thoughts/shared/plans/2026-05-06-group-GH-1085-hygiene-multi-repo.md
+++ b/thoughts/shared/plans/2026-05-06-group-GH-1085-hygiene-multi-repo.md
@@ -147,12 +147,12 @@ Add `repository?: string` to the `HygieneItem` type and update `toHygieneItem()`
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — no errors
-- [ ] `npm test` — all tests pass, including the 6 new repository-preservation tests
+- [x] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — no errors
+- [x] `npm test` — all tests pass, including the 6 new repository-preservation tests
 
 #### Manual Verification:
-- [ ] `HygieneItem` type definition includes `repository?: string`
-- [ ] `toHygieneItem` copies `item.repository` through unchanged
+- [x] `HygieneItem` type definition includes `repository?: string`
+- [x] `toHygieneItem` copies `item.repository` through unchanged
 
 **Creates for next phase**: `HygieneItem` carries repository data end-to-end so Phase 3's per-repo grouping can read it. Phase 2 doesn't strictly need Phase 1 to compile, but completing it first keeps the type consistent across all phases.
 


### PR DESCRIPTION
## Summary

Phase 1 of #563 (sub-issue #1085). Foundational data-plumbing change so `project_hygiene` items carry `repository` through to consumers — required before per-repo aggregation/rendering can land in subsequent phases.

- `lib/hygiene.ts`: add `repository?: string` to `HygieneItem`; `toHygieneItem()` spreads `repository` conditionally so the key is omitted (not `undefined`) when source has none — matches `dashboard.ts` precedent
- 7 new tests in `__tests__/hygiene.test.ts` covering all six section functions plus a regression for the omit-when-absent invariant

This phase is purely additive — no behavior changes for existing single-project / single-repo callers.

## Plan & review

- Plan: [2026-05-06-group-GH-1085-hygiene-multi-repo.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-06-group-GH-1085-hygiene-multi-repo.md) (Phase 1)
- Critique: [2026-05-06-GH-1085-critique.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-06-GH-1085-critique.md)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1161/1161 passing (7 new tests added)
- [x] `repository` key preserved when source has it
- [x] `repository` key omitted (not `undefined`) when source lacks it

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)