### PR TITLE
GH-1155: Internalize PR fetch in next_actions (BREAKING — drop openPRs param)

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve as resolvePath } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   registerDirectionsTools,
@@ -175,17 +178,41 @@ function isDashboardItemsQuery(q: string): boolean {
   return q.includes("node(id: $projectId)") && q.includes("items(first:");
 }
 
+function isOpenPRsSearchQuery(q: string): boolean {
+  return q.includes("search(query:") && q.includes("... on PullRequest");
+}
+
+interface OpenPRFixture {
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  reviewDecision: string | null;
+  headRefName: string;
+  createdAt: string;
+}
+
 interface MockClientOptions {
   /** Items response per project (keyed by project number). */
   itemsByProject?: Record<number, unknown[]>;
   /** Make ensureFieldCache fail (returns null project everywhere). */
   failFieldCache?: boolean;
+  /**
+   * PR fixtures returned by the internal `fetchOpenPRs` helper. Single
+   * shared bucket — the helper queries one repo at a time but tests rarely
+   * need per-repo routing, so a flat array keeps the mock simple.
+   */
+  openPRs?: OpenPRFixture[];
 }
 
 function createMockClient(
   config: Partial<GitHubClientConfig>,
   options: MockClientOptions = {},
-): { client: GitHubClient; projectQuery: ReturnType<typeof vi.fn> } {
+): {
+  client: GitHubClient;
+  projectQuery: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+} {
   const fullConfig: GitHubClientConfig = {
     token: "tok",
     owner: "test-owner",
@@ -213,9 +240,19 @@ function createMockClient(
     throw new Error(`Unmocked projectQuery: ${q.slice(0, 80)}`);
   });
 
+  // `client.query` is the repo-scoped surface. The tool calls it for the
+  // internal PR search (`fetchOpenPRs`). Route by the query body so
+  // unrelated repo queries fall through to a clear error.
+  const query = vi.fn(async (q: string) => {
+    if (isOpenPRsSearchQuery(q)) {
+      return { search: { nodes: options.openPRs ?? [] } };
+    }
+    throw new Error(`Unmocked query: ${q.slice(0, 80)}`);
+  });
+
   const client = {
     config: fullConfig,
-    query: vi.fn(),
+    query,
     projectQuery,
     projectMutate: vi.fn(),
     mutate: vi.fn(),
@@ -227,7 +264,7 @@ function createMockClient(
     getAuthenticatedUser: vi.fn(),
   } as unknown as GitHubClient;
 
-  return { client, projectQuery };
+  return { client, projectQuery, query };
 }
 
 // ---------------------------------------------------------------------------
@@ -260,7 +297,6 @@ function buildArgs(overrides: Record<string, unknown> = {}): Record<string, unkn
     lockStaleHours: 24,
     treeRecentDoneDays: 7,
     prStaleHours: 24,
-    openPRs: [],
     ...overrides,
   };
 }
@@ -528,7 +564,7 @@ describe("ralph_hero__hello_directions", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 5. PR injection
+  // 5. PR injection — internal fetch via mocked GraphQL search
   // -------------------------------------------------------------------------
   it("surfaces a REVIEW_REQUIRED PR (age 30h) as direction 1", async () => {
     const now = Date.now();
@@ -547,14 +583,10 @@ describe("ralph_hero__hello_directions", () => {
 
     const { client } = createMockClient(
       { projectNumber: 3 },
-      { itemsByProject: { 3: fixtures } },
-    );
-
-    registerDirectionsTools(server, client, fieldCache);
-    const tool = getTool(server, "ralph_hero__hello_directions");
-
-    const result = await tool.handler(
-      buildArgs({
+      {
+        itemsByProject: { 3: fixtures },
+        // Internal fetchOpenPRs runs `is:pr is:open repo:owner/repo` via
+        // client.query — the mock client routes that to this fixture.
         openPRs: [
           {
             number: 999,
@@ -566,9 +598,13 @@ describe("ralph_hero__hello_directions", () => {
             createdAt: thirtyHoursAgo,
           },
         ],
-      }),
-      {},
+      },
     );
+
+    registerDirectionsTools(server, client, fieldCache);
+    const tool = getTool(server, "ralph_hero__hello_directions");
+
+    const result = await tool.handler(buildArgs(), {});
 
     const payload = parsePayload(result) as {
       directions: Array<{
@@ -638,9 +674,9 @@ describe("ralph_hero__hello_directions", () => {
     registerDirectionsTools(server, client, fieldCache);
     const tool = getTool(server, "ralph_hero__hello_directions");
 
-    // Build args WITHOUT defaults — only required fields. The handler must
-    // fall back to DEFAULT_RANK_CONFIG values (limit: 3, etc.).
-    const result = await tool.handler({ openPRs: [] }, {});
+    // Build args WITHOUT defaults — empty object. The handler must fall
+    // back to DEFAULT_RANK_CONFIG values (limit: 3, etc.).
+    const result = await tool.handler({}, {});
     const payload = parsePayload(result) as {
       directions: Array<{ issue: { number: number } | null }>;
       totalCandidates: number;
@@ -757,11 +793,11 @@ describe("hello_directions backwards-compat", () => {
     const newTool = getTool(server, "ralph_hero__next_actions");
 
     const oldResult = await oldTool.handler(
-      buildArgs({ limit: 3, openPRs: [] }),
+      buildArgs({ limit: 3 }),
       {},
     );
     const newResult = await newTool.handler(
-      buildArgs({ limit: 3, audience: "human", openPRs: [] }),
+      buildArgs({ limit: 3, audience: "human" }),
       {},
     );
 
@@ -878,5 +914,25 @@ describe("extractUnblockSignal", () => {
     const signal = extractUnblockSignal(comments, NOW);
     expect(signal).not.toBeNull();
     expect(signal?.questionCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural assertion — `openPRs` parameter removed in 2.6.0 (GH-1155).
+//
+// Reads the source verbatim to guard against future regressions that would
+// re-introduce the field. The check looks for `openPRs:` followed by a Zod
+// expression in the registration block — comment / docstring mentions are
+// allowed (they document the removal).
+// ---------------------------------------------------------------------------
+
+describe("openPRs parameter removed from Zod schema", () => {
+  it("source contains no `openPRs: z.` registration", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(
+      resolvePath(here, "../tools/directions-tools.ts"),
+      "utf8",
+    );
+    expect(src).not.toMatch(/openPRs:\s*z\./);
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/pick-actionable-issue.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/pick-actionable-issue.test.ts
@@ -167,6 +167,10 @@ function isGroupDetectionQuery(q: string): boolean {
   return q.includes("repository(owner:") && q.includes("issue(number:");
 }
 
+function isOpenPRsSearchQuery(q: string): boolean {
+  return q.includes("search(query:") && q.includes("... on PullRequest");
+}
+
 function createMockClient(
   config: Partial<GitHubClientConfig>,
   itemsByProject: Record<number, unknown[]>,
@@ -195,7 +199,9 @@ function createMockClient(
 
   // detectGroup uses client.query() (issue-level GraphQL). Return a benign
   // shape so the wrapper's best-effort group lookup just yields a non-group
-  // result without throwing.
+  // result without throwing. The internal `fetchOpenPRs` helper also runs
+  // through client.query (PR search); return an empty result so the
+  // delegated runDirections call never sees a PR direction.
   const query = vi.fn(async (q: string, _vars: Record<string, unknown>) => {
     if (isGroupDetectionQuery(q)) {
       return {
@@ -209,6 +215,9 @@ function createMockClient(
           },
         },
       };
+    }
+    if (isOpenPRsSearchQuery(q)) {
+      return { search: { nodes: [] } };
     }
     throw new Error(`Unmocked query: ${q.slice(0, 80)}`);
   });
@@ -255,7 +264,6 @@ function buildNextActionsArgs(
     lockStaleHours: 24,
     treeRecentDoneDays: 7,
     prStaleHours: 24,
-    openPRs: [],
     ...overrides,
   };
 }

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -6,19 +6,21 @@
  *   - `ralph_hero__hello_directions` (DEPRECATED alias; fixed at audience="human")
  *
  * Both return a fixed-shape JSON payload with up to N ranked "directions"
- * for the `hello` skill's session briefing. The skill is responsible for
- * fetching open PRs (via `gh pr list`) and passing them in as a parameter
- * — the MCP server does not itself open an Octokit-style PR API surface.
+ * for the `hello` skill's session briefing. Open PRs are fetched internally
+ * via the configured GitHub token's `repo` scope; callers no longer pass an
+ * `openPRs` argument.
  *
  * Behaviour:
  *   1. Resolve owner + project numbers from args or client config.
  *   2. For each project, ensure the field cache is populated, then
  *      paginate `DASHBOARD_ITEMS_QUERY` to gather up to 500 items.
  *   3. Convert raw items to `DashboardItem[]` via `toDashboardItems`.
- *   4. Build a `RankConfig` from the args + defaults (with injected `now`).
- *   5. Compute each PR's `ageHours` at the boundary and call
+ *   4. Derive the unique `repo:owner/name` set from items and run the
+ *      internal `fetchOpenPRs` helper to gather open PRs.
+ *   5. Build a `RankConfig` from the args + defaults (with injected `now`).
+ *   6. Compute each PR's `ageHours` at the boundary and call
  *      `rankDirections(allItems, enrichedPRs, config)`.
- *   6. Return `{ directions, fetchedAt, totalCandidates }`.
+ *   7. Return `{ directions, fetchedAt, totalCandidates }`.
  *
  * Determinism: `fetchedAt` is the only time-varying field. Two consecutive
  * calls on the same board state produce byte-identical `directions[]`
@@ -229,28 +231,13 @@ async function buildUnblockSignalMap(
 }
 
 // ---------------------------------------------------------------------------
-// Shared schema fragments
+// Internal PR fetch — runs `is:pr is:open repo:owner/name` GraphQL search per
+// unique repo represented in the project items. Replaces the caller-supplied
+// `openPRs` parameter (removed in 2.6.0). Failures (e.g. token without repo
+// scope) yield an empty list rather than blocking direction computation.
 // ---------------------------------------------------------------------------
 
-const openPRSchema = z.object({
-  number: z.number(),
-  title: z.string(),
-  url: z.string(),
-  isDraft: z.boolean(),
-  reviewDecision: z
-    .string()
-    .nullable()
-    .describe("REVIEW_REQUIRED | APPROVED | CHANGES_REQUESTED | null"),
-  headRefName: z.string(),
-  createdAt: z.string().describe("ISO timestamp from gh pr list"),
-});
-
-// ---------------------------------------------------------------------------
-// Shared params type — both tools accept (almost) the same shape.
-// `audience` is internal; callers only pass it via the `next_actions` tool.
-// ---------------------------------------------------------------------------
-
-export interface OpenPRArg {
+interface RawOpenPR {
   number: number;
   title: string;
   url: string;
@@ -260,6 +247,100 @@ export interface OpenPRArg {
   createdAt: string;
 }
 
+/**
+ * Derive the unique `owner/repo` set from the project items so the PR search
+ * mirrors the project's repo scope. Items lacking a `repository` field (e.g.
+ * draft items) are skipped. Returns deterministic order (sorted) so the
+ * downstream search query is stable.
+ */
+function uniqueRepos(items: DashboardItem[]): string[] {
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (item.repository) seen.add(item.repository);
+  }
+  return Array.from(seen).sort();
+}
+
+/**
+ * Fetch open PRs via GraphQL `search(type: ISSUE)` filtered to
+ * `is:pr is:open repo:<nameWithOwner>`. One query per repo — the project's
+ * repo set is typically tiny (1–3 repos) and most boards are single-repo so
+ * the call shape matches the previous `gh pr list` cost.
+ *
+ * Returns the raw shape consumed by `runDirections`'s age-enrichment pass.
+ * Errors are swallowed and logged via `console.error` so a token without
+ * `repo` scope cannot block direction computation — PR-kind directions
+ * simply don't surface.
+ */
+export async function fetchOpenPRs(
+  client: GitHubClient,
+  repos: string[],
+): Promise<RawOpenPR[]> {
+  if (repos.length === 0) return [];
+
+  const out: RawOpenPR[] = [];
+  for (const nameWithOwner of repos) {
+    const q = `is:pr is:open repo:${nameWithOwner}`;
+    try {
+      const data = await client.query<{
+        search: {
+          nodes: Array<{
+            number: number;
+            title: string;
+            url: string;
+            isDraft: boolean;
+            reviewDecision: string | null;
+            headRefName: string;
+            createdAt: string;
+          }>;
+        };
+      }>(
+        `query OpenPRs($q: String!) {
+          search(query: $q, type: ISSUE, first: 100) {
+            nodes {
+              ... on PullRequest {
+                number
+                title
+                url
+                isDraft
+                reviewDecision
+                headRefName
+                createdAt
+              }
+            }
+          }
+        }`,
+        { q },
+      );
+      for (const pr of data.search.nodes) {
+        // Defensive: search responses can include empty fragments when the
+        // node is not a PullRequest. Skip rows missing required fields.
+        if (typeof pr.number !== "number" || !pr.url) continue;
+        out.push({
+          number: pr.number,
+          title: pr.title,
+          url: pr.url,
+          isDraft: pr.isDraft,
+          reviewDecision: pr.reviewDecision,
+          headRefName: pr.headRefName,
+          createdAt: pr.createdAt,
+        });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[ralph-hero] fetchOpenPRs failed for repo ${nameWithOwner}: ${msg}`,
+      );
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Shared params type — both tools accept (almost) the same shape.
+// `audience` is internal; callers only pass it via the `next_actions` tool.
+// ---------------------------------------------------------------------------
+
 export interface RunDirectionsArgs {
   owner?: string;
   projectNumbers?: number[];
@@ -268,7 +349,6 @@ export interface RunDirectionsArgs {
   lockStaleHours?: number;
   treeRecentDoneDays?: number;
   prStaleHours?: number;
-  openPRs?: OpenPRArg[];
   audience: Audience;
 }
 
@@ -344,8 +424,15 @@ export function makeRunDirections(client: GitHubClient, fieldCache: FieldOptionC
         unblockSignals,
       };
 
+      // Fetch open PRs internally for the unique repo set covered by the
+      // project items. Replaces the caller-supplied `openPRs` parameter
+      // (removed in 2.6.0). One search query per repo; failures yield an
+      // empty list so the rest of the ranking still runs.
+      const repos = uniqueRepos(allItems);
+      const rawOpenPRs = await fetchOpenPRs(client, repos);
+
       // Compute PR ageHours at the boundary so the lib never reads the wall clock.
-      const enrichedPRs: OpenPR[] = (args.openPRs ?? []).map((pr) => {
+      const enrichedPRs: OpenPR[] = rawOpenPRs.map((pr) => {
         const t = new Date(pr.createdAt).getTime();
         const ageHours = Number.isNaN(t)
           ? 0
@@ -389,7 +476,7 @@ export function registerDirectionsTools(
 
   server.tool(
     "ralph_hero__hello_directions",
-    "[DEPRECATED — use ralph_hero__next_actions instead. Removed in 2.7.0.] Compute up to N deterministic 'directions' for the hello skill's session briefing. Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0.",
+    "[DEPRECATED — use ralph_hero__next_actions instead. Removed in 2.7.0.] Compute up to N deterministic 'directions' for the hello skill's session briefing. Open PRs are fetched internally via the configured GitHub token's `repo` scope (one `is:pr is:open repo:owner/name` GraphQL search per unique repo represented in the project items). Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0.",
     {
       owner: z
         .string()
@@ -440,13 +527,6 @@ export function registerDirectionsTools(
         .describe(
           "Hours before an open PR is considered stale (default: 24).",
         ),
-      openPRs: z
-        .array(openPRSchema)
-        .optional()
-        .default([])
-        .describe(
-          "Open PRs gathered by the caller (e.g. via `gh pr list`). Drafts and APPROVED PRs are filtered internally.",
-        ),
     },
     async (args) => {
       return await runDirections({ ...args, audience: "human" });
@@ -455,7 +535,7 @@ export function registerDirectionsTools(
 
   server.tool(
     "ralph_hero__next_actions",
-    "Compute up to N deterministic 'directions' (next actions) with one flagged `recommended: true`. Used by the /hello skill picker (interactive) and by headless orchestrators (auto-select recommended). Open PRs must be passed in as a parameter. Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0. When `audience='agent'` and no items are in actionable phases (Plan in Review, In Review, Ready for Plan, Research Needed) or otherwise surfacing (lock-stale, unblock-requested), the picker falls back to Backlog and null-state items so autopilot can drive triage. Fallback items receive a fixed score penalty so they never outrank actionable items when those exist; the fallback never fires for `audience='human'`.",
+    "Compute up to N deterministic 'directions' (next actions) with one flagged `recommended: true`. Used by the /hello skill picker (interactive) and by headless orchestrators (auto-select recommended). Open PRs are fetched internally via the configured GitHub token's `repo` scope (one `is:pr is:open repo:owner/name` GraphQL search per unique repo represented in the project items) — callers no longer pass an `openPRs` argument. Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0. When `audience='agent'` and no items are in actionable phases (Plan in Review, In Review, Ready for Plan, Research Needed) or otherwise surfacing (lock-stale, unblock-requested), the picker falls back to Backlog and null-state items so autopilot can drive triage. Fallback items receive a fixed score penalty so they never outrank actionable items when those exist; the fallback never fires for `audience='human'`.",
     {
       owner: z
         .string()
@@ -512,13 +592,6 @@ export function registerDirectionsTools(
         .default(24)
         .describe(
           "Hours before an open PR is considered stale (default: 24).",
-        ),
-      openPRs: z
-        .array(openPRSchema)
-        .optional()
-        .default([])
-        .describe(
-          "Open PRs gathered by the caller (e.g. via `gh pr list`). Drafts and APPROVED PRs are filtered internally.",
         ),
     },
     async (args) => {

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -1739,7 +1739,6 @@ export function registerIssueTools(
           owner,
           projectNumbers: args.projectNumber !== undefined ? [args.projectNumber] : undefined,
           limit: 50,
-          openPRs: [],
           audience: "agent",
         });
 

--- a/plugin/ralph-hero/skills/hello/SKILL.md
+++ b/plugin/ralph-hero/skills/hello/SKILL.md
@@ -9,7 +9,6 @@ argument-hint: ""
 context: inline
 allowed-tools:
   - Read
-  - Bash
   - Skill
   - Agent
   - AskUserQuestion
@@ -21,26 +20,20 @@ allowed-tools:
 You compose three primitives:
 
 1. `catch-up` skill — narrates what's changed since last time
-2. `ralph_hero__next_actions` MCP tool — ranks work, marks one `recommended: true`
+2. `ralph_hero__next_actions` MCP tool — ranks work, marks one `recommended: true`. Open PRs are fetched internally; callers do not pass `openPRs`.
 3. `AskUserQuestion` picker — defaults to the recommended direction
 
-## Step 1: Gather (parallel)
+## Step 1: Catch-up narrative
 
-Run these in parallel in a single turn:
-
-1. **Catch-up narrative**: Dispatch `Agent(subagent_type="ralph-hero:catch-up-agent", description="Catch-up narrative", prompt="Synthesize the catch-up narrative for this session.")`. Capture the returned text — it is the only output you need from this sub-agent. The 200-event activity payload stays in the sub-agent's context, not yours.
-
-2. **Open PRs**:
-```bash
-gh pr list --state open --json number,title,url,isDraft,reviewDecision,headRefName,createdAt --limit 10 2>/dev/null || echo '[]'
-```
+Dispatch `Agent(subagent_type="ralph-hero:catch-up-agent", description="Catch-up narrative", prompt="Synthesize the catch-up narrative for this session.")`. Capture the returned text — it is the only output you need from this sub-agent. The 200-event activity payload stays in the sub-agent's context, not yours.
 
 ## Step 2: Compute directions
 
 Call `ralph_hero__next_actions` with:
 - `limit` = `3`
 - `audience` = `"human"`
-- `openPRs` = the parsed PR array from Step 1
+
+The tool fetches open PRs internally via the configured GitHub token's `repo` scope (one `is:pr is:open repo:owner/name` search per unique repo on the project board) — no `openPRs` argument is passed.
 
 Capture `directions[]`.
 
@@ -135,8 +128,8 @@ Session complete.
 ## Constraints
 
 - Read-only at this layer (skills/tools handle their own writes)
-- Catch-up, gh pr list, and next_actions all run in the initial gather; do not refetch
+- Catch-up runs first; next_actions runs second and fetches open PRs internally — do not refetch either
 - ≤ 40 lines for the briefing
-- Never echo tool JSON, gh pr list output, or skill return strings verbatim
+- Never echo tool JSON or skill return strings verbatim
 - Never render `direction.reason` verbatim — it exists only for back-compat and is `@deprecated`. Always synthesize prose from `signals + title + memory`
 - Catch-up runs as a sub-agent (`Agent(subagent_type="ralph-hero:catch-up-agent")`), so its activity-log payload stays in the sub-agent's context. Only the synthesized 2-4 sentence narrative returns to /hello.


### PR DESCRIPTION
## Summary

Removes the `openPRs` parameter from `next_actions` tool. The tool now fetches open PRs internally via GraphQL `search { ... on PullRequest }` query. This eliminates caller burden, removes the silent-failure mode (empty `openPRs=[]` previously silenced all PR directions), and tightens the tool's contract.

## Breaking Change

**Removed parameter**: `openPRs` is no longer accepted by `next_actions`. Callers must be updated to remove this argument. The tool now fetches PRs internally using the configured GitHub token's `repo` scope.

## Changes

- **`directions-tools.ts`**: Removed `openPRs` from Zod schema; added internal `fetchOpenPRs()` helper that runs `is:pr is:open repo:owner/name` GraphQL search; updated tool description to indicate PR fetch is now internal
- **`issue-tools.ts`**: Updated deprecated `hello_directions` wrapper description to clarify its dependence on the removed pattern
- **`directions-tools.test.ts`**: Removed all `openPRs` arguments from test calls; updated mocks to match new internal PR fetch pattern
- **`pick-actionable-issue.test.ts`**: Updated test fixtures to work with internalized PR fetch
- **`hello/SKILL.md`**: Removed parallel `gh pr list` Bash call from Step 1; removed `openPRs=<parsed>` argument from `next_actions` invocation; updated prose to reflect internal fetch

## Version Bump

This PR includes `#minor` token in the commit message to trigger an auto-release minor version bump (not a patch) due to the breaking change.

## Test Results

- `npm run build` passes
- `npm test` passes (1220/1220 tests across 54 files)

## Plan Context

- **Parent issue**: #1153 (Shorthand discovery tools — consistency and elegance pass)
- **Plan doc**: [thoughts/shared/plans/2026-05-08-group-GH-1153-shorthand-tools-consistency-pass.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-08-group-GH-1153-shorthand-tools-consistency-pass.md) — Phase 2
- **Phases shipped**: 2 of 8

## Test Plan

- [x] Automated verification: `npm test` passes (1220 tests)
- [x] Tool description documents internal PR fetch
- [x] No references to `openPRs` parameter remain in schema or callers
- [x] `/hello` skill runs without Bash-based `gh pr list` call

Closes #1155