### PR TITLE
GH-1169: list_issues defaults state=OPEN, diverging from dashboard family which sees closed issues with non-Done workflow states

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/cross-tool-consistency.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/cross-tool-consistency.test.ts
@@ -26,6 +26,8 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerDirectionsTools } from "../tools/directions-tools.js";
 import { registerDashboardTools } from "../tools/dashboard-tools.js";
@@ -825,5 +827,122 @@ describe("cross-tool count consistency", () => {
       humanNumbers,
       "next_actions(audience=human) does NOT surface the null-state item",
     ).not.toContain(1012);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_issues / pipeline_dashboard agreement on closed-non-terminal issues
+// (GH-1169)
+//
+// Before GH-1169, `list_issues` defaulted `state: "OPEN"` and excluded
+// closed-but-non-terminal-workflow issues from no-state-arg callers. The
+// dashboard family had no equivalent filter, so the two tools disagreed on
+// visibility for an issue whose Workflow State was advanced to a
+// non-terminal value (e.g., "Plan in Review") while the underlying GitHub
+// issue happened to be CLOSED. This regression test pins the post-fix
+// agreement so a future re-introduction of an implicit OPEN default would
+// fail loudly.
+// ---------------------------------------------------------------------------
+
+describe("list_issues / pipeline_dashboard closed-non-terminal agreement (GH-1169)", () => {
+  let server: McpServer;
+  let fieldCache: FieldOptionCache;
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "0.0.0" });
+    fieldCache = new FieldOptionCache();
+  });
+
+  it("list_issues (no state arg) and pipeline_dashboard agree on closed-non-terminal issues", async () => {
+    // Fixture with one CLOSED issue whose Workflow State is non-terminal —
+    // the exact shape produced by sync-pr-merge.yml advancing a linked
+    // issue's workflow state to "Done" without closing the GitHub issue
+    // (research §Path B). We use "Plan in Review" because it is a
+    // non-terminal phase the dashboard surfaces.
+    const fixture = [
+      rawIssue({
+        number: 7001,
+        title: "7001 OPEN Plan in Review",
+        workflowState: "Plan in Review",
+        state: "OPEN",
+        updatedAt: offsetIso(1 * HOUR_MS),
+      }),
+      rawIssue({
+        number: 7002,
+        title: "7002 CLOSED Plan in Review (divergent state)",
+        workflowState: "Plan in Review",
+        state: "CLOSED",
+        closedAt: offsetIso(2 * HOUR_MS),
+        updatedAt: offsetIso(1 * HOUR_MS),
+      }),
+    ];
+    const { client } = createMockClient(
+      { projectNumber: 3 },
+      { itemsByProject: { 3: fixture } },
+    );
+    const tools = registerAll(server, client, fieldCache);
+
+    // list_issues with NO state arg — relies on the GH-1169 default removal.
+    const listResult = await tools.listIssues.handler(
+      { workflowState: "Plan in Review", limit: 50, orderBy: "CREATED_AT" },
+      {},
+    );
+    const listIssues = parsePayload(listResult) as {
+      items: Array<{ number: number; state: string }>;
+    };
+    const listNumbers = listIssues.items.map((i) => i.number).sort();
+
+    // pipeline_dashboard — no state filter exists; both items appear in the
+    // Plan in Review phase bucket.
+    const dashboardResult = await tools.dashboard.handler(
+      { format: "json", includeHealth: true, doneWindowDays: 7, archiveAgeDays: 14, issuesPerPhase: 10 },
+      {},
+    );
+    const dashboard = parsePayload(dashboardResult) as {
+      phases: Array<{ state: string; issues: Array<{ number: number }> }>;
+    };
+    const pirPhase = dashboard.phases.find((p) => p.state === "Plan in Review");
+    expect(pirPhase, "pipeline_dashboard exposes Plan in Review phase").toBeDefined();
+    const dashboardNumbers = (pirPhase?.issues ?? []).map((i) => i.number).sort();
+
+    // Cross-tool agreement: same set of issue numbers in both tools.
+    expect(
+      listNumbers,
+      "list_issues (no state) surfaces both OPEN and CLOSED Plan-in-Review items",
+    ).toEqual([7001, 7002]);
+    expect(
+      dashboardNumbers,
+      "pipeline_dashboard surfaces both OPEN and CLOSED Plan-in-Review items",
+    ).toEqual([7001, 7002]);
+    expect(
+      listNumbers,
+      "list_issues and pipeline_dashboard agree on closed-non-terminal visibility",
+    ).toEqual(dashboardNumbers);
+  });
+
+  it("list_groups still defaults state=OPEN (regression pin)", async () => {
+    // GH-1169 deliberately left `list_groups`'s OPEN default in place — the
+    // acceptance criteria named `list_issues`, `next_actions`, and
+    // `pipeline_dashboard` but not `list_groups`. This regression pin
+    // documents the current behavior so a future change to `list_groups`
+    // has to update this test deliberately.
+    //
+    // Read the source string directly (no runtime call needed — the
+    // Zod-default change is a source-level invariant) and assert the
+    // `.default("OPEN")` is still present on the `state` field in
+    // relationship-tools.ts. The plan document references
+    // relationship-tools.ts:1204-1208 as the parallel default site.
+    const relationshipToolsSrc = fs.readFileSync(
+      path.resolve(__dirname, "../tools/relationship-tools.ts"),
+      "utf-8",
+    );
+    // Match the state-on-list_groups schema block: an `.enum(["OPEN", "CLOSED"])`
+    // followed by `.optional().default("OPEN")`. The match is loose enough
+    // to survive whitespace/comment changes but strict enough to catch a
+    // default removal.
+    expect(
+      relationshipToolsSrc,
+      "list_groups still has .default(\"OPEN\") on state (regression pin from GH-1169)",
+    ).toMatch(/state:\s*z\s*\.enum\(\["OPEN",\s*"CLOSED"\]\)\s*\.optional\(\)\s*\.default\("OPEN"\)/);
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/issue-tools.test.ts
@@ -3,9 +3,14 @@
  * structure, and filter chain completeness without making API calls.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerIssueTools } from "../tools/issue-tools.js";
+import type { GitHubClient } from "../github-client.js";
+import type { GitHubClientConfig } from "../types.js";
+import { FieldOptionCache } from "../lib/cache.js";
 
 const issueToolsSrc = fs.readFileSync(
   path.resolve(__dirname, "../tools/issue-tools.ts"),
@@ -237,7 +242,7 @@ describe("list_issues iteration filter structural", () => {
     // list_issues tool description should mention iteration in returned fields
     const toolDesc = issueToolsSrc.slice(
       issueToolsSrc.indexOf("ralph_hero__list_issues"),
-      issueToolsSrc.indexOf("ralph_hero__list_issues") + 500,
+      issueToolsSrc.indexOf("ralph_hero__list_issues") + 1000,
     );
     expect(toolDesc).toContain("iteration");
   });
@@ -305,5 +310,264 @@ describe("list_issues scan-until-exhausted pagination (GH-1172)", () => {
       issueToolsSrc.indexOf('"ralph_hero__list_issues"') + 800,
     );
     expect(toolBlock).toMatch(/full project scan|all project items/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_issues state default removal (GH-1169)
+//
+// Before GH-1169, `state` had `.default("OPEN")` in the Zod schema, so
+// callers that did not pass `state` were silently restricted to OPEN issues.
+// This diverged from the dashboard family (pipeline_dashboard, next_actions,
+// project_hygiene, capture_snapshot), which has no equivalent state filter
+// — closed issues with non-terminal workflow states appeared in dashboards
+// but were invisible to list_issues.
+//
+// The fix is to drop the Zod default so `state` is genuinely optional. The
+// existing `if (args.state)` guard at the filter site already does the right
+// thing when `state` is undefined (skip the filter entirely). These runtime
+// tests pin the new behavior end-to-end through the registered handler.
+// ---------------------------------------------------------------------------
+
+interface RawIssueFixture {
+  number: number;
+  title: string;
+  workflowState?: string | null;
+  state?: string;
+}
+
+/** Build a node.items.nodes[] entry shaped like the list_issues GraphQL response. */
+function rawIssueForStateTest(fix: RawIssueFixture): unknown {
+  const fieldValues: Array<Record<string, unknown>> = [];
+  if (fix.workflowState !== undefined && fix.workflowState !== null) {
+    fieldValues.push({
+      __typename: "ProjectV2ItemFieldSingleSelectValue",
+      name: fix.workflowState,
+      field: { name: "Workflow State" },
+    });
+  }
+
+  return {
+    id: `item-${fix.number}`,
+    type: "ISSUE",
+    content: {
+      __typename: "Issue",
+      number: fix.number,
+      title: fix.title,
+      state: fix.state ?? "OPEN",
+      stateReason: null,
+      url: `https://github.com/test-owner/test-repo/issues/${fix.number}`,
+      createdAt: "2026-05-01T00:00:00Z",
+      updatedAt: "2026-05-12T00:00:00Z",
+      closedAt: fix.state === "CLOSED" ? "2026-05-11T00:00:00Z" : null,
+      labels: { nodes: [] },
+      assignees: { nodes: [] },
+      repository: { nameWithOwner: "test-owner/test-repo", name: "test-repo" },
+      subIssues: { totalCount: 0 },
+      trackedIssues: { nodes: [] },
+      trackedInIssues: { nodes: [] },
+    },
+    fieldValues: { nodes: fieldValues },
+  };
+}
+
+function itemsResponseForStateTest(nodes: unknown[]): unknown {
+  return {
+    node: {
+      items: {
+        totalCount: nodes.length,
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes,
+      },
+    },
+  };
+}
+
+function fieldCacheResponseForStateTest(projectId = "project-id-3"): unknown {
+  return {
+    user: {
+      projectV2: {
+        id: projectId,
+        fields: {
+          nodes: [
+            {
+              id: "field-ws-id",
+              name: "Workflow State",
+              dataType: "SINGLE_SELECT",
+              options: [
+                { id: "opt-pir", name: "Plan in Review" },
+                { id: "opt-ip", name: "In Progress" },
+                { id: "opt-done", name: "Done" },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function isFieldCacheQuery(q: string): boolean {
+  return q.includes("projectV2(number:") && q.includes("fields(first:");
+}
+
+function isItemsQuery(q: string): boolean {
+  return q.includes("node(id: $projectId)") && q.includes("items(first:");
+}
+
+function createMockClientForStateTest(fixture: unknown[]): GitHubClient {
+  const fullConfig: GitHubClientConfig = {
+    token: "tok",
+    owner: "test-owner",
+    repo: "test-repo",
+    projectNumber: 3,
+    projectOwner: "test-owner",
+  };
+
+  const projectQuery = vi.fn(async (q: string, vars: Record<string, unknown>) => {
+    if (isFieldCacheQuery(q)) {
+      return fieldCacheResponseForStateTest(`project-id-${vars.number}`);
+    }
+    if (isItemsQuery(q)) {
+      return itemsResponseForStateTest(fixture);
+    }
+    throw new Error(`Unmocked projectQuery: ${q.slice(0, 80)}`);
+  });
+
+  const query = vi.fn(async (q: string) => {
+    throw new Error(`Unmocked query: ${q.slice(0, 80)}`);
+  });
+
+  return {
+    config: fullConfig,
+    query,
+    projectQuery,
+    projectMutate: vi.fn(),
+    mutate: vi.fn(),
+    getCache: vi.fn(() => ({
+      get: vi.fn(),
+      set: vi.fn(),
+      invalidateQueries: vi.fn(),
+    })),
+    getAuthenticatedUser: vi.fn(),
+  } as unknown as GitHubClient;
+}
+
+interface HandlerResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+interface RegisteredTool {
+  handler: (args: unknown, extra: unknown) => Promise<HandlerResult>;
+}
+
+function getListIssuesHandler(server: McpServer): RegisteredTool {
+  const tools = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+  const tool = tools?.["ralph_hero__list_issues"];
+  if (!tool) throw new Error("ralph_hero__list_issues not registered");
+  return tool;
+}
+
+function parsePayload(result: HandlerResult): unknown {
+  expect(result.content).toHaveLength(1);
+  return JSON.parse(result.content[0].text);
+}
+
+describe("list_issues state arg behavior (GH-1169)", () => {
+  let server: McpServer;
+  let fieldCache: FieldOptionCache;
+
+  // Two-item fixture: one OPEN + one CLOSED, both with the same non-terminal
+  // workflow state ("Plan in Review"). This mirrors the exact divergence the
+  // research doc identified — sync-pr-merge.yml advancing workflow state to
+  // a non-terminal value without closing the GitHub issue. With the OPEN
+  // default removed, both items must surface to a no-state-arg caller.
+  const fixture = [
+    rawIssueForStateTest({
+      number: 5001,
+      title: "5001 OPEN Plan in Review",
+      workflowState: "Plan in Review",
+      state: "OPEN",
+    }),
+    rawIssueForStateTest({
+      number: 5002,
+      title: "5002 CLOSED Plan in Review",
+      workflowState: "Plan in Review",
+      state: "CLOSED",
+    }),
+  ];
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "0.0.0" });
+    fieldCache = new FieldOptionCache();
+  });
+
+  it("list_issues with no state arg returns both OPEN and CLOSED issues", async () => {
+    const client = createMockClientForStateTest(fixture);
+    registerIssueTools(server, client, fieldCache);
+    const handler = getListIssuesHandler(server);
+
+    // No `state` arg — relies on the new default (undefined = no state filter).
+    const result = await handler.handler(
+      { workflowState: "Plan in Review", limit: 50, orderBy: "CREATED_AT" },
+      {},
+    );
+
+    const payload = parsePayload(result) as {
+      filteredCount: number;
+      items: Array<{ number: number; state: string }>;
+    };
+    const numbers = payload.items.map((i) => i.number).sort();
+    expect(
+      numbers,
+      "no-state-arg call should return BOTH the OPEN and the CLOSED issue",
+    ).toEqual([5001, 5002]);
+    expect(payload.filteredCount, "filteredCount matches items.length").toBe(2);
+  });
+
+  it("list_issues with state=OPEN still excludes CLOSED issues", async () => {
+    const client = createMockClientForStateTest(fixture);
+    registerIssueTools(server, client, fieldCache);
+    const handler = getListIssuesHandler(server);
+
+    const result = await handler.handler(
+      { state: "OPEN", workflowState: "Plan in Review", limit: 50, orderBy: "CREATED_AT" },
+      {},
+    );
+
+    const payload = parsePayload(result) as {
+      filteredCount: number;
+      items: Array<{ number: number; state: string }>;
+    };
+    const numbers = payload.items.map((i) => i.number);
+    expect(
+      numbers,
+      "explicit state=OPEN preserves pre-GH-1169 narrowing behavior",
+    ).toEqual([5001]);
+    expect(payload.items[0].state).toBe("OPEN");
+  });
+
+  it("list_issues with state=CLOSED still excludes OPEN issues", async () => {
+    const client = createMockClientForStateTest(fixture);
+    registerIssueTools(server, client, fieldCache);
+    const handler = getListIssuesHandler(server);
+
+    const result = await handler.handler(
+      { state: "CLOSED", workflowState: "Plan in Review", limit: 50, orderBy: "CREATED_AT" },
+      {},
+    );
+
+    const payload = parsePayload(result) as {
+      filteredCount: number;
+      items: Array<{ number: number; state: string }>;
+    };
+    const numbers = payload.items.map((i) => i.number);
+    expect(
+      numbers,
+      "explicit state=CLOSED returns only the closed issue",
+    ).toEqual([5002]);
+    expect(payload.items[0].state).toBe("CLOSED");
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts
@@ -61,7 +61,7 @@ export function registerIssueTools(
   // -------------------------------------------------------------------------
   server.tool(
     "ralph_hero__list_issues",
-    "List issues from a GitHub repository with optional filters. Fetches all project items (full project scan, no silent 500-cap) and applies filters client-side, so items at any board position are visible regardless of default ordering. Returns: number, title, state, workflowState, estimate, priority, iteration, labels, assignees. Use workflowState filter to find issues in a specific phase. Use iteration filter with @current/@next or sprint title. Recovery: if no results, broaden filters or check that issues exist in the project.",
+    "List issues from a GitHub repository with optional filters. Fetches all project items (full project scan, no silent 500-cap) and applies filters client-side, so items at any board position are visible regardless of default ordering. By default returns issues in any state (both OPEN and CLOSED) so visibility matches the dashboard family (pipeline_dashboard, next_actions, project_hygiene); pass the `state` parameter (\"OPEN\" or \"CLOSED\") to narrow. Returns: number, title, state, workflowState, estimate, priority, iteration, labels, assignees. Use workflowState filter to find issues in a specific phase. Use iteration filter with @current/@next or sprint title. Recovery: if no results, broaden filters or check that issues exist in the project.",
     {
       owner: z
         .string()
@@ -113,8 +113,10 @@ export function registerIssueTools(
       state: z
         .enum(["OPEN", "CLOSED"])
         .optional()
-        .default("OPEN")
-        .describe("Issue state filter (default: OPEN)"),
+        .describe(
+          "Issue state filter. When omitted, returns issues in any state " +
+          "(matches dashboard-family behavior). Pass 'OPEN' or 'CLOSED' to narrow.",
+        ),
       reason: z
         .enum(["completed", "not_planned", "reopened"])
         .optional()

--- a/thoughts/shared/plans/2026-05-12-GH-1169-list-issues-state-default-alignment.md
+++ b/thoughts/shared/plans/2026-05-12-GH-1169-list-issues-state-default-alignment.md
@@ -138,10 +138,10 @@ Make `list_issues`'s `state` parameter genuinely optional (no Zod default), upda
 
 #### Automated Verification:
 
-- [ ] `npm run build` (from `plugin/ralph-hero/mcp-server/`) — no errors
-- [ ] `npm test` (from `plugin/ralph-hero/mcp-server/`) — all suites pass including new regression tests
-- [ ] `npx vitest run src/__tests__/issue-tools.test.ts` — the three new state-arg tests pass
-- [ ] `npx vitest run src/__tests__/cross-tool-consistency.test.ts` — the new cross-tool consistency test passes
+- [x] `npm run build` (from `plugin/ralph-hero/mcp-server/`) — no errors
+- [x] `npm test` (from `plugin/ralph-hero/mcp-server/`) — all suites pass including new regression tests
+- [x] `npx vitest run src/__tests__/issue-tools.test.ts` — the three new state-arg tests pass
+- [x] `npx vitest run src/__tests__/cross-tool-consistency.test.ts` — the new cross-tool consistency test passes
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

Dropped the `.default("OPEN")` from the Zod schema for the `state` parameter in `list_issues`, aligning its behavior with the dashboard family (`pipeline_dashboard`, `next_actions`, `project_hygiene`, etc.) which have no state filter and surface closed issues with non-terminal workflow states.

## Plan

[Implementation Plan](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-GH-1169-list-issues-state-default-alignment.md)

## BEHAVIOR CHANGE

**Callers relying on the implicit `state: "OPEN"` default must now pass `state: "OPEN"` explicitly.**

This change aligns `list_issues` with the dashboard family, which never had a state filter and thus already return closed-but-non-terminal-workflow issues (e.g., a `state: "CLOSED"` issue with `Workflow State: "Plan in Review"`).

## Test plan

- [x] Automated verification per plan Success Criteria
  - `npm run build` — no errors
  - `npm test` — all 1385 suites pass, including 5 new regression tests:
    - `issue-tools.test.ts`: 3 tests pinning the new default (no state arg returns both OPEN and CLOSED; explicit state values still narrow correctly for back-compat)
    - `cross-tool-consistency.test.ts`: 2 tests asserting `list_issues` (no state arg) and `pipeline_dashboard` agree on closed-non-terminal issues; `list_groups` still defaults OPEN (regression pin)
- [ ] Manual verification per plan Success Criteria
  - Reload MCP server in Claude Code; call `ralph_hero__list_issues(workflowState: "Done")` with no state arg, confirm closed Done issues are returned
  - Call `ralph_hero__list_issues(workflowState: "Plan in Review", state: "OPEN")`, confirm back-compat (only open issues)
  - Inspect tool description in Claude Code's MCP debug panel — confirm new wording present

Closes #1169