### PR TITLE
GH-1121: Phase 3 — direct unit tests for untested mcp-server lib modules

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/dashboard-fetch.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/dashboard-fetch.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Direct unit tests for `lib/dashboard-fetch.ts`.
+ *
+ * Splits coverage into:
+ *   1. `toDashboardItems` — pure-function tests, no mocks.
+ *   2. `fetchDashboardItems` — mock `client.projectQuery` via vi.fn();
+ *      pre-populate `FieldOptionCache` to short-circuit `ensureFieldCache`,
+ *      and `vi.mock` the helpers module to inject the failure path for the
+ *      `ensureFieldCache rejects` case.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock must be hoisted before module import. We provide a controllable
+// `ensureFieldCache` so a single test can force it to reject for one project.
+const ensureFieldCacheMock = vi.fn(async () => {
+  /* default: succeed (no-op) */
+});
+vi.mock("../lib/helpers.js", async () => {
+  const actual = await vi.importActual<typeof import("../lib/helpers.js")>(
+    "../lib/helpers.js",
+  );
+  return {
+    ...actual,
+    ensureFieldCache: (...args: any[]) => ensureFieldCacheMock(...args),
+  };
+});
+
+import {
+  toDashboardItems,
+  fetchDashboardItems,
+  type RawDashboardItem,
+} from "../lib/dashboard-fetch.js";
+import { FieldOptionCache } from "../lib/cache.js";
+import type { GitHubClient } from "../github-client.js";
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function makeRawIssue(overrides: Partial<RawDashboardItem["content"]> = {}, fieldValues: any[] = []): RawDashboardItem {
+  return {
+    id: "PVTI_1",
+    type: "ISSUE",
+    content: {
+      __typename: "Issue",
+      number: 1,
+      title: "Test issue",
+      state: "OPEN",
+      updatedAt: "2026-05-01T00:00:00Z",
+      closedAt: null,
+      assignees: { nodes: [] },
+      trackedInIssues: { nodes: [] },
+      trackedIssues: { nodes: [] },
+      repository: { nameWithOwner: "octo/demo", name: "demo" },
+      subIssues: { totalCount: 0 },
+      ...overrides,
+    },
+    fieldValues: { nodes: fieldValues },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// toDashboardItems — pure
+// ---------------------------------------------------------------------------
+
+describe("toDashboardItems", () => {
+  it("filters out non-Issue content (PRs and DraftIssues are dropped)", () => {
+    const raw: RawDashboardItem[] = [
+      makeRawIssue(),
+      {
+        id: "PVTI_2",
+        type: "PULL_REQUEST",
+        content: { __typename: "PullRequest", number: 2, title: "PR" },
+        fieldValues: { nodes: [] },
+      } as any,
+      {
+        id: "PVTI_3",
+        type: "DRAFT_ISSUE",
+        content: { __typename: "DraftIssue", title: "Draft" },
+        fieldValues: { nodes: [] },
+      } as any,
+    ];
+
+    const result = toDashboardItems(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+  });
+
+  it("maps Workflow State / Priority / Estimate single-select fields onto items", () => {
+    const raw = [
+      makeRawIssue({}, [
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: "In Progress",
+          field: { name: "Workflow State" },
+        },
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: "P1",
+          field: { name: "Priority" },
+        },
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: "S",
+          field: { name: "Estimate" },
+        },
+      ]),
+    ];
+    const [item] = toDashboardItems(raw);
+    expect(item.workflowState).toBe("In Progress");
+    expect(item.priority).toBe("P1");
+    expect(item.estimate).toBe("S");
+  });
+
+  it("flattens assignees to string[]", () => {
+    const raw = [
+      makeRawIssue({
+        assignees: { nodes: [{ login: "alice" }, { login: "bob" }] },
+      }),
+    ];
+    const [item] = toDashboardItems(raw);
+    expect(item.assignees).toEqual(["alice", "bob"]);
+  });
+
+  it("maps trackedIssues -> blockedBy with workflowState=Done iff source state CLOSED", () => {
+    const raw = [
+      makeRawIssue({
+        trackedIssues: {
+          nodes: [
+            { number: 50, state: "CLOSED" },
+            { number: 60, state: "OPEN" },
+          ],
+        },
+      }),
+    ];
+    const [item] = toDashboardItems(raw);
+    expect(item.blockedBy).toEqual([
+      { number: 50, workflowState: "Done" },
+      { number: 60, workflowState: null },
+    ]);
+  });
+
+  it("sets parentNumber and parentState from trackedInIssues.nodes[0]", () => {
+    const raw = [
+      makeRawIssue({
+        trackedInIssues: {
+          nodes: [{ number: 99, state: "OPEN", closedAt: null }],
+        },
+      }),
+    ];
+    const [item] = toDashboardItems(raw);
+    expect(item.parentNumber).toBe(99);
+    expect(item.parentState).toBe("OPEN");
+  });
+
+  it("propagates projectNumber, projectTitle, repository, and iteration fields", () => {
+    const raw = [
+      makeRawIssue({}, [
+        {
+          __typename: "ProjectV2ItemFieldIterationValue",
+          iterationId: "iter-1",
+          title: "Sprint 1",
+          startDate: "2026-05-01",
+          duration: 14,
+        },
+      ]),
+    ];
+    const [item] = toDashboardItems(raw, 7, "Demo Project");
+    expect(item.projectNumber).toBe(7);
+    expect(item.projectTitle).toBe("Demo Project");
+    expect(item.repository).toBe("octo/demo");
+    expect(item.iterationId).toBe("iter-1");
+    expect(item.iterationTitle).toBe("Sprint 1");
+    expect(item.iterationStartDate).toBe("2026-05-01");
+    expect(item.iterationDuration).toBe(14);
+  });
+
+  it("defaults title to '(untitled)' and updatedAt to epoch when missing", () => {
+    const raw: RawDashboardItem[] = [
+      {
+        id: "PVTI_X",
+        type: "ISSUE",
+        content: {
+          __typename: "Issue",
+          number: 1,
+          // title and updatedAt intentionally omitted
+        } as any,
+        fieldValues: { nodes: [] },
+      },
+    ];
+    const [item] = toDashboardItems(raw);
+    expect(item.title).toBe("(untitled)");
+    expect(item.updatedAt).toBe(new Date(0).toISOString());
+    expect(item.subIssueCount).toBe(0);
+    expect(item.assignees).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchDashboardItems
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock GitHubClient where projectQuery is a vi.fn that we can
+ * pre-program to return shaped responses for:
+ *   - the project-title query (`node { title }`)
+ *   - the DASHBOARD_ITEMS_QUERY (paginated items connection)
+ */
+function makeMockClient(opts: {
+  owner?: string;
+  projectNumber?: number;
+  projectNumbers?: number[];
+}): {
+  client: GitHubClient;
+  projectQuery: ReturnType<typeof vi.fn>;
+} {
+  const projectQuery = vi.fn();
+  const client = {
+    config: {
+      token: "x",
+      owner: opts.owner,
+      repo: "demo",
+      projectNumber: opts.projectNumber,
+      projectNumbers: opts.projectNumbers,
+    },
+    projectQuery: (q: string, v: any) => projectQuery(q, v),
+  } as unknown as GitHubClient;
+  return { client, projectQuery };
+}
+
+const FIELDS_FIXTURE = [
+  {
+    id: "field-ws",
+    name: "Workflow State",
+    options: [{ id: "opt-1", name: "In Progress" }],
+  },
+];
+
+beforeEach(() => {
+  ensureFieldCacheMock.mockReset();
+  ensureFieldCacheMock.mockImplementation(async () => {
+    /* default: succeed */
+  });
+});
+
+describe("fetchDashboardItems — error paths", () => {
+  it("throws when no owner is resolvable", async () => {
+    const { client } = makeMockClient({ projectNumber: 3 });
+    const cache = new FieldOptionCache();
+    await expect(fetchDashboardItems(client, cache)).rejects.toThrow(
+      /owner is required/,
+    );
+  });
+
+  it("throws when no project numbers are configured", async () => {
+    const { client } = makeMockClient({ owner: "octo" });
+    const cache = new FieldOptionCache();
+    await expect(fetchDashboardItems(client, cache)).rejects.toThrow(
+      /No project numbers configured/,
+    );
+  });
+});
+
+describe("fetchDashboardItems — explicit projectNumber arg", () => {
+  it("uses the explicit arg over config and queries with the resolved projectId", async () => {
+    const { client, projectQuery } = makeMockClient({
+      owner: "octo",
+      projectNumber: 99, // config
+    });
+    const cache = new FieldOptionCache();
+    cache.populate(7, "PVT_proj_explicit", FIELDS_FIXTURE);
+
+    // projectQuery is called for: (1) title fetch, (2) items pagination
+    projectQuery.mockImplementation(async (q: string, vars: any) => {
+      if (!q.includes("items(first:")) {
+        return { node: { title: "Explicit Project" } };
+      }
+      // items query
+      expect(vars.projectId).toBe("PVT_proj_explicit");
+      return {
+        node: {
+          items: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: "PVTI_E",
+                type: "ISSUE",
+                content: {
+                  __typename: "Issue",
+                  number: 42,
+                  title: "From explicit",
+                  state: "OPEN",
+                  updatedAt: "2026-05-01T00:00:00Z",
+                  closedAt: null,
+                  assignees: { nodes: [] },
+                  trackedInIssues: { nodes: [] },
+                  trackedIssues: { nodes: [] },
+                  repository: { nameWithOwner: "octo/demo", name: "demo" },
+                  subIssues: { totalCount: 0 },
+                },
+                fieldValues: { nodes: [] },
+              },
+            ],
+          },
+        },
+      };
+    });
+
+    const result = await fetchDashboardItems(client, cache, 7);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].number).toBe(42);
+    expect(result.items[0].projectNumber).toBe(7);
+    expect(result.items[0].projectTitle).toBe("Explicit Project");
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+describe("fetchDashboardItems — multi-project fan-out", () => {
+  it("fans out across config.projectNumbers and tags items per project", async () => {
+    const { client, projectQuery } = makeMockClient({
+      owner: "octo",
+      projectNumbers: [3, 4],
+    });
+    const cache = new FieldOptionCache();
+    cache.populate(3, "PVT_p3", FIELDS_FIXTURE);
+    cache.populate(4, "PVT_p4", FIELDS_FIXTURE);
+
+    projectQuery.mockImplementation(async (q: string, vars: any) => {
+      if (!q.includes("items(first:")) {
+        return { node: { title: vars.projectId === "PVT_p3" ? "P3" : "P4" } };
+      }
+      const num = vars.projectId === "PVT_p3" ? 100 : 200;
+      return {
+        node: {
+          items: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: `PVTI_${num}`,
+                type: "ISSUE",
+                content: {
+                  __typename: "Issue",
+                  number: num,
+                  title: `From project ${num}`,
+                  state: "OPEN",
+                  updatedAt: "2026-05-01T00:00:00Z",
+                  closedAt: null,
+                  assignees: { nodes: [] },
+                  trackedInIssues: { nodes: [] },
+                  trackedIssues: { nodes: [] },
+                  repository: { nameWithOwner: "octo/demo", name: "demo" },
+                  subIssues: { totalCount: 0 },
+                },
+                fieldValues: { nodes: [] },
+              },
+            ],
+          },
+        },
+      };
+    });
+
+    const result = await fetchDashboardItems(client, cache);
+    expect(result.items).toHaveLength(2);
+    const byNum = new Map(result.items.map((i) => [i.number, i]));
+    expect(byNum.get(100)?.projectNumber).toBe(3);
+    expect(byNum.get(200)?.projectNumber).toBe(4);
+    expect(byNum.get(100)?.projectTitle).toBe("P3");
+    expect(byNum.get(200)?.projectTitle).toBe("P4");
+  });
+});
+
+describe("fetchDashboardItems — partial failure", () => {
+  it("records a warning and skips a project when ensureFieldCache rejects", async () => {
+    const { client, projectQuery } = makeMockClient({
+      owner: "octo",
+      projectNumbers: [3, 4],
+    });
+    const cache = new FieldOptionCache();
+    // Only project 4 is populated; project 3 will fail via ensureFieldCache mock
+    cache.populate(4, "PVT_p4", FIELDS_FIXTURE);
+
+    ensureFieldCacheMock.mockImplementation(
+      async (_c: any, _f: any, _o: string, pn: number) => {
+        if (pn === 3) throw new Error("boom");
+      },
+    );
+
+    projectQuery.mockImplementation(async (q: string) => {
+      if (!q.includes("items(first:")) return { node: { title: "P4" } };
+      return {
+        node: {
+          items: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: "PVTI_S",
+                type: "ISSUE",
+                content: {
+                  __typename: "Issue",
+                  number: 7,
+                  title: "Survivor",
+                  state: "OPEN",
+                  updatedAt: "2026-05-01T00:00:00Z",
+                  closedAt: null,
+                  assignees: { nodes: [] },
+                  trackedInIssues: { nodes: [] },
+                  trackedIssues: { nodes: [] },
+                  repository: { nameWithOwner: "octo/demo", name: "demo" },
+                  subIssues: { totalCount: 0 },
+                },
+                fieldValues: { nodes: [] },
+              },
+            ],
+          },
+        },
+      };
+    });
+
+    const result = await fetchDashboardItems(client, cache);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].number).toBe(7);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/Project #3.*boom.*skipping/);
+  });
+
+  it("warns and skips when fieldCache.getProjectId returns undefined", async () => {
+    const { client, projectQuery } = makeMockClient({
+      owner: "octo",
+      projectNumbers: [9],
+    });
+    // ensureFieldCache succeeds (mocked default), but cache is empty
+    const cache = new FieldOptionCache();
+
+    const result = await fetchDashboardItems(client, cache);
+    expect(result.items).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/Project #9.*could not resolve project ID.*skipping/);
+    expect(projectQuery).not.toHaveBeenCalled();
+  });
+
+  it("project-title fetch failure is non-fatal", async () => {
+    const { client, projectQuery } = makeMockClient({
+      owner: "octo",
+      projectNumber: 3,
+    });
+    const cache = new FieldOptionCache();
+    cache.populate(3, "PVT_p3", FIELDS_FIXTURE);
+
+    projectQuery.mockImplementation(async (q: string) => {
+      if (!q.includes("items(first:")) {
+        throw new Error("title fetch failed");
+      }
+      return {
+        node: {
+          items: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: "PVTI_T",
+                type: "ISSUE",
+                content: {
+                  __typename: "Issue",
+                  number: 1,
+                  title: "Untitled-project item",
+                  state: "OPEN",
+                  updatedAt: "2026-05-01T00:00:00Z",
+                  closedAt: null,
+                  assignees: { nodes: [] },
+                  trackedInIssues: { nodes: [] },
+                  trackedIssues: { nodes: [] },
+                  repository: { nameWithOwner: "octo/demo", name: "demo" },
+                  subIssues: { totalCount: 0 },
+                },
+                fieldValues: { nodes: [] },
+              },
+            ],
+          },
+        },
+      };
+    });
+
+    const result = await fetchDashboardItems(client, cache);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].projectTitle).toBeUndefined();
+  });
+});
+
+describe("fetchDashboardItems — pagination", () => {
+  it("walks pages until hasNextPage=false", async () => {
+    const { client, projectQuery } = makeMockClient({
+      owner: "octo",
+      projectNumber: 3,
+    });
+    const cache = new FieldOptionCache();
+    cache.populate(3, "PVT_p3", FIELDS_FIXTURE);
+
+    let page = 0;
+    projectQuery.mockImplementation(async (q: string) => {
+      if (!q.includes("items(first:")) return { node: { title: "P3" } };
+      page += 1;
+      const isLast = page === 2;
+      return {
+        node: {
+          items: {
+            totalCount: 2,
+            pageInfo: { hasNextPage: !isLast, endCursor: isLast ? null : "cursor-1" },
+            nodes: [
+              {
+                id: `PVTI_p${page}`,
+                type: "ISSUE",
+                content: {
+                  __typename: "Issue",
+                  number: page,
+                  title: `Item ${page}`,
+                  state: "OPEN",
+                  updatedAt: "2026-05-01T00:00:00Z",
+                  closedAt: null,
+                  assignees: { nodes: [] },
+                  trackedInIssues: { nodes: [] },
+                  trackedIssues: { nodes: [] },
+                  repository: { nameWithOwner: "octo/demo", name: "demo" },
+                  subIssues: { totalCount: 0 },
+                },
+                fieldValues: { nodes: [] },
+              },
+            ],
+          },
+        },
+      };
+    });
+
+    const result = await fetchDashboardItems(client, cache);
+    expect(result.items.map((i) => i.number).sort()).toEqual([1, 2]);
+    expect(page).toBe(2);
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/__tests__/group-detection.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/group-detection.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Direct unit tests for `lib/group-detection.ts`.
+ *
+ * Covers the public `detectGroup()` entry point. Mocks `GitHubClient.query`
+ * with shaped GraphQL responses — no real network. Each test scopes its mock
+ * inline so fixtures don't leak between cases.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { detectGroup } from "../lib/group-detection.js";
+import type { GitHubClient } from "../github-client.js";
+
+// ---------------------------------------------------------------------------
+// Fixture builders for the SEED_QUERY / EXPAND_QUERY response shape
+// ---------------------------------------------------------------------------
+
+interface SeedNodeFixture {
+  id: string;
+  number: number;
+  title: string;
+  state: string;
+  blocking?: Array<{ number: number; repository?: { owner: { login: string }; name: string } }>;
+  blockedBy?: Array<{ number: number; repository?: { owner: { login: string }; name: string } }>;
+}
+
+interface DepFixture {
+  id: string;
+  number: number;
+  title: string;
+  state: string;
+  repository?: { owner: { login: string }; name: string };
+}
+
+interface IssueFixture {
+  id: string;
+  number: number;
+  title: string;
+  state: string;
+  parent?: {
+    id: string;
+    number: number;
+    title: string;
+    state: string;
+    subIssues: SeedNodeFixture[];
+  } | null;
+  subIssues?: SeedNodeFixture[];
+  blocking?: DepFixture[];
+  blockedBy?: DepFixture[];
+}
+
+function shapeIssue(f: IssueFixture) {
+  return {
+    id: f.id,
+    number: f.number,
+    title: f.title,
+    state: f.state,
+    parent: f.parent
+      ? {
+          ...f.parent,
+          subIssues: {
+            nodes: f.parent.subIssues.map((s) => ({
+              ...s,
+              blocking: { nodes: s.blocking ?? [] },
+              blockedBy: { nodes: s.blockedBy ?? [] },
+            })),
+          },
+        }
+      : null,
+    subIssues: {
+      nodes: (f.subIssues ?? []).map((s) => ({
+        ...s,
+        blocking: { nodes: s.blocking ?? [] },
+        blockedBy: { nodes: s.blockedBy ?? [] },
+      })),
+    },
+    blocking: { nodes: f.blocking ?? [] },
+    blockedBy: { nodes: f.blockedBy ?? [] },
+  };
+}
+
+/**
+ * Build a mock GitHubClient.query that looks up `IssueFixture` by issue
+ * number. Returns `null` for unknown numbers (simulating a deleted issue).
+ */
+function makeClient(fixtures: IssueFixture[]): GitHubClient {
+  const byNumber = new Map(fixtures.map((f) => [f.number, f]));
+  const queryFn = vi.fn(async (_q: string, vars: any) => {
+    const fixture = byNumber.get(vars.number);
+    if (!fixture) {
+      return { repository: { issue: null } };
+    }
+    return { repository: { issue: shapeIssue(fixture) } };
+  });
+  return {
+    query: queryFn,
+    config: { token: "x", owner: "octo", repo: "demo" },
+  } as unknown as GitHubClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("detectGroup — standalone issue", () => {
+  it("returns isGroup=false with single ticket when no relationships exist", async () => {
+    const client = makeClient([
+      { id: "I_1", number: 1, title: "Solo", state: "OPEN" },
+    ]);
+
+    const result = await detectGroup(client, "octo", "demo", 1);
+
+    expect(result.isGroup).toBe(false);
+    expect(result.totalTickets).toBe(1);
+    expect(result.groupTickets).toHaveLength(1);
+    expect(result.groupTickets[0].number).toBe(1);
+    expect(result.groupPrimary.number).toBe(1);
+  });
+});
+
+describe("detectGroup — parent + sub-issues", () => {
+  it("returns the sibling group when called on the parent number", async () => {
+    const parentSubs: SeedNodeFixture[] = [
+      { id: "I_11", number: 11, title: "Child A", state: "OPEN" },
+      { id: "I_12", number: 12, title: "Child B", state: "OPEN" },
+      { id: "I_13", number: 13, title: "Child C", state: "OPEN" },
+    ];
+    const client = makeClient([
+      {
+        id: "I_10",
+        number: 10,
+        title: "Epic",
+        state: "OPEN",
+        subIssues: parentSubs,
+      },
+    ]);
+
+    const result = await detectGroup(client, "octo", "demo", 10);
+
+    // Parent seed with subIssueNumbers populated => group is the children
+    expect(result.totalTickets).toBe(3);
+    expect(result.groupTickets.map((g) => g.number).sort()).toEqual([11, 12, 13]);
+    expect(result.isGroup).toBe(true);
+  });
+
+  it("returns the same group when called on a child number, with primary set to first child by topo order", async () => {
+    const parentSubs: SeedNodeFixture[] = [
+      { id: "I_11", number: 11, title: "Child A", state: "OPEN" },
+      { id: "I_12", number: 12, title: "Child B", state: "OPEN" },
+      { id: "I_13", number: 13, title: "Child C", state: "OPEN" },
+    ];
+    const client = makeClient([
+      {
+        id: "I_11",
+        number: 11,
+        title: "Child A",
+        state: "OPEN",
+        parent: {
+          id: "I_10",
+          number: 10,
+          title: "Epic",
+          state: "OPEN",
+          subIssues: parentSubs,
+        },
+      },
+    ]);
+
+    const result = await detectGroup(client, "octo", "demo", 11);
+
+    expect(result.totalTickets).toBe(3);
+    expect(result.groupTickets.map((g) => g.number).sort()).toEqual([11, 12, 13]);
+    // Topo sort breaks ties by issue number ascending => primary is #11
+    expect(result.groupPrimary.number).toBe(11);
+  });
+});
+
+describe("detectGroup — blockedBy chain within a sibling group", () => {
+  it("topologically orders siblings by blockedBy", async () => {
+    // Parent #100 with sub-issues 10, 20, 30 where 10 blocks 20 blocks 30.
+    // Seed on any sub-issue should yield the whole sibling group ordered topologically.
+    const parentSubs: SeedNodeFixture[] = [
+      {
+        id: "I_10",
+        number: 10,
+        title: "C",
+        state: "OPEN",
+        blocking: [{ number: 20 }],
+      },
+      {
+        id: "I_20",
+        number: 20,
+        title: "B",
+        state: "OPEN",
+        blocking: [{ number: 30 }],
+        blockedBy: [{ number: 10 }],
+      },
+      {
+        id: "I_30",
+        number: 30,
+        title: "A",
+        state: "OPEN",
+        blockedBy: [{ number: 20 }],
+      },
+    ];
+    const client = makeClient([
+      {
+        id: "I_20",
+        number: 20,
+        title: "B",
+        state: "OPEN",
+        parent: {
+          id: "I_100",
+          number: 100,
+          title: "Epic",
+          state: "OPEN",
+          subIssues: parentSubs,
+        },
+      },
+    ]);
+
+    const result = await detectGroup(client, "octo", "demo", 20);
+
+    expect(result.totalTickets).toBe(3);
+    const numbers = result.groupTickets.map((g) => g.number);
+    // Topo: C(10) -> B(20) -> A(30)
+    expect(numbers).toEqual([10, 20, 30]);
+    // Order field is sequential 1..N
+    expect(result.groupTickets.map((g) => g.order)).toEqual([1, 2, 3]);
+    // Primary is the unblocked node
+    expect(result.groupPrimary.number).toBe(10);
+  });
+});
+
+describe("detectGroup — cross-repo dependency", () => {
+  it("tags a cross-repo dependency with the repository field", async () => {
+    // Seed in octo/demo blocked by an issue in other-org/other-repo.
+    const client = makeClient([
+      {
+        id: "I_100",
+        number: 100,
+        title: "Local",
+        state: "OPEN",
+        blockedBy: [
+          {
+            id: "I_99",
+            number: 99,
+            title: "Cross",
+            state: "OPEN",
+            repository: { owner: { login: "other-org" }, name: "other-repo" },
+          },
+        ],
+      },
+      // Cross-repo target — same number 99 in the lookup map
+      { id: "I_99", number: 99, title: "Cross", state: "OPEN" },
+    ]);
+
+    const result = await detectGroup(client, "octo", "demo", 100);
+
+    expect(result.totalTickets).toBe(2);
+    const cross = result.groupTickets.find((g) => g.number === 99);
+    expect(cross).toBeDefined();
+    expect(cross!.repository).toBe("other-org/other-repo");
+    // Local issue should NOT have a repository field
+    const local = result.groupTickets.find((g) => g.number === 100);
+    expect(local!.repository).toBeUndefined();
+  });
+});
+
+describe("detectGroup — error path", () => {
+  it("throws when the seed issue is not found", async () => {
+    const client = makeClient([]); // no fixtures => null
+
+    await expect(detectGroup(client, "octo", "demo", 404)).rejects.toThrow(
+      /Issue #404 not found/,
+    );
+  });
+});
+
+describe("detectGroup — expand transitively via dependencies", () => {
+  it("expands a dependency target not present in the seed graph", async () => {
+    // Seed #50 has subIssues [51, 52]. Sub-issue 51 is blockedBy #99 (not yet
+    // in the map). The expand loop must fetch #99.
+    const client = makeClient([
+      {
+        id: "I_50",
+        number: 50,
+        title: "Parent50",
+        state: "OPEN",
+        subIssues: [
+          {
+            id: "I_51",
+            number: 51,
+            title: "Sub51",
+            state: "OPEN",
+            blockedBy: [{ number: 99 }],
+          },
+          { id: "I_52", number: 52, title: "Sub52", state: "OPEN" },
+        ],
+      },
+      // 99 returned only via expand fetch
+      { id: "I_99", number: 99, title: "Far", state: "OPEN" },
+    ]);
+
+    const result = await detectGroup(client, "octo", "demo", 50);
+    // Group members are sub-issues 51, 52 + transitively 99 (joins via dep)
+    const numbers = result.groupTickets.map((g) => g.number).sort();
+    expect(numbers).toContain(51);
+    expect(numbers).toContain(52);
+    expect(numbers).toContain(99);
+  });
+
+  it("gracefully skips a dependency target that the API returns null for", async () => {
+    // Seed has a blockedBy dep #777 that does not resolve when expanded.
+    // (Note: direct deps are still added to the map from the seed payload
+    //  even if EXPAND fails. Test that the algorithm completes without
+    //  throwing on the missing expansion.)
+    const client = makeClient([
+      {
+        id: "I_60",
+        number: 60,
+        title: "Seed",
+        state: "OPEN",
+        subIssues: [
+          {
+            id: "I_61",
+            number: 61,
+            title: "Sub",
+            state: "OPEN",
+            blockedBy: [{ number: 777 }],
+          },
+        ],
+      },
+      // 777 intentionally absent from fixtures => makeClient returns null
+    ]);
+
+    const result = await detectGroup(client, "octo", "demo", 60);
+    // Algorithm must not throw, and produces a coherent result with the
+    // sub-issues it could resolve.
+    expect(result.totalTickets).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/__tests__/rate-limiter.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Direct unit tests for `lib/rate-limiter.ts`.
+ *
+ * Phase 3 of GH-1118 (test coverage hardening). Asserts the public surface of
+ * the `RateLimiter` class:
+ *   - `update()` + `getStatus()` round-trip
+ *   - `checkBeforeRequest()` no-op above warning threshold
+ *   - warning-zone log without sleep
+ *   - critical-zone sleep capped at 60s (via fake timers)
+ *   - critical-zone no-sleep when reset is in the past
+ *   - custom thresholds override defaults
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RateLimiter } from "../lib/rate-limiter.js";
+
+describe("RateLimiter.update + getStatus", () => {
+  it("update() reflects new remaining and resetAt in getStatus()", () => {
+    const rl = new RateLimiter();
+    const resetIso = "2030-01-01T00:00:00.000Z";
+    rl.update({ remaining: 4321, resetAt: resetIso, limit: 5000, cost: 1 } as any);
+
+    const status = rl.getStatus();
+    expect(status.remaining).toBe(4321);
+    expect(status.resetAt).toBeInstanceOf(Date);
+    expect(status.resetAt.toISOString()).toBe(resetIso);
+    expect(status.isLow).toBe(false);
+    expect(status.isCritical).toBe(false);
+  });
+
+  it("getStatus() flags isLow=true when remaining <= warningThreshold", () => {
+    const rl = new RateLimiter();
+    rl.update({ remaining: 80, resetAt: "2030-01-01T00:00:00Z" } as any);
+    const status = rl.getStatus();
+    expect(status.isLow).toBe(true);
+    expect(status.isCritical).toBe(false);
+  });
+
+  it("getStatus() flags isCritical=true when remaining <= blockThreshold", () => {
+    const rl = new RateLimiter();
+    rl.update({ remaining: 30, resetAt: "2030-01-01T00:00:00Z" } as any);
+    const status = rl.getStatus();
+    expect(status.isLow).toBe(true);
+    expect(status.isCritical).toBe(true);
+  });
+});
+
+describe("RateLimiter.checkBeforeRequest — warning thresholds", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is a no-op when remaining > warningThreshold", async () => {
+    const rl = new RateLimiter();
+    rl.update({ remaining: 5000, resetAt: new Date(Date.now() + 60_000).toISOString() } as any);
+
+    await rl.checkBeforeRequest();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs warning but does not sleep when blockThreshold < remaining <= warningThreshold", async () => {
+    const rl = new RateLimiter();
+    // 75 is in [51, 100] — warning zone with defaults
+    rl.update({ remaining: 75, resetAt: new Date(Date.now() + 60_000).toISOString() } as any);
+
+    const start = Date.now();
+    await rl.checkBeforeRequest();
+    const elapsed = Date.now() - start;
+
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(errSpy.mock.calls[0][0]).toContain("approaching threshold");
+    // No sleep: should resolve essentially synchronously
+    expect(elapsed).toBeLessThan(50);
+  });
+});
+
+describe("RateLimiter.checkBeforeRequest — critical zone", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("sleeps (capped at 60s) when remaining <= blockThreshold and reset is in the future", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2030-01-01T00:00:00.000Z");
+    vi.setSystemTime(now);
+
+    const rl = new RateLimiter();
+    // resetAt 5 minutes (300s) in the future — should cap at 60s
+    const resetAt = new Date(now.getTime() + 5 * 60_000).toISOString();
+    rl.update({ remaining: 10, resetAt } as any);
+
+    const promise = rl.checkBeforeRequest();
+    let resolved = false;
+    promise.then(() => {
+      resolved = true;
+    });
+
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(errSpy.mock.calls[0][0]).toContain("critically low");
+
+    // Advance 59s — should not yet be resolved
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(resolved).toBe(false);
+
+    // Advance the remaining 1s (total 60s) — promise should resolve
+    await vi.advanceTimersByTimeAsync(1_000);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it("does not sleep when remaining <= blockThreshold but resetAt is in the past", async () => {
+    const rl = new RateLimiter();
+    // resetAt in the past => msUntilReset <= 0
+    rl.update({ remaining: 10, resetAt: new Date(Date.now() - 60_000).toISOString() } as any);
+
+    const start = Date.now();
+    await rl.checkBeforeRequest();
+    const elapsed = Date.now() - start;
+
+    // Critical-zone branch is taken but no log is emitted (only logs when waiting)
+    // and no sleep happens.
+    expect(elapsed).toBeLessThan(50);
+  });
+});
+
+describe("RateLimiter custom thresholds", () => {
+  it("custom warningThreshold and blockThreshold override defaults", () => {
+    const rl = new RateLimiter({ warningThreshold: 200, blockThreshold: 100 });
+
+    rl.update({ remaining: 250, resetAt: "2030-01-01T00:00:00Z" } as any);
+    expect(rl.getStatus().isLow).toBe(false);
+
+    rl.update({ remaining: 150, resetAt: "2030-01-01T00:00:00Z" } as any);
+    expect(rl.getStatus().isLow).toBe(true);
+    expect(rl.getStatus().isCritical).toBe(false);
+
+    rl.update({ remaining: 100, resetAt: "2030-01-01T00:00:00Z" } as any);
+    expect(rl.getStatus().isCritical).toBe(true);
+  });
+});

--- a/thoughts/shared/plans/2026-05-09-GH-1121-mcp-server-lib-unit-tests.md
+++ b/thoughts/shared/plans/2026-05-09-GH-1121-mcp-server-lib-unit-tests.md
@@ -140,9 +140,9 @@ Author three new vitest files under `plugin/ralph-hero/mcp-server/src/__tests__/
 
 #### Automated Verification:
 
-- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` passes with three new files included.
-- [ ] `npm run build` (tsc) — no errors.
-- [ ] Per-file coverage on `lib/rate-limiter.ts`, `lib/group-detection.ts`, `lib/dashboard-fetch.ts` each ≥ 80% lines as reported by `@vitest/coverage-v8`.
+- [x] `npm test` in `plugin/ralph-hero/mcp-server/` passes with three new files included.
+- [x] `npm run build` (tsc) — no errors.
+- [x] Per-file coverage on `lib/rate-limiter.ts`, `lib/group-detection.ts`, `lib/dashboard-fetch.ts` each ≥ 80% lines as reported by `@vitest/coverage-v8`. (Achieved: 100% / 85.22% / 100% lines.)
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

Adds three vitest files covering the public surface of `lib/rate-limiter.ts`, `lib/group-detection.ts`, and `lib/dashboard-fetch.ts` — modules that previously had no direct vitest coverage. Pattern matches the existing fixture + vi.mock approach in cache.test.ts and github-client.test.ts.

Per-module line coverage: rate-limiter 100%, group-detection 85.22%, dashboard-fetch 100% (all ≥ 80% target).

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-09-GH-1121-mcp-server-lib-unit-tests.md

Phases shipped: 1 of 1

## Test plan

- [x] Automated verification per plan Success Criteria
  - `npm test` in `plugin/ralph-hero/mcp-server/` passes with three new files included
  - `npm run build` (tsc) — no errors
  - Per-file coverage on `lib/rate-limiter.ts`, `lib/group-detection.ts`, `lib/dashboard-fetch.ts` each ≥ 80% lines
- [ ] Manual verification per plan Success Criteria
  - Apply a no-op refactor to one target module — tests still pass
  - Mutate one observable behavior — at least one of the new tests fails with a clear assertion message
- [ ] Cross-phase integration check

Closes #1121