### PR TITLE
GH-1126: Phase 8 - Expand ralph-knowledge retrieval eval suite 8 to 16 golden queries

### DIFF
--- a/plugin/ralph-knowledge/evals/golden-queries.json
+++ b/plugin/ralph-knowledge/evals/golden-queries.json
@@ -50,6 +50,54 @@
       "query": "landcrawler permit raw data migration hardening",
       "expectedSubstrings": ["2026-04-24-landcrawler-backend-hardening-postmortem"],
       "type": "specific-keyword"
+    },
+    {
+      "n": 9,
+      "query": "chunked embeddings for the nightly dream loop ingestion",
+      "expectedSubstrings": ["2026-04-16-GH-0761-ralph-knowledge-chunked-embeddings-dream-loop"],
+      "type": "mixed"
+    },
+    {
+      "n": 10,
+      "query": "reciprocal rank fusion calibration and observability",
+      "expectedSubstrings": ["2026-04-26-GH-0899-rrf-calibration-observability"],
+      "type": "specific-keyword"
+    },
+    {
+      "n": 11,
+      "query": "MMR diversity reranking to reduce duplicate results",
+      "expectedSubstrings": ["2026-04-26-GH-0902-mmr-diversity-reranking-ralph-knowledge"],
+      "type": "specific-keyword"
+    },
+    {
+      "n": 12,
+      "query": "how to avoid leaking GPU memory when running embeddings repeatedly",
+      "expectedSubstrings": ["2026-04-29-GH-911-release-embedder-tensors"],
+      "type": "mixed"
+    },
+    {
+      "n": 13,
+      "query": "softmax temperature and score normalization for hybrid retrieval",
+      "expectedSubstrings": ["2026-04-26-softmax-and-rerank-calibration"],
+      "type": "mixed"
+    },
+    {
+      "n": 14,
+      "query": "passing state between subagents during a long running plan",
+      "expectedSubstrings": ["2026-04-22-context-handoff-topology"],
+      "type": "mixed"
+    },
+    {
+      "n": 15,
+      "query": "extracting Obsidian-style double bracket links from notes",
+      "expectedSubstrings": ["2026-04-26-ralph-knowledge-wikilink-extractor"],
+      "type": "mixed"
+    },
+    {
+      "n": 16,
+      "query": "postmortem on database migration failures in scraper backend",
+      "expectedSubstrings": ["2026-04-24-landcrawler-backend-hardening-postmortem"],
+      "type": "mixed"
     }
   ]
 }

--- a/plugin/ralph-knowledge/scripts/eval-retrieval.ts
+++ b/plugin/ralph-knowledge/scripts/eval-retrieval.ts
@@ -1,7 +1,7 @@
 /**
  * GH-920 — knowledge_search retrieval-quality CI guard.
  *
- * Loads the 8 hand-curated golden queries from `evals/golden-queries.json`,
+ * Loads the 16 hand-curated golden queries from `evals/golden-queries.json`,
  * reindexes the pinned `__tests__/eval-corpus/` fixture into a tmp-dir SQLite
  * DB, runs each query through `HybridSearch.search()` with `rerank: false`
  * (the default RRF-only path), and computes Hit@1, Hit@5, MRR.
@@ -15,7 +15,7 @@
  *   # Always exits 0; just prints the summary:
  *   npx tsx plugin/ralph-knowledge/scripts/eval-retrieval.ts
  *
- *   # Exits 1 if Hit@5 < 5/8 (62.5%):
+ *   # Exits 1 if Hit@5 < 15/16 (93.75%):
  *   npx tsx plugin/ralph-knowledge/scripts/eval-retrieval.ts --assert
  */
 import { mkdtempSync, readFileSync } from "node:fs";
@@ -30,15 +30,16 @@ import { embed } from "../src/embedder.js";
 import { reindex } from "../src/reindex.js";
 
 /**
- * Hit@5 floor — raise to 6/8 (75%) once stable.
+ * Hit@5 floor — set with one-query slack below the observed baseline.
  *
- * Set conservatively below the verified 87.5% (7/8) post-reranker baseline so
- * a slightly noisy CI run does not flake on the threshold even though the
- * default RRF-only path consistently exceeds it. The threshold is in
- * absolute query-count units (not a percentage) to match the `${n}/8`
- * formatting convention from `benchmark/eval-rerank.mjs`.
+ * 2026-05-09 (GH-1126): Suite expanded 8 → 16 queries. Locally observed
+ * Hit@5 = 16/16 (100%) on the default RRF-only path. Threshold set to
+ * `observed − 1 = 15/16` for one-query slack so a single noisy/flaky CI
+ * run does not trip the gate even though steady-state retrieval is perfect.
+ * Threshold is in absolute query-count units (not a percentage) to match
+ * the `${n}/16` formatting convention from `benchmark/eval-rerank.mjs`.
  */
-const HIT5_THRESHOLD = 5; // 5/8 = 62.5% — raise to 6/8 (75%) once stable
+const HIT5_THRESHOLD = 15; // 2026-05-09: observed 16/16 → threshold 15/16 (one-query slack)
 
 interface GoldenQuery {
   n: number;

--- a/thoughts/shared/plans/2026-05-09-GH-1126-expand-retrieval-eval-16-queries.md
+++ b/thoughts/shared/plans/2026-05-09-GH-1126-expand-retrieval-eval-16-queries.md
@@ -68,12 +68,12 @@ Existing queries cover 8 of 11 corpus docs. Three corpus docs are unused: `chunk
 
 ### Verification
 
-- [ ] `golden-queries.json` contains 16 queries numbered 1..16
-- [ ] `npm run eval:retrieval -- --assert` passes from `plugin/ralph-knowledge/`
-- [ ] `HIT5_THRESHOLD` set to `(observed Hit@5 − 1)` with inline date-stamped comment
-- [ ] Removing one expected doc ID from a passing query locally drops Hit@5 below threshold and exits 1
-- [ ] At least 8 of 16 queries have `type: "mixed"` (semantic) — not trivial title match
-- [ ] CI build-and-test-knowledge job passes on main
+- [x] `golden-queries.json` contains 16 queries numbered 1..16
+- [x] `npm run eval:retrieval -- --assert` passes from `plugin/ralph-knowledge/`
+- [x] `HIT5_THRESHOLD` set to `(observed Hit@5 − 1)` with inline date-stamped comment
+- [x] Removing one expected doc ID from a passing query locally drops Hit@5 below threshold and exits 1
+- [x] At least 8 of 16 queries have `type: "mixed"` (semantic) — not trivial title match
+- [x] CI build-and-test-knowledge job passes on main
 
 ## What We're NOT Doing
 
@@ -107,12 +107,12 @@ Add 8 new golden queries to the JSON, measure observed Hit@5 on the expanded sui
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] JSON has 16 entries with `n: 1..16`, monotonically increasing
-  - [ ] Each new entry has `query`, `expectedSubstrings` (1-3 items), `type` ("specific-keyword" or "mixed")
-  - [ ] At least 4 of the 8 new queries have `type: "mixed"` (so 8+ of 16 total are semantic)
-  - [ ] Every `expectedSubstrings` value matches a real basename under `plugin/ralph-knowledge/__tests__/eval-corpus/` (use the basename without `.md`)
-  - [ ] Suggested topic coverage: chunked embeddings dream-loop (GH-0761), RRF calibration (GH-0899), MMR diversity (GH-0902), backend hardening postmortem, wikilink extractor (paraphrased), softmax + rerank calibration (paraphrased), embedder tensor release (paraphrased), context handoff (paraphrased)
-  - [ ] JSON is valid (parseable by `JSON.parse`); trailing commas absent; 2-space indent matches existing style
+  - [x] JSON has 16 entries with `n: 1..16`, monotonically increasing
+  - [x] Each new entry has `query`, `expectedSubstrings` (1-3 items), `type` ("specific-keyword" or "mixed")
+  - [x] At least 4 of the 8 new queries have `type: "mixed"` (so 8+ of 16 total are semantic)
+  - [x] Every `expectedSubstrings` value matches a real basename under `plugin/ralph-knowledge/__tests__/eval-corpus/` (use the basename without `.md`)
+  - [x] Suggested topic coverage: chunked embeddings dream-loop (GH-0761), RRF calibration (GH-0899), MMR diversity (GH-0902), backend hardening postmortem, wikilink extractor (paraphrased), softmax + rerank calibration (paraphrased), embedder tensor release (paraphrased), context handoff (paraphrased)
+  - [x] JSON is valid (parseable by `JSON.parse`); trailing commas absent; 2-space indent matches existing style
 
 #### Task 1.2: Measure observed Hit@5 locally
 
@@ -121,9 +121,9 @@ Add 8 new golden queries to the JSON, measure observed Hit@5 on the expanded sui
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] Run `cd plugin/ralph-knowledge && npm run eval:retrieval` (no `--assert`) and capture the printed Hit@5 line
-  - [ ] Record the observed `hit5Count` value (e.g., `14/16`); note any queries with `rank: -` for debugging
-  - [ ] If observed Hit@5 < 12/16 (75%), revise weak queries in 1.1 (prefer paraphrases that test real semantics, not adversarial mismatches) and re-run
+  - [x] Run `cd plugin/ralph-knowledge && npm run eval:retrieval` (no `--assert`) and capture the printed Hit@5 line
+  - [x] Record the observed `hit5Count` value (e.g., `14/16`); note any queries with `rank: -` for debugging
+  - [x] If observed Hit@5 < 12/16 (75%), revise weak queries in 1.1 (prefer paraphrases that test real semantics, not adversarial mismatches) and re-run
 
 #### Task 1.3: Update HIT5_THRESHOLD with date-stamped comment
 
@@ -132,10 +132,10 @@ Add 8 new golden queries to the JSON, measure observed Hit@5 on the expanded sui
 - **complexity**: low
 - **depends_on**: [1.2]
 - **acceptance**:
-  - [ ] `HIT5_THRESHOLD` constant updated to `observed_hit5 - 1` (e.g., observed 14/16 → threshold 13)
-  - [ ] Inline comment updated: includes date `2026-05-09`, the observed Hit@5 value, and the slack rationale (`one-query slack`)
-  - [ ] JSDoc block comment at top of file updated: `8` → `16` and `5/8 (62.5%)` → new ratio
-  - [ ] `loadGoldenQueries` and runner code unchanged (no architectural changes)
+  - [x] `HIT5_THRESHOLD` constant updated to `observed_hit5 - 1` (e.g., observed 14/16 → threshold 13)
+  - [x] Inline comment updated: includes date `2026-05-09`, the observed Hit@5 value, and the slack rationale (`one-query slack`)
+  - [x] JSDoc block comment at top of file updated: `8` → `16` and `5/8 (62.5%)` → new ratio
+  - [x] `loadGoldenQueries` and runner code unchanged (no architectural changes)
 
 #### Task 1.4: Mutation-test the threshold (negative test)
 
@@ -144,22 +144,22 @@ Add 8 new golden queries to the JSON, measure observed Hit@5 on the expanded sui
 - **complexity**: low
 - **depends_on**: [1.3]
 - **acceptance**:
-  - [ ] Temporarily mutate one passing query's `expectedSubstrings` to a non-matching string in a local copy, run `npm run eval:retrieval -- --assert`, confirm `process.exitCode === 1` and `ASSERT FAIL` printed
-  - [ ] Revert the mutation; confirm `npm run eval:retrieval -- --assert` prints `PASS` and exit code is 0
-  - [ ] No file under version control is left mutated after this task
+  - [x] Temporarily mutate one passing query's `expectedSubstrings` to a non-matching string in a local copy, run `npm run eval:retrieval -- --assert`, confirm `process.exitCode === 1` and `ASSERT FAIL` printed
+  - [x] Revert the mutation; confirm `npm run eval:retrieval -- --assert` prints `PASS` and exit code is 0
+  - [x] No file under version control is left mutated after this task
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `cd plugin/ralph-knowledge && npm run build` — no errors
-- [ ] `cd plugin/ralph-knowledge && npm run eval:retrieval -- --assert` — exits 0 with `PASS` log line
-- [ ] `cd plugin/ralph-knowledge && npm test` — all tests passing (no test files touched, but coverage thresholds from Phase 2 still met)
+- [x] `cd plugin/ralph-knowledge && npm run build` — no errors
+- [x] `cd plugin/ralph-knowledge && npm run eval:retrieval -- --assert` — exits 0 with `PASS` log line
+- [x] `cd plugin/ralph-knowledge && npm test` — all tests passing (no test files touched, but coverage thresholds from Phase 2 still met)
 
 #### Manual Verification:
 
-- [ ] Threshold comment in `eval-retrieval.ts` reads naturally and includes the 2026-05-09 date
-- [ ] Per-query log lines show plausible top-rank results across both keyword and mixed queries
+- [x] Threshold comment in `eval-retrieval.ts` reads naturally and includes the 2026-05-09 date
+- [x] Per-query log lines show plausible top-rank results across both keyword and mixed queries
 
 **Creates for next phase**: N/A (final phase of parent epic #1118)
 


### PR DESCRIPTION
## Summary

Added 8 new golden queries to the retrieval eval suite, expanding from 8 to 16 queries with improved semantic coverage (9 of 16 now type=mixed). Locally observed Hit@5 = 16/16 on the default RRF-only path. Raised HIT5_THRESHOLD from 5 to 15 (observed - 1 with one-query slack) per acceptance criteria, with date-stamped inline comment.

## Plan

[thoughts/shared/plans/2026-05-09-GH-1126-expand-retrieval-eval-16-queries.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-09-GH-1126-expand-retrieval-eval-16-queries.md)

Phases shipped: 1 of 1 (atomic phase within parent epic #1118)

## Test plan

- [x] Automated verification: `npm run eval:retrieval -- --assert` passes with 16/16 Hit@5
- [x] Mutation test: blanking one expected ID drops Hit@5 below threshold and exits 1
- [x] Mixed-query coverage: 9 of 16 queries are semantic (exceeds ≥8 target)
- [x] Corpus re-use: 8 new queries span previously-untouched docs (GH-0761, GH-0899, GH-0902) plus paraphrased variants of existing topics
- [x] Threshold documented with 2026-05-09 date and one-query slack rationale

Closes #1126