### PR TITLE
GH-1097: Phase 1: Enable Claude Code OTel → local Langfuse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,9 +257,47 @@ The CLI's `resolve-env.sh` searches in order: shell env → repo `settings.local
 | `RALPH_GH_REPO_TOKEN` | No | Separate repo token (falls back to main token, then to `gh auth token`) |
 | `RALPH_GH_PROJECT_TOKEN` | No | Separate project token (falls back to repo token) |
 | `RALPH_GH_PROJECT_OWNER` | No | Project owner if different from repo owner |
-| `RALPH_DEBUG` | No | Set to `"true"` to enable JSONL debug logging and register debug tools |
+| `RALPH_DEBUG` | No | Set to `"true"` to enable JSONL debug logging, register debug tools, and activate OpenTelemetry export (when `OTEL_*` vars are also set). Acts as the master switch for all debug surfaces. |
 
 **Do NOT put tokens in `.mcp.json`** — the `.mcp.json` has no `env` block; the MCP server inherits the parent environment.
+
+### OpenTelemetry export to local Langfuse
+
+When `RALPH_DEBUG=true` is set alongside the `OTEL_*` env vars below, Claude Code exports `mcp.tool.*` spans, hook events, and session lifecycle traces over OTLP/HTTP. The MCP server (Phase 2+) attaches `ralph_hero.graphql` child spans inside the same trace context. The local Langfuse harness at `~/projects/langfuse/` (documented in `~/projects/CLAUDE.md` under "Local ADK + Langfuse testing harness") is the default ingestion target.
+
+**`RALPH_DEBUG` is the activation switch.** All four `OTEL_*` vars are no-ops when `RALPH_DEBUG` is unset — the MCP server skips OTel SDK initialization entirely and emits zero outbound traffic to `:3100`.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CLAUDE_CODE_ENABLE_TELEMETRY` | No | unset | Set to `"1"` to enable Claude Code's native OpenTelemetry export. Required for Claude Code to emit `mcp.tool.*` and hook spans. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | unset | OTLP/HTTP receiver URL. For the local Langfuse harness, use `http://localhost:3100/api/public/otel/v1/traces`. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | No | unset | Comma-separated header list passed on every OTLP export. Use this to inject the Langfuse basic-auth header (see below). |
+| `OTEL_SERVICE_NAME` | No | unset | Logical service name attached as a resource attribute on every span. Recommended: `claude-code` for the host process, `ralph-hero` for MCP server child spans. |
+
+**Basic-auth header construction.** Langfuse's public OTLP endpoint requires basic auth with the project's public key as username and secret key as password. The default local-dev credentials are `pk-lf-local-dev:sk-lf-local-dev`. Construct the header value once:
+
+```bash
+printf '%s' "pk-lf-local-dev:sk-lf-local-dev" | base64
+# -> cGstbGYtbG9jYWwtZGV2OnNrLWxmLWxvY2FsLWRldg==
+```
+
+Then set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic cGstbGYtbG9jYWwtZGV2OnNrLWxmLWxvY2FsLWRldg==`. The literal header value (key + `=` + base64) is what OTel SDKs expect; do not wrap the value in quotes inside the env var.
+
+**Sample `.claude/settings.local.json` snippet.** Copy-paste the `env` block into `~/.claude/settings.json` (user-scoped) or `<project>/.claude/settings.local.json` (project-scoped, gitignored). The endpoint assumes the local Langfuse harness is running on port 3100 (see `~/projects/CLAUDE.md` for stack bring-up: `cd ~/projects/langfuse && ./scripts/up.sh`).
+
+```json
+{
+  "env": {
+    "RALPH_DEBUG": "true",
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:3100/api/public/otel/v1/traces",
+    "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Basic cGstbGYtbG9jYWwtZGV2OnNrLWxmLWxvY2FsLWRldg==",
+    "OTEL_SERVICE_NAME": "claude-code"
+  }
+}
+```
+
+After editing the settings file, restart Claude Code so the MCP server inherits the new env. With `RALPH_DEBUG` unset (or absent from the `env` block), the MCP server bypasses OTel init regardless of the `OTEL_*` values.
 
 ## GitHub Actions Workflows
 

--- a/thoughts/shared/plans/2026-05-11-group-GH-1097-debug-mode-otel-langfuse.md
+++ b/thoughts/shared/plans/2026-05-11-group-GH-1097-debug-mode-otel-langfuse.md
@@ -114,11 +114,11 @@ Document the four `OTEL_*` env vars and the `RALPH_DEBUG` activation pattern in 
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] "Environment Variables" section in `CLAUDE.md` documents `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`
-  - [ ] Each env var has: required/optional flag, default value, one-sentence description
-  - [ ] Note that `RALPH_DEBUG=true` is the activation switch for OTel — the four `OTEL_*` vars are no-ops when `RALPH_DEBUG` is unset
-  - [ ] Basic-auth header construction documented: `Authorization=Basic $(printf '%s' "pk-lf-local-dev:sk-lf-local-dev" | base64)`
-  - [ ] Cross-link to `~/projects/CLAUDE.md` Langfuse harness section for stack setup
+  - [x] "Environment Variables" section in `CLAUDE.md` documents `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`
+  - [x] Each env var has: required/optional flag, default value, one-sentence description
+  - [x] Note that `RALPH_DEBUG=true` is the activation switch for OTel — the four `OTEL_*` vars are no-ops when `RALPH_DEBUG` is unset
+  - [x] Basic-auth header construction documented: `Authorization=Basic $(printf '%s' "pk-lf-local-dev:sk-lf-local-dev" | base64)`
+  - [x] Cross-link to `~/projects/CLAUDE.md` Langfuse harness section for stack setup
 
 #### Task 1.2: Add settings.local.json sample to docs
 - **files**: `CLAUDE.md` (modify)
@@ -126,9 +126,9 @@ Document the four `OTEL_*` env vars and the `RALPH_DEBUG` activation pattern in 
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] A code-fenced JSON block showing the full `env` block with all five vars (`RALPH_DEBUG`, `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`)
-  - [ ] Snippet uses `http://localhost:3100/api/public/otel/v1/traces` as the endpoint
-  - [ ] Snippet is copy-pasteable into `~/.claude/settings.json` or a per-repo `.claude/settings.local.json`
+  - [x] A code-fenced JSON block showing the full `env` block with all five vars (`RALPH_DEBUG`, `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`)
+  - [x] Snippet uses `http://localhost:3100/api/public/otel/v1/traces` as the endpoint
+  - [x] Snippet is copy-pasteable into `~/.claude/settings.json` or a per-repo `.claude/settings.local.json`
 
 #### Task 1.3: Manual verification + hook propagation check
 - **files**: `CLAUDE.md` (modify — append verification commands), `thoughts/shared/research/2026-05-11-otel-claude-code-langfuse-verification.md` (create)


### PR DESCRIPTION
## Summary

Document OpenTelemetry export configuration in CLAUDE.md for Claude Code-to-Langfuse integration. Adds `OTEL_*` env vars, `RALPH_DEBUG` activation pattern, basic-auth header construction, and sample `settings.local.json` snippet. No code changes — Phase 1 of the Debug Mode & Self-Healing Observability group plan.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-11-group-GH-1097-debug-mode-otel-langfuse.md

Phases shipped: 1 of 5 (group issues)

## Test plan

- [x] Automated verification: CLAUDE.md parses correctly, docs are complete
- [ ] Manual verification per plan — Task 1.3 is owner-run and deferred per plan instructions

Closes #1097