### PR TITLE
GH-1129: list_issues: remove misleading totalCount field

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
@@ -260,3 +260,23 @@ describe("removed tools verification (GH-454)", () => {
     expect(issueToolsSrc).not.toContain("function computeDistance");
   });
 });
+
+// ---------------------------------------------------------------------------
+// list_issues totalCount removal (GH-1129)
+// ---------------------------------------------------------------------------
+
+describe("list_issues totalCount removal (GH-1129)", () => {
+  it("does not return the misleading totalCount field in the response", () => {
+    // Regression guard: the list_issues toolSuccess call must not include
+    // `totalCount: itemsResult.totalCount` — that value is the unfiltered
+    // project board total and was confusing analysts. See GH-1129.
+    expect(issueToolsSrc).not.toContain("totalCount: itemsResult.totalCount");
+  });
+
+  it("still returns filteredCount derived from formattedItems.length", () => {
+    // Positive guard: filteredCount is the surviving count field and must
+    // remain in the toolSuccess response so callers keep getting an accurate
+    // post-filter count.
+    expect(issueToolsSrc).toContain("filteredCount: formattedItems.length");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -493,7 +493,6 @@ export function registerIssueTools(
         });
 
         return toolSuccess({
-          totalCount: itemsResult.totalCount,
           filteredCount: formattedItems.length,
           items: formattedItems,
         });

--- a/thoughts/shared/plans/2026-05-07-GH-1129-list-issues-totalcount-misleading.md
+++ b/thoughts/shared/plans/2026-05-07-GH-1129-list-issues-totalcount-misleading.md
@@ -58,11 +58,11 @@ The pagination helper (`src/lib/pagination.ts:46-100`) captures `totalCount` fro
 
 ### Verification
 
-- [ ] `ralph_hero__list_issues` response no longer contains a `totalCount` key
-- [ ] `filteredCount` and `items` continue to reflect the post-filter result set unchanged
-- [ ] `npm run build` passes with no errors
-- [ ] `npm test` passes (existing tests unchanged + new regression test green)
-- [ ] No other tool's response shape is altered (only `list_issues`)
+- [x] `ralph_hero__list_issues` response no longer contains a `totalCount` key
+- [x] `filteredCount` and `items` continue to reflect the post-filter result set unchanged
+- [x] `npm run build` passes with no errors
+- [x] `npm test` passes (existing tests unchanged + new regression test green)
+- [x] No other tool's response shape is altered (only `list_issues`)
 
 ## What We're NOT Doing
 
@@ -93,11 +93,11 @@ Delete the `totalCount: itemsResult.totalCount` line from the `toolSuccess` retu
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Line `totalCount: itemsResult.totalCount,` is deleted from the `toolSuccess` call (currently at line 496)
-  - [ ] The remaining `toolSuccess` call returns `{ filteredCount: formattedItems.length, items: formattedItems }`
-  - [ ] No other lines in `issue-tools.ts` are modified — the GraphQL query at line 221 still selects `totalCount` (cosmetic payload field, intentionally left alone)
-  - [ ] `itemsResult.totalCount` is no longer referenced anywhere in the `list_issues` handler scope (may still be referenced inside `paginateConnection` internals — that is fine)
-  - [ ] `npm run build` passes (no TS errors from the change)
+  - [x] Line `totalCount: itemsResult.totalCount,` is deleted from the `toolSuccess` call (currently at line 496)
+  - [x] The remaining `toolSuccess` call returns `{ filteredCount: formattedItems.length, items: formattedItems }`
+  - [x] No other lines in `issue-tools.ts` are modified — the GraphQL query at line 221 still selects `totalCount` (cosmetic payload field, intentionally left alone)
+  - [x] `itemsResult.totalCount` is no longer referenced anywhere in the `list_issues` handler scope (may still be referenced inside `paginateConnection` internals — that is fine)
+  - [x] `npm run build` passes (no TS errors from the change)
 
 #### Task 1.2: Add structural regression test asserting `totalCount` is absent from list_issues response
 - **files**: `plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts` (modify)
@@ -105,19 +105,19 @@ Delete the `totalCount: itemsResult.totalCount` line from the `toolSuccess` retu
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] A new `describe("list_issues totalCount removal (GH-1129)", ...)` block is added to the existing test file, following the file's structural-assertion style (uses `issueToolsSrc` already loaded at top of file via `fs.readFileSync`)
-  - [ ] Includes an assertion that `issueToolsSrc` does NOT contain the literal substring `totalCount: itemsResult.totalCount` (regression guard)
-  - [ ] Includes an assertion that `issueToolsSrc` DOES contain `filteredCount: formattedItems.length` (positive guard — confirms the surviving field stays)
-  - [ ] `npm test` passes including the new tests
-  - [ ] Existing tests are not modified
+  - [x] A new `describe("list_issues totalCount removal (GH-1129)", ...)` block is added to the existing test file, following the file's structural-assertion style (uses `issueToolsSrc` already loaded at top of file via `fs.readFileSync`)
+  - [x] Includes an assertion that `issueToolsSrc` does NOT contain the literal substring `totalCount: itemsResult.totalCount` (regression guard)
+  - [x] Includes an assertion that `issueToolsSrc` DOES contain `filteredCount: formattedItems.length` (positive guard — confirms the surviving field stays)
+  - [x] `npm test` passes including the new tests
+  - [x] Existing tests are not modified
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — no errors
-- [ ] `npm test` (in `plugin/ralph-hero/mcp-server/`) — all passing including the two new structural assertions
-- [ ] `npx vitest run src/__tests__/issue-tools.test.ts` — passes
+- [x] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — no errors
+- [x] `npm test` (in `plugin/ralph-hero/mcp-server/`) — all passing including the two new structural assertions
+- [x] `npx vitest run src/__tests__/issue-tools.test.ts` — passes
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

Removes the misleading \`totalCount\` field from the \`ralph_hero__list_issues\` MCP tool response. The field reported the unfiltered GraphQL project board total (700+ items including closed issues/PRs) rather than the actual filtered result count, causing real analyst confusion. The \`filteredCount\` field already provides the accurate post-filter count.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-07-GH-1129-list-issues-totalcount-misleading.md

Phases shipped: 1 of 1

## Test plan

- [x] Automated verification per plan Success Criteria
  - \`npm run build\` passes with no errors
  - \`npm test\` passes (existing tests unchanged + new regression test green)
  - \`npx vitest run src/__tests__/issue-tools.test.ts\` passes
- [x] Structural assertions confirm \`totalCount\` is absent from response and \`filteredCount\` survives
- [x] Manual verification with live ralph-hero project confirmed response shape

Closes #1129