### PR TITLE
GH-1009: ralph-val verdict format and hallucination prevention fixes (GH-1193, GH-1194)

### DIFF
--- a/plugin/ralph-hero/skills/ralph-val/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-val/SKILL.md
@@ -143,6 +143,47 @@ From the worktree directory, execute each automated verification criterion:
 
 Record each check as PASS or FAIL with details.
 
+**Citation Gate (required for every file-content check):**
+
+Before claiming any file fails a content check, you MUST:
+
+1. Run `cat <file>` or the equivalent read command from the worktree
+2. Quote the relevant lines verbatim in the verdict (use a fenced code block)
+3. State explicitly why the quoted content does or does not satisfy the plan criterion
+
+You may NOT report a file-content failure based on inference from the plan text alone.
+If you cannot read the file (missing, permission error), record that as the failure reason — not an inferred content assertion.
+
+**Example — correct citation chain for a failing file-content check:**
+
+````
+- [ ] plugin/ralph-playwright/.claude-plugin/plugin.json — FAIL (missing `skills` array)
+
+  Read from worktree:
+  ```json
+  {
+    "name": "ralph-playwright",
+    "version": "0.1.0",
+    "description": "..."
+  }
+  ```
+
+  Plan requires a `skills` array with 7 entries. The quoted content has no `skills` key,
+  so the criterion is not satisfied.
+````
+
+**Example — what NOT to do (fabricated assertion, no citation):**
+
+```
+- [ ] plugin.json — FAIL (4 substantive failures)
+  1. Missing `skills` array
+  2. Missing `agents` array
+  3. Prohibited fields present
+  4. Wrong version (0.2.0 instead of 0.1.0)
+```
+
+This form is prohibited because none of the four claims is backed by quoted file content. The model is inferring from the plan body rather than reading the file. If the file genuinely has these problems, the verdict must quote the actual offending lines.
+
 ## Step 6.5: Drift Log Verification
 
 Search the issue comments (from the fetched issue response) for `## Drift Log — Phase N` headers.

--- a/plugin/ralph-hero/skills/ralph-val/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-val/SKILL.md
@@ -194,6 +194,18 @@ Classify each failure, then choose the verdict:
 - Only mechanical failures → `FIX` (list the fix commands)
 - Any substantive failure → `FAIL`
 
+**Verdict format (strict):**
+
+The verdict line MUST begin with exactly one of:
+
+```
+VALIDATION PASS
+VALIDATION FIX
+VALIDATION FAIL
+```
+
+Do NOT substitute other status words (e.g. `BLOCKED`, `COMPLETE`, `Phase Assessment`, `Status: ❌`). These are not recognized by `val-postcondition.sh` and will cause the Stop hook to block. Use the literal `VALIDATION PASS|FIX|FAIL` prefix verbatim — no emoji, no bold, no alternate vocabulary.
+
 Output the validation report:
 
 ```
@@ -219,6 +231,28 @@ Verdict: [PASS/FIX/FAIL]
 [If FIX: list each mechanical fix command]
 [If FAIL: list each substantive failure with specific details]
 ```
+
+**Negative example — DO NOT emit verdicts like this:**
+
+```
+### Phase Assessment
+
+**Status**: ❌ **BLOCKED** — Does not meet acceptance criteria
+```
+
+The string `BLOCKED` is borrowed from issue-workflow vocabulary and is NOT a valid val verdict. Replace with:
+
+```
+VALIDATION FAIL
+Issue: #NNN
+Plan: [plan path]
+Worktree: [worktree path]
+
+### Substantive Failures:
+- [ ] [specific failing check with details]
+```
+
+Similarly invalid: `Status: ❌`, `COMPLETE`, `Phase Assessment` as the verdict prefix. Only `VALIDATION PASS`, `VALIDATION FIX`, or `VALIDATION FAIL` (followed by the report body) is accepted.
 
 ## Step 8: Post GitHub Comment
 


### PR DESCRIPTION
## Summary

Fixes two substantive defects in ralph-val that caused Scenario C eval failure:

1. **Verdict format contract violation** — The skill's Step 7 prescription for `VALIDATION [PASS/FIX/FAIL]` was interpreted too loosely. The val-agent substituted `Status: ❌ BLOCKED` (borrowed from workflow domain) instead of the required literal prefix. The fix tightens SKILL.md Step 7 with explicit literal-form requirements and a negative example showing disallowed verdicts. Also batches the #1011 fix (accept VALIDATION FIX in postcondition hook).

2. **Hallucinated file-content failures** — The val-agent fabricated four specific file failures against `plugin/ralph-playwright/.claude-plugin/plugin.json` despite those assertions being entirely false. The agent inferred plausible-sounding criteria from the plan body instead of reading the actual file. The fix adds a Citation Gate requirement to SKILL.md Step 6: before claiming any file-content failure, the agent MUST run `cat <file>`, quote the relevant lines verbatim, and state explicitly why the quoted content fails the criterion. Inference from the plan alone is prohibited.

## Test Status

All integration tests pass:
- `val-postcondition.sh` bash syntax: clean
- `val-postcondition.test.sh`: 9 of 9 test cases pass (including new case 3b for VALIDATION FIX)

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-group-GH-1009-ralph-val-correctness-cluster.md

## Test plan

- [x] `bash -n plugin/ralph-hero/hooks/scripts/val-postcondition.sh` — no syntax errors
- [x] `bash plugin/ralph-hero/hooks/scripts/__tests__/val-postcondition.test.sh` — all 9 cases pass (original 8 + new 3b for VALIDATION FIX)
- [x] Read SKILL.md Step 7 — negative example present, literal prefix requirement explicit, no ambiguous bracket notation
- [x] Read SKILL.md Step 6 — Citation Gate requirement present with positive and negative examples

Closes #1193
Closes #1194
Closes #1009
Closes #1011