### PR TITLE
fix(release): upgrade npm for OIDC + repoint .mcp.json to last-published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,12 @@ jobs:
           cache: npm
           cache-dependency-path: plugin/ralph-hero/mcp-server/package-lock.json
 
+      # Upgrade npm to >= 11.5.1 — required for OIDC trusted publishing.
+      # Node 22 ships with npm 10.x, which silently fails OIDC and returns
+      # a misleading 404 from the registry on `npm publish`.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 

--- a/plugin/ralph-hero/.mcp.json
+++ b/plugin/ralph-hero/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "ralph-github": {
       "command": "npx",
-      "args": ["-y", "ralph-hero-mcp-server@2.5.105"],
+      "args": ["-y", "ralph-hero-mcp-server@2.5.94"],
       "cwd": "${CLAUDE_PLUGIN_ROOT}"
     }
   }


### PR DESCRIPTION
## Summary

Two-part hotfix for the user-facing MCP outage that started after #1074 migrated npm publish to OIDC trusted publishing.

**Root cause**: npm OIDC trusted publishing requires npm CLI ≥ 11.5.1, but the GitHub runner ships npm 10.x with Node 22. The CLI silently skipped the OIDC exchange and the registry returned a misleading `404 Not Found - PUT https://registry.npmjs.org/ralph-hero-mcp-server` on every release run.

**Symptom**: Every release since #1074 bumped `mcp-server/package.json`, tagged, committed, and rewrote `plugin/ralph-hero/.mcp.json` to a new pinned version — but `npm publish` 404'd, so the version was never actually on npm. Plugin users updating got `npx -y ralph-hero-mcp-server@2.5.105` → 404 → MCP unreachable.

## Changes

- **`.github/workflows/release.yml`** — add `npm install -g npm@latest` step right before `npm ci` so the publish step has npm ≥ 11.5.1. Unblocks future releases.
- **`plugin/ralph-hero/.mcp.json`** — repoint from `2.5.105` (ghost, never published) back to `2.5.94` (last successful publish, 2026-05-04). Restores MCP reachability for users on `main` immediately after this PR merges.

The next successful release will automatically advance the `.mcp.json` pin via the workflow's existing "Pin version in justfile and .mcp.json" step.

## Test plan

- [x] `.mcp.json` parses; `npx -y ralph-hero-mcp-server@2.5.94` boots cleanly (verified locally before PR).
- [x] Trusted publisher entry on npmjs.com confirmed correct: `cdubiel08/ralph-hero`, `release.yml`, no environment.
- [ ] After merge, watch the next release run — `npm install -g npm@latest` should make `npm publish --provenance --access public` succeed and bump `latest` past `2.5.94`.
- [ ] If publish succeeds, confirm `.mcp.json` is auto-bumped to the newly-published version on the same release commit.

## Follow-up (separate PRs)

- Reorder `release.yml` so `npm publish` runs **before** the version bump commit/tag/push, so a publish failure doesn't leave a ghost version on `main`. (Tracking issue suggested.)
- Consider unpublishing or deprecating the 11 ghost npm version tags (`v2.5.95`–`v2.5.105`) — git tags exist but the npm versions don't, which is confusing for anyone walking the tag history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)