### PR TITLE
GH-1123: Phase 5: Hook gate tests for impl/pr/merge state machine

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/__tests__/impl-plan-required.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/impl-plan-required.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Tests for impl-plan-required.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/impl-plan-required.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/impl-plan-required.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+make_input() {
+  local fp="$1"
+  jq -nc --arg p "$fp" '{tool_input:{file_path:$p}}'
+}
+
+echo "Testing $SCRIPT"
+
+# Use TEST_DIR as a synthetic project root with no plans, to ensure
+# the gate cannot find a plan via find_existing_artifact.
+mkdir -p "$TEST_DIR/thoughts/shared/plans"
+
+echo
+echo "Test case 1: file_path under /thoughts/ -> exit 0 (allow regardless)"
+INPUT="$(make_input '/abs/path/thoughts/shared/plans/foo.md')"
+echo "$INPUT" | env CLAUDE_PROJECT_DIR="$TEST_DIR" RALPH_TICKET_ID=GH-99999 "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "thoughts/ path: exit 0"
+
+echo
+echo "Test case 2: RALPH_REQUIRES_PLAN=false + src/foo.ts -> exit 0 (opt-out)"
+INPUT="$(make_input '/abs/src/foo.ts')"
+echo "$INPUT" | env RALPH_REQUIRES_PLAN=false CLAUDE_PROJECT_DIR="$TEST_DIR" RALPH_TICKET_ID=GH-99999 "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "RALPH_REQUIRES_PLAN=false: exit 0"
+
+echo
+echo "Test case 3: required + no plan found for ticket -> exit 2 (block)"
+INPUT="$(make_input '/abs/src/foo.ts')"
+echo "$INPUT" | env -u RALPH_REQUIRES_PLAN -u RALPH_PLAN_REFERENCE \
+  CLAUDE_PROJECT_DIR="$TEST_DIR" RALPH_TICKET_ID=GH-99999 "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "no plan found: exit 2"
+
+echo
+echo "Test case 4: plan exists for ticket -> exit 0 (allow)"
+touch "$TEST_DIR/thoughts/shared/plans/2026-05-09-GH-99999-test.md"
+INPUT="$(make_input '/abs/src/foo.ts')"
+echo "$INPUT" | env -u RALPH_REQUIRES_PLAN -u RALPH_PLAN_REFERENCE \
+  CLAUDE_PROJECT_DIR="$TEST_DIR" RALPH_TICKET_ID=GH-99999 "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "plan exists: exit 0"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/impl-postcondition.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/impl-postcondition.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tests for impl-postcondition.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/impl-postcondition.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/impl-postcondition.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+echo "Testing $SCRIPT"
+
+echo
+echo "Test case 1: RALPH_COMMAND unset -> exit 0 (short-circuit)"
+( unset RALPH_COMMAND RALPH_TICKET_ID; echo '{}' | "$SCRIPT" >/dev/null 2>&1 )
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "RALPH_COMMAND unset: exit 0"
+
+echo
+echo "Test case 2: non-impl command short-circuits regardless of other env"
+echo '{}' | RALPH_COMMAND=research RALPH_TICKET_ID=GH-99999 "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "non-impl command: exit 0"
+
+echo
+echo "Test case 3: RALPH_COMMAND=impl + RALPH_TICKET_ID=GH-99999 with no matching worktree -> exit 2 (block)"
+# cwd is TEST_DIR (not a git repo) so PROJECT_ROOT falls back to cwd; no worktrees/GH-99999 dir.
+( cd "$TEST_DIR" && echo '{}' | RALPH_COMMAND=impl RALPH_TICKET_ID=GH-99999 "$SCRIPT" >/dev/null 2>&1 )
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "no matching worktree: exit 2"
+
+echo
+echo "Test case 4: RALPH_COMMAND=impl + worktree dir exists -> exit 0 (allow)"
+mkdir -p "$TEST_DIR/worktrees/GH-99999"
+( cd "$TEST_DIR" && echo '{}' | RALPH_COMMAND=impl RALPH_TICKET_ID=GH-99999 "$SCRIPT" >/dev/null 2>&1 )
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "worktree exists: exit 0"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/impl-staging-gate.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/impl-staging-gate.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Tests for impl-staging-gate.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/impl-staging-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/impl-staging-gate.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+make_input() {
+  local cmd="$1"
+  jq -nc --arg c "$cmd" '{tool_input:{command:$c}}'
+}
+
+echo "Testing $SCRIPT"
+
+echo
+echo "Test case 1: RALPH_COMMAND=impl + 'git add path/to/file.ts' -> exit 0 (happy)"
+INPUT="$(make_input 'git add path/to/file.ts')"
+echo "$INPUT" | env RALPH_COMMAND=impl "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "specific file staging: exit 0"
+
+echo
+echo "Test case 2: RALPH_COMMAND=impl + 'git add -A' -> exit 2 (block)"
+INPUT="$(make_input 'git add -A')"
+echo "$INPUT" | env RALPH_COMMAND=impl "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "git add -A: exit 2"
+
+echo
+echo "Test case 3: RALPH_COMMAND=impl + 'git add .' -> exit 2 (block)"
+INPUT="$(make_input 'git add .')"
+echo "$INPUT" | env RALPH_COMMAND=impl "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "git add .: exit 2"
+
+echo
+echo "Test case 4: RALPH_COMMAND unset + 'git add -A' -> exit 0 (short-circuit)"
+INPUT="$(make_input 'git add -A')"
+echo "$INPUT" | env -u RALPH_COMMAND "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "non-impl short-circuit: exit 0"
+
+echo
+echo "Test case 5: RALPH_COMMAND=impl + 'git add -u' -> exit 0 (allowed flag)"
+INPUT="$(make_input 'git add -u')"
+echo "$INPUT" | env RALPH_COMMAND=impl "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "git add -u: exit 0"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/impl-state-gate.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/impl-state-gate.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tests for impl-state-gate.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/impl-state-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/impl-state-gate.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+make_input() {
+  local state="$1"
+  if [[ -z "$state" ]]; then
+    echo '{"tool_input":{}}'
+  else
+    jq -nc --arg s "$state" '{tool_input:{workflowState:$s}}'
+  fi
+}
+
+echo "Testing $SCRIPT"
+
+echo
+echo "Test case 1: default valid states + 'In Review' -> exit 0 (happy)"
+INPUT="$(make_input 'In Review')"
+echo "$INPUT" | env -u RALPH_VALID_OUTPUT_STATES "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "default + In Review: exit 0"
+
+echo
+echo "Test case 2: default valid states + 'Done' -> exit 2 (block)"
+INPUT="$(make_input 'Done')"
+echo "$INPUT" | env -u RALPH_VALID_OUTPUT_STATES "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "default + Done: exit 2"
+
+echo
+echo "Test case 3: empty workflowState -> exit 0 (short-circuit)"
+INPUT="$(make_input '')"
+echo "$INPUT" | env -u RALPH_VALID_OUTPUT_STATES "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "empty state: exit 0"
+
+echo
+echo "Test case 4: custom override 'Done' + 'Done' -> exit 0 (allow)"
+INPUT="$(make_input 'Done')"
+echo "$INPUT" | env RALPH_VALID_OUTPUT_STATES="Done" "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "custom override Done: exit 0"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/impl-worktree-gate.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/impl-worktree-gate.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tests for impl-worktree-gate.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/impl-worktree-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/impl-worktree-gate.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+make_input() {
+  local fp="$1"
+  jq -nc --arg p "$fp" '{tool_input:{file_path:$p}}'
+}
+
+echo "Testing $SCRIPT"
+
+echo
+echo "Test case 1: RALPH_COMMAND unset -> exit 0 (short-circuit)"
+INPUT="$(make_input '/anywhere/foo.ts')"
+echo "$INPUT" | env -u RALPH_COMMAND "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "non-impl short-circuit: exit 0"
+
+echo
+echo "Test case 2: RALPH_COMMAND=impl + thoughts/ path -> exit 0 (allow research artifact)"
+INPUT="$(make_input '/abs/thoughts/foo.md')"
+echo "$INPUT" | RALPH_COMMAND=impl "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "thoughts/ path: exit 0"
+
+echo
+echo "Test case 3: RALPH_COMMAND=impl + file inside RALPH_WORKTREE_PATHS -> exit 0 (allow)"
+INPUT="$(make_input '/tmp/wt-1/src/foo.ts')"
+echo "$INPUT" | RALPH_COMMAND=impl RALPH_WORKTREE_PATHS=/tmp/wt-1 "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "in-worktree path: exit 0"
+
+echo
+echo "Test case 4: RALPH_COMMAND=impl + file outside worktree -> exit 2 (block)"
+INPUT="$(make_input '/tmp/other/foo.ts')"
+( cd /tmp && echo "$INPUT" | RALPH_COMMAND=impl RALPH_WORKTREE_PATHS=/tmp/wt-1 "$SCRIPT" >/dev/null 2>&1 )
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "out-of-worktree path: exit 2"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/lock-claim-validator.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/lock-claim-validator.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Tests for lock-claim-validator.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/lock-claim-validator.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/lock-claim-validator.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+echo "Testing $SCRIPT"
+
+echo
+echo "Test case 1: tool_name='Bash' -> exit 0 (allow non-save-issue)"
+INPUT='{"tool_name":"Bash","tool_input":{"workflowState":"In Progress"}}'
+echo "$INPUT" | RALPH_CURRENT_STATE="In Progress" "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "non-save-issue tool: exit 0"
+
+echo
+echo "Test case 2: save_issue + non-lock target 'In Review' -> exit 0 (allow)"
+INPUT='{"tool_name":"ralph_hero__save_issue","tool_input":{"workflowState":"In Review"}}'
+echo "$INPUT" | RALPH_CURRENT_STATE="In Progress" "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "non-lock target: exit 0"
+
+echo
+echo "Test case 3: save_issue + lock target + already locked -> exit 2 (block double-lock)"
+INPUT='{"tool_name":"ralph_hero__save_issue","tool_input":{"workflowState":"In Progress","issueNumber":42}}'
+echo "$INPUT" | RALPH_CURRENT_STATE="In Progress" "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "double-lock: exit 2"
+
+echo
+echo "Test case 4: save_issue + lock target + non-lock current state -> exit 0 (allow first-claim)"
+INPUT='{"tool_name":"ralph_hero__save_issue","tool_input":{"workflowState":"In Progress","issueNumber":42}}'
+echo "$INPUT" | RALPH_CURRENT_STATE="Ready for Plan" "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "first-claim: exit 0"
+
+echo
+echo "Test case 5: save_issue + lock target + RALPH_CURRENT_STATE unset -> exit 0 (cannot validate)"
+INPUT='{"tool_name":"ralph_hero__save_issue","tool_input":{"workflowState":"In Progress"}}'
+echo "$INPUT" | env -u RALPH_CURRENT_STATE "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "current state unset: exit 0"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/merge-state-gate.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/merge-state-gate.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Tests for merge-state-gate.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/merge-state-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/merge-state-gate.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+echo "Testing $SCRIPT"
+
+echo
+echo "Test case 1: workflowState='Done' -> exit 0 (happy default)"
+INPUT='{"tool_input":{"workflowState":"Done"}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "Done: exit 0"
+
+echo
+echo "Test case 2: workflowState='Human Needed' -> exit 0 (happy default)"
+INPUT='{"tool_input":{"workflowState":"Human Needed"}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "Human Needed: exit 0"
+
+echo
+echo "Test case 3: workflowState='In Review' -> exit 2 (block — not allowed for merge)"
+INPUT='{"tool_input":{"workflowState":"In Review"}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "In Review: exit 2"
+
+echo
+echo "Test case 4: empty input (no state field) -> exit 0 (short-circuit)"
+INPUT='{"tool_input":{}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "empty state: exit 0"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/__tests__/pr-state-gate.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/pr-state-gate.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Tests for pr-state-gate.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/pr-state-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/pr-state-gate.sh"
+TEST_DIR="$(mktemp -d)"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+echo "Testing $SCRIPT"
+
+echo
+echo "Test case 1: workflowState='In Review' -> exit 0 (happy default)"
+INPUT='{"tool_input":{"workflowState":"In Review"}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "In Review: exit 0"
+
+echo
+echo "Test case 2: alternate-key targetState='Human Needed' -> exit 0"
+INPUT='{"tool_input":{"targetState":"Human Needed"}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "alternate key targetState: exit 0"
+
+echo
+echo "Test case 3: workflowState='Done' -> exit 2 (block)"
+INPUT='{"tool_input":{"workflowState":"Done"}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "2" "$EXIT_CODE" "Done: exit 2"
+
+echo
+echo "Test case 4: empty input (no state field) -> exit 0 (short-circuit)"
+INPUT='{"tool_input":{}}'
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "empty state: exit 0"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Add 8 new `.test.sh` files under `plugin/ralph-hero/hooks/scripts/__tests__/` covering the highest-leverage gates that protect the workflow state machine. Each test mirrors the structure of `val-postcondition.test.sh` — mktemp dir, JSONL stdin via heredoc/echo, hand-rolled `assert_eq`, exit-code assertions. No hook scripts modified; tests assert current behavior only.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1123/thoughts/shared/plans/2026-05-09-GH-1123-hook-gate-tests-impl-pr-merge.md

Phases shipped: 1 of 1 (standalone issue)

## Test plan

- [x] All 8 new `.test.sh` files pass locally
- [x] For each test file: `bash <path>` exits 0
- [x] Each test file has at least 3 `assert_eq` cases per plan spec
- [x] Manually regressed one gate locally; its test failed as expected, reverted
- [x] All 8 test files created under `plugin/ralph-hero/hooks/scripts/__tests__/`
- [ ] CI `test-hooks` job executes all 11 test files (3 existing + 8 new) and reports green
- [ ] Spot-read each test file: assertions match the leading comment of the corresponding hook script
- [ ] Local sweep: `for t in plugin/ralph-hero/hooks/scripts/__tests__/*.test.sh; do bash "$t" || exit 1; done` exits 0

Closes #1123