### PR TITLE
GH-1158: Surface repo-scope mismatch via health_check warning (orphanRepoIssues) — Phase 5

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/health-check.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/health-check.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for `detectOrphanRepoIssues` — the helper that powers the
+ * `orphanRepoIssues` warning in the `health_check` MCP tool.
+ *
+ * The tool registration itself lives inline in `index.ts` and is wired to a
+ * live MCP server, so unit tests target the pure helper directly with a
+ * mocked `GitHubClient`. This keeps the tests fast and deterministic while
+ * still asserting the field contract (count, repoOpen, boardItems, sample, note).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  detectOrphanRepoIssues,
+  ORPHAN_REPO_ISSUES_NOTE,
+  ORPHAN_SAMPLE_LIMIT,
+} from "../lib/health.js";
+import type { GitHubClient } from "../github-client.js";
+
+/**
+ * Build a mock GitHubClient with `query` and `projectQuery` stubbed to
+ * return the supplied repo and board issue numbers.
+ *
+ * Notes:
+ * - `query()` mock returns a single page (we never test pagination here).
+ * - `projectQuery()` mock returns the items under `user.projectV2.items`
+ *   so the helper's user-first lookup path resolves on the first try.
+ */
+function makeMockClient(opts: {
+  repoOpenCount: number;
+  repoOpenNumbers: number[];
+  boardItemCount: number;
+  boardIssueNumbers: number[];
+}): GitHubClient {
+  const queryMock = vi.fn().mockResolvedValue({
+    repository: {
+      issues: {
+        totalCount: opts.repoOpenCount,
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: opts.repoOpenNumbers.map((number) => ({ number })),
+      },
+    },
+  });
+
+  const projectQueryMock = vi.fn().mockResolvedValue({
+    user: {
+      projectV2: {
+        items: {
+          totalCount: opts.boardItemCount,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: opts.boardIssueNumbers.map((number) => ({
+            type: "ISSUE",
+            content: { __typename: "Issue", number },
+          })),
+        },
+      },
+    },
+  });
+
+  return {
+    query: queryMock,
+    projectQuery: projectQueryMock,
+    mutate: vi.fn(),
+    projectMutate: vi.fn(),
+    getRateLimitStatus: vi.fn(),
+    getCache: vi.fn(),
+    getAuthenticatedUser: vi.fn(),
+    restPost: vi.fn(),
+    config: {
+      token: "test",
+      owner: "test-owner",
+      repo: "test-repo",
+      projectNumber: 1,
+      projectOwner: "test-owner",
+    },
+  } as unknown as GitHubClient;
+}
+
+describe("detectOrphanRepoIssues", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when every OPEN repo issue is on the board", async () => {
+    const client = makeMockClient({
+      repoOpenCount: 3,
+      repoOpenNumbers: [10, 11, 12],
+      boardItemCount: 3,
+      boardIssueNumbers: [10, 11, 12],
+    });
+
+    const result = await detectOrphanRepoIssues(
+      client,
+      "test-owner",
+      "test-repo",
+      "test-owner",
+      1,
+    );
+
+    // Clean board → null → caller omits the field entirely.
+    expect(result).toBeNull();
+  });
+
+  it("returns orphan summary when repo has issues missing from the board", async () => {
+    // 35 OPEN repo issues, only 4 on board — this is the today's-known-delta
+    // case from the audit (31 orphans).
+    const repoNumbers = Array.from({ length: 35 }, (_, i) => i + 1);
+    const boardNumbers = [10, 11, 12, 13];
+
+    const client = makeMockClient({
+      repoOpenCount: 35,
+      repoOpenNumbers: repoNumbers,
+      boardItemCount: 4,
+      boardIssueNumbers: boardNumbers,
+    });
+
+    const result = await detectOrphanRepoIssues(
+      client,
+      "test-owner",
+      "test-repo",
+      "test-owner",
+      1,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(31);
+    expect(result!.repoOpen).toBe(35);
+    expect(result!.boardItems).toBe(4);
+    // Sample is capped at ORPHAN_SAMPLE_LIMIT entries, sorted ascending.
+    expect(result!.sample.length).toBe(ORPHAN_SAMPLE_LIMIT);
+    expect(result!.sample).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 14]);
+    expect(result!.note).toBe(ORPHAN_REPO_ISSUES_NOTE);
+  });
+
+  it("sample contains all orphans when fewer than the limit", async () => {
+    const client = makeMockClient({
+      repoOpenCount: 5,
+      repoOpenNumbers: [1, 2, 3, 4, 5],
+      boardItemCount: 3,
+      boardIssueNumbers: [1, 2, 3],
+    });
+
+    const result = await detectOrphanRepoIssues(
+      client,
+      "test-owner",
+      "test-repo",
+      "test-owner",
+      1,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(2);
+    // Only 2 orphans → sample has 2 entries, NOT padded to ORPHAN_SAMPLE_LIMIT.
+    expect(result!.sample).toEqual([4, 5]);
+    expect(result!.sample.length).toBe(2);
+  });
+
+  it("ignores PRs and DraftIssues on the board", async () => {
+    // Board contains an ISSUE, a PR, and a DraftIssue. Only the ISSUE
+    // should count as overlap with the repo's OPEN issue set.
+    const queryMock = vi.fn().mockResolvedValue({
+      repository: {
+        issues: {
+          totalCount: 2,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [{ number: 100 }, { number: 200 }],
+        },
+      },
+    });
+
+    const projectQueryMock = vi.fn().mockResolvedValue({
+      user: {
+        projectV2: {
+          items: {
+            totalCount: 3,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              // The matching ISSUE — should overlap with repo issue 100.
+              { type: "ISSUE", content: { __typename: "Issue", number: 100 } },
+              // A PR on the board — must NOT count as repo-issue overlap.
+              { type: "PULL_REQUEST", content: { __typename: "PullRequest", number: 200 } },
+              // A draft issue — must NOT count.
+              { type: "DRAFT_ISSUE", content: { __typename: "DraftIssue" } },
+            ],
+          },
+        },
+      },
+    });
+
+    const client = {
+      query: queryMock,
+      projectQuery: projectQueryMock,
+      mutate: vi.fn(),
+      projectMutate: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getCache: vi.fn(),
+      getAuthenticatedUser: vi.fn(),
+      restPost: vi.fn(),
+      config: {
+        token: "test",
+        owner: "test-owner",
+        repo: "test-repo",
+        projectNumber: 1,
+        projectOwner: "test-owner",
+      },
+    } as unknown as GitHubClient;
+
+    const result = await detectOrphanRepoIssues(
+      client,
+      "test-owner",
+      "test-repo",
+      "test-owner",
+      1,
+    );
+
+    // Issue 100 IS on the board (as type=ISSUE). Issue 200 is only present
+    // as a PR — it should still count as an orphan because the helper
+    // operates on the OPEN-issue set, not the OPEN-issue-or-PR set.
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(1);
+    expect(result!.sample).toEqual([200]);
+  });
+
+  it("falls back to organization owner when user lookup returns null", async () => {
+    // Simulate a project owned by an org: the user(login) call returns null
+    // (or its projectV2 is null), and the helper should retry as organization.
+    let callCount = 0;
+    const projectQueryMock = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      // First call: user(login) returns no project → triggers org fallback.
+      if (callCount === 1) {
+        return { user: null };
+      }
+      // Second call: organization(login) returns the project.
+      return {
+        organization: {
+          projectV2: {
+            items: {
+              totalCount: 2,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                { type: "ISSUE", content: { __typename: "Issue", number: 1 } },
+                { type: "ISSUE", content: { __typename: "Issue", number: 2 } },
+              ],
+            },
+          },
+        },
+      };
+    });
+
+    const queryMock = vi.fn().mockResolvedValue({
+      repository: {
+        issues: {
+          totalCount: 3,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [{ number: 1 }, { number: 2 }, { number: 3 }],
+        },
+      },
+    });
+
+    const client = {
+      query: queryMock,
+      projectQuery: projectQueryMock,
+      mutate: vi.fn(),
+      projectMutate: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getCache: vi.fn(),
+      getAuthenticatedUser: vi.fn(),
+      restPost: vi.fn(),
+      config: {
+        token: "test",
+        owner: "test-owner",
+        repo: "test-repo",
+        projectNumber: 1,
+        projectOwner: "test-org",
+      },
+    } as unknown as GitHubClient;
+
+    const result = await detectOrphanRepoIssues(
+      client,
+      "test-owner",
+      "test-repo",
+      "test-org",
+      1,
+    );
+
+    // Issue 3 is the orphan — repo has it, board has only 1 and 2.
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(1);
+    expect(result!.sample).toEqual([3]);
+    // Both user and org calls were attempted on the first page.
+    expect(projectQueryMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("note text is the canonical exported constant", async () => {
+    // Asserting the exact prose ensures downstream consumers (logs, UI)
+    // can pattern-match against ORPHAN_REPO_ISSUES_NOTE without drift.
+    expect(ORPHAN_REPO_ISSUES_NOTE).toContain("not on the project board");
+    expect(ORPHAN_REPO_ISSUES_NOTE).toContain("next_actions");
+    expect(ORPHAN_REPO_ISSUES_NOTE).toContain("list_issues");
+    expect(ORPHAN_REPO_ISSUES_NOTE).toContain("pipeline_dashboard");
+    expect(ORPHAN_REPO_ISSUES_NOTE).toContain("project_hygiene");
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -18,6 +18,7 @@ import { FieldOptionCache } from "./lib/cache.js";
 import { createDebugLogger, wrapServerToolWithLogging, type DebugLogger } from "./lib/debug-logger.js";
 import { toolSuccess, toolError, resolveProjectOwner } from "./types.js";
 import { resolveRepoFromProject } from "./lib/helpers.js";
+import { detectOrphanRepoIssues, type OrphanRepoIssuesResult } from "./lib/health.js";
 import { registerProjectTools } from "./tools/project-tools.js";
 import { registerIssueTools } from "./tools/issue-tools.js";
 import { registerRelationshipTools } from "./tools/relationship-tools.js";
@@ -213,7 +214,7 @@ function registerCoreTools(server: McpServer, client: GitHubClient): void {
   // Health check tool - comprehensive validation of auth, repo, project, and fields
   server.tool(
     "ralph_hero__health_check",
-    "Validate GitHub API connectivity, token permissions, repo access, project access, and required fields",
+    "Validate GitHub API connectivity, token permissions, repo access, project access, and required fields. Also surfaces repo-scope mismatch via the `orphanRepoIssues` field when OPEN issues exist in the repo but are NOT on the configured project board (such issues are invisible to discovery tools like next_actions, list_issues, pipeline_dashboard, project_hygiene). The field is omitted entirely when the board contains every OPEN repo issue. Shape when present: `{ count, repoOpen, boardItems, sample: number[], note }` — `sample` is up to 10 orphan issue numbers (ascending) for diagnostic display.",
     {},
     async () => {
       const checks: Record<string, { status: string; detail?: string }> = {};
@@ -343,6 +344,36 @@ function registerCoreTools(server: McpServer, client: GitHubClient): void {
         };
       }
 
+      // 5. Orphan repo issues check — only runs when both repo and project
+      // access succeeded above. Failures here are non-fatal: orphan detection
+      // is informational and shouldn't downgrade the overall health status,
+      // because the underlying access checks already capture the real failure
+      // mode (broken token, missing project, etc.).
+      let orphanRepoIssues: OrphanRepoIssuesResult | null = null;
+      if (
+        checks.repoAccess?.status === "ok" &&
+        checks.projectAccess?.status === "ok" &&
+        client.config.owner &&
+        client.config.repo &&
+        projOwner &&
+        projNum
+      ) {
+        try {
+          orphanRepoIssues = await detectOrphanRepoIssues(
+            client,
+            client.config.owner,
+            client.config.repo,
+            projOwner,
+            projNum,
+          );
+        } catch (e) {
+          // Non-fatal — log via stderr but don't fail health_check.
+          console.error(
+            `[ralph-hero] Orphan repo issues check failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
+      }
+
       // Token source detection — re-derive which env vars resolved
       const repoTokenSource = resolveEnv("RALPH_GH_REPO_TOKEN")
         ? "RALPH_GH_REPO_TOKEN"
@@ -379,6 +410,9 @@ function registerCoreTools(server: McpServer, client: GitHubClient): void {
               ? `Repo operations use ${repoTokenSource}, project operations use ${projectTokenSource}`
               : `Both repo and project operations use ${repoTokenSource}`,
         },
+        // Omit the field entirely when there are no orphans, per the field's
+        // contract (`null` from `detectOrphanRepoIssues` means "clean board").
+        ...(orphanRepoIssues ? { orphanRepoIssues } : {}),
       });
     },
   );

--- a/plugin/ralph-hero/mcp-server/src/lib/health.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/health.ts
@@ -1,0 +1,269 @@
+/**
+ * Health-check helpers — pure functions that probe the GitHub API for
+ * configuration drift between the project board and its underlying repo.
+ *
+ * `detectOrphanRepoIssues` compares the set of OPEN issues in the configured
+ * repo against the set of `type=ISSUE` items on the configured project
+ * board. Issues present in the repo but not on the board are "orphans" —
+ * they exist but are structurally invisible to the discovery tools
+ * (`next_actions`, `list_issues`, `pipeline_dashboard`, `project_hygiene`),
+ * which all read from the project board.
+ *
+ * Surfaced via `health_check` so users discover the mismatch without having
+ * to grep `gh issue list` against the board contents by hand.
+ */
+
+import type { GitHubClient } from "../github-client.js";
+
+/**
+ * Maximum number of orphan issue numbers to include in the response sample.
+ * The sample is for diagnostic display only; the full set is summarized via `count`.
+ */
+export const ORPHAN_SAMPLE_LIMIT = 10;
+
+/**
+ * Page size used when paginating repo issues and project items.
+ *
+ * GitHub GraphQL caps `first:` at 100. Most projects fit comfortably in a
+ * handful of pages — pagination is implemented for correctness, not because
+ * every call hits it.
+ */
+const PAGE_SIZE = 100;
+
+/**
+ * Hard cap on pages walked when enumerating repo issues or project items.
+ * Defensive: prevents a runaway loop on a misconfigured giant repo.
+ */
+const MAX_PAGES = 20;
+
+/**
+ * Result shape for `detectOrphanRepoIssues`.
+ *
+ * - `count`: number of OPEN repo issues that are NOT on the project board.
+ * - `repoOpen`: total count of OPEN issues in the repo (for context).
+ * - `boardItems`: count of `type=ISSUE` items on the project board.
+ * - `sample`: up to `ORPHAN_SAMPLE_LIMIT` orphan issue numbers, sorted ascending.
+ * - `note`: human-readable guidance shown to the user.
+ *
+ * When `count === 0`, the helper returns `null` instead of this shape so
+ * callers can omit the field entirely from the `health_check` response.
+ */
+export interface OrphanRepoIssuesResult {
+  count: number;
+  repoOpen: number;
+  boardItems: number;
+  sample: number[];
+  note: string;
+}
+
+/**
+ * Standard explanatory note attached to the orphan-repo-issues warning.
+ * Lifted to a constant so tests can assert against a single canonical string.
+ */
+export const ORPHAN_REPO_ISSUES_NOTE =
+  "Issues exist in the repo that are not on the project board. They are " +
+  "invisible to discovery tools (next_actions, list_issues, pipeline_dashboard, " +
+  "project_hygiene). To make them visible, add them to the project or use " +
+  "'gh issue list' directly.";
+
+/**
+ * GraphQL response shape for the paginated repo OPEN issues query.
+ */
+interface IssuesConnection {
+  totalCount: number;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: Array<{ number: number }>;
+}
+interface RepoIssuesPage {
+  repository: {
+    issues: IssuesConnection;
+  } | null;
+}
+
+/**
+ * GraphQL response shape for the paginated project items query.
+ *
+ * Tries `user(login)` first, then `organization(login)`; both share this shape.
+ */
+interface ProjectItemsConnection {
+  totalCount: number;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: Array<{
+    type: string;
+    content: { __typename: string; number?: number } | null;
+  }>;
+}
+interface ProjectV2WithItems {
+  items: ProjectItemsConnection | null;
+}
+interface ProjectItemsPage {
+  projectV2: ProjectV2WithItems | null;
+}
+
+/**
+ * Fetch all OPEN issue numbers in the repo via paginated GraphQL.
+ *
+ * Returns `{ totalCount, numbers }`. `totalCount` is taken from the first
+ * page (it is constant across pages). `numbers` is the union of all
+ * `node.number` values walked.
+ */
+async function fetchRepoOpenIssueNumbers(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+): Promise<{ totalCount: number; numbers: Set<number> }> {
+  const numbers = new Set<number>();
+  let totalCount = 0;
+  let cursor: string | null = null;
+  let pages = 0;
+
+  while (pages < MAX_PAGES) {
+    const response: RepoIssuesPage = await client.query<RepoIssuesPage>(
+      `query($owner: String!, $repo: String!, $cursor: String, $first: Int!) {
+        repository(owner: $owner, name: $repo) {
+          issues(states: OPEN, first: $first, after: $cursor) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
+            nodes { number }
+          }
+        }
+      }`,
+      { owner, repo, cursor, first: PAGE_SIZE },
+    );
+
+    const page: IssuesConnection | undefined = response.repository?.issues;
+    if (!page) break;
+
+    if (pages === 0) totalCount = page.totalCount;
+    for (const node of page.nodes) numbers.add(node.number);
+
+    if (!page.pageInfo.hasNextPage) break;
+    cursor = page.pageInfo.endCursor;
+    pages += 1;
+  }
+
+  return { totalCount, numbers };
+}
+
+/**
+ * Fetch all `type=ISSUE` item numbers on the project board via paginated GraphQL.
+ *
+ * The query tries `user(login)` first, then falls back to `organization(login)`
+ * to handle both account types. PRs and DraftIssues are skipped — only true
+ * `Issue`-typed content with a `number` field is collected.
+ */
+async function fetchBoardIssueNumbers(
+  client: GitHubClient,
+  projectOwner: string,
+  projectNumber: number,
+): Promise<{ totalCount: number; numbers: Set<number> }> {
+  const numbers = new Set<number>();
+  let totalCount = 0;
+  let cursor: string | null = null;
+  let pages = 0;
+
+  // The project items query is identical across user/org owner — only the
+  // root selector changes. Build a closure that runs the same shape and
+  // tries both owner types on the first page.
+  const runQuery = async (cur: string | null): Promise<ProjectV2WithItems | null> => {
+    for (const ownerType of ["user", "organization"]) {
+      try {
+        const res: Record<string, ProjectItemsPage> = await client.projectQuery<
+          Record<string, ProjectItemsPage>
+        >(
+          `query($owner: String!, $number: Int!, $cursor: String, $first: Int!) {
+            ${ownerType}(login: $owner) {
+              projectV2(number: $number) {
+                items(first: $first, after: $cursor) {
+                  totalCount
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    type
+                    content {
+                      __typename
+                      ... on Issue { number }
+                    }
+                  }
+                }
+              }
+            }
+          }`,
+          { owner: projectOwner, number: projectNumber, cursor: cur, first: PAGE_SIZE },
+        );
+        const proj = res[ownerType]?.projectV2;
+        if (proj) return proj;
+      } catch {
+        // Try next owner type
+      }
+    }
+    return null;
+  };
+
+  while (pages < MAX_PAGES) {
+    const proj = await runQuery(cursor);
+    if (!proj || !proj.items) break;
+
+    if (pages === 0) totalCount = proj.items.totalCount;
+    for (const node of proj.items.nodes) {
+      // Only count Issue-typed content. Type field is "ISSUE" but we double-check
+      // via __typename because draft-issue items can have type=DRAFT_ISSUE and
+      // should never count as repo-issue overlap.
+      if (
+        node.type === "ISSUE" &&
+        node.content?.__typename === "Issue" &&
+        typeof node.content.number === "number"
+      ) {
+        numbers.add(node.content.number);
+      }
+    }
+
+    if (!proj.items.pageInfo.hasNextPage) break;
+    cursor = proj.items.pageInfo.endCursor;
+    pages += 1;
+  }
+
+  return { totalCount, numbers };
+}
+
+/**
+ * Detect repo issues that are absent from the project board.
+ *
+ * Returns the orphan summary when at least one orphan exists, or `null`
+ * when the board contains every OPEN repo issue.
+ *
+ * Returns `null` (not an empty result) so the `health_check` caller can
+ * omit the field entirely on a clean board — keeping the response tight
+ * for the common no-orphans case.
+ */
+export async function detectOrphanRepoIssues(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  projectOwner: string,
+  projectNumber: number,
+): Promise<OrphanRepoIssuesResult | null> {
+  const [repoSide, boardSide] = await Promise.all([
+    fetchRepoOpenIssueNumbers(client, owner, repo),
+    fetchBoardIssueNumbers(client, projectOwner, projectNumber),
+  ]);
+
+  // Orphans = OPEN issues in the repo whose number is NOT in the board set.
+  // We compare against the actual numbers walked rather than just totalCount,
+  // because a board may contain issues from OTHER repos (multi-repo project)
+  // — those would inflate `boardItems` but contribute zero to the overlap.
+  const orphanNumbers: number[] = [];
+  for (const n of repoSide.numbers) {
+    if (!boardSide.numbers.has(n)) orphanNumbers.push(n);
+  }
+  orphanNumbers.sort((a, b) => a - b);
+
+  if (orphanNumbers.length === 0) return null;
+
+  return {
+    count: orphanNumbers.length,
+    repoOpen: repoSide.totalCount,
+    boardItems: boardSide.totalCount,
+    sample: orphanNumbers.slice(0, ORPHAN_SAMPLE_LIMIT),
+    note: ORPHAN_REPO_ISSUES_NOTE,
+  };
+}


### PR DESCRIPTION
## Summary

Adds an `orphanRepoIssues` warning field to the `health_check` tool response when OPEN issues exist in the repo but are not on the configured project board. This phase (Phase 5 of GH-1153 group plan) makes the repo-scope mismatch visible to users, surfacing issues that are structurally invisible to all discovery tools (next_actions, list_issues, pipeline_dashboard, project_hygiene).

Today's audit found 35 OPEN repo issues but only 4 on the project board — 31 were invisible to shorthand tools. This PR makes that delta discoverable.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-08-group-GH-1153-shorthand-tools-consistency-pass.md#phase-5-surface-repo-scope-mismatch-via-health_check-warning

Phase 5 of 8 in the GH-1153 consistency-and-elegance pass.

## Changes

**New file: `src/lib/health.ts`**
- Pure `detectOrphanRepoIssues()` helper that paginates both repo OPEN issues and project board items
- Handles user/organization project owner fallback (tries both via `projectQuery`)
- Filters PRs and DraftIssues from board overlap check (only counts type=ISSUE items)
- Returns `null` when no orphans exist (clean state) so the field can be cleanly omitted from `health_check` response
- Includes `count`, `repoOpen`, `boardItems`, `sample` (up to 10 issue numbers), and canonical `note` explaining visibility

**Modified: `src/index.ts`**
- Wires `detectOrphanRepoIssues()` into the `health_check` handler (~line 344)
- Non-fatal error handling: failures in orphan detection don't downgrade overall health status
- Updated tool description to document the new field and its contract

**New file: `src/__tests__/health-check.test.ts`**
- 6 comprehensive unit tests covering:
  - Clean board (no orphans) → returns null
  - Known-delta case (35 repo, 4 board → 31 orphans)
  - Sample capping (fewer orphans than limit)
  - Filtering PRs and DraftIssues
  - User/organization owner fallback
  - Note text assertion

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes (1261/1261 across 57 files)
- [x] New health-check tests all pass

## Notes

- XS estimate, additive change (not breaking)
- Field is cleanly omitted when `count === 0` (returns `null` from helper)
- Paginated queries handle large repos (defensive MAX_PAGES guard included)
- Non-fatal error handling preserves overall health_check contract: repo/project access checks remain the signal for auth/permission failures

Closes #1158