### PR TITLE
GH-1156: Unify count field names across discovery tools (BREAKING)

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/board-items-naming.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/board-items-naming.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Structural assertions for the cross-tool `boardItems` naming convention.
+ *
+ * Phase 3 of GH-1153 unified the response-level "raw count" field across
+ * `next_actions`, `pipeline_dashboard`, and `project_hygiene` — all three
+ * now expose `boardItems` (the count of items on the project board pre-filter).
+ *
+ * These tests are guard rails so a future refactor can't silently regress
+ * the contract by renaming the field back to `totalCandidates`/`totalIssues`/
+ * `totalItems` on a top-level discovery-tool response.
+ *
+ * Tool-specific filtered counts (`directions[].length`, `phases[].count`,
+ * `filteredCount`, `summary[category]`) keep their distinct names. Same for
+ * per-iteration `IterationBreakdown.totalIssues` (per-iteration count) and
+ * `WorkStreamSummary.totalIssues` (per-stream count from the stream-detection
+ * tool, which is a separate concept).
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SRC_ROOT = resolve(__dirname, "..");
+
+function read(relative: string): string {
+  return readFileSync(resolve(SRC_ROOT, relative), "utf8");
+}
+
+describe("boardItems naming — structural assertions", () => {
+  it("DashboardData.boardItems is declared in lib/dashboard.ts", () => {
+    const src = read("lib/dashboard.ts");
+    // The interface declaration must reference boardItems as the top-level
+    // raw-count field on DashboardData.
+    expect(src).toMatch(/boardItems:\s*number/);
+    // The buildDashboard return must populate boardItems (not the old name).
+    expect(src).toMatch(/boardItems:\s*items\.length/);
+  });
+
+  it("HygieneReport.boardItems is declared in lib/hygiene.ts", () => {
+    const src = read("lib/hygiene.ts");
+    expect(src).toMatch(/boardItems:\s*number/);
+    expect(src).toMatch(/boardItems:\s*items\.length/);
+  });
+
+  it("next_actions return shape uses boardItems in tools/directions-tools.ts", () => {
+    const src = read("tools/directions-tools.ts");
+    expect(src).toMatch(/boardItems:\s*allItems\.length/);
+  });
+
+  it("dashboard.ts does NOT use the old totalIssues name on DashboardData", () => {
+    const src = read("lib/dashboard.ts");
+    // DashboardData interface must not contain `totalIssues:`. The
+    // `IterationBreakdown.totalIssues` (per-iteration) is fine — it is a
+    // distinct concept and lives behind `iter.totalIssues`/`group.totalIssues`.
+    // We check that the top-level DashboardData block doesn't contain the
+    // old name by looking inside the `export interface DashboardData {` block.
+    const match = src.match(
+      /export interface DashboardData \{[\s\S]*?\n\}/,
+    );
+    expect(match).toBeTruthy();
+    expect(match![0]).not.toMatch(/^\s*totalIssues:/m);
+  });
+
+  it("hygiene.ts does NOT use the old totalItems name on HygieneReport", () => {
+    const src = read("lib/hygiene.ts");
+    const match = src.match(/export interface HygieneReport \{[\s\S]*?\n\}/);
+    expect(match).toBeTruthy();
+    expect(match![0]).not.toMatch(/^\s*totalItems:/m);
+  });
+
+  it("directions-tools.ts does NOT emit totalCandidates", () => {
+    const src = read("tools/directions-tools.ts");
+    expect(src).not.toMatch(/totalCandidates/);
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/__tests__/dashboard.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/dashboard.test.ts
@@ -843,7 +843,7 @@ describe("formatMarkdown", () => {
     // Use manually constructed data to avoid pipeline_gap warnings from empty phases
     const healthy: import("../lib/dashboard.js").DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 1,
+      boardItems: 1,
       phases: [{ state: "Backlog", count: 1, estimatePoints: 0, issues: [] }],
       health: { ok: true, warnings: [] },
       archive: { eligibleForArchive: 0, eligibleItems: [], recentlyCompleted: 0, archiveThresholdDays: 14 },
@@ -935,7 +935,7 @@ describe("formatAscii", () => {
     // Use manually constructed data to avoid pipeline_gap warnings from empty phases
     const healthy: import("../lib/dashboard.js").DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 1,
+      boardItems: 1,
       phases: [{ state: "Backlog", count: 1, estimatePoints: 0, issues: [] }],
       health: { ok: true, warnings: [] },
       archive: { eligibleForArchive: 0, eligibleItems: [], recentlyCompleted: 0, archiveThresholdDays: 14 },
@@ -980,7 +980,7 @@ describe("buildDashboard", () => {
     const data = buildDashboard(items, DEFAULT_HEALTH_CONFIG, NOW);
 
     expect(data.generatedAt).toBeTruthy();
-    expect(data.totalIssues).toBe(3);
+    expect(data.boardItems).toBe(3);
     expect(data.phases.length).toBeGreaterThan(0);
     expect(data.health).toBeDefined();
     expect(typeof data.health.ok).toBe("boolean");
@@ -990,7 +990,7 @@ describe("buildDashboard", () => {
   it("with default config produces expected structure", () => {
     const data = buildDashboard([], DEFAULT_HEALTH_CONFIG, NOW);
 
-    expect(data.totalIssues).toBe(0);
+    expect(data.boardItems).toBe(0);
     expect(data.health.ok).toBe(false); // pipeline gaps generate info warnings
     // All phases should be present
     for (const state of STATE_ORDER) {
@@ -1449,7 +1449,7 @@ describe("multi-project dashboard", () => {
     ];
 
     const data = buildDashboard(items, DEFAULT_HEALTH_CONFIG, NOW);
-    expect(data.totalIssues).toBe(3);
+    expect(data.boardItems).toBe(3);
     expect(findPhase(data.phases, "Backlog").count).toBe(2);
     expect(findPhase(data.phases, "In Progress").count).toBe(1);
   });
@@ -1461,7 +1461,7 @@ describe("multi-project dashboard", () => {
     ];
 
     const data = buildDashboard(items, DEFAULT_HEALTH_CONFIG, NOW);
-    expect(data.totalIssues).toBe(2);
+    expect(data.boardItems).toBe(2);
     expect(findPhase(data.phases, "Backlog").count).toBe(1);
     expect(findPhase(data.phases, "In Progress").count).toBe(1);
   });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
@@ -386,11 +386,11 @@ describe("ralph_hero__hello_directions", () => {
         score: number;
       }>;
       fetchedAt: string;
-      totalCandidates: number;
+      boardItems: number;
     };
 
     expect(result.isError).toBeUndefined();
-    expect(payload.totalCandidates).toBe(5);
+    expect(payload.boardItems).toBe(5);
     expect(payload.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(payload.directions).toHaveLength(3);
 
@@ -475,12 +475,12 @@ describe("ralph_hero__hello_directions", () => {
     const result = await tool.handler(buildArgs(), {});
     const payload = parsePayload(result) as {
       directions: unknown[];
-      totalCandidates: number;
+      boardItems: number;
     };
 
     expect(result.isError).toBeUndefined();
     expect(payload.directions).toEqual([]);
-    expect(payload.totalCandidates).toBe(0);
+    expect(payload.boardItems).toBe(0);
   });
 
   // -------------------------------------------------------------------------
@@ -526,11 +526,11 @@ describe("ralph_hero__hello_directions", () => {
     const result = await tool.handler(buildArgs(), {});
     const payload = parsePayload(result) as {
       directions: Array<{ issue: { number: number } | null }>;
-      totalCandidates: number;
+      boardItems: number;
     };
 
     expect(result.isError).toBeUndefined();
-    expect(payload.totalCandidates).toBe(3);
+    expect(payload.boardItems).toBe(3);
 
     // Both projects were queried (2 field-cache + 2 items = 4 calls).
     expect(projectQuery.mock.calls.length).toBeGreaterThanOrEqual(4);
@@ -679,11 +679,11 @@ describe("ralph_hero__hello_directions", () => {
     const result = await tool.handler({}, {});
     const payload = parsePayload(result) as {
       directions: Array<{ issue: { number: number } | null }>;
-      totalCandidates: number;
+      boardItems: number;
     };
 
     expect(result.isError).toBeUndefined();
-    expect(payload.totalCandidates).toBe(5);
+    expect(payload.boardItems).toBe(5);
     // Default limit of 3 was honored.
     expect(payload.directions).toHaveLength(3);
     // Top three by priority.

--- a/plugin/ralph-hero/mcp-server/src/__tests__/hygiene.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/hygiene.test.ts
@@ -325,7 +325,7 @@ describe("buildHygieneReport", () => {
     );
     expect(report.summary.staleCount).toBe(report.staleItems.length);
     expect(report.summary.orphanCount).toBe(report.orphanedItems.length);
-    expect(report.totalItems).toBe(3);
+    expect(report.boardItems).toBe(3);
   });
 
   it("computes field coverage percentage", () => {
@@ -459,8 +459,8 @@ describe("buildHygieneReport", () => {
       NOW,
     );
 
-    // totalItems sums across both projects
-    expect(report.totalItems).toBe(10);
+    // boardItems sums across both projects
+    expect(report.boardItems).toBe(10);
 
     // Archive candidates: from both projects (#1 from proj 3, #102 from proj 5)
     expect(report.archiveCandidates.length).toBe(2);
@@ -528,7 +528,7 @@ describe("buildHygieneReport", () => {
 
     const report = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
 
-    expect(report.totalItems).toBe(2);
+    expect(report.boardItems).toBe(2);
     expect(report.duplicateCandidates).toHaveLength(1);
     const pair = report.duplicateCandidates[0].items;
     const pairNums = [pair[0].number, pair[1].number].sort((a, b) => a - b);
@@ -1257,8 +1257,8 @@ describe("groupBy=repo composition (Phase 4)", () => {
       "owner/repo-a",
       "owner/repo-b",
     ]);
-    expect(repoResults["owner/repo-a"].totalItems).toBe(1);
-    expect(repoResults["owner/repo-b"].totalItems).toBe(1);
+    expect(repoResults["owner/repo-a"].boardItems).toBe(1);
+    expect(repoResults["owner/repo-b"].boardItems).toBe(1);
   });
 
   it("buckets items with no repository under '(unknown)'", () => {
@@ -1290,8 +1290,8 @@ describe("groupBy=repo composition (Phase 4)", () => {
       );
     }
     expect(repoResults["(unknown)"]).toBeDefined();
-    expect(repoResults["(unknown)"].totalItems).toBe(1);
-    expect(repoResults["owner/repo-a"].totalItems).toBe(1);
+    expect(repoResults["(unknown)"].boardItems).toBe(1);
+    expect(repoResults["owner/repo-a"].boardItems).toBe(1);
   });
 
   it("each per-repo HygieneReport contains only that repo's items in every section", () => {
@@ -1483,8 +1483,8 @@ describe("groupBy=repo composition (Phase 4)", () => {
       );
     }
 
-    expect(repoResults["owner/repo-a"].totalItems).toBe(2);
-    expect(repoResults["owner/repo-b"].totalItems).toBe(1);
+    expect(repoResults["owner/repo-a"].boardItems).toBe(2);
+    expect(repoResults["owner/repo-b"].boardItems).toBe(1);
 
     // repo-a's stale items should include both #1 (project 3) and #2 (project 5)
     const repoAStaleNums = repoResults["owner/repo-a"].staleItems
@@ -1515,7 +1515,7 @@ describe("groupBy=repo composition (Phase 4)", () => {
     const merged = buildHygieneReport(items, DEFAULT_HYGIENE_CONFIG, NOW);
 
     // Standard fields present
-    expect(merged.totalItems).toBe(2);
+    expect(merged.boardItems).toBe(2);
     expect(merged.staleItems).toBeDefined();
     expect(merged.summary).toBeDefined();
     // Phase 3 emits repoBreakdowns when items span >=2 repos; this is the

--- a/plugin/ralph-hero/mcp-server/src/__tests__/metrics.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/metrics.test.ts
@@ -226,7 +226,7 @@ describe("extractHighlights", () => {
   it("recentlyCompleted returns Done phase issues", () => {
     const data: DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 2,
+      boardItems: 2,
       phases: [
         {
           state: "Done",
@@ -268,7 +268,7 @@ describe("extractHighlights", () => {
   it("newlyAdded returns recent Backlog items", () => {
     const data: DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 2,
+      boardItems: 2,
       phases: [
         {
           state: "Backlog",
@@ -309,7 +309,7 @@ describe("extractHighlights", () => {
   it("excludes old Backlog items", () => {
     const data: DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 1,
+      boardItems: 1,
       phases: [
         {
           state: "Backlog",
@@ -338,7 +338,7 @@ describe("extractHighlights", () => {
   it("handles missing Done/Backlog phases gracefully", () => {
     const data: DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 1,
+      boardItems: 1,
       phases: [
         { state: "In Progress", count: 1, issues: [] },
       ],
@@ -397,7 +397,7 @@ describe("calculateMetrics", () => {
     // Manually construct dashboard without pipeline_gap warnings
     const data: DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 1,
+      boardItems: 1,
       phases: [
         {
           state: "Done",
@@ -432,7 +432,7 @@ describe("calculateMetrics", () => {
 
     const data: DashboardData = {
       generatedAt: new Date(NOW).toISOString(),
-      totalIssues: 1,
+      boardItems: 1,
       phases: [],
       health: {
         ok: false,

--- a/plugin/ralph-hero/mcp-server/src/__tests__/snapshots.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/snapshots.test.ts
@@ -175,7 +175,7 @@ describe("toSnapshot", () => {
   function makeData(): DashboardData {
     return {
       generatedAt: "2026-05-05T12:00:00.000Z",
-      totalIssues: 5,
+      boardItems: 5,
       phases: [
         {
           state: "Backlog",
@@ -276,7 +276,7 @@ describe("toSnapshot", () => {
       projectNumber: 7,
       data: {
         generatedAt: "2026-05-05T12:00:00.000Z",
-        totalIssues: 0,
+        boardItems: 0,
         phases: [],
         health: { ok: true, warnings: [] },
         archive: {

--- a/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/dashboard.ts
@@ -138,7 +138,14 @@ export interface StreamDashboardSection {
 
 export interface DashboardData {
   generatedAt: string; // ISO timestamp
-  totalIssues: number;
+  // `boardItems` is the raw count of items on the project board pre-filter,
+  // including PRs (carryover behavior — `DashboardItem[]` includes any non-DRAFT
+  // project item with a `content` node). Uniform across discovery tools
+  // (next_actions, pipeline_dashboard, project_hygiene). Per-phase `count`
+  // values reflect that phase's bucket; for `Done` and `Canceled`, the count
+  // is bounded by `doneWindowDays` (default 7) and may be smaller than the
+  // actual phase membership.
+  boardItems: number;
   phases: PhaseSnapshot[];
   health: {
     ok: boolean;
@@ -802,7 +809,7 @@ export function buildDashboard(
 
   return {
     generatedAt: new Date(now).toISOString(),
-    totalIssues: items.length,
+    boardItems: items.length,
     phases,
     health: {
       ok: warnings.length === 0,
@@ -832,7 +839,7 @@ export function formatMarkdown(
   lines.push(`# Pipeline Status`);
   lines.push(`_Generated: ${data.generatedAt}_`);
   lines.push("");
-  lines.push(`**Total issues**: ${data.totalIssues}`);
+  lines.push(`**Board items**: ${data.boardItems}`);
   lines.push("");
 
   // Phase table

--- a/plugin/ralph-hero/mcp-server/src/lib/hygiene.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/hygiene.ts
@@ -69,7 +69,12 @@ export interface HygieneRepoBreakdown {
 
 export interface HygieneReport {
   generatedAt: string;
-  totalItems: number;
+  // `boardItems` is the raw count of items on the project board pre-filter.
+  // Uniform across discovery tools (next_actions, pipeline_dashboard,
+  // project_hygiene). Per-category counts (`summary.archiveCandidateCount`,
+  // `summary.staleCount`, etc.) are post-filter and may sum to less than
+  // `boardItems`.
+  boardItems: number;
   archiveCandidates: HygieneItem[];
   staleItems: HygieneItem[];
   orphanedItems: HygieneItem[];
@@ -432,7 +437,7 @@ export function buildHygieneReport(
 
   return {
     generatedAt: new Date(now).toISOString(),
-    totalItems: items.length,
+    boardItems: items.length,
     archiveCandidates,
     staleItems,
     orphanedItems,
@@ -468,7 +473,7 @@ export function formatHygieneMarkdown(report: HygieneReport): string {
   lines.push("# Project Hygiene Report");
   lines.push(`_Generated: ${report.generatedAt}_`);
   lines.push("");
-  lines.push(`**Total items**: ${report.totalItems}`);
+  lines.push(`**Board items**: ${report.boardItems}`);
   lines.push("");
 
   // Summary

--- a/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/dashboard-tools.ts
@@ -50,7 +50,7 @@ export function registerDashboardTools(
 ): void {
   server.tool(
     "ralph_hero__pipeline_dashboard",
-    "Generate pipeline status dashboard with issue counts per workflow phase, health indicators, and formatted output. Returns structured data with optional markdown or ASCII rendering.",
+    "Generate pipeline status dashboard with issue counts per workflow phase, health indicators, and formatted output. Returns structured data with optional markdown or ASCII rendering. Top-level `boardItems` is the raw count of all project items including PRs (uniform across discovery tools — next_actions, pipeline_dashboard, project_hygiene). Per-phase `count` values reflect that phase's bucket; for `Done` and `Canceled`, the count is bounded by `doneWindowDays` (default 7) and may be smaller than the actual phase membership. Per-iteration `totalIssues` is a distinct concept (iteration-scoped count).",
     {
       owner: z
         .string()

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -20,7 +20,7 @@
  *   5. Build a `RankConfig` from the args + defaults (with injected `now`).
  *   6. Compute each PR's `ageHours` at the boundary and call
  *      `rankDirections(allItems, enrichedPRs, config)`.
- *   7. Return `{ directions, fetchedAt, totalCandidates }`.
+ *   7. Return `{ directions, fetchedAt, boardItems }`.
  *
  * Determinism: `fetchedAt` is the only time-varying field. Two consecutive
  * calls on the same board state produce byte-identical `directions[]`
@@ -454,7 +454,11 @@ export function makeRunDirections(client: GitHubClient, fieldCache: FieldOptionC
       return toolSuccess({
         directions,
         fetchedAt: now.toISOString(),
-        totalCandidates: allItems.length,
+        // `boardItems` is the raw count of items on the project board pre-filter
+        // (sum across all configured project numbers). Uniform across discovery
+        // tools (next_actions, pipeline_dashboard, project_hygiene). The number
+        // of returned `directions` is bounded by `limit` and may be much smaller.
+        boardItems: allItems.length,
       });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -476,7 +480,7 @@ export function registerDirectionsTools(
 
   server.tool(
     "ralph_hero__hello_directions",
-    "[DEPRECATED — use ralph_hero__next_actions instead. Removed in 2.7.0.] Compute up to N deterministic 'directions' for the hello skill's session briefing. Open PRs are fetched internally via the configured GitHub token's `repo` scope (one `is:pr is:open repo:owner/name` GraphQL search per unique repo represented in the project items). Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0.",
+    "[DEPRECATED — use ralph_hero__next_actions instead. Removed in 2.7.0.] Compute up to N deterministic 'directions' for the hello skill's session briefing. Open PRs are fetched internally via the configured GitHub token's `repo` scope (one `is:pr is:open repo:owner/name` GraphQL search per unique repo represented in the project items). Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0. Returns `{ directions, fetchedAt, boardItems }` where `boardItems` is the raw count of items on the project board pre-filter (uniform across discovery tools); the returned `directions` array is bounded by `limit`.",
     {
       owner: z
         .string()
@@ -535,7 +539,7 @@ export function registerDirectionsTools(
 
   server.tool(
     "ralph_hero__next_actions",
-    "Compute up to N deterministic 'directions' (next actions) with one flagged `recommended: true`. Used by the /hello skill picker (interactive) and by headless orchestrators (auto-select recommended). Open PRs are fetched internally via the configured GitHub token's `repo` scope (one `is:pr is:open repo:owner/name` GraphQL search per unique repo represented in the project items) — callers no longer pass an `openPRs` argument. Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0. When `audience='agent'` and no items are in actionable phases (Plan in Review, In Review, Ready for Plan, Research Needed) or otherwise surfacing (lock-stale, unblock-requested), the picker falls back to Backlog and null-state items so autopilot can drive triage. Fallback items receive a fixed score penalty so they never outrank actionable items when those exist; the fallback never fires for `audience='human'`.",
+    "Compute up to N deterministic 'directions' (next actions) with one flagged `recommended: true`. Used by the /hello skill picker (interactive) and by headless orchestrators (auto-select recommended). Open PRs are fetched internally via the configured GitHub token's `repo` scope (one `is:pr is:open repo:owner/name` GraphQL search per unique repo represented in the project items) — callers no longer pass an `openPRs` argument. Each direction includes a structured signals object (staleDays, staleThresholdDays, tiedAtScore, estimateWeight, parentChainNote) for skills to synthesize prose. The legacy 'reason' string is @deprecated and removed in 2.7.0. When `audience='agent'` and no items are in actionable phases (Plan in Review, In Review, Ready for Plan, Research Needed) or otherwise surfacing (lock-stale, unblock-requested), the picker falls back to Backlog and null-state items so autopilot can drive triage. Fallback items receive a fixed score penalty so they never outrank actionable items when those exist; the fallback never fires for `audience='human'`. Returns `{ directions, fetchedAt, boardItems }` where `boardItems` is the raw count of items on the project board pre-filter (uniform across discovery tools); the returned `directions` array is bounded by `limit`.",
     {
       owner: z
         .string()

--- a/plugin/ralph-hero/mcp-server/src/tools/hygiene-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/hygiene-tools.ts
@@ -40,7 +40,7 @@ export function registerHygieneTools(
 ): void {
   server.tool(
     "ralph_hero__project_hygiene",
-    "Generate a project board hygiene report. Identifies archive candidates, stale items, orphaned backlog entries, missing fields, WIP violations, and duplicate candidates. Returns: report with 7 sections + summary stats.",
+    "Generate a project board hygiene report. Identifies archive candidates, stale items, orphaned backlog entries, missing fields, WIP violations, and duplicate candidates. Returns: report with 7 sections + summary stats. Top-level `boardItems` is the raw count of items on the project board pre-filter (uniform across discovery tools — next_actions, pipeline_dashboard, project_hygiene). Per-category counts in `summary` (archiveCandidateCount, staleCount, orphanCount, fieldCoveragePercent, wipViolationCount, duplicateCandidateCount) are post-filter and represent distinct buckets.",
     {
       owner: z
         .string()

--- a/plugin/ralph-hero/skills/hello/__tests__/synthesis.smoke.md
+++ b/plugin/ralph-hero/skills/hello/__tests__/synthesis.smoke.md
@@ -99,7 +99,7 @@ issue):
     }
   ],
   "fetchedAt": "2026-05-03T14:25:00.000Z",
-  "totalCandidates": 47
+  "boardItems": 47
 }
 ```
 
@@ -146,7 +146,7 @@ Expected behaviour (the skill synthesizes prose):
     }
   ],
   "fetchedAt": "2026-05-03T14:25:00.000Z",
-  "totalCandidates": 1
+  "boardItems": 1
 }
 ```
 

--- a/plugin/ralph-hero/skills/report/SKILL.md
+++ b/plugin/ralph-hero/skills/report/SKILL.md
@@ -73,7 +73,7 @@ _Generated: {generatedAt}_
 |-------|------:|-------:|
 | {state} | {count} | {estimatePoints} |
 
-**Total**: {totalIssues} issues
+**Board items**: {boardItems}
 
 ## Velocity
 


### PR DESCRIPTION
## Summary

Standardize the response-level "raw count" field across `next_actions`, `pipeline_dashboard`, and `project_hygiene` to a single canonical name: `boardItems` (count of all `DashboardItem`s pre-filter). This is a **BREAKING** change — external callers reading the old field names (`totalCandidates`, `totalIssues`) will break.

Per-tool filtered counts (`directions[].length`, `phases[].count`, `filteredCount`, `summary[category]`) and per-iteration/per-stream buckets (`IterationBreakdown.totalIssues`, `WorkStreamSummary.totalIssues`) keep their distinct names because they describe different concepts.

## Plan

[Phase 3 of GH-1153](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-08-group-GH-1153-shorthand-tools-consistency-pass.md#phase-3-unify-count-field-names-across-discovery-tools)

Phase 3 of 8 (group plan)

## Changes

- **directions-tools.ts**: `totalCandidates` → `boardItems`
- **dashboard.ts + dashboard-tools.ts**: `totalIssues` (top-level) → `boardItems`; added comment clarifying `boardItems` includes PRs on project board
- **hygiene-tools.ts + hygiene.ts**: added `boardItems` to `project_hygiene` return shape
- **Tool descriptions**: all three discovery tools now document the `boardItems` field semantics
- **Tests**: updated all existing tests; added new structural test `board-items-naming.test.ts` asserting old names are absent from source
- **Skills**: `report/SKILL.md` and `hello/__tests__/synthesis.smoke.md` updated for new field names

## Test plan

- [x] All 1226 tests pass (+6 new structural assertions for `board-items-naming.test.ts`)
- [x] `npm run build` passes with no TypeScript errors
- [x] All 3 tools return `boardItems` field with correct value
- [x] `grep "totalCandidates|totalIssues"` in `src/tools/` and `src/lib/` returns 0 hits (except pagination helpers, out of scope)
- [x] Commit message includes `#minor` for auto-release minor version bump

## Breaking change note

This PR includes `#minor` in the commit message to bump the package version to the next minor release (semver convention for breaking changes during pre-1.0). External callers of the MCP server who read `totalCandidates`, `totalIssues` (top-level), or `totalItems` from the discovery tools must migrate to the new `boardItems` field name.

Closes #1156