### PR TITLE
GH-1154: Widen next_actions for audience=agent (Backlog/null-state fallback)

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
@@ -142,6 +142,74 @@ describe("audience param", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 0b2. audience=agent Backlog fallback (GH-1154)
+// ---------------------------------------------------------------------------
+
+describe("audience=agent Backlog fallback", () => {
+  it("agent audience: Backlog-only board returns the Backlog item as a direction", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        priority: "P2",
+      }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 3, audience: "agent" }));
+    expect(result).toHaveLength(1);
+    expect(result[0].issue?.number).toBe(1);
+    expect(result[0].issue?.workflowState).toBe("Backlog");
+    expect(result[0].kind).toBe("issue");
+  });
+
+  it("agent audience: null-state items also surface via the fallback", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: null,
+        priority: "P2",
+      }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 3, audience: "agent" }));
+    expect(result).toHaveLength(1);
+    expect(result[0].issue?.number).toBe(1);
+    expect(result[0].issue?.workflowState).toBeNull();
+  });
+
+  it("agent audience: mixed Backlog + actionable returns the actionable item (fallback does NOT fire)", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        priority: "P0", // even high priority Backlog must lose to any actionable item
+      }),
+      makeItem({
+        number: 2,
+        workflowState: "Ready for Plan",
+        priority: "P2",
+      }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 3, audience: "agent" }));
+    // Fallback only fires when the post-phase scored set is empty.
+    // With #2 in Ready for Plan, scored has one entry, so #1 is filtered out.
+    expect(result).toHaveLength(1);
+    expect(result[0].issue?.number).toBe(2);
+    expect(result[0].issue?.workflowState).toBe("Ready for Plan");
+  });
+
+  it("human audience: Backlog-only board returns no directions (fallback is agent-only)", () => {
+    const items = [
+      makeItem({
+        number: 1,
+        workflowState: "Backlog",
+        priority: "P0",
+      }),
+    ];
+    const result = rankDirections(items, [], makeConfig({ limit: 3, audience: "human" }));
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 0c. Differentiated stale reasons (Phase 2.3)
 // ---------------------------------------------------------------------------
 

--- a/plugin/ralph-hero/mcp-server/src/lib/directions.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/directions.ts
@@ -252,6 +252,14 @@ const PR_REVIEW_REQUIRED_BOOST = -200;
 const HUMAN_NEEDED_UNBLOCK_BOOST = -150;
 
 /**
+ * Penalty applied to Backlog / null-state items that surface only via the
+ * `audience === "agent"` fallback. Large positive value ensures Backlog
+ * fallback items always rank below any actionable-phase item — Backlog
+ * surfaces only when the actionable pool is empty.
+ */
+const AGENT_BACKLOG_FALLBACK_PENALTY = 100;
+
+/**
  * Per-estimate penalty applied when audience === "agent". Larger items
  * cost more (positive score), pushing them down the ranking so agent
  * loops dispatch on XS/S items first.
@@ -834,6 +842,29 @@ export function rankDirections(
 
     const { score, kind, tags, signals } = scoreIssue(item, items, config);
     scored.push({ item, score, kind, tags, signals });
+  }
+
+  // 1b. Phase fallback for autonomous audience: when no items passed the
+  //     standard phase filter, widen the candidate set to include items in
+  //     `Backlog` and items with a null `workflowState`. This restores
+  //     autopilot's ability to clear a Backlog-heavy board. Fallback items
+  //     get +AGENT_BACKLOG_FALLBACK_PENALTY so they always rank below any
+  //     actionable-phase item — they surface only when the actionable pool
+  //     is empty. Mirrors the blocker fallback in step 2.
+  if (config.audience === "agent" && scored.length === 0) {
+    for (const item of items) {
+      if (item.workflowState !== "Backlog" && item.workflowState !== null) {
+        continue;
+      }
+      const { score, kind, tags, signals } = scoreIssue(item, items, config);
+      scored.push({
+        item,
+        score: score + AGENT_BACKLOG_FALLBACK_PENALTY,
+        kind,
+        tags,
+        signals,
+      });
+    }
   }
 
   // 2. Drop blocked items unless that would empty the candidate set.

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -455,7 +455,7 @@ export function registerDirectionsTools(
 
   server.tool(
     "ralph_hero__next_actions",
-    "Compute up to N deterministic 'directions' (next actions) with one flagged `recommended: true`. Used by the /hello skill picker (interactive) and by headless orchestrators (auto-select recommended). Open PRs must be passed in as a parameter. Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0.",
+    "Compute up to N deterministic 'directions' (next actions) with one flagged `recommended: true`. Used by the /hello skill picker (interactive) and by headless orchestrators (auto-select recommended). Open PRs must be passed in as a parameter. Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0. When `audience='agent'` and no items are in actionable phases (Plan in Review, In Review, Ready for Plan, Research Needed) or otherwise surfacing (lock-stale, unblock-requested), the picker falls back to Backlog and null-state items so autopilot can drive triage. Fallback items receive a fixed score penalty so they never outrank actionable items when those exist; the fallback never fires for `audience='human'`.",
     {
       owner: z
         .string()


### PR DESCRIPTION
## Summary

Add a fallback branch in `next_actions` candidate selection: when `audience === "agent"` AND no items pass `isCandidatePhase`, widen the candidate set to include items in `Backlog` and items with `workflowState === null`. Restores autopilot's ability to clear a Backlog-heavy board. Fallback items receive a +100 penalty so they never outrank actionable items when those exist.

## Plan

[Phase 1 of GH-1153 group plan](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-08-group-GH-1153-shorthand-tools-consistency-pass.md#phase-1-widen-next_actions-for-audienceagent-backlognnull-state-fallback)

Phases shipped: 1 of 8 (group issues)

## Test plan

- [x] Automated verification per plan Success Criteria
  - [x] `npm run build` passes
  - [x] `npm test src/__tests__/directions.test.ts` passes including 3 new cases
  - [x] No other test file regresses (1219 tests across 54 files pass)
- [ ] Manual verification per plan Success Criteria
  - [ ] Against the live ralph-hero project (Backlog: 1, all other actionable phases: 0), `mcp call ralph_hero__next_actions audience=agent` returns at least one direction with `kind=issue` for the Backlog item
  - [ ] Re-running the autopilot dry-run completes Step 2 with a non-empty candidate list

Changes:
- `plugin/ralph-hero/mcp-server/src/lib/directions.ts` — insert fallback after existing phase filter block; add `AGENT_BACKLOG_FALLBACK_PENALTY = 100` constant
- `plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts` — update tool description to document the fallback
- `plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts` — add 3 test cases (agent+Backlog-only → returns Backlog; agent+mixed → returns actionable; human+Backlog-only → empty)

Closes #1154