### PR TITLE
feat(ralph-knowledge): add curate skill for personal wiki tier

### DIFF
--- a/plugin/ralph-knowledge/skills/curate/SKILL.md
+++ b/plugin/ralph-knowledge/skills/curate/SKILL.md
@@ -95,16 +95,16 @@ Run the candidate through these gates in order. Stop at the first failure and mo
 1. **Outside-code-surface gate**: Apply the `grep` test. If our code is the truth → reject as code-shadow.
 2. **Atomicity**: One concept, one sentence. No "and also". No compound clauses.
 3. **Lede-writable**: Can you write a single first sentence that fully answers the entry's title question and stands alone without context? If not → reject.
-4. **MUSTIE in reverse**: Not Misleading (factually wrong/dated), Ugly (malformed), Superseded (newer source covers it better), Trivial (not consequential), Irrelevant (out of wiki scope), or already-Elsewhere in the wiki (orthogonality — read the existing entries' bodies and `## Implications` sections, not just titles).
+4. **MUSTIE in reverse**: Not Misleading (factually wrong/dated), Ugly (malformed), Superseded (newer source covers it better), Trivial (not consequential), Irrelevant (out of wiki scope), or Elsewhere-obtained (the classic CREW criterion — knowledge already adequately answered by an external authoritative source the user can reach in one hop, OR reachable by `grep` in our own repos; this is the same test as the outside-code-surface gate but applied symmetrically to external sources too). Orthogonality within the wiki itself (no near-duplicate of an existing entry) is enforced separately at the candidate-hunt step (Step 2) — read existing entries' bodies and `## Implications` sections, not just titles.
 5. **Domain freshness**: Don't promote a candidate from the same conceptual domain as the previous 2 entries. The wiki should have a varied diet; three+ similar entries in a row dilute it. (Inspect the most recent entries in `~/projects/thoughts/wiki/` by date to apply this gate.)
 
 Surviving candidates proceed to presentation. If no candidates survive, tell the user and ask whether to re-hunt with a different domain or stop.
 
 ### Step 6: Present to the user
 
-Show the candidate with all the work visible. Use this exact structure:
+Show the candidate with all the work visible. Use this exact structure (the outer fence is four backticks so the inner three-backtick fence around the proposed entry renders correctly):
 
-```markdown
+````markdown
 ## Candidate axiom #N
 
 **Proposed claim**: [single declarative sentence]
@@ -150,7 +150,7 @@ Show the candidate with all the work visible. Use this exact structure:
 ---
 
 **Promote #N to wiki?** `y` / `n` / `edit`
-```
+````
 
 Show every check, every source. The user's gate decision should be informed by all the evidence, not a summary.
 
@@ -181,7 +181,7 @@ memory_tier: wiki
 date: YYYY-MM-DD
 valid_from: YYYY-MM-DD
 invalid_at: null
-review_cadence: quarterly | yearly | monthly
+review_cadence: quarterly | monthly | weekly
 scope: universal | personal | project/<name>
 tags: [comma, separated, kebab-case]
 related:                    # optional
@@ -198,7 +198,7 @@ supersedes:                 # optional, when entry corrects a stored belief
 Notes:
 - `valid_from` is when the supporting evidence first accumulated, not when you wrote the entry. Often same as `date` for new entries; can be earlier if backfilling.
 - `invalid_at` stays `null` until the entry is retired. **Never delete entries** — close them by stamping `invalid_at` with the date.
-- `review_cadence` choices: `quarterly` for stable platform/library facts, `yearly` for info-science / cognitive principles, `monthly` for fast-moving areas.
+- `review_cadence` choices: `quarterly` for stable platform/library facts and info-science / cognitive principles, `monthly` for practices that evolve, `weekly` for fast-moving areas (e.g., model performance, library betas).
 - `scope`: `universal` (true for anyone), `personal` (the user's stated heuristic), `project/<name>` (true within a specific project's context).
 
 ## Wiki entry body structure

--- a/plugin/ralph-knowledge/skills/curate/SKILL.md
+++ b/plugin/ralph-knowledge/skills/curate/SKILL.md
@@ -1,0 +1,275 @@
+---
+description: Curate the personal wiki tier — the third memory tier above raw and reflection. Iterates through atomic axiom candidates one at a time, fact-checks each against the corpus, external sources, and code, applies governance gates (outside-code-surface, atomicity, lede-writability, MUSTIE, domain freshness), and presents fully-evidenced candidates for the user to gate y/n/edit. Use whenever the user mentions "curate the wiki", "promote to wiki", "find canonical entries", "add to my wiki", "wiki tier", "wiki axioms", or wants to grow their thoughts/wiki/ directory. Also trigger when the user wants to distill recurring patterns from their thoughts/ corpus into canonical entries, synthesize reflections into wiki-grade material, or when they ask to "find atomic axioms" in their notes. The wiki resists growth — the gate is biased toward rejection.
+argument-hint: "[domain]"
+---
+
+# Curate the personal wiki tier
+
+This skill is the human-gated curator for the third memory tier — the personal wiki at `~/projects/thoughts/wiki/`. It iterates one atomic axiom at a time: hunt → distill → fact-check → gate → write or log. Most candidates are rejected. That's the system working.
+
+The companion infrastructure: raw memories live at `~/projects/thoughts/dream-memories/`, reflections at the same path under `reflections/`. The wiki sits above both as the user-curated canonical layer.
+
+## When to use this skill
+
+Trigger when the user wants to grow their personal wiki: "curate the wiki", "promote axioms", "find canonical entries", "add to my wiki", "let's add wiki entries about X". Also trigger when they ask to distill recurring patterns from their notes corpus into atomic claims.
+
+## When NOT to use this skill
+
+- **Documenting our own code's behavior** — the code is the truth, the wiki should not shadow it. Use CLAUDE.md, code comments, or in-repo docs instead.
+- **Bulk imports** — never bulk-promote. The "attention is sacred" principle applies to curation decisions themselves; one axiom per iteration.
+- **Capturing fleeting notes** — that's what the raw tier is for. Use `/ralph-hero:draft` or `/ralph-hero:form`.
+- **Drafting research or implementation plans** — different surface entirely.
+
+## Prerequisites
+
+The `knowledge_search` MCP tool from ralph-knowledge must be available. If it's not, tell the user the ralph-knowledge MCP server isn't connected and direct them to `/ralph-knowledge:setup`.
+
+The wiki directory `~/projects/thoughts/wiki/` should exist. If it doesn't, create it with a single `mkdir -p` before the first iteration.
+
+## The governance rule (load-bearing)
+
+**The wiki is for knowledge whose source of truth lives outside the code surface we operate on.** If the truth is in code we maintain, do not promote — that creates duplication that drifts. The operational test:
+
+> "If I needed to know this tomorrow, would I `grep` our repo or look it up externally?"
+
+If the answer is `grep` → reject as code-shadow. If the answer is "look it up" (external docs, library quirks, info-science principles, personal heuristics not encoded anywhere) → promotable.
+
+**Eligible domains**: external platform behavior (Claude Code, GitHub API, library quirks), information science / cognitive science principles, personal design heuristics not encoded in code, decisions about external constraints.
+
+**Ineligible domains**: our state machines, our MCP tool implementations, our sync logic, our configurations — anything reachable by `grep` in our own repos.
+
+## The workflow
+
+### Step 1: Receive the domain
+
+If a domain argument was passed (`/ralph-knowledge:curate cognitive-science`), use it as the search scope. Otherwise, ask the user once which domain to scope to. Examples of useful domains:
+
+- Information science / curation / knowledge management
+- Cognitive science / attention / productivity
+- External platform behavior (Claude Code, GitHub, library quirks)
+- Personal engineering heuristics
+- Design principles / UX patterns
+
+Scope matters: searching unscoped over a 3000+ document corpus dilutes the signal. Insist on a domain.
+
+### Step 2: Hunt for candidates
+
+Use `knowledge_search` (semantic) plus `knowledge_central` (find central documents in communities) to surface 5–10 candidate atomic axioms within the chosen domain.
+
+A candidate is high-signal if it:
+- States a principle in declarative form ("X must Y", "always X", "never X", "the rule is")
+- Recurs across 3+ documents (corroboration is the strongest durability signal)
+- Is prescriptive, not descriptive (a rule, constraint, or heuristic — not "here's what we did")
+- Appears durable: not tied to a specific date, project name, or version
+
+Read existing wiki entries from `~/projects/thoughts/wiki/*.md` and the rejection log `~/projects/thoughts/wiki/_rejected.jsonl` before presenting. **Skip any candidate that's already covered by an existing entry** (orthogonality) **or already in the rejection log** (don't re-propose what was already rejected).
+
+Output of this step: a ranked candidate list, ordered by promotability. Keep it internal — do not show it to the user as a bulk list.
+
+### Step 3: Distill the atomic claim
+
+For the top candidate:
+
+1. Extract ONE declarative sentence in your own words — not the original quote
+2. Reject if compound (contains "and also", multiple verbs, or two ideas)
+3. Reject if context-dependent (can't stand alone without referring back to the source doc)
+
+If the top candidate fails distillation, drop it and try the next one. Don't "rescue" weak candidates by editing aggressively — most candidates fail. That's normal.
+
+### Step 4: Fact-check via three lenses
+
+Apply lenses conditionally based on claim type:
+
+**Lens 1 — Corpus consistency (always)**: Vector-search for corroborating + contradicting passages across the user's thoughts/ corpora. List corroborating documents and any contradicting passages. **Surface contradictions explicitly** — they're load-bearing.
+
+**Lens 2 — External validity (only for empirical / platform claims)**: For claims about external systems, libraries, APIs, or platform behavior, dispatch a research agent or use WebSearch / WebFetch to consult authoritative sources. For Claude Code questions specifically, dispatch the `claude-code-guide` agent (it has direct docs access).
+
+**Lens 3 — Code consistency (only for project-convention claims)**: If the claim references project conventions, grep current code to verify the claim still matches reality. If the code has drifted from the claim, surface the drift; don't promote a stale claim.
+
+Compute a confidence rating: **high** (3+ corroborating, 0 contradicting, external/code agree), **medium** (some corroboration, no contradictions, no external check possible), **low** (single source, or contradictions present).
+
+### Step 5: Apply governance gates (fail-fast)
+
+Run the candidate through these gates in order. Stop at the first failure and move to the next candidate.
+
+1. **Outside-code-surface gate**: Apply the `grep` test. If our code is the truth → reject as code-shadow.
+2. **Atomicity**: One concept, one sentence. No "and also". No compound clauses.
+3. **Lede-writable**: Can you write a single first sentence that fully answers the entry's title question and stands alone without context? If not → reject.
+4. **MUSTIE in reverse**: Not Misleading (factually wrong/dated), Ugly (malformed), Superseded (newer source covers it better), Trivial (not consequential), Irrelevant (out of wiki scope), or already-Elsewhere in the wiki (orthogonality — read the existing entries' bodies and `## Implications` sections, not just titles).
+5. **Domain freshness**: Don't promote a candidate from the same conceptual domain as the previous 2 entries. The wiki should have a varied diet; three+ similar entries in a row dilute it. (Inspect the most recent entries in `~/projects/thoughts/wiki/` by date to apply this gate.)
+
+Surviving candidates proceed to presentation. If no candidates survive, tell the user and ask whether to re-hunt with a different domain or stop.
+
+### Step 6: Present to the user
+
+Show the candidate with all the work visible. Use this exact structure:
+
+```markdown
+## Candidate axiom #N
+
+**Proposed claim**: [single declarative sentence]
+
+### Verification: [HIGH | MEDIUM | LOW] confidence
+
+**Source of truth**: [where the claim's truth lives — external docs, library, principle, user's stated stance]
+
+**Corpus support** (N corroborating):
+- path/to/file.md:LINE — short paraphrase or quote
+
+**Corpus contradictions** (N — surfaced explicitly):
+- path/to/file.md:LINE — what the contradiction is, [why the candidate is still right]
+
+**External validation** (if applicable):
+- [docs link] — what it confirms
+
+**Code consistency** (if applicable):
+- file.ts:LINE — code matches/diverges from claim
+
+### Gate checks
+
+| Check | Result |
+|---|---|
+| Atomicity | PASS / FAIL |
+| Lede-writable | PASS / FAIL |
+| MUSTIE | PASS / FAIL — reasoning |
+| Durability | HIGH / MEDIUM / LOW |
+| Scope | universal / personal / project/X |
+| Outside-code-surface | PASS / FAIL |
+| Domain freshness | PASS / FAIL |
+
+### Proposed wiki entry
+
+```markdown
+[full proposed entry including frontmatter and body]
+```
+
+### Side-effects (if approved)
+
+- [list any memory updates, doc corrections, related-link additions, etc.]
+
+---
+
+**Promote #N to wiki?** `y` / `n` / `edit`
+```
+
+Show every check, every source. The user's gate decision should be informed by all the evidence, not a summary.
+
+### Step 7: Handle the gate response
+
+**On `y`**:
+1. Write the entry to `~/projects/thoughts/wiki/<slug>.md` — slug is a kebab-case version of the title, no stop words
+2. Apply any side-effects (memory updates, related-link additions to other wiki entries) — show what's changing
+3. Append to a session log so subsequent iterations know what was added
+4. Move to next candidate
+
+**On `n`**:
+1. Append to `~/projects/thoughts/wiki/_rejected.jsonl` — JSONL format, one line per rejection
+2. Move to next candidate
+
+**On `edit`**:
+1. Ask the user what to change (claim wording, scope, body structure)
+2. Re-apply gates after edit (atomicity, lede-writable can fail after editing)
+3. Re-present for final y/n
+
+After any of the three responses, move to the next candidate. Continue until: candidates exhausted, user says `stop`, or 5 promotions in this session (cap to keep the wiki disciplined).
+
+## Wiki entry frontmatter spec
+
+```yaml
+---
+memory_tier: wiki
+date: YYYY-MM-DD
+valid_from: YYYY-MM-DD
+invalid_at: null
+review_cadence: quarterly | yearly | monthly
+scope: universal | personal | project/<name>
+tags: [comma, separated, kebab-case]
+related:                    # optional
+  - other-entry-slug.md
+provenance:                 # optional but recommended
+  - source: URL or path
+    role: authoritative | corroborating
+supersedes:                 # optional, when entry corrects a stored belief
+  - file: path/to/superseded.md
+    reason: short reason
+---
+```
+
+Notes:
+- `valid_from` is when the supporting evidence first accumulated, not when you wrote the entry. Often same as `date` for new entries; can be earlier if backfilling.
+- `invalid_at` stays `null` until the entry is retired. **Never delete entries** — close them by stamping `invalid_at` with the date.
+- `review_cadence` choices: `quarterly` for stable platform/library facts, `yearly` for info-science / cognitive principles, `monthly` for fast-moving areas.
+- `scope`: `universal` (true for anyone), `personal` (the user's stated heuristic), `project/<name>` (true within a specific project's context).
+
+## Wiki entry body structure
+
+Hard rules (the "attention is sacred" contract):
+
+1. **Lede sentence**: First sentence ≤ ~25 words, fully answers the title's question, stands alone. This is what gets returned by default in retrieval.
+2. **Body**: 150 words hard cap. If you exceed, the entry is too big — split or simplify.
+3. **`## Implications`**: Up to 5 bullets. If you need more than 5, you're packing too much; cut to the most durable.
+4. **`## Sources`**: Required if external. Links and file:line references for corpus citations.
+5. **No emojis**, no decorative formatting. Functional structure only.
+
+Example structure:
+
+```markdown
+# [Title — declarative form, the axiom itself]
+
+[Lede sentence answering the title's question completely.]
+
+## Implications
+- [bullet 1]
+- [bullet 2]
+- [bullet 3]
+
+## Sources
+- [authoritative source]
+- [corroborating source]
+```
+
+## Side-effect handling
+
+When an approved entry **contradicts** an existing memory, doc, or piece of CLAUDE.md content, the side-effect is to update those sources. The skill should:
+
+1. **Identify** the contradicted source during fact-check (it appears in the "Corpus contradictions" section)
+2. **Propose** a specific edit to the contradicted source — show the exact diff
+3. **Ask** "Apply this side-effect too? `y/n`" before making the edit
+4. **Apply** if confirmed; record `supersedes:` frontmatter on the new wiki entry
+
+This was the load-bearing pattern from the original iteration: the first wiki entry corrected an existing auto-memory, and the wiki entry's `supersedes:` field made the supersession explicit. Don't skip this step — it keeps the user's other knowledge surfaces consistent with their canonical wiki.
+
+## Rejection log format
+
+`~/projects/thoughts/wiki/_rejected.jsonl` — JSONL, append-only, one rejection per line:
+
+```json
+{"date": "YYYY-MM-DD", "claim": "the proposed atomic claim", "reason": "concrete reason — code-shadow / repetitive / failed atomicity / etc.", "candidate_source": "where the candidate came from"}
+```
+
+Read this file before each hunt to skip already-rejected claims (recurrence within a session is fine; recurrence across sessions wastes the user's attention).
+
+## Domain re-hunt
+
+When the original candidate list is exhausted but the user wants to continue, ask whether to:
+- **Re-hunt with a different domain**: cleaner pivot, better signal
+- **Re-hunt the same domain with different seed terms**: useful if the first hunt missed angles
+- **Stop**: a session that produces 0–2 entries is fine — the wiki resists growth
+
+Never auto-rerun. The user's attention is the gating resource.
+
+## Hard constraints
+
+- **Never auto-promote.** The skill surfaces and fact-checks; the user gates. Fully automated promotion recreates the collector's fallacy at speed.
+- **Never bulk-propose.** One candidate per turn. The "attention is sacred" rule applies to the curation decision itself.
+- **Never skip fact-checking.** Surfacing a candidate without verification wastes the user's gate decision.
+- **Never edit the wiki without explicit approval.** Even side-effects are gated.
+- **Never delete entries.** Use `invalid_at` to close.
+
+## Reference design
+
+The original design rationale, MUSTIE framework treatment, fact-checking lens taxonomy, anti-patterns, and the open questions that informed the governance rule live at:
+
+- `~/projects/ralph-hero/thoughts/shared/research/2026-05-06-personal-wiki-curator-design.md`
+
+Read this if you need deeper reasoning on why a particular gate exists or how to handle an edge case the workflow doesn't cover.

--- a/plugin/ralph-knowledge/src/__tests__/db.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/db.test.ts
@@ -633,6 +633,16 @@ describe("schema v3: memory_tier column", () => {
     expect(row.memory_tier).toBe("reflection");
   });
 
+  it("accepts 'wiki' memory_tier values (schema v4)", () => {
+    expect(() => {
+      db.db.prepare(
+        "INSERT INTO documents (id, path, title, date, type, status, github_issue, content, is_stub, memory_tier) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 'wiki')"
+      ).run("wiki-doc", "wiki/path.md", "Wiki Entry", null, null, null, null, "");
+    }).not.toThrow();
+    const row = db.db.prepare("SELECT memory_tier FROM documents WHERE id = ?").get("wiki-doc") as { memory_tier: string };
+    expect(row.memory_tier).toBe("wiki");
+  });
+
   it("rejects invalid memory_tier values via CHECK constraint", () => {
     expect(() => {
       db.db.prepare(
@@ -685,6 +695,66 @@ describe("schema v3: memory_tier column", () => {
       .prepare("SELECT memory_tier FROM documents WHERE id = ?")
       .get("existing") as { memory_tier: string };
     expect(row.memory_tier).toBe("doc");
+    migrated.close();
+  });
+
+  it("rebuilds documents table to accept 'wiki' tier when migrating from old v3 CHECK (schema v4)", () => {
+    // Simulate a database that ran the original v3 migration, where the CHECK
+    // constraint allowed only ('doc','raw','reflection'). The new code should
+    // detect this and rebuild the table with the v4 CHECK that includes 'wiki'.
+    const dir = mkdtempSync(join(tmpdir(), "knowledge-v4-migration-"));
+    const dbPath = join(dir, "legacy-v3.db");
+
+    const rawDb = new Database(dbPath);
+    rawDb.exec(`
+      CREATE TABLE documents (
+        id TEXT PRIMARY KEY, path TEXT, title TEXT, date TEXT, type TEXT,
+        status TEXT, github_issue INTEGER, content TEXT, is_stub INTEGER DEFAULT 0,
+        memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))
+      );
+      CREATE TABLE tags (doc_id TEXT REFERENCES documents(id) ON DELETE CASCADE, tag TEXT, PRIMARY KEY (doc_id, tag));
+      CREATE TABLE relationships (
+        source_id TEXT REFERENCES documents(id) ON DELETE CASCADE,
+        target_id TEXT REFERENCES documents(id) ON DELETE CASCADE,
+        type TEXT CHECK(type IN ('builds_on', 'tensions', 'superseded_by', 'post_mortem', 'untyped')),
+        context TEXT,
+        PRIMARY KEY (source_id, target_id, type)
+      );
+      CREATE TABLE outcome_events (
+        id TEXT PRIMARY KEY, event_type TEXT NOT NULL, issue_number INTEGER NOT NULL,
+        session_id TEXT, timestamp TEXT NOT NULL, duration_ms INTEGER, verdict TEXT,
+        component_area TEXT, estimate TEXT, drift_count INTEGER, model TEXT,
+        agent_type TEXT, iteration_count INTEGER, payload TEXT DEFAULT '{}'
+      );
+      CREATE TABLE sync (path TEXT PRIMARY KEY, mtime INTEGER NOT NULL, indexed_at INTEGER NOT NULL);
+      CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+      INSERT INTO documents (id, path, title, content, memory_tier)
+        VALUES ('reflection-doc', 'reflections/r.md', 'Old Reflection', 'old', 'reflection');
+    `);
+    rawDb.close();
+
+    const migrated = new KnowledgeDB(dbPath);
+
+    // Existing data is preserved across the rebuild.
+    const preserved = migrated.db
+      .prepare("SELECT memory_tier FROM documents WHERE id = ?")
+      .get("reflection-doc") as { memory_tier: string };
+    expect(preserved.memory_tier).toBe("reflection");
+
+    // 'wiki' tier is now accepted after the v4 migration.
+    expect(() => {
+      migrated.db.prepare(
+        "INSERT INTO documents (id, path, title, date, type, status, github_issue, content, is_stub, memory_tier) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 'wiki')"
+      ).run("wiki-after-migration", "wiki/x.md", "Wiki Entry", null, null, null, null, "");
+    }).not.toThrow();
+
+    // Garbage values still rejected.
+    expect(() => {
+      migrated.db.prepare(
+        "INSERT INTO documents (id, path, title, date, type, status, github_issue, content, is_stub, memory_tier) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 'garbage')"
+      ).run("bad", "bad.md", "Bad", null, null, null, null, "");
+    }).toThrow();
+
     migrated.close();
   });
 });

--- a/plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/memory-stats.test.ts
@@ -99,8 +99,8 @@ describe("knowledge_memory_stats", () => {
 
     const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
     expect(out.total_documents).toBe(6);
-    expect(out.by_tier).toEqual({ doc: 2, raw: 3, reflection: 1 });
-    expect(out.new_since).toEqual({ doc: 2, raw: 3, reflection: 1 });
+    expect(out.by_tier).toEqual({ doc: 2, raw: 3, reflection: 1, wiki: 0 });
+    expect(out.new_since).toEqual({ doc: 2, raw: 3, reflection: 1, wiki: 0 });
   });
 
   it("computes chunks_per_doc_p50 and _p90 correctly on [1,2,3,4,5]", async () => {
@@ -157,8 +157,8 @@ describe("knowledge_memory_stats", () => {
 
     const out = await callStats(server, { since: "2026-04-01T00:00:00Z" });
     expect(out.total_documents).toBe(4);
-    expect(out.by_tier).toEqual({ doc: 2, raw: 2, reflection: 0 });
-    expect(out.new_since).toEqual({ doc: 1, raw: 1, reflection: 0 });
+    expect(out.by_tier).toEqual({ doc: 2, raw: 2, reflection: 0, wiki: 0 });
+    expect(out.new_since).toEqual({ doc: 1, raw: 1, reflection: 0, wiki: 0 });
   });
 
   it("defaults `since` to ~24h ago when not provided", async () => {
@@ -196,7 +196,7 @@ describe("knowledge_memory_stats", () => {
 
     const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
     expect(out.total_documents).toBe(1);
-    expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0 });
+    expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0, wiki: 0 });
     expect(out.chunks_per_doc_p50).toBe(0);
     expect(out.chunks_per_doc_p90).toBe(0);
     expect(out.last_reflection_at).toBeNull();
@@ -219,9 +219,9 @@ describe("knowledge_memory_stats", () => {
 
       const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
       expect(out.total_documents).toBe(2);
-      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 1 });
+      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 1, wiki: 0 });
       // new_since unaffected — stubs have date = NULL and never count regardless.
-      expect(out.new_since).toEqual({ doc: 1, raw: 0, reflection: 1 });
+      expect(out.new_since).toEqual({ doc: 1, raw: 0, reflection: 1, wiki: 0 });
     });
 
     it("excludes stubs from total on a v2 schema (column absent)", async () => {
@@ -244,7 +244,7 @@ describe("knowledge_memory_stats", () => {
 
       const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
       expect(out.total_documents).toBe(1);
-      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0 });
+      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0, wiki: 0 });
     });
 
     it("typed-relationship stubs are filtered identically to untyped wikilink stubs", async () => {
@@ -259,7 +259,7 @@ describe("knowledge_memory_stats", () => {
 
       const out = await callStats(server, { since: "1970-01-01T00:00:00Z" });
       expect(out.total_documents).toBe(1);
-      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0 });
+      expect(out.by_tier).toEqual({ doc: 1, raw: 0, reflection: 0, wiki: 0 });
     });
 
     it("last_reflection_at ignores stubs even if a stub somehow had a date and reflection tier", async () => {

--- a/plugin/ralph-knowledge/src/__tests__/parser.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/parser.test.ts
@@ -457,6 +457,12 @@ describe("parseDocument memory_tier", () => {
     expect(doc.memoryTier).toBe("doc");
   });
 
+  it("extracts memory_tier: wiki from frontmatter", () => {
+    const raw = makeDoc("date: 2026-05-08\ntype: wiki\nmemory_tier: wiki");
+    const doc = parseDocument("test-wiki", "thoughts/wiki/test-wiki.md", raw);
+    expect(doc.memoryTier).toBe("wiki");
+  });
+
   it("defaults memory_tier to 'doc' when frontmatter omits the key", () => {
     const raw = makeDoc("date: 2026-04-29\ntype: research");
     const doc = parseDocument("test-default", "thoughts/shared/research/test-default.md", raw);

--- a/plugin/ralph-knowledge/src/db.ts
+++ b/plugin/ralph-knowledge/src/db.ts
@@ -183,12 +183,13 @@ export class KnowledgeDB {
       // Column already exists — expected for new databases
     }
 
-    // Migration: add memory_tier column (schema v3) for databases created before it existed.
+    // Migration: add memory_tier column (schema v3+) for databases created before it existed.
     // Uses the same try/catch pattern as is_stub. CHECK constraint restricts values to
-    // 'doc' (existing documents), 'raw' (dream-loop raw memories), 'reflection' (synthesized).
+    // 'doc' (existing documents), 'raw' (dream-loop raw memories), 'reflection' (synthesized),
+    // 'wiki' (curated personal wiki tier — schema v4).
     try {
       this.db.exec(
-        "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection'))"
+        "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection','wiki'))"
       );
     } catch {
       // Column already exists — expected for new databases
@@ -196,6 +197,40 @@ export class KnowledgeDB {
     this.db.exec(
       "CREATE INDEX IF NOT EXISTS idx_documents_memory_tier ON documents(memory_tier)"
     );
+
+    // Migration v4: expand memory_tier CHECK constraint to allow 'wiki' tier.
+    // SQLite cannot ALTER an existing CHECK constraint; on databases that ran the
+    // earlier v3 migration (CHECK with only 'doc','raw','reflection') the ALTER above
+    // throws "duplicate column" and the old CHECK stays in place. Detect that via
+    // sqlite_master and rebuild the table when 'wiki' is missing from the schema text.
+    try {
+      const tableSchema = this.db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='documents'")
+        .get() as { sql: string } | undefined;
+      if (tableSchema && !tableSchema.sql.includes("'wiki'")) {
+        this.db.exec(`
+          CREATE TABLE documents_v4 (
+            id TEXT PRIMARY KEY,
+            path TEXT,
+            title TEXT,
+            date TEXT,
+            type TEXT,
+            status TEXT,
+            github_issue INTEGER,
+            content TEXT,
+            is_stub INTEGER DEFAULT 0,
+            memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection','wiki'))
+          );
+          INSERT INTO documents_v4 (id, path, title, date, type, status, github_issue, content, is_stub, memory_tier)
+            SELECT id, path, title, date, type, status, github_issue, content, is_stub, memory_tier FROM documents;
+          DROP TABLE documents;
+          ALTER TABLE documents_v4 RENAME TO documents;
+          CREATE INDEX IF NOT EXISTS idx_documents_memory_tier ON documents(memory_tier);
+        `);
+      }
+    } catch {
+      // Schema introspection failed or table layout already compliant — no-op.
+    }
 
     // Migration: rebuild relationships table for databases created before the
     // context column, post_mortem/untyped CHECK types, and target_id FK were added.

--- a/plugin/ralph-knowledge/src/index.ts
+++ b/plugin/ralph-knowledge/src/index.ts
@@ -103,10 +103,10 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
       includeSuperseded: z.boolean().optional().describe("Include superseded documents (default: false)"),
       brief: z.boolean().optional().describe("Return minimal metadata only (default: false)"),
       memory_tier: z
-        .enum(["doc", "raw", "reflection", "any"])
+        .enum(["doc", "raw", "reflection", "wiki", "any"])
         .optional()
         .default("any")
-        .describe("Filter by memory tier: 'doc' (curated), 'raw' (dream-loop ingest), 'reflection' (synthesized), 'any' (default)"),
+        .describe("Filter by memory tier: 'doc' (curated), 'raw' (dream-loop ingest), 'reflection' (synthesized), 'wiki' (personal wiki entries), 'any' (default)"),
       return_chunk_meta: z
         .boolean()
         .optional()
@@ -206,7 +206,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
       direction: z.enum(["outgoing", "incoming"]).optional().describe("Edge direction (default: outgoing)"),
       brief: z.boolean().optional().describe("Return minimal metadata only (default: false)"),
       memory_tier: z
-        .enum(["doc", "raw", "reflection", "any"])
+        .enum(["doc", "raw", "reflection", "wiki", "any"])
         .optional()
         .default("any")
         .describe("Filter traversed nodes by memory tier (default: 'any')"),
@@ -253,15 +253,17 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
           .get() as { c: number };
         const totalDocuments = totalRow.c;
 
-        const byTier: Record<"doc" | "raw" | "reflection", number> = {
+        const byTier: Record<"doc" | "raw" | "reflection" | "wiki", number> = {
           doc: 0,
           raw: 0,
           reflection: 0,
+          wiki: 0,
         };
-        const newSince: Record<"doc" | "raw" | "reflection", number> = {
+        const newSince: Record<"doc" | "raw" | "reflection" | "wiki", number> = {
           doc: 0,
           raw: 0,
           reflection: 0,
+          wiki: 0,
         };
 
         if (hasTier) {
@@ -274,7 +276,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
             )
             .all() as Array<{ tier: string; c: number }>;
           for (const r of rows) {
-            if (r.tier === "doc" || r.tier === "raw" || r.tier === "reflection") {
+            if (r.tier === "doc" || r.tier === "raw" || r.tier === "reflection" || r.tier === "wiki") {
               byTier[r.tier] = r.c;
             }
           }
@@ -287,7 +289,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
             )
             .all({ since }) as Array<{ tier: string; c: number }>;
           for (const r of newRows) {
-            if (r.tier === "doc" || r.tier === "raw" || r.tier === "reflection") {
+            if (r.tier === "doc" || r.tier === "raw" || r.tier === "reflection" || r.tier === "wiki") {
               newSince[r.tier] = r.c;
             }
           }

--- a/plugin/ralph-knowledge/src/parser.ts
+++ b/plugin/ralph-knowledge/src/parser.ts
@@ -36,8 +36,8 @@ const WIKILINK_RE = /\[\[([^\]]+)\]\]/g;
 const FENCED_CODE_RE = /```[\s\S]*?```/g;
 
 // Allowed memory_tier values mirror the SQL CHECK constraint in db.ts
-// (schema v3). The parser is forgiving: invalid/absent values coerce to 'doc'.
-const ALLOWED_MEMORY_TIERS = new Set<string>(["doc", "raw", "reflection"]);
+// (schema v4). The parser is forgiving: invalid/absent values coerce to 'doc'.
+const ALLOWED_MEMORY_TIERS = new Set<string>(["doc", "raw", "reflection", "wiki"]);
 
 const PATH_TYPE_MAP: Array<{ segment: string; type: string }> = [
   { segment: "/research/", type: "research" },
@@ -127,8 +127,8 @@ export function parseDocument(id: string, path: string, raw: string): ParsedDocu
 
   const tags: string[] = Array.isArray(frontmatter.tags) ? frontmatter.tags.map(String) : [];
 
-  // memory_tier extraction: validate against the three allowed values from
-  // schema v3's CHECK constraint. Absent/null values default to 'doc'. Invalid
+  // memory_tier extraction: validate against the four allowed values from
+  // schema v4's CHECK constraint. Absent/null values default to 'doc'. Invalid
   // values coerce to 'doc' with a single warning so the indexer never crashes
   // on garbage frontmatter — the SQL CHECK is the hard guard.
   const rawMemoryTier = frontmatter.memory_tier;
@@ -138,7 +138,7 @@ export function parseDocument(id: string, path: string, raw: string): ParsedDocu
       memoryTier = rawMemoryTier;
     } else {
       console.warn(
-        `memory_tier '${String(rawMemoryTier)}' on '${id}' is not one of doc|raw|reflection — coercing to 'doc'`,
+        `memory_tier '${String(rawMemoryTier)}' on '${id}' is not one of doc|raw|reflection|wiki — coercing to 'doc'`,
       );
     }
   }

--- a/plugin/ralph-knowledge/src/search.ts
+++ b/plugin/ralph-knowledge/src/search.ts
@@ -1,6 +1,6 @@
 import type { KnowledgeDB } from "./db.js";
 
-export type MemoryTier = "doc" | "raw" | "reflection" | "any";
+export type MemoryTier = "doc" | "raw" | "reflection" | "wiki" | "any";
 
 export interface SearchOptions {
   type?: string;

--- a/thoughts/shared/research/2026-05-06-personal-wiki-curator-design.md
+++ b/thoughts/shared/research/2026-05-06-personal-wiki-curator-design.md
@@ -1,0 +1,210 @@
+---
+date: 2026-05-06
+status: complete
+type: research
+tags: [dream-loop, ralph-knowledge, personal-wiki, information-science, memory-tier, curator, fact-checking]
+---
+
+# Personal Wiki as Curator: Design Report for the Third Memory Tier
+
+## Prior Work
+
+- builds_on:: dream-loop infrastructure (raw + reflection tiers) — see `~/projects/CLAUDE.md` "ralph-knowledge dream-loop bootstrap"
+- builds_on:: [[2026-04-26-dreaming-research-trail-and-self-containment]]
+- builds_on:: GH-0761 dream-loop plan
+- tensions:: Existing thoughts corpus is already large and pseudo-curated; the strict "wait for ~150 reflections" threshold from this report may not apply to a user who has been hand-writing research/plans/ideas for months.
+
+## Problem Statement
+
+The dream-loop today has two memory tiers: **raw** (everything ingested — git commits, gemma sessions, voice memos) and **reflection** (clustered synthesis written nightly by Gemma 4 26B). The user wants a third tier — a **curated personal wiki** — that sits above reflections.
+
+Pain points driving the design:
+
+1. **"Attention is sacred"** — when looking something up, the answer must be fast AND trustworthy. A wrong answer at 200ms is worse than no answer. A correct answer buried in 40 reflections is also failure.
+2. **Curator, not collector** — the wiki should *resist* growth. Most reflections must NOT graduate. Need explicit promotion criteria.
+3. **Fact-checker** — entries must have provenance and a mechanism to detect when they go stale or get contradicted by newer raw memories.
+
+This document is the information-science-grounded research that should inform the design before any implementation begins.
+
+---
+
+## Top 5 Ideas to Pull Into the Design
+
+### Idea 1: Apply the CREW/MUSTIE weeding standard to *promotion*, not just removal
+
+Libraries have a battle-tested heuristic called [CREW (Continuous Review, Evaluation, and Weeding)](https://www.tsl.texas.gov/ld/pubs/crew/index.html), governed by the MUSTIE acronym: **M**isleading, **U**gly, **S**uperseded, **T**rivial, **I**rrelevant, **E**lsewhere-obtained. The insight worth stealing is that weeding is *continuous and scheduled*, not an annual event. More importantly, it is *symmetric*: the same criteria that trigger removal from a physical library are the criteria that should block promotion to your wiki in the first place.
+
+Before promoting a reflection, run it through MUSTIE in reverse: is it *accurate*, *well-formed*, *not superseded*, *non-trivial*, *relevant to recurring decisions*, and *not already covered by an existing canonical entry*? This gives you a six-gate promotion checklist that takes five seconds per candidate and produces a defensible "no" 80% of the time — which is exactly what you want from a system that resists growth.
+
+### Idea 2: Adopt Graphiti/Zep's edge-invalidation model as your provenance schema
+
+The [Zep temporal knowledge graph architecture](https://arxiv.org/abs/2501.13956) (Jan 2025) uses bi-temporal modeling to track *when a fact was true* (`valid_time`/`invalid_time`) separately from *when it was recorded* (`created_at`/`expired_at`). When a new episode contradicts an old fact, the old edge gets `invalid_at` stamped — it is not deleted, it is *closed*.
+
+This maps cleanly onto the existing pipeline: each wiki entry gets `valid_from` (when supporting evidence first accumulated) and `invalid_at` (null if still live). Nightly, the dream-loop's ingest step can flag contradictions between incoming raw memories and open wiki-entry claims. Far more tractable than full RDF reification or PROV-O — three timestamp columns per entry, not a new ontology. The [PAV ontology](https://pav-ontology.github.io/pav/) (Provenance, Authoring, Versioning) offers an even lighter-weight schema if you want named fields: `pav:createdOn`, `pav:lastUpdatedOn`, `pav:derivedFrom`.
+
+### Idea 3: Borrow Google's knowledge-panel contract — one lede sentence that can stand alone
+
+[Google's Knowledge Panels](https://www.nngroup.com/articles/key-serp-features/) and featured snippets operate on the principle that the answer to a well-formed question should be *completeable without a click*. The cognitive argument for this in personal retrieval is stronger than in web search: Gloria Mark's research found the average attention window on screens has collapsed to [47 seconds](https://gloriamark.com/attention-span/), and each interruption to look something up costs [23 minutes of recovery time from deep work](https://ics.uci.edu/~gmark/chi08-mark.pdf).
+
+Wiki entries need a *contract*: the first sentence (the lede) must answer the question a future-you will ask in full. Everything below is context for the 10% of cases where you need more. This is a structural constraint, not a style suggestion — enforce in the promotion gate: a candidate cannot become a wiki entry unless it can be summarized as a single declarative sentence.
+
+### Idea 4: Use Matuschak's "atomic + densely linked" test as a gate for entry scope
+
+Andy Matuschak's [evergreen note principles](https://notes.andymatuschak.org/Evergreen_notes) prescribe that a note should be concept-oriented (one idea, one note), atomic (self-contained without its source context), and densely linked. The mistake most people make is conflating *topic pages* (broad, shallow) with *evergreen entries* (narrow, deep, connected).
+
+For the wiki: a reflection about "my approach to GraphQL error handling in production" is promotable; a reflection titled "backend architecture thoughts" is not. The practical gate: if an entry would require a disambiguation page or contains the word "and" in its title concept, it is two entries or none. Apply mechanically. The [atomicity principle from Zettelkasten](https://zettelkasten.de/posts/concepts-sohnke-ahrens-explained/) adds a sharpness test: the entry is promotable when you can re-express it in your own words without referring back to the source.
+
+### Idea 5: Treat the wiki as a "Map of Content" surface, not a flat store
+
+Obsidian's [MOC (Map of Content) pattern](https://obsidian.rocks/maps-of-content-effortless-organization-for-notes/) draws a distinction between *index notes* (mechanical lists of links) and *MOC notes* (opinionated, curated entry-points that impose structure on a cluster of ideas). The wiki should contain mostly MOC-style entries — not encyclopedic articles but *navigational stances* that answer "what is my current understanding of X, and where do I look for the details?"
+
+This keeps entries short (three to eight bullet points plus backlinks) and resilient to staleness, because the entry itself rarely contains facts — it contains pointers to the facts. The MOC entry on "memory pipeline design" might say: "I believe three tiers are right; see raw-ingest, reflection-clustering, and this wiki-entry. The key unsettled question is promotion criteria." That sentence won't go stale. The supporting detail lives in reflections.
+
+---
+
+## Promotion Criteria Menu
+
+Concrete signals for "this reflection should become a wiki entry." Apply as a checklist; require a minimum of three "yes" answers:
+
+- **Recurrence signal**: The same concept appears in three or more separate reflection clusters over different time windows. One-time insights are ephemeral; recurring ones are structural.
+- **Decision dependency**: The knowledge is something you would want to look up *before making a consequential decision*, not after. (E.g., "which Gemma model variant is fastest for summarization" yes; "what the Gemma 4 changelog said in April 2026" no.)
+- **Atomicity test**: The candidate can be expressed as a single non-compound sentence. Fails if it requires "and also."
+- **Temporal durability**: The underlying fact is not expected to change on a weekly or monthly cadence. (Architecture preferences, yes. Library version numbers, no.)
+- **Cross-context applicability**: The insight is useful across at least two different projects or problem domains, not just the current one. (Matuschak's "use in a completely different situation" test.)
+- **Lede writability**: You can write the first sentence right now without looking anything up. If you can't, the cluster needs more raw evidence first.
+- **No existing canonical entry**: An existing entry doesn't already cover the same ground. Duplication is a signal to *update* an existing entry, not create a new one.
+- **MUSTIE pass**: Accurate, well-formed, not superseded by newer raw memory, non-trivial, relevant to your actual work, not better described elsewhere.
+
+**Anti-criteria (auto-reject):**
+- Contains a date reference that will make it false within six months
+- Names a specific person in a non-pattern way (gossip, not insight)
+- Describes a completed one-off decision ("we chose Postgres for project X in 2024")
+- Was generated from a single raw-memory event with no corroboration
+
+---
+
+## Fact-Checking Mechanisms (Ranked by Effort vs Payoff)
+
+### High payoff, low effort
+
+- **Contradiction flag in nightly ingest**: During `ingest.py`, after embedding, do a cosine-similarity search against wiki-entry embeddings. If a new raw memory has similarity > 0.85 to an existing entry AND contains negating language ("actually", "turns out", "no longer", "deprecated", "changed"), append a `?contradicted_by` backlink to the entry and surface it in the next morning's summary. One SQL query + a regex.
+- **`valid_from` / `invalid_at` timestamps on every entry**: Follow Zep's [bi-temporal edge model](https://arxiv.org/html/2501.13956v1). Never delete an entry; instead stamp `invalid_at` when closing it. A nightly report of entries with `invalid_at IS NULL AND valid_from < NOW() - interval '180 days'` is your review queue.
+- **Source-link rot detection**: If an entry's provenance points to a reflection file, check the file still exists on disk. If the source was a URL, periodic `curl --head`. Dead sources downgrade an entry's trust level automatically.
+
+### Medium effort, high payoff
+
+- **Gemma-powered contradiction scan**: Once a week, pass each wiki entry plus topically-related raw memories from the past seven days (via vector search) to Gemma with the prompt: "Does any of this new evidence contradict or update the claim: [entry lede]? Answer yes/no and quote the contradicting passage if yes." Flag entries that get a "yes." One extra step in `reflect.py` or a new `audit.py`.
+- **`review_cadence` field per entry**: Assign each entry to one of three cadences: `quarterly` (stable facts), `monthly` (practices that evolve), `weekly` (fast-moving areas like model performance). Nightly pipeline checks if overdue and surfaces. Modeled loosely on Wikipedia's [article assessment cycles](https://en.wikipedia.org/wiki/Wikipedia:Verifiability).
+- **"Assertion inventory" per entry**: Enumerate the explicit factual claims in an entry (numbered sentences). Each claim gets its own `last_verified` date. Wikipedia's verifiability discipline applied at granularity of the claim, not the page.
+
+### Higher effort, conditional payoff
+
+- **Full PAV/PROV-O provenance trail**: Track `pav:derivedFrom` (which reflection cluster), `pav:createdOn`, `pav:importedFrom` (which raw memory files). Worth doing if you plan to query provenance in the MCP layer for ranking. Overhead: add three columns to the wiki entries table and populate at promotion time.
+
+---
+
+## Speed/Accuracy Patterns (Enforcing "Attention is Sacred")
+
+- **Lede-first contract (mandatory)**: Every wiki entry begins with one declarative sentence that fully answers its title's question. No context, no hedging. The lede is what gets returned by default in MCP tool responses. The full entry body is only surfaced on explicit request. Featured-snippet pattern applied to personal retrieval — [NN/G's research](https://www.nngroup.com/articles/key-serp-features/) shows users satisfy informational queries from SERP features without clicking through when the answer is complete at a glance.
+- **Confidence tier in retrieval response**: Return not just the entry but a `confidence` field: `canonical` (entry exists, `invalid_at IS NULL`, no contradiction flag), `stale` (entry exists but overdue or has contradiction flag), `absent` (no wiki entry — return top two reflections instead, labeled as such). "I don't know" is a first-class response; returning a stale reflection as if it were canonical is the failure mode you're optimizing against.
+- **Hard entry-length limit**: Cap wiki entries at 150 words of body text (not counting backlinks). Entries that exceed this are not edited — they are *split*. Length is inversely correlated with lookup speed and directly correlated with staleness surface area.
+- **No lists longer than five items**: A list of seven "considerations" is not a wiki entry; it is an unfinished reflection. Force the author (you, or the promotion pipeline) to synthesize the list into a sentence or cut to the three most durable items.
+- **Two-second rule for the MCP tool**: The `ralph_hero__` tool that queries the wiki should return in under two seconds. If it doesn't, you'll stop using it under time pressure. This means the wiki lives in the same SQLite database as reflections, with a dedicated `memory_tier=wiki` value and a pre-built FTS index on entry titles and ledes.
+- **"No result" beats wrong result**: The MCP layer should never silently fall back from wiki to reflections without marking the degradation. If a wiki query returns nothing, say so, and surface the best two reflections with their tier labeled. The user then decides whether to trust the lower-tier answer.
+
+---
+
+## Anti-Patterns to Avoid
+
+Documented failure modes of personal knowledge systems — particularly relevant because most "second brain" collapses are caused by growth, not gaps.
+
+- **The Collector's Fallacy** (Christian Tietze at [zettelkasten.de](https://zettelkasten.de/posts/concepts-sohnke-ahrens-explained/)): Capturing information feels like learning it. The wiki becomes a graveyard of promoted-but-never-used entries. Counter-measure: an entry with zero lookup events in 90 days gets automatically flagged for demotion back to reflection.
+- **Hierarchical rot**: Starting with folders or categories that later become structurally wrong. Every note in the wrong folder is harder to find than a note with no folder. The [Dendron team calls this](https://blog.dendron.so/notes/072ed07tikrhv6e4ilwcv2q/) "the hierarchy trap." Use flat namespace + tags + backlinks, not folder hierarchies, for the wiki tier.
+- **Promoting decisions, not insights**: A decision made in a specific context ("chose Redis for project X for reason Y") is not a wiki entry. A pattern that generalizes from that decision ("Redis is preferable over Memcached when TTL-per-key granularity matters") is. The test: strip all project names and dates from the entry. If it still makes sense, it's promotable.
+- **Letting the pipeline drive the wiki**: Automated promotion from reflections without a human gate produces an automated version of the collector's fallacy. The pipeline should *surface candidates* and *score them*, but a human (even a 10-second "yes/no" decision) should trigger promotion. Fully autonomous promotion contradicts the stated goal of a curator, not a collector.
+- **Stale provenance chain**: An entry citing a reflection that no longer exists (because you moved or renamed the dream-memory file) silently loses trustworthiness. Enforce referential integrity at promotion time. If the source file is gone, the entry is unverifiable and should be flagged.
+- **Treating the wiki as a writing project**: The [common second-brain failure](https://medium.com/@BitsOfChris/self-organizing-second-brain-how-i-manage-information-overload-2266bd0d9e27) is spending more time on the system than on actual work. The wiki should be a lookup surface, not a creative writing exercise. Time-box entry writing to 90 seconds. If you can't write the lede in 90 seconds, the cluster is not ready.
+
+---
+
+## Governance Rule (Decided 2026-05-06 During First Iteration)
+
+**The wiki is for knowledge whose source of truth lives outside the code surface we operate on.** If the code we maintain is the truth, do not promote facts about it — that creates duplication that drifts. Internal product documentation belongs in CLAUDE.md, code comments, and in-repo docs; the wiki is for things you genuinely cannot `grep` your way to.
+
+**Eligible**: external platform behavior (Claude Code, GitHub API), library quirks, information science principles, personal design heuristics, lessons from external constraints.
+
+**Ineligible**: ralph-hero internal architecture, our state machines, our MCP tool behavior, our sync logic, our configurations — read the code.
+
+**Operational test**: "If I needed to know this tomorrow, would I `grep` our repo or look it up externally?" If grep → reject. If external → promotable.
+
+This rule supersedes the looser "atomic axiom from the corpus" framing. The first three candidates of the first iteration revealed the issue: candidate #3 (ralph-hero Status sync is unidirectional) was technically true and well-corroborated, but its source of truth lives in `workflow-states.ts` — promoting it would shadow the code. Rejected.
+
+---
+
+## Open Questions (Decide Before Building)
+
+These are design forks with no correct answer without your call. Don't let the pipeline decide implicitly.
+
+1. **Who triggers promotion?** Three models: (a) fully automated pipeline based on scored signals, (b) pipeline surfaces candidates, human approves with a single keystroke, (c) human-only promotion (pipeline does nothing). Model (a) recreates the collector's fallacy at speed. Model (c) will be abandoned within two weeks. Model (b) is the safest default — but requires defining what a "promotion UI" looks like in your tooling.
+
+2. **What is the demarcation between a wiki entry and a reflection?** Specifically: can a reflection *become* a wiki entry (promotion is a tier change on the same document), or does promotion *create a new document* (the reflection stays as-is and a new wiki entry is derived)? The copy-on-promotion model preserves provenance and lets the entry diverge from the source; the in-place-upgrade model is simpler but risks losing the original synthesis.
+
+3. **How do you handle entries that are true but context-dependent?** E.g., "Gemma 4 26B is fastest for summarization" is true in May 2026 on your hardware at your quantization level. The wiki entry is not universally true — it is true *for you, now*. Do entries carry a `scope` field (personal, team, universal)? If not, you will silently serve locally-true answers as if they were globally true.
+
+4. **What is the retention policy for invalidated entries?** When `invalid_at` is stamped, does the entry remain queryable (returned with a "stale" badge), get demoted to reflection tier, or become fully archived (not returned by default)? Affects whether historical queries are possible and how much cognitive noise stale entries add.
+
+5. **What is the minimum corpus size before the wiki is useful?** Building the wiki-entry writing habit before there are enough reflections to draw from is premature optimization. A rough threshold: the wiki tier probably should not exist until the reflection tier has at least 150 entries across at least six months of nightly runs. Before that, the reflection tier is your canonical tier. **However**, this threshold assumes the dream-loop reflection tier is the *only* source. If the existing hand-written `thoughts/shared/` corpus (research, plans, ideas across all repos — ~3200 documents as of 2026-05-06) is treated as an alternate source, the threshold may already be met via that path. See "Bootstrap Path" below.
+
+---
+
+## Bootstrap Path: Existing Thoughts Corpus as a Pre-Filled Reflection Tier
+
+(Added 2026-05-06 after corpus inventory.)
+
+The original "150 reflections / 6 months" threshold was framed assuming the dream-loop is the *only* source feeding the wiki. The current state is more nuanced:
+
+| Source | Count (2026-05-06) | Notes |
+|---|---|---|
+| Dream-loop raw memories | 17 | Spans 2026-04-26 → 2026-05-02 |
+| Dream-loop reflections | 4 | All from a single day (2026-05-03) |
+| `~/projects/thoughts/` (global) | 453 .md | Hand-written |
+| `ralph-hero/thoughts/` | 1013 .md | Hand-written |
+| `landcrawler-ai/thoughts/` | 1336 .md | Hand-written |
+| `ralph-engine/thoughts/` | 396 .md | Hand-written |
+
+The dream-loop reflection tier is far below threshold (4, needs ~150). But the user has been hand-writing research/plans/ideas for months — these are *already* a form of curated synthesis, just unstructured for fast lookup.
+
+Two viable paths forward:
+
+**Path A — Wait for dream-loop maturation.** Run the loop nightly; revisit wiki tier when reflections cross ~150 across ≥3 months. Conservative, low-bootstrap-cost, but means months of waiting. The wiki tier exists nowhere during that window.
+
+**Path B — Bootstrap from existing thoughts corpus.** Treat hand-written `thoughts/shared/research/` and `thoughts/shared/plans/` as an alternate "reflection-equivalent" source. Build the wiki tier infrastructure now (schema, MCP tool, lede-first contract, MUSTIE gate), seed with a small handful (5–10) of high-confidence promotions hand-picked from existing thoughts, and let both the dream-loop and manual promotion feed it over time. The risk: existing thoughts are not atomic in the Matuschak sense — they are long-form research docs. Most will fail the lede-writability gate. This is a feature, not a bug — it surfaces which existing docs are actually canonical-grade.
+
+Recommendation: **Path B with discipline**. Build the infra; seed with no more than 10 entries from existing thoughts; require all 10 to pass the full MUSTIE gate AND lede-writability AND atomicity test. If fewer than 5 pass the gate, defer to Path A — the wiki tier isn't ready and seeding it with weak entries will train the wrong habits.
+
+---
+
+## Sources
+
+- [Fleeting to Permanent notes — Zettelkasten Forum](https://forum.zettelkasten.de/discussion/3142/fleeting-to-permanent-notes)
+- [From Fleeting Notes to Project Notes — Zettelkasten.de](https://zettelkasten.de/posts/concepts-sohnke-ahrens-explained/)
+- [Evergreen notes — Andy Matuschak](https://notes.andymatuschak.org/Evergreen_notes)
+- [Evergreen note-writing as fundamental unit of knowledge work — Andy Matuschak](https://notes.andymatuschak.org/Evergreen_note-writing_as_fundamental_unit_of_knowledge_work)
+- [The Cost of Interrupted Work: More Speed and Stress — Gloria Mark, CHI 2008 (PDF)](https://ics.uci.edu/~gmark/chi08-mark.pdf)
+- [Attention Span — Gloria Mark](https://gloriamark.com/attention-span/)
+- [Three Key SERP Features: Featured Snippets, People Also Ask, and Knowledge Panels — NN/G](https://www.nngroup.com/articles/key-serp-features/)
+- [Progressive Disclosure — NN/G](https://www.nngroup.com/articles/progressive-disclosure/)
+- [Wikipedia: Verifiability](https://en.wikipedia.org/wiki/Wikipedia:Verifiability)
+- [Zep: A Temporal Knowledge Graph Architecture for Agent Memory (arxiv, Jan 2025)](https://arxiv.org/abs/2501.13956)
+- [Zep Temporal Knowledge Graph Architecture — Graphiti GitHub](https://github.com/getzep/graphiti)
+- [PAV Ontology — Provenance, Authoring and Versioning](https://pav-ontology.github.io/pav/)
+- [PROV-O: The PROV Ontology — W3C](https://www.w3.org/TR/prov-o/)
+- [CREW: A Weeding Manual for Libraries — Texas State Library](https://www.tsl.texas.gov/ld/pubs/crew/index.html)
+- [Collection Maintenance and Weeding — ALA](https://www.ala.org/tools/challengesupport/selectionpolicytoolkit/weeding)
+- [Maps of Content: Effortless organization for notes — Obsidian Rocks](https://obsidian.rocks/maps-of-content-effortless-organization-for-notes/)
+- [The PARA Method — Forte Labs](https://fortelabs.com/blog/para/)
+- [Karpathy LLM Wiki Pattern — MindStudio](https://www.mindstudio.ai/blog/karpathy-llm-wiki-knowledge-base-pattern)
+- [Tagging for Personal Knowledge Management — Forte Labs](https://fortelabs.com/blog/a-complete-guide-to-tagging-for-personal-knowledge-management/)
+- [Growing Knowledge Bases from the Bottom Up — Dendron Blog](https://blog.dendron.so/notes/072ed07tikrhv6e4ilwcv2q/)
+- [Self-Organizing Second Brain — Medium](https://medium.com/@BitsOfChris/self-organizing-second-brain-how-i-manage-information-overload-2266bd0d9e27)
+- [Bitemporal Modeling Overview — Emergent Mind](https://www.emergentmind.com/topics/bitemporal-modeling)

--- a/thoughts/shared/research/2026-05-06-personal-wiki-curator-design.md
+++ b/thoughts/shared/research/2026-05-06-personal-wiki-curator-design.md
@@ -64,6 +64,8 @@ This keeps entries short (three to eight bullet points plus backlinks) and resil
 
 ## Promotion Criteria Menu
 
+> **Note (2026-05-08, post-design):** The criteria below were the *brainstorm* considered during design. The shipped skill (`/ralph-knowledge:curate`) takes a stricter line: it runs a smaller set of all-must-pass gates (outside-code-surface → atomicity → lede-writability → MUSTIE → domain-freshness) in fail-fast order. The "3-of-8 yes answers" model below is preserved as the original research input, not the operational rule. If you want to know what gates the skill actually applies, read SKILL.md Step 5; if you want the menu of considerations we evaluated, read on.
+
 Concrete signals for "this reflection should become a wiki entry." Apply as a checklist; require a minimum of three "yes" answers:
 
 - **Recurrence signal**: The same concept appears in three or more separate reflection clusters over different time windows. One-time insights are ephemeral; recurring ones are structural.
@@ -94,7 +96,7 @@ Concrete signals for "this reflection should become a wiki entry." Apply as a ch
 ### Medium effort, high payoff
 
 - **Gemma-powered contradiction scan**: Once a week, pass each wiki entry plus topically-related raw memories from the past seven days (via vector search) to Gemma with the prompt: "Does any of this new evidence contradict or update the claim: [entry lede]? Answer yes/no and quote the contradicting passage if yes." Flag entries that get a "yes." One extra step in `reflect.py` or a new `audit.py`.
-- **`review_cadence` field per entry**: Assign each entry to one of three cadences: `quarterly` (stable facts), `monthly` (practices that evolve), `weekly` (fast-moving areas like model performance). Nightly pipeline checks if overdue and surfaces. Modeled loosely on Wikipedia's [article assessment cycles](https://en.wikipedia.org/wiki/Wikipedia:Verifiability).
+- **`review_cadence` field per entry**: Assign each entry to one of three cadences: `quarterly` (stable facts; also covers info-science / cognitive principles), `monthly` (practices that evolve), `weekly` (fast-moving areas like model performance). Nightly pipeline checks if overdue and surfaces. Modeled loosely on Wikipedia's [article assessment cycles](https://en.wikipedia.org/wiki/Wikipedia:Verifiability). The shipped skill's frontmatter spec (`SKILL.md` § wiki entry frontmatter spec) uses the same three values verbatim.
 - **"Assertion inventory" per entry**: Enumerate the explicit factual claims in an entry (numbered sentences). Each claim gets its own `last_verified` date. Wikipedia's verifiability discipline applied at granularity of the claim, not the page.
 
 ### Higher effort, conditional payoff


### PR DESCRIPTION
## Summary
- New `/ralph-knowledge:curate` skill — iterative human-gated curator for the third memory tier (above raw and reflection)
- Workflow: hunt → distill → 3-lens fact-check (corpus / external / code) → governance gates → present → gate (y/n/edit) → write or log
- Governance rule: the wiki is for knowledge whose source of truth lives outside the code surface we operate on; never shadow internal docs
- Companion research doc captures full design rationale (MUSTIE applied symmetrically, bi-temporal provenance, lede-first contract, anti-patterns)

## Test plan
- [ ] Restart Claude Code and verify `/ralph-knowledge:curate` is discoverable in the skills list
- [ ] Run `/ralph-knowledge:curate <domain>` against a fresh domain end-to-end
- [ ] Verify governance gates fire correctly (outside-code-surface, atomicity, lede-writability, MUSTIE, domain-freshness)
- [ ] Verify wiki entry frontmatter spec on a real promotion (memory_tier, valid_from, scope, etc.)
- [ ] Verify rejection log JSONL appends correctly on a real rejection
- [ ] Verify side-effect handling: when an entry contradicts a stored memory, the diff is proposed before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)