### PR TITLE
feat(hygiene): auto-compute repoBreakdowns + render per-repo markdown

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/hygiene.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/hygiene.test.ts
@@ -851,3 +851,357 @@ describe("repository field preservation", () => {
     expect("repository" in result[0]).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// repoBreakdowns auto-emission (Phase 3)
+// ---------------------------------------------------------------------------
+
+describe("repoBreakdowns auto-emission", () => {
+  it("single-repo input produces report.repoBreakdowns === undefined", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "In Progress",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    expect(report.repoBreakdowns).toBeUndefined();
+  });
+
+  it("zero-item input produces report.repoBreakdowns === undefined", () => {
+    const report = buildHygieneReport([], DEFAULT_HYGIENE_CONFIG, NOW);
+    expect(report.repoBreakdowns).toBeUndefined();
+  });
+
+  it("2-repo input produces repoBreakdowns with exactly 2 keys matching repo names", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        repository: "owner/repo-b",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    expect(report.repoBreakdowns).toBeDefined();
+    expect(Object.keys(report.repoBreakdowns!).sort()).toEqual([
+      "owner/repo-a",
+      "owner/repo-b",
+    ]);
+  });
+
+  it("each per-repo breakdown contains only items from that repo", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-b",
+      }),
+      makeItem({
+        number: 3,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-b",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    expect(report.repoBreakdowns).toBeDefined();
+
+    const repoA = report.repoBreakdowns!["owner/repo-a"];
+    expect(repoA).toBeDefined();
+    expect(repoA.staleItems).toHaveLength(1);
+    expect(repoA.staleItems[0].number).toBe(1);
+
+    const repoB = report.repoBreakdowns!["owner/repo-b"];
+    expect(repoB).toBeDefined();
+    expect(repoB.staleItems).toHaveLength(2);
+    const staleNumbers = repoB.staleItems.map((i) => i.number).sort();
+    expect(staleNumbers).toEqual([2, 3]);
+  });
+
+  it("items with no repository bucketed under '(unknown)' when other repos present", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        // no repository
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    expect(report.repoBreakdowns).toBeDefined();
+    expect(Object.keys(report.repoBreakdowns!).sort()).toEqual([
+      "(unknown)",
+      "owner/repo-a",
+    ]);
+    expect(report.repoBreakdowns!["(unknown)"].repoName).toBe("(unknown)");
+  });
+
+  it("per-repo summary counts match per-repo section lengths", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Done",
+        closedAt: new Date(NOW - 20 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-b",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    const repoA = report.repoBreakdowns!["owner/repo-a"];
+    expect(repoA.summary.archiveCandidateCount).toBe(
+      repoA.archiveCandidates.length,
+    );
+    expect(repoA.summary.archiveCandidateCount).toBe(1);
+    const repoB = report.repoBreakdowns!["owner/repo-b"];
+    expect(repoB.summary.staleCount).toBe(repoB.staleItems.length);
+    expect(repoB.summary.staleCount).toBe(1);
+  });
+
+  it("per-repo breakdowns do NOT recursively contain repoBreakdowns", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        repository: "owner/repo-b",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    for (const [, breakdown] of Object.entries(report.repoBreakdowns!)) {
+      // HygieneRepoBreakdown shape: no repoBreakdowns field exists on it
+      expect(
+        (breakdown as Record<string, unknown>).repoBreakdowns,
+      ).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatHygieneMarkdown — Per-Repository Breakdown rendering (Phase 3)
+// ---------------------------------------------------------------------------
+
+describe("formatHygieneMarkdown — Per-Repository Breakdown", () => {
+  it("single-repo input does NOT contain 'Per-Repository Breakdown' (regression-safe)", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    const md = formatHygieneMarkdown(report);
+    expect(md).not.toContain("Per-Repository Breakdown");
+    expect(md).not.toContain("## Per-Repository Breakdown");
+  });
+
+  it("zero-repo input does NOT contain 'Per-Repository Breakdown'", () => {
+    const report = buildHygieneReport([], DEFAULT_HYGIENE_CONFIG, NOW);
+    const md = formatHygieneMarkdown(report);
+    expect(md).not.toContain("Per-Repository Breakdown");
+  });
+
+  it("2-repo input contains '## Per-Repository Breakdown' and one '### owner/repo' heading per repo", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-b",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    const md = formatHygieneMarkdown(report);
+    expect(md).toContain("## Per-Repository Breakdown");
+    expect(md).toContain("### owner/repo-a");
+    expect(md).toContain("### owner/repo-b");
+  });
+
+  it("per-repo sub-sections render in alphabetical repo-name order", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "zeta/repo",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "alpha/repo",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    const md = formatHygieneMarkdown(report);
+    const alphaIdx = md.indexOf("### alpha/repo");
+    const zetaIdx = md.indexOf("### zeta/repo");
+    expect(alphaIdx).toBeGreaterThan(0);
+    expect(zetaIdx).toBeGreaterThan(0);
+    expect(alphaIdx).toBeLessThan(zetaIdx);
+  });
+
+  it("per-repo sub-section omits empty section tables", () => {
+    // repo-a: a Done archive candidate only (no stale/orphan/etc).
+    // repo-b: a Backlog item with assignee, age 10d → stale only (no orphan,
+    // no archive). Both repos exercise different sections.
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Done",
+        closedAt: new Date(NOW - 20 * DAY_MS).toISOString(),
+        estimate: "S",
+        priority: "P1",
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Backlog",
+        assignees: ["alice"],
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        estimate: "S",
+        priority: "P1",
+        repository: "owner/repo-b",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    const md = formatHygieneMarkdown(report);
+    // Per-Repository Breakdown should appear
+    expect(md).toContain("## Per-Repository Breakdown");
+
+    const aStart = md.indexOf("### owner/repo-a");
+    const bStart = md.indexOf("### owner/repo-b");
+    expect(aStart).toBeLessThan(bStart);
+
+    // The repo-a sub-section should contain Archive Candidates only.
+    const repoASlice = md.slice(aStart, bStart);
+    expect(repoASlice).toContain("#### Archive Candidates");
+    expect(repoASlice).not.toContain("#### Stale Items");
+    expect(repoASlice).not.toContain("#### Orphaned Items");
+    expect(repoASlice).not.toContain("#### Field Gaps");
+    expect(repoASlice).not.toContain("#### WIP Violations");
+    expect(repoASlice).not.toContain("#### Duplicate Candidates");
+
+    // The repo-b sub-section should contain Stale Items only.
+    const repoBSlice = md.slice(bStart);
+    expect(repoBSlice).toContain("#### Stale Items");
+    expect(repoBSlice).not.toContain("#### Archive Candidates");
+    expect(repoBSlice).not.toContain("#### Orphaned Items");
+    expect(repoBSlice).not.toContain("#### Field Gaps");
+    expect(repoBSlice).not.toContain("#### WIP Violations");
+    expect(repoBSlice).not.toContain("#### Duplicate Candidates");
+  });
+
+  it("byte-identical markdown for single-repo input vs no-repo input (backward-compat)", () => {
+    // This guards Phase 3's backward-compat promise: when repoBreakdowns is
+    // undefined the markdown formatter must produce the same output it
+    // produced before Phase 3 existed.
+    const itemsWithRepo = [
+      makeItem({
+        number: 42,
+        workflowState: "Done",
+        closedAt: new Date(NOW - 20 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+    ];
+    const itemsNoRepo = [
+      makeItem({
+        number: 42,
+        workflowState: "Done",
+        closedAt: new Date(NOW - 20 * DAY_MS).toISOString(),
+      }),
+    ];
+    const reportWithRepo = buildHygieneReport(
+      itemsWithRepo,
+      DEFAULT_HYGIENE_CONFIG,
+      NOW,
+    );
+    const reportNoRepo = buildHygieneReport(
+      itemsNoRepo,
+      DEFAULT_HYGIENE_CONFIG,
+      NOW,
+    );
+
+    expect(reportWithRepo.repoBreakdowns).toBeUndefined();
+    expect(reportNoRepo.repoBreakdowns).toBeUndefined();
+
+    const mdWithRepo = formatHygieneMarkdown(reportWithRepo);
+    const mdNoRepo = formatHygieneMarkdown(reportNoRepo);
+    expect(mdWithRepo).toBe(mdNoRepo);
+    expect(mdWithRepo).not.toContain("Per-Repository Breakdown");
+  });
+
+  it("renders per-repo Stale Items rows with correct issue numbers", () => {
+    const items = [
+      makeItem({
+        number: 101,
+        title: "Repo A stale item",
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-a",
+      }),
+      makeItem({
+        number: 202,
+        title: "Repo B stale item",
+        workflowState: "Backlog",
+        updatedAt: new Date(NOW - 10 * DAY_MS).toISOString(),
+        repository: "owner/repo-b",
+      }),
+    ];
+    const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
+    const md = formatHygieneMarkdown(report);
+
+    const aStart = md.indexOf("### owner/repo-a");
+    const bStart = md.indexOf("### owner/repo-b");
+    const repoASlice = md.slice(aStart, bStart);
+    const repoBSlice = md.slice(bStart);
+
+    expect(repoASlice).toContain("#101");
+    expect(repoASlice).toContain("Repo A stale item");
+    expect(repoASlice).not.toContain("#202");
+
+    expect(repoBSlice).toContain("#202");
+    expect(repoBSlice).toContain("Repo B stale item");
+    expect(repoBSlice).not.toContain("#101");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/lib/hygiene.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/hygiene.ts
@@ -6,6 +6,7 @@
  */
 
 import { TERMINAL_STATES } from "./workflow-states.js";
+import { groupDashboardItemsByRepo } from "./dashboard.js";
 import type { DashboardItem } from "./dashboard.js";
 
 // ---------------------------------------------------------------------------
@@ -41,6 +42,31 @@ export interface DuplicateCandidate {
   similarity: number; // 0-1
 }
 
+export interface HygieneSummary {
+  archiveCandidateCount: number;
+  staleCount: number;
+  orphanCount: number;
+  fieldCoveragePercent: number;
+  wipViolationCount: number;
+  duplicateCandidateCount: number;
+}
+
+export interface HygieneRepoBreakdown {
+  repoName: string;
+  archiveCandidates: HygieneItem[];
+  staleItems: HygieneItem[];
+  orphanedItems: HygieneItem[];
+  fieldGaps: { missingEstimate: HygieneItem[]; missingPriority: HygieneItem[] };
+  wipViolations: Array<{
+    state: string;
+    count: number;
+    limit: number;
+    items: HygieneItem[];
+  }>;
+  duplicateCandidates: DuplicateCandidate[];
+  summary: HygieneSummary;
+}
+
 export interface HygieneReport {
   generatedAt: string;
   totalItems: number;
@@ -55,14 +81,8 @@ export interface HygieneReport {
     items: HygieneItem[];
   }>;
   duplicateCandidates: DuplicateCandidate[];
-  summary: {
-    archiveCandidateCount: number;
-    staleCount: number;
-    orphanCount: number;
-    fieldCoveragePercent: number;
-    wipViolationCount: number;
-    duplicateCandidateCount: number;
-  };
+  summary: HygieneSummary;
+  repoBreakdowns?: Record<string, HygieneRepoBreakdown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -301,6 +321,64 @@ export function findDuplicateCandidates(
 // ---------------------------------------------------------------------------
 
 /**
+ * Build a per-repo hygiene breakdown. Runs each section function over the
+ * supplied items (a single repo's subset of the merged item set).
+ *
+ * Does NOT recursively emit `repoBreakdowns` — per-repo breakdowns are flat.
+ */
+function buildRepoBreakdown(
+  repoName: string,
+  items: DashboardItem[],
+  config: HygieneConfig,
+  now: number,
+): HygieneRepoBreakdown {
+  const archiveCandidates = findArchiveCandidates(
+    items,
+    now,
+    config.archiveDays,
+  );
+  const staleItems = findStaleItems(items, now, config.staleDays);
+  const orphanedItems = findOrphanedItems(items, now, config.orphanDays);
+  const fieldGaps = findFieldGaps(items, now);
+  const wipViolations = findWipViolations(items, now, config.wipLimits);
+  const duplicateCandidates = findDuplicateCandidates(
+    items,
+    now,
+    config.similarityThreshold,
+  );
+
+  const nonTerminal = items.filter((item) => {
+    const ws = item.workflowState;
+    return !ws || !TERMINAL_STATES.includes(ws);
+  });
+  const withBothFields = nonTerminal.filter(
+    (item) => item.estimate !== null && item.priority !== null,
+  );
+  const fieldCoveragePercent =
+    nonTerminal.length > 0
+      ? Math.round((withBothFields.length / nonTerminal.length) * 100)
+      : 100;
+
+  return {
+    repoName,
+    archiveCandidates,
+    staleItems,
+    orphanedItems,
+    fieldGaps,
+    wipViolations,
+    duplicateCandidates,
+    summary: {
+      archiveCandidateCount: archiveCandidates.length,
+      staleCount: staleItems.length,
+      orphanCount: orphanedItems.length,
+      fieldCoveragePercent,
+      wipViolationCount: wipViolations.length,
+      duplicateCandidateCount: duplicateCandidates.length,
+    },
+  };
+}
+
+/**
  * Build a complete hygiene report from project items.
  */
 export function buildHygieneReport(
@@ -336,6 +414,22 @@ export function buildHygieneReport(
       ? Math.round((withBothFields.length / nonTerminal.length) * 100)
       : 100;
 
+  // Per-repo breakdown (only emitted when items span 2+ repos, mirroring
+  // buildDashboard's repoBreakdowns threshold at lib/dashboard.ts:781).
+  const repoGroups = groupDashboardItemsByRepo(items);
+  let repoBreakdowns: Record<string, HygieneRepoBreakdown> | undefined;
+  if (Object.keys(repoGroups).length >= 2) {
+    repoBreakdowns = {};
+    for (const [repoName, repoItems] of Object.entries(repoGroups)) {
+      repoBreakdowns[repoName] = buildRepoBreakdown(
+        repoName,
+        repoItems,
+        config,
+        now,
+      );
+    }
+  }
+
   return {
     generatedAt: new Date(now).toISOString(),
     totalItems: items.length,
@@ -353,6 +447,7 @@ export function buildHygieneReport(
       wipViolationCount: wipViolations.length,
       duplicateCandidateCount: duplicateCandidates.length,
     },
+    ...(repoBreakdowns ? { repoBreakdowns } : {}),
   };
 }
 
@@ -473,6 +568,119 @@ export function formatHygieneMarkdown(report: HygieneReport): string {
       );
     }
     lines.push("");
+  }
+
+  // Per-repository breakdown (only for multi-repo). Mirrors
+  // formatMarkdown's per-repo rendering at lib/dashboard.ts:948+.
+  if (
+    report.repoBreakdowns &&
+    Object.keys(report.repoBreakdowns).length >= 2
+  ) {
+    lines.push("## Per-Repository Breakdown");
+    lines.push("");
+
+    const sortedRepos = Object.values(report.repoBreakdowns).sort((a, b) =>
+      a.repoName.localeCompare(b.repoName),
+    );
+
+    for (const repo of sortedRepos) {
+      lines.push(`### ${repo.repoName}`);
+      lines.push("");
+
+      let renderedAny = false;
+
+      if (repo.archiveCandidates.length > 0) {
+        lines.push("#### Archive Candidates");
+        lines.push("| Issue | Title | State | Age |");
+        lines.push("|-------|-------|-------|-----|");
+        for (const item of repo.archiveCandidates) {
+          lines.push(formatItemRow(item));
+        }
+        lines.push("");
+        renderedAny = true;
+      }
+
+      if (repo.staleItems.length > 0) {
+        lines.push("#### Stale Items");
+        lines.push("| Issue | Title | State | Age |");
+        lines.push("|-------|-------|-------|-----|");
+        for (const item of repo.staleItems) {
+          lines.push(formatItemRow(item));
+        }
+        lines.push("");
+        renderedAny = true;
+      }
+
+      if (repo.orphanedItems.length > 0) {
+        lines.push("#### Orphaned Items");
+        lines.push("| Issue | Title | State | Age |");
+        lines.push("|-------|-------|-------|-----|");
+        for (const item of repo.orphanedItems) {
+          lines.push(formatItemRow(item));
+        }
+        lines.push("");
+        renderedAny = true;
+      }
+
+      const repoTotalGaps =
+        repo.fieldGaps.missingEstimate.length +
+        repo.fieldGaps.missingPriority.length;
+      if (repoTotalGaps > 0) {
+        lines.push("#### Field Gaps");
+        if (repo.fieldGaps.missingEstimate.length > 0) {
+          lines.push("##### Missing Estimate");
+          lines.push("| Issue | Title | State | Age |");
+          lines.push("|-------|-------|-------|-----|");
+          for (const item of repo.fieldGaps.missingEstimate) {
+            lines.push(formatItemRow(item));
+          }
+          lines.push("");
+        }
+        if (repo.fieldGaps.missingPriority.length > 0) {
+          lines.push("##### Missing Priority");
+          lines.push("| Issue | Title | State | Age |");
+          lines.push("|-------|-------|-------|-----|");
+          for (const item of repo.fieldGaps.missingPriority) {
+            lines.push(formatItemRow(item));
+          }
+          lines.push("");
+        }
+        renderedAny = true;
+      }
+
+      if (repo.wipViolations.length > 0) {
+        lines.push("#### WIP Violations");
+        for (const v of repo.wipViolations) {
+          lines.push(`##### ${v.state}: ${v.count} items (limit: ${v.limit})`);
+          lines.push("| Issue | Title | State | Age |");
+          lines.push("|-------|-------|-------|-----|");
+          for (const item of v.items) {
+            lines.push(formatItemRow(item));
+          }
+          lines.push("");
+        }
+        renderedAny = true;
+      }
+
+      if (repo.duplicateCandidates.length > 0) {
+        lines.push("#### Duplicate Candidates");
+        lines.push("| Issue A | Title A | Issue B | Title B | Similarity |");
+        lines.push("|---------|---------|---------|---------|------------|");
+        for (const dup of repo.duplicateCandidates) {
+          const [a, b] = dup.items;
+          lines.push(
+            `| #${a.number} | ${a.title} | #${b.number} | ${b.title} | ${dup.similarity.toFixed(2)} |`,
+          );
+        }
+        lines.push("");
+        renderedAny = true;
+      }
+
+      if (!renderedAny) {
+        lines.push("_No hygiene issues_");
+        lines.push("");
+      }
+    }
   }
 
   return lines.join("\n");

--- a/thoughts/shared/plans/2026-05-06-group-GH-1085-hygiene-multi-repo.md
+++ b/thoughts/shared/plans/2026-05-06-group-GH-1085-hygiene-multi-repo.md
@@ -283,8 +283,8 @@ Add per-repo breakdowns to `HygieneReport` (mirroring `DashboardData.repoBreakdo
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` — no errors
-- [ ] `npm test` — all tests pass, including the new repoBreakdowns tests
+- [x] `npm run build` — no errors
+- [x] `npm test` — all tests pass, including the new repoBreakdowns tests
 
 #### Manual Verification:
 - [ ] Live invocation with multi-repo project shows `## Per-Repository Breakdown` in markdown


### PR DESCRIPTION
## Summary

Phase 3 of #563 (sub-issue #1087). Auto-emits per-repo `repoBreakdowns` when items span 2+ repos, and renders a `## Per-Repository Breakdown` markdown section.

- New `HygieneSummary` + `HygieneRepoBreakdown` types
- Reuses `groupDashboardItemsByRepo` from `lib/dashboard.ts:1043`
- New `buildRepoBreakdown` helper in `lib/hygiene.ts` runs the 6 section functions over per-repo subsets; emits when `repoCount >= 2` (matches dashboard threshold at `lib/dashboard.ts:781`)
- Markdown: per-repo sections use `####` / `#####` heading levels so they don't collide with the global flat report; repos sorted alphabetically; conditional spread omits the key (not `undefined`) for single-repo callers
- 14 new tests; single-repo callers verified byte-identical

## Plan & review

- Plan: [2026-05-06-group-GH-1085-hygiene-multi-repo.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-06-group-GH-1085-hygiene-multi-repo.md) (Phase 3)
- Critique: [2026-05-06-GH-1085-critique.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-06-GH-1085-critique.md)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1177/1177 passing (14 new tests)
- [x] Single-repo markdown byte-identical
- [x] Multi-repo emits `## Per-Repository Breakdown`

Closes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)