### PR TITLE
fix(status): GH-986/987 sister skill eval fixes

### DIFF
--- a/plugin/ralph-hero/skills/status/SKILL.md
+++ b/plugin/ralph-hero/skills/status/SKILL.md
@@ -37,8 +37,19 @@ Fetch the pipeline dashboard with the requested format:
    - `format`: parsed format or `"markdown"`
    - `includeHealth`: true
    - `issuesPerPhase`: 5
-3. Display the `formatted` field (for markdown/ascii) or the structured data (for json).
-4. If health warnings exist with severity `critical`, highlight them prominently.
+3. Route the display rendering by format (see Step 4 below for exact rules).
+4. **Display rendering — route by format:**
+
+   **If `format == "json"`:**
+   - Emit the dashboard object literally inside a fenced ```json``` code block, using `JSON.stringify(dashboard, null, 2)` (pretty-printed, 2-space indent).
+   - **DO NOT narrate or summarize the JSON.** Do not add a preamble like "Here's the pipeline status..." or a postamble like "The pipeline has N critical warnings." Emit the fenced JSON block and stop.
+   - Do not re-render the JSON as markdown bullet lists, headings, tables, or prose. The agent's response in JSON mode is the fenced JSON code block — nothing else.
+
+   **If `format == "markdown"` or `format == "ascii"`:**
+   - Emit the dashboard's `formatted` field verbatim.
+   - Do not re-render or restructure the content.
+
+5. If health warnings exist with severity `critical`, highlight them prominently. In JSON mode, the warnings are already in the JSON payload — do not re-surface them in prose.
 
 ## Output
 

--- a/plugin/ralph-hero/skills/status/SKILL.md
+++ b/plugin/ralph-hero/skills/status/SKILL.md
@@ -51,6 +51,51 @@ Fetch the pipeline dashboard with the requested format:
 
 5. If health warnings exist with severity `critical`, highlight them prominently. In JSON mode, the warnings are already in the JSON payload — do not re-surface them in prose.
 
-## Output
+## Output Scope
 
-Display the dashboard output directly. Do not add additional commentary unless there are critical health warnings.
+Display the dashboard output directly. Do not add additional commentary unless there are critical health warnings, in which case the **only** acceptable addition is surfacing the raw warning list verbatim from the dashboard payload.
+
+This skill is a **read-only, passive render of pipeline state plus raw warnings**. It is NOT a triage tool, NOT an analyst, NOT a recommender.
+
+**NEVER:**
+- Prescribe actions, fixes, or remediation steps ("should be split", "needs closure", "ought to be archived", "Here's what you should do").
+- Add diagnostic framing or interpretive commentary ("Pipeline gaps indicate no active work", "Backlog congestion suggests stale work", "This indicates...").
+- Synthesize "Key Findings", "Recommendations", "Next Steps", "Suggested Actions", or any analyst-style summary section.
+- Group, rank, editorialize, or contextualize warnings beyond what the dashboard payload already encodes.
+- Cross-reference issues to call out which "should" be split, closed, or archived.
+
+Remediation, triage, and follow-up analysis belong to `/ralph-hero:hygiene`, `/ralph-hero:triage`, or `/ralph-hero:hello` — NOT to `/ralph-hero:status`. After surfacing the raw warning list, STOP.
+
+**Negative example (do NOT produce output like this):**
+
+```
+### Critical Issues
+
+**48 CRITICAL health warnings** — issues stuck beyond 96-hour threshold:
+- **Backlog**: 23 issues stuck (oldest: #362, #503 at 1490h)
+
+### Key Findings
+
+1. **Pipeline gaps**: All active phases are empty — work flows straight
+   from Ready for Plan to Done with no intermediate stops.
+2. **Backlog congestion**: 22 issues waiting; #503 and #505-#507 are
+   62+ days old.
+3. **#731 should be split** — it's a P1, L item blocking the loop.
+4. **Archive eligible**: 135 items in Done/Canceled can be archived.
+```
+
+The "Key Findings" block, the "should be split" recommendation, the "can be archived" suggestion, and the "Pipeline gaps indicate..." diagnostic framing are all out of scope. Surface the raw warning list and stop.
+
+**Correct shape:**
+
+```
+[dashboard.formatted verbatim]
+
+### Critical Health Warnings (N)
+
+- #362 — stuck 1490h in Backlog
+- #503 — stuck 1488h in Backlog
+- ...
+```
+
+No analysis, no recommendations, no framing — just the raw list.

--- a/thoughts/shared/reviews/2026-05-12-GH-1201-critique.md
+++ b/thoughts/shared/reviews/2026-05-12-GH-1201-critique.md
@@ -1,0 +1,78 @@
+---
+date: 2026-05-12
+github_issue: 1201
+github_url: https://github.com/cdubiel08/ralph-hero/issues/1201
+plan_document: thoughts/shared/plans/2026-05-12-group-GH-1203-1207-memory-tier-productization.md
+status: approved
+type: review
+tags: [plan-review, memory-tier, dream-loop, ralph-knowledge, ralph-engine, group-plan]
+---
+
+# Plan Critique - GH-1201 Memory-Tier Productization (Group Plan, 5 Phases)
+
+## Summary
+
+**Verdict**: APPROVED
+
+This is a 5-phase group plan covering GH-1203 through GH-1207, children of parent epic GH-1201. Phase 1 (GH-1203) is already implemented and CLOSED — its inclusion documents the unblocker that the rest of the group depends on. Phases 2-5 are scoped, atomic, and dispatchable. Every task carries the five required fields (files, tdd, complexity, depends_on, acceptance) and acceptance criteria are concrete + verifiable. Technical claims spot-verified against `embedder.ts`, `reindex.ts`, `index.ts`, `parser.ts`, `ingest.py`, the plist template, `config.yaml`, the 6 target SKILL.md files, and the ralph-engine knowledge package.
+
+## Dimension Scores
+
+### 1. Completeness — PASS
+All five phases have an Overview, Tasks (with full per-task fields), and Phase Success Criteria split into Automated + Manual. Top-level sections (Prior Work, Overview, Shared Constraints, Current State Analysis, Desired End State, What We're NOT Doing, Implementation Approach, Integration Testing, References) are all present. References cite specific file paths and line numbers.
+
+### 2. Feasibility — PASS
+Spot-verified technical claims:
+- `embedChunks(string[])` already exists at `plugin/ralph-knowledge/src/embedder.ts:66-115` (Phase 1's Task 1.1, marked `[x]`).
+- Reindex buffer + `EMBED_BATCH_SIZE` + GC hint already present at `reindex.ts:149-219` (Phase 1's Task 1.2 + 1.4, marked `[x]`).
+- ingest.py `_run_reindex` already captures `capture_output=True` and emits last-50 stderr lines at `ingest.py:471-521` (Phase 1's Task 1.5, marked `[x]`).
+- `knowledge_search` MCP tool already accepts `memory_tier` enum at `plugin/ralph-knowledge/src/index.ts:105-109` — Phase 2's "policy wrapper, not schema change" claim is correct.
+- Plist hard-codes `/Users/dubiel/...` at template lines 6 (Label), 11 (cd + cmd), 21 (StandardOutPath), 23 (StandardErrorPath), 29 (RALPH_KNOWLEDGE_CONFIG) — Phase 4 Task 4.1's "5 occurrences" claim verified.
+- ralph-engine `sqlite-knowledge-store.ts` and `parser.ts` have zero `memory_tier` references — Phase 5's diverged-schema claim verified.
+- `config.yaml` line 12 already contains `/Users/dubiel/projects/ralph-engine` — Phase 5 Task 5.4 correctly notes "no change needed".
+- All 6 target SKILL.md files currently use `knowledge_search`; none use `knowledge_recall` — Phase 2's grep verification target is reachable.
+- Parser's `memory_tier` coercion to `'doc'` with warning is real (`parser.ts:130-144`) — Phase 5 Task 5.2's "mirrors ralph-hero parser behavior exactly" target is correct.
+
+No phantom files. No bad references. Patterns are valid (Stop hook precedent in ralph-unblock, MCP tool registration pattern at `index.ts:95-197`).
+
+### 3. Clarity — PASS
+Phase Success Criteria use the canonical `- [ ] Automated:` / `- [ ] Manual:` split. Acceptance criteria within tasks are concrete (exact file paths, exact grep targets, exact tier-count semantics, exact runtime budgets like "<500ms" for the Stop hook). One example of the rigor: Task 1.6's acceptance criterion specifies `Exits 0 iff doc > 0 AND raw > 0 AND reflection > 0 (wiki is allowed to be 0)` — testable without ambiguity. Phase 1's `[x]` checkmarks vs `[ ]` unchecked items make the "already done / deferred for manual" boundary explicit.
+
+### 4. Scope — PASS
+"What We're NOT Doing" section enumerates 8 explicit exclusions including the high-risk ones (embedding model swap, auto-promotion to wiki, engine schema migration off metadata JSON, screenpipe, parser/db Phase 1 refactor). Shared Constraints section adds 9 more hard rules (fixed enum, additive-only engine, dream-loop stays Python, Stop hook narrow blast radius, no LLM in hooks, idempotent bootstrap, no parsedDocs regression, tier filter is already plumbed). The "additive only" engine rule is particularly important and explicit.
+
+### 5. Dispatchability — PASS
+Every task across all 5 phases carries the five required fields. Sample audit:
+
+| Task | files | tdd | complexity | depends_on | acceptance |
+|------|-------|-----|------------|------------|------------|
+| 1.1 | yes (1 file, modify) | true | medium | null | 6 criteria |
+| 1.2 | yes (2 files: 1 modify, 1 read) | true | high | [1.1] | 8 criteria |
+| 2.1 | yes (1 file, modify) | true | medium | null | 8 criteria |
+| 2.2 | yes (6 files, all modify) | false | medium | [2.1] | 6 criteria |
+| 3.1 | yes (1 file, modify) | true | medium | null | 8 criteria |
+| 3.2 | yes (1 file, create) | false | medium | null | 8 criteria |
+| 4.2 | yes (1 file, create) | false | medium | [4.1] | 5 criteria |
+| 5.1 | yes (2 files, modify) | true | medium | null | 8 criteria |
+| 5.3 | yes (3 files + tests) | true | medium | [5.1] | 5 criteria |
+
+Phase-level dependencies are explicit (`depends_on: [phase-1]` on Phases 2/3/4/5; Phase 5 only depends on Phase 1, allowing parallel execution after Phase 1). Each phase ends with a "Creates for next phase" sentence stating what artifact the next phase consumes. Integration Testing section at the top-level covers cross-phase interactions (end-to-end smoke, dream-now, fresh-machine simulation, cross-surface ralph-hero -> ralph-engine reflection visibility).
+
+The only marginally weaker item is Task 3.4 ("recognizes `dream-memories/agent/` as additional scan source OR documents that the existing config already covers it") — phrased as a research-first task. This is acceptable for a "verify-and-decide" task but a dispatchee should know to write the test even if no code change is needed (Task already says so).
+
+## Group-Specific Verification
+
+- **Phase dependency graph**: 1 -> {2, 3, 4, 5}. After Phase 1, 2/3/4 are sequenced for verification clarity (not for technical blocking), and Phase 5 is independently dispatchable. Plan explicitly states this (line 37, line 92-95).
+- **Integration testing section** present (line 509-517) with 7 cross-phase scenarios.
+- **Group framing**: parent issue GH-1201 has 5 children matching the plan. Sub-issue GH-1203 is Done; siblings 1204-1207 are in Plan in Review along with the parent. Convergence is met per pipeline detection.
+
+## Minor Notes (non-blocking)
+
+1. **Phase 4 Task 4.1 label semantics**: the plan correctly converts the plist Label to `com.__USER__.dream-loop`, but the existing CLAUDE.md instructions reference `com.dubiel.dream-loop.plist` by name. Phase 4 Task 4.1 says "Existing CLAUDE.md instructions explaining manual `cp` + hand-edit are left in place but marked deprecated" — confirm the rename produces a clean migration for users who already loaded `com.dubiel.dream-loop` (will need a `launchctl unload` old / `load` new transition). Not a blocker; document during implementation.
+2. **Phase 1 already-done acknowledgment**: Phase 1's `[x]` automated-verification marks make clear the implementation has landed. Two `[ ]` items remain (live-corpus reindex + verify:tiers). These are gated on manual execution. Suggest the implementer for Phase 2 (or whoever opens the next worktree) runs the live reindex once and reports tier counts in the parent issue comment thread — clears Phase 1's manual verification and gives Phase 2-5 a clean substrate. Plan already notes this: "Creates for next phase: a healthy 4-tier DB".
+3. **Task 5.5 optional gate**: marked "Optional" with a decision-fork ("if engine indexes the same tree but does NOT need per-chunk granularity, skip"). This is fine — the acceptance criterion correctly demands the decision be recorded with a code comment or plan amendment. Dispatchee will have agency.
+4. **Phase 3 Task 3.2 secrets regex**: covers `gh[ps]_`, `sk-`, `ghp_`, `xoxb-`. Consider adding `AKIA[0-9A-Z]{16}` (AWS access keys) and `https://hooks.slack.com/services/`. Non-blocking — can be added in the patch itself.
+
+## Verdict
+
+APPROVED. The plan is dispatchable, verifiable, and accurately reflects the codebase. Phase 1's already-landed work is correctly accounted for. Phases 2-5 are atomic, well-scoped, and independently shippable after Phase 1's substrate. Proceed to implementation.


### PR DESCRIPTION
## Summary

Fixed two related evaluation failures in the status skill:
- **GH-986**: JSON output mode was rendering markdown prose instead of valid JSON. Updated Step 4 to explicitly route display by format, with an explicit "DO NOT narrate" instruction for JSON mode.
- **GH-987**: Skill was emitting remediation recommendations and analyst-style framing beyond raw warning surfacing. Added Output Scope section declaring read-only passive render contract with negative/positive examples.

## Implementation Plan

Two atomic commits on feature/GH-986:
1. **08818465** - `fix(status): emit JSON literally in JSON mode (GH-986)` - Routes Step 4 by format, emits `JSON.stringify()` in JSON mode with explicit narration prohibition
2. **38789821** - `fix(status): bound output to raw surfacing, prohibit remediation prose (GH-987)` - Adds Output Scope section with forbidden patterns and examples

## Test plan

- [x] Verify JSON mode emits literal JSON in fenced code block (no prose preamble/postamble)
- [x] Verify markdown mode passes through `formatted` field verbatim
- [x] Verify critical warnings are surfaced but not analyzed/remediated
- [x] Confirm Output Scope section explicitly forbids prescriptions, diagnostic framing, Key Findings synthesis

Closes #986
Closes #987