### PR TITLE
GH-1209: save_issue(workflowState='Human Needed') silently closes the GitHub issue

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
@@ -162,7 +162,6 @@ describe("WORKFLOW_STATE_TO_STATUS", () => {
   it("maps terminal states to Done", () => {
     expect(WORKFLOW_STATE_TO_STATUS["Done"]).toBe("Done");
     expect(WORKFLOW_STATE_TO_STATUS["Canceled"]).toBe("Done");
-    expect(WORKFLOW_STATE_TO_STATUS["Human Needed"]).toBe("Done");
   });
 });
 

--- a/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
@@ -155,6 +155,10 @@ describe("WORKFLOW_STATE_TO_STATUS", () => {
     expect(WORKFLOW_STATE_TO_STATUS["In Review"]).toBe("In Progress");
   });
 
+  it("maps Human Needed to Todo (not Done — would trigger auto-close)", () => {
+    expect(WORKFLOW_STATE_TO_STATUS["Human Needed"]).toBe("Todo");
+  });
+
   it("maps terminal states to Done", () => {
     expect(WORKFLOW_STATE_TO_STATUS["Done"]).toBe("Done");
     expect(WORKFLOW_STATE_TO_STATUS["Canceled"]).toBe("Done");

--- a/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/workflow-states.test.ts
@@ -3,6 +3,7 @@ import {
   STATE_ORDER,
   VALID_STATES,
   PARENT_GATE_STATES,
+  HUMAN_STATES,
   WORKFLOW_STATE_TO_STATUS,
   SKIP_ENTRY_STATES,
   stateIndex,
@@ -162,6 +163,12 @@ describe("WORKFLOW_STATE_TO_STATUS", () => {
   it("maps terminal states to Done", () => {
     expect(WORKFLOW_STATE_TO_STATUS["Done"]).toBe("Done");
     expect(WORKFLOW_STATE_TO_STATUS["Canceled"]).toBe("Done");
+  });
+
+  it("never maps a HUMAN_STATES member to Done (would trigger auto-close)", () => {
+    for (const state of HUMAN_STATES) {
+      expect(WORKFLOW_STATE_TO_STATUS[state]).not.toBe("Done");
+    }
   });
 });
 

--- a/plugin/ralph-hero/mcp-server/src/lib/workflow-states.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/workflow-states.ts
@@ -141,5 +141,5 @@ export const WORKFLOW_STATE_TO_STATUS: Record<string, string> = {
   "In Review": "In Progress",
   "Done": "Done",
   "Canceled": "Done",
-  "Human Needed": "Done",
+  "Human Needed": "Todo",
 };


### PR DESCRIPTION
## Summary

Fixed a critical bug where `save_issue(workflowState='Human Needed')` silently closes the GitHub issue and overwrites Workflow State back to "Done", erasing the caller's escalation intent.

The root cause: `WORKFLOW_STATE_TO_STATUS["Human Needed"]` was incorrectly mapped to "Done", which triggered GitHub Projects V2's built-in auto-close workflow. Remapped to "Todo" (aligning with other `HUMAN_STATES` members), preventing the spurious close and sync-state clobbering.

Three-commit TDD sequence:
1. Add failing regression test pinning `Human Needed → Todo` Status sync
2. Fix the mapping and drop the bug-codifying assertion
3. Add invariant test ensuring no `HUMAN_STATES` member maps to "Done"

Full test suite: 1293 passed / 2 skipped (net +1 test).

## Plan

Implementation plan: https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-save-issue-human-needed-silent-close.md

## Test plan

- [x] Automated verification per plan Success Criteria (full vitest suite passes)
- [x] Regression test added (GH-1210)
- [x] Mapping fix applied (GH-1211)
- [x] Invariant test ensures no HUMAN_STATES member maps to Done (GH-1212)

Closes #1210, Closes #1211, Closes #1212, Closes #1209