### PR TITLE
GH-1011: fix(ralph-val): val-postcondition.sh reminder excludes VALIDATION FIX verdict

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/__tests__/val-postcondition.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/val-postcondition.test.sh
@@ -64,6 +64,15 @@ EXIT_CODE=$?
 assert_eq "0" "$EXIT_CODE" "VALIDATION FAIL in transcript: exit 0"
 
 echo
+echo "Test case 3b: VALIDATION FIX verdict in transcript -> exit 0"
+TRANSCRIPT="$TEST_DIR/transcript-fix.jsonl"
+make_transcript "VALIDATION FIX — only mechanical failures" "$TRANSCRIPT"
+INPUT="$(jq -nc --arg p "$TRANSCRIPT" '{transcript_path:$p,stop_hook_active:false}')"
+echo "$INPUT" | "$SCRIPT" >/dev/null 2>&1
+EXIT_CODE=$?
+assert_eq "0" "$EXIT_CODE" "VALIDATION FIX in transcript: exit 0"
+
+echo
 echo "Test case 4: Queue empty in transcript -> exit 0"
 TRANSCRIPT="$TEST_DIR/transcript-empty.jsonl"
 make_transcript "No In Progress issues found. Queue empty." "$TRANSCRIPT"

--- a/plugin/ralph-hero/hooks/scripts/val-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/val-postcondition.sh
@@ -4,6 +4,7 @@
 #
 # Accepts as terminal output any of:
 #   - "VALIDATION PASS"   — clean run with all checks passing
+#   - "VALIDATION FIX"    — only mechanical failures (auto-fixable, e.g. lint/format)
 #   - "VALIDATION FAIL"   — substantive failure(s) found
 #   - "Queue empty"       — queue-picking branch found no eligible work
 #                           (paired with synthetic "VALIDATION PASS — no work" verdict in skill)
@@ -22,11 +23,11 @@ fi
 
 # Read the transcript and look for a recognized verdict marker. The transcript is
 # a JSONL stream of message records; grep across the raw file is sufficient since
-# we only care whether any of the three marker phrases appears anywhere.
+# we only care whether any of the four marker phrases appears anywhere.
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 
 if [[ -n "$TRANSCRIPT_PATH" && -f "$TRANSCRIPT_PATH" ]]; then
-  if grep -qE 'VALIDATION PASS|VALIDATION FAIL|Queue empty' "$TRANSCRIPT_PATH"; then
+  if grep -qE 'VALIDATION PASS|VALIDATION FIX|VALIDATION FAIL|Queue empty' "$TRANSCRIPT_PATH"; then
     exit 0
   fi
 fi

--- a/plugin/ralph-hero/hooks/scripts/val-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/val-postcondition.sh
@@ -31,5 +31,5 @@ if [[ -n "$TRANSCRIPT_PATH" && -f "$TRANSCRIPT_PATH" ]]; then
   fi
 fi
 
-echo "Ensure you have produced a VALIDATION PASS, VALIDATION FAIL, or Queue empty verdict with specific check results before stopping." >&2
+echo "Ensure you have produced a VALIDATION PASS, VALIDATION FIX, VALIDATION FAIL, or Queue empty verdict with specific check results before stopping." >&2
 exit 2


### PR DESCRIPTION
## Summary

Updated the val-postcondition.sh reminder string to include VALIDATION FIX as a valid verdict alongside PASS, FAIL, and Queue empty. This aligns the hook's user-facing message with the documented contract in ralph-val and finish skills.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-group-GH-1009-ralph-val-correctness-cluster.md

Phases shipped: 1 of 4 (group issues GH-1009, GH-1010, GH-1011, GH-1012)

## Test plan

- [x] Automated verification per plan Success Criteria
  - [x] bash -n plugin/ralph-hero/hooks/scripts/val-postcondition.sh — no syntax errors
  - [x] bash plugin/ralph-hero/hooks/scripts/__tests__/val-postcondition.test.sh — all 8 cases pass
- [ ] Manual verification per plan Success Criteria
  - [ ] The reminder string echoed to stderr contains "VALIDATION FIX"

Closes #1011