### PR TITLE
fix(release): add --force to npm self-upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,10 @@ jobs:
       # Upgrade npm to >= 11.5.1 — required for OIDC trusted publishing.
       # Node 22 ships with npm 10.x, which silently fails OIDC and returns
       # a misleading 404 from the registry on `npm publish`.
+      # `--force` works around the in-place self-upgrade module-loading bug
+      # where new npm tries to import modules from the old install mid-upgrade.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --force
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Follow-up to #1093. The `npm install -g npm@latest` step failed with `MODULE_NOT_FOUND: promise-retry` — a known in-place self-upgrade bug where new npm reuses old npm's modules mid-install. `--force` bypasses the broken intermediate state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)