### PR TITLE
fix(merge,finish): bypass formal-review requirement on self-authored PRs (#932)

### DIFF
--- a/plugin/ralph-hero/skills/finish/SKILL.md
+++ b/plugin/ralph-hero/skills/finish/SKILL.md
@@ -149,6 +149,17 @@ gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
 
 - If `APPROVED`: continue to Step 5.
 - If `CHANGES_REQUESTED`: proceed to Step 4a (Code Review Fix Cycle).
+- If still null/empty: the code-review skill posts a comment but never creates a formal review (so `reviewDecision` never changes from null). Branch on self-authorship:
+
+  ```bash
+  PR_AUTHOR=$(gh pr view PR_NUMBER --json author --jq '.author.login')
+  CURRENT_USER=$(gh api user --jq '.login')
+  LAST_COMMENT=$(gh pr view PR_NUMBER --json comments --jq '.comments | map(select(.body | startswith("### Code review"))) | last | .body')
+  ```
+
+  - If `PR_AUTHOR == CURRENT_USER` AND `LAST_COMMENT` contains the literal string `No issues found`: code review passed clean on a self-authored single-contributor repo (GitHub blocks self-approval, so a formal `APPROVED` is unattainable). Treat as APPROVED-equivalent and continue to Step 5.
+  - If `PR_AUTHOR == CURRENT_USER` AND `LAST_COMMENT` contains `Found ` (i.e., the "Found N issues" variant): code review flagged issues. Proceed to Step 4a (Code Review Fix Cycle).
+  - Otherwise (multi-author repo with null `reviewDecision`, or no code-review comment found): output `FINISH BLOCKED` with `Reason: Code review did not produce a reviewDecision and no self-authored fallback applies` and stop.
 
 ### Interactive mode (`RALPH_REVIEW_MODE=interactive`, default)
 
@@ -218,7 +229,7 @@ After impl-agent completes, re-run code review once:
 Skill("code-review:code-review", "PR_NUMBER")
 ```
 
-Then re-check `reviewDecision`:
+Then re-check `reviewDecision` (same self-authored fallback as Step 4):
 
 - If `APPROVED`: continue to Step 5.
 - If `CHANGES_REQUESTED` again: stop. Max 1 fix cycle. Output:
@@ -229,6 +240,17 @@ Issue: #NNN
 PR: #PR_NUMBER
 Reason: Code review feedback unresolved after 1 fix cycle.
 ```
+
+- If still null/empty: branch on self-authorship + last code-review comment content:
+
+  ```bash
+  PR_AUTHOR=$(gh pr view PR_NUMBER --json author --jq '.author.login')
+  CURRENT_USER=$(gh api user --jq '.login')
+  LAST_COMMENT=$(gh pr view PR_NUMBER --json comments --jq '.comments | map(select(.body | startswith("### Code review"))) | last | .body')
+  ```
+
+  - If `PR_AUTHOR == CURRENT_USER` AND `LAST_COMMENT` contains `No issues found`: the fix cycle resolved the feedback. Continue to Step 5.
+  - Otherwise: stop with `FINISH BLOCKED` and `Reason: Code review feedback unresolved after 1 fix cycle`.
 
 ## Step 5: Merge (dispatch ralph-merge)
 

--- a/plugin/ralph-hero/skills/ralph-merge/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-merge/SKILL.md
@@ -137,6 +137,14 @@ PR_COMMENT_COUNT=$(gh pr view PR_NUMBER --json comments --jq '.comments | length
 ```
 
 - If the issue's estimate is `XS` AND `PR_COMMENT_COUNT == 0`: small unreviewed changes are permitted. Proceed to Step 4a (the autonomous merge gate also re-checks this exception when `RALPH_AUTO_MERGE=true`).
+- Otherwise check self-authorship:
+
+```bash
+PR_AUTHOR=$(gh pr view PR_NUMBER --json author --jq '.author.login')
+CURRENT_USER=$(gh api user --jq '.login')
+```
+
+- If `PR_AUTHOR == CURRENT_USER`: the PR is self-authored on a single-contributor repo. GitHub blocks self-approval (`Can not approve your own pull request`), so a formal `APPROVED` review is unattainable. Treat as APPROVED-equivalent and proceed to Step 4a. The orchestrating caller (finish) is responsible for ensuring code review passed before invoking ralph-merge — `finish` dispatches `impl-agent` on MUST_FIX feedback and only invokes ralph-merge once code review resolves clean. See [GH-932](https://github.com/cdubiel08/ralph-hero/issues/932) for the bootstrap rationale.
 - Otherwise: output and stop:
 
 ```
@@ -164,7 +172,8 @@ When `RALPH_AUTO_MERGE=true`, evaluate **all** of the following criteria. If any
 ### Criteria (ALL must hold)
 
 1. **Review approved**: `gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'` returns `APPROVED`.
-   - Exception: an XS-estimated issue with zero review comments is treated as approved (small changes do not require explicit review approval). Use `gh pr view PR_NUMBER --json comments --jq '.comments | length'` and the issue's `estimate` field to detect this case.
+   - **Exception (XS small changes)**: an XS-estimated issue with zero review comments is treated as approved (small changes do not require explicit review approval). Use `gh pr view PR_NUMBER --json comments --jq '.comments | length'` and the issue's `estimate` field to detect this case.
+   - **Exception (self-authored single-contributor repo)**: if `gh pr view PR_NUMBER --json author --jq '.author.login'` equals `gh api user --jq '.login'`, the PR was authored by the orchestrator user. GitHub blocks self-approval, so a formal `APPROVED` review is unattainable. Treat as APPROVED-equivalent. The caller (finish) is responsible for ensuring code review passed before invoking ralph-merge.
 2. **CI green**: `gh pr checks PR_NUMBER --json name,state,conclusion` returns checks where every entry has `state: completed` AND `conclusion: success`. Pending or failing checks block the merge.
 3. **PR open and mergeable**: `gh pr view PR_NUMBER --json state,mergeable --jq '{state,mergeable}'` shows `state: OPEN` and `mergeable: MERGEABLE`. A `CONFLICTING` or `UNKNOWN` mergeable status blocks.
 


### PR DESCRIPTION
## Summary

- `ralph-merge` Step 4 + 4a: treat self-authored PRs (PR author == `gh api user`) with null `reviewDecision` as APPROVED-equivalent. GitHub blocks self-approval on single-contributor repos, so a formal APPROVED is unattainable; the caller (`finish`) gates MUST_FIX upstream.
- `finish` Step 4 + 4a: after running `code-review:code-review` and finding `reviewDecision` still null, branch on self-authorship plus the last `### Code review` comment body. `No issues found` → proceed to merge. `Found N issues` → fix cycle.

Bootstrap-merged via `gh pr merge --admin` since `RALPH_REVIEW_MODE=auto` cannot yet merge self-authored PRs (the bug this PR fixes).

## Test plan

- [ ] Re-run `/ralph-hero:autopilot` after merge. Hero in auto mode should drive a self-authored PR end-to-end without stalling at the merge gate.
- [ ] Manual sanity check: an `In Review` PR (#1121–#1126) processed via `/ralph-hero:finish NNN` should reach `MERGED` without the prior `MERGE BLOCKED — Code review required` stall.
- [ ] Multi-author repos retain the existing formal-review gate (no regression — the new branch only activates when `PR_AUTHOR == CURRENT_USER`).

Closes #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)