### PR TITLE
GH-1204: Phase 2 — Role-based retrieval (knowledge_recall)

### DIFF
--- a/plugin/ralph-hero/skills/plan/SKILL.md
+++ b/plugin/ralph-hero/skills/plan/SKILL.md
@@ -24,6 +24,8 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
   - AskUserQuestion
 ---
 
@@ -79,8 +81,9 @@ Then wait for the user's input.
    - **CRITICAL**: DO NOT spawn sub-tasks before reading these files yourself in the main context
    - **NEVER** read files partially - if a file is mentioned, read it completely
 
-   **Knowledge graph shortcut**: If a knowledge search tool is available, try it first to find related research documents on the topic keywords, type "research", limit 5.
+   **Knowledge graph shortcut**: If `knowledge_recall` is available, call `knowledge_recall(query="[topic keywords]", role="planner", brief=true, limit=5)` first. The planner tier policy `[reflection, wiki, doc]` surfaces synthesized insights + curated knowledge for the planning frame while excluding raw observations.
    If results are returned, read the top matches for context. This supplements (not replaces) the issue comment check and thoughts-locator search below.
+   For explicit-tier control (e.g., looking up a specific artifact by type), call `knowledge_search(query="...", type="research", brief=true)` directly — `knowledge_search` remains available alongside `knowledge_recall`.
 
 2. **If a `#NNN` issue was provided**, fetch it directly: fetch the full issue details for issue NNN (title, body, comments, workflow state, relationships).
    Read the full response including comments. Check comments for linked research documents (look for `## Research Document` header per Artifact Comment Protocol).

--- a/plugin/ralph-hero/skills/ralph-impl/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-impl/SKILL.md
@@ -55,6 +55,8 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
 ---
 
 ## Configuration (resolved at load time)
@@ -100,9 +102,12 @@ After fetching the issue, check its current state:
 
 1. **Read issue and all comments**: Fetch the full issue details for the issue number.
 
+1a. **Pre-implementation context (implementer-tier memory)**: If `knowledge_recall` is available, call `knowledge_recall(query="[issue title + key file paths/component names]", role="implementer", brief=true, limit=5)` BEFORE reading the plan. The implementer tier policy `[wiki, doc]` returns ONLY canonical references — never raw memory or speculative reflections — keeping the implementation grounded in agreed-upon truth. Read the top matches for context, then continue.
+   If `knowledge_recall` is unavailable or returns nothing, skip this step and proceed directly to step 2.
+
 2. **Find linked plan document**:
 
-   **Knowledge graph shortcut**: If a knowledge search tool is available, try it first: search for "implementation plan GH-${number} [issue title keywords]", type "plan", limit 3.
+   **Knowledge graph shortcut**: If a knowledge search tool is available, try it first: search for "implementation plan GH-${number} [issue title keywords]", type "plan", limit 3. Prefer `knowledge_recall(role="implementer", type="plan", ...)` for the role-aware default, or `knowledge_search(type="plan", ...)` for explicit-tier control.
    If a high-relevance result is returned, read that file directly and skip steps 1-8 below. If not available or no results, continue with standard Artifact Comment Protocol discovery below.
 
    **Artifact shortcut**: If `--plan-doc` flag was provided in args and the file exists on disk, read it directly and skip the discovery sequence below. If the file does not exist, log `"Artifact flag path not found, falling back to discovery: [path]"` and continue with standard discovery.

--- a/plugin/ralph-hero/skills/ralph-plan/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-plan/SKILL.md
@@ -52,6 +52,8 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__sync_plan_graph
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
 ---
 
 ## Configuration (resolved at load time)
@@ -158,8 +160,9 @@ The parent plan's shared constraints are inherited verbatim into this plan's `##
 
 1. **For each issue** (dependency order):
 
-   **Knowledge graph shortcut**: If a knowledge search tool is available, try it first: search for "research GH-${number} [issue title keywords]", type "research", limit 3.
+   **Knowledge graph shortcut**: If `knowledge_recall` is available, call `knowledge_recall(query="research GH-${number} [issue title keywords]", role="planner", type="research", limit=3, brief=true)`. The planner tier policy `[reflection, wiki, doc]` surfaces synthesized insights and curated knowledge for the planning frame.
    If a high-relevance result is returned, read that file directly and skip steps 1-7 below. If not available or no results, continue with standard Artifact Comment Protocol discovery below.
+   For explicit-tier lookup (e.g., `memory_tier="wiki"` only), call `knowledge_search(query="...", type="research", limit=3)` directly — both tools remain available.
 
    **Artifact shortcut**: If `--research-doc` flag was provided in args and the file exists on disk, read it directly and skip the discovery sequence below for that issue. If the file does not exist, log `"Artifact flag path not found, falling back to discovery: [path]"` and continue with standard discovery. For groups, the flag covers the primary issue only; other members use standard discovery.
 

--- a/plugin/ralph-hero/skills/ralph-research/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-research/SKILL.md
@@ -44,6 +44,7 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
@@ -149,12 +150,12 @@ This information is consumed by the hero skill during tree expansion to override
 
 ### Step 3c: Knowledge Graph Prior Art Discovery
 
-If `knowledge_search`, `knowledge_traverse`, or `knowledge_query_outcomes` MCP tools are available (from the ralph-knowledge plugin), perform prior-art discovery directly before dispatching sub-agents. If unavailable, skip to Step 4.
+If `knowledge_recall`, `knowledge_search`, `knowledge_traverse`, or `knowledge_query_outcomes` MCP tools are available (from the ralph-knowledge plugin), perform prior-art discovery directly before dispatching sub-agents. If unavailable, skip to Step 4.
 
 This step runs autonomously — no user questions, just detect-and-act. Run the following calls in order:
 
-1. `knowledge_search(query="[issue topic]", type="research", brief=true)` — find prior research documents on this topic.
-2. `knowledge_search(query="[issue topic]", type="plan", brief=true)` — find existing plans that may overlap with the issue.
+1. `knowledge_recall(query="[issue topic]", role="researcher", type="research", brief=true)` — role-aware tier policy `[raw, reflection, doc]` surfaces both raw observations and synthesized insights for the researcher frame.
+2. `knowledge_recall(query="[issue topic]", role="researcher", type="plan", brief=true)` — same tier policy, scoped to plan-type documents for overlap detection.
 3. `knowledge_query_outcomes(component_area="[area inferred from issue]", aggregate=true)` — if a component area is identifiable from the issue body, files referenced, or the registry lookup in Step 3a, retrieve aggregate pipeline history (pass/fail trends, drift counts, common blockers).
 
 **How to use the results:**
@@ -164,6 +165,8 @@ This step runs autonomously — no user questions, just detect-and-act. Run the 
 
 **Brief-first pattern:**
 - Use `brief: true` for discovery (returns titles + snippets without full content). Only `Read` documents you select for deep analysis. This saves context window.
+
+**Power-user note:** `knowledge_recall` wraps `knowledge_search` with the researcher tier policy. If you need an explicit tier (e.g., `memory_tier="wiki"` only), call `knowledge_search` directly — both tools remain available.
 
 If the searches return nothing relevant, proceed to Step 4 with full sub-agent dispatch — the knowledge graph may be stale or sparse on this topic. Do NOT skip sub-agent dispatch on the basis of an empty knowledge result alone.
 
@@ -225,7 +228,7 @@ The document must begin with a `## Prior Work` section immediately after the tit
 
 - `builds_on::` for documents this research extends or was informed by
 - `tensions::` for documents whose conclusions conflict with findings here
-- Populate from thoughts-locator and thoughts-analyzer results gathered during the research phase, plus any prior-art discovered in Step 3c via `knowledge_search`
+- Populate from thoughts-locator and thoughts-analyzer results gathered during the research phase, plus any prior-art discovered in Step 3c via `knowledge_recall` / `knowledge_search`
 - If no relevant prior work exists, include the section with "None identified."
 - Use filenames without extension as wikilink targets
 
@@ -429,7 +432,7 @@ The Step 3c prior-art discovery, evidence weighting, Pipeline History section, a
 
 1. **Tools unavailable** (MCP server not running, plugin not installed, or tools not in the runtime allowlist): skip Step 3c entirely and rely on the `thoughts-locator` sub-agent in Step 4 — it always works via grep/glob and will populate Prior Work via filesystem scan. Add a footnote to the research document under Prior Work: `Knowledge graph unavailable — prior work discovery via file scan only`. Do not block the research workflow on missing knowledge tools.
 
-2. **Tools available but `knowledge_search` returns zero results**: try broader search terms first (remove specific qualifiers, drop component prefixes), then fall back to grep-based search of the `thoughts/` directory. Do NOT skip sub-agent dispatch — an empty knowledge result may indicate a stale or sparsely-indexed graph rather than a true absence of prior art. Continue with full Step 4 sub-agent dispatch and let `thoughts-locator` cross-check the filesystem.
+2. **Tools available but `knowledge_recall` (or `knowledge_search`) returns zero results**: try broader search terms first (remove specific qualifiers, drop component prefixes), then fall back to grep-based search of the `thoughts/` directory. Do NOT skip sub-agent dispatch — an empty knowledge result may indicate a stale or sparsely-indexed graph rather than a true absence of prior art. Continue with full Step 4 sub-agent dispatch and let `thoughts-locator` cross-check the filesystem.
 
 The Step 8 outcome recording (`knowledge_record_outcome`) is also subject to graceful degradation — silently skip the call if the tool is unavailable. The workflow advancement to "Ready for Plan" must still complete even when the outcome ledger cannot be written.
 

--- a/plugin/ralph-hero/skills/research/SKILL.md
+++ b/plugin/ralph-hero/skills/research/SKILL.md
@@ -18,6 +18,7 @@ allowed-tools:
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
   - AskUserQuestion
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
 ---
@@ -78,12 +79,12 @@ Then wait for the user's research query.
 
 ### Step 2.5: Knowledge Graph Prior Art Discovery
 
-If `knowledge_search`, `knowledge_traverse`, or `knowledge_query_outcomes` MCP tools are available (from the ralph-knowledge plugin), perform prior-art discovery directly before dispatching sub-agents. If unavailable, skip to Step 3.
+If `knowledge_recall`, `knowledge_search`, `knowledge_traverse`, or `knowledge_query_outcomes` MCP tools are available (from the ralph-knowledge plugin), perform prior-art discovery directly before dispatching sub-agents. If unavailable, skip to Step 3.
 
 Run the following calls in order:
 
-1. `knowledge_search(query="[research topic]", type="research", brief=true)` — find prior research documents on this topic.
-2. `knowledge_search(query="[research topic]", type="plan", brief=true)` — find existing plans that may overlap with the question.
+1. `knowledge_recall(query="[research topic]", role="researcher", type="research", brief=true)` — role-aware tier policy `[raw, reflection, doc]` surfaces both raw observations and synthesized insights for the researcher frame.
+2. `knowledge_recall(query="[research topic]", role="researcher", type="plan", brief=true)` — same tier policy, scoped to plan-type documents for overlap detection.
 3. (Optional) `knowledge_query_outcomes(component_area="[area]", aggregate=true)` — if the issue maps to a known component area (e.g., `src/tools/`, `plugin/ralph-knowledge/`), retrieve aggregate pipeline history (pass/fail trends, drift counts, common blockers).
 
 **How to use the results:**
@@ -91,6 +92,8 @@ Run the following calls in order:
 
 **Brief-first pattern:**
 - Use `brief: true` for discovery (returns titles + snippets without full content). Only `Read` documents you select for deep analysis. This saves context window.
+
+**Power-user note:** `knowledge_recall` wraps `knowledge_search` with the researcher tier policy. If you need an explicit tier (e.g., `memory_tier="wiki"` only), call `knowledge_search` directly — both tools remain available.
 
 If the searches return nothing relevant, proceed to Step 3 with full sub-agent dispatch — the knowledge graph may be stale or sparse on this topic. Do NOT skip sub-agent dispatch on the basis of an empty knowledge result alone.
 
@@ -372,7 +375,7 @@ The Step 2.5 prior-art discovery, evidence weighting, and outcome lookups all de
 
 1. **Tools unavailable** (MCP server not running, plugin not installed, or tools not in the runtime allowlist): skip Step 2.5 entirely and rely on the `thoughts-locator` sub-agent in Step 3 — it always works via grep/glob and will populate Prior Work via filesystem scan. Add a footnote to the research document under Prior Work: `Knowledge graph unavailable — prior work discovery via file scan only`. Do not block the research workflow on missing knowledge tools.
 
-2. **Tools available but `knowledge_search` returns zero results**: try broader search terms first (remove specific qualifiers, drop component prefixes), then fall back to grep-based search of the `thoughts/` directory. Do NOT skip sub-agent dispatch — an empty knowledge result may indicate a stale or sparsely-indexed graph rather than a true absence of prior art. Continue with full Step 3 sub-agent dispatch and let `thoughts-locator` cross-check the filesystem.
+2. **Tools available but `knowledge_recall` (or `knowledge_search`) returns zero results**: try broader search terms first (remove specific qualifiers, drop component prefixes), then fall back to grep-based search of the `thoughts/` directory. Do NOT skip sub-agent dispatch — an empty knowledge result may indicate a stale or sparsely-indexed graph rather than a true absence of prior art. Continue with full Step 3 sub-agent dispatch and let `thoughts-locator` cross-check the filesystem.
 
 ## Important notes
 - Always use parallel Task agents to maximize efficiency and minimize context usage

--- a/plugin/ralph-hero/skills/retro/SKILL.md
+++ b/plugin/ralph-hero/skills/retro/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
   - Agent
   - AskUserQuestion
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
 ---
 
@@ -137,13 +138,13 @@ After all sub-agents return, fold their findings into the relevant pain-point se
 
 ### Optional Knowledge Graph Dedup
 
-If `mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search` is available, run a brief dedup check for each high-severity pain point:
+If `mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall` is available, run a brief dedup check for each high-severity pain point using the researcher tier policy `[raw, reflection, doc]` — this surfaces both raw observations of similar friction AND synthesized insights from prior reflections, which is exactly what a retro dedup wants:
 
 ```
-knowledge_search(query="[pain point summary]", type="research", brief=true, limit=3)
+knowledge_recall(query="[pain point summary]", role="researcher", type="research", brief=true, limit=3)
 ```
 
-If a close match is found, mention it in the eventual research doc (`Prior Work` section). If the tool is unavailable, skip this — degrade gracefully.
+If a close match is found, mention it in the eventual research doc (`Prior Work` section). If `knowledge_recall` is unavailable, fall back to `knowledge_search(query="...", type="research", brief=true, limit=3)`. If neither tool is available, skip this — degrade gracefully.
 
 ## Step 4: Present Findings for Review
 
@@ -209,7 +210,7 @@ tags: [retro, session-friction, [+ relevant component tags]]
 
 ## Prior Work
 
-- builds_on:: [[any-related-research-doc]] (research — primary evidence, if found via knowledge_search)
+- builds_on:: [[any-related-research-doc]] (research — primary evidence, if found via knowledge_recall / knowledge_search)
 - builds_on:: [[any-related-postmortem]] (report — if a recent team session covered overlapping ground)
 
 (If no prior work found, leave a single line: `_No prior work found via knowledge graph or thoughts scan._`)

--- a/plugin/ralph-knowledge/README.md
+++ b/plugin/ralph-knowledge/README.md
@@ -100,6 +100,48 @@ Patterns behave exactly like `.gitignore`:
 Directories whose names start with `.` or `_` are also always skipped, as a
 fast-path before any matcher is consulted.
 
+## Choosing between `knowledge_search` and `knowledge_recall`
+
+ralph-knowledge exposes two retrieval MCP tools that wrap the same underlying
+hybrid search. They differ on **who decides the tier policy**:
+
+| Tool | When to use | Tier handling |
+|------|-------------|---------------|
+| `knowledge_search` | Power-user / explicit path. You know the tier and want full control over `rerank`, `lambda`, `return_diagnostics`, chunk metadata, etc. | You pass `memory_tier` explicitly (`doc`, `raw`, `reflection`, `wiki`, or `any` — default `any`). |
+| `knowledge_recall` | Default for agents and skills. You declare your role and the tool picks the right tiers. | A role-keyed policy fans out one rerank-enabled `hybrid.search()` per tier in the role's list, then merges and re-ranks. |
+
+### Role -> tier policy
+
+`knowledge_recall(query, role, ...)` follows this fixed policy map:
+
+| Role | Tiers (priority order) | Intent |
+|------|------------------------|--------|
+| `researcher` | `raw`, `reflection`, `doc` | Recovery of unfiltered observations + synthesized insights + curated research. Excludes wiki (we are looking for things the wiki does not already cover). |
+| `planner` | `reflection`, `wiki`, `doc` | Bias toward synthesized insights + canonical curated knowledge; excludes raw observations to keep the planning frame stable. |
+| `implementer` | `wiki`, `doc` | Only canonical references — never raw memory or speculative reflections. Keeps implementations grounded in agreed-upon truth. |
+| `reviewer` | `wiki`, `doc` | Same constraints as implementer — review against the canonical surface, not the raw or speculative tiers. |
+| `triager` | `doc`, `wiki` | Doc-first for issue context, wiki as fallback. |
+
+### Cost notes
+
+- `knowledge_recall` always runs the cross-encoder reranker (`rerank=true`)
+  because role-aware retrieval is the most context-sensitive call path in the
+  surface. Expect a one-time ~0.5-1 s cold-start (ONNX model load on the first
+  call after process boot) and ~25-45 ms per (query, doc) pair on warm calls.
+- Each tier sub-query targets <50 ms; a 3-tier fanout totals <150 ms before
+  reranking.
+- If a tier sub-query throws (e.g., transient DB lock), `knowledge_recall`
+  logs the error to stderr and continues with the remaining tiers — degraded
+  results rather than a hard failure.
+
+### Power-user override
+
+Skills can mix both tools. For example, `/ralph-hero:plan` calls
+`knowledge_recall(role="planner", ...)` for the default tier-balanced context
+gather, and ALSO calls `knowledge_search(type="research", ...)` for an explicit
+artifact lookup where it needs a precise type filter. Keeping both tools in a
+skill's allowlist is the recommended pattern.
+
 ## Environment variables
 
 | Variable | Purpose |

--- a/plugin/ralph-knowledge/src/__tests__/recall.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/recall.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { KnowledgeDB } from "../db.js";
+
+/**
+ * Phase 2 (GH-1204) tests for the `knowledge_recall` MCP tool.
+ *
+ * Verifies the role-to-tier policy fans out one hybrid.search call per tier,
+ * merges and re-ranks results, dedups by id, and surfaces the same payload
+ * shape as `knowledge_search`. Uses stubs to avoid the ONNX model download
+ * (mirrors `index.test.ts`).
+ */
+
+function mockEmbedding(seed: number): Float32Array {
+  const v = new Float32Array(384);
+  for (let i = 0; i < 384; i++) v[i] = Math.sin(seed * (i + 1) * 0.1);
+  let norm = 0;
+  for (let i = 0; i < v.length; i++) norm += v[i] * v[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < v.length; i++) v[i] /= norm;
+  return v;
+}
+
+function hashSeed(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h) % 1000;
+}
+
+const mockEmbedFn = async (text: string) => mockEmbedding(hashSeed(text));
+
+async function callTool(
+  toolServer: McpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const registeredTools = (toolServer as unknown as Record<string, unknown>)
+    ._registeredTools as Record<
+    string,
+    { handler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown> }
+  >;
+  const tool = registeredTools?.[name];
+  if (!tool) throw new Error(`Tool "${name}" not registered`);
+  return tool.handler(args, {}) as Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+/**
+ * Ensure v3 schema (memory_tier column + chunks table) on the test DB. Mirrors
+ * the helper in index.test.ts.
+ */
+function ensureV3Schema(db: KnowledgeDB): void {
+  const rows = db.db.prepare("PRAGMA table_info(documents)").all() as Array<{ name: string }>;
+  if (!rows.some((r) => r.name === "memory_tier")) {
+    db.db.exec(
+      "ALTER TABLE documents ADD COLUMN memory_tier TEXT NOT NULL DEFAULT 'doc' CHECK(memory_tier IN ('doc','raw','reflection','wiki'))",
+    );
+  }
+  db.db.exec(
+    `CREATE TABLE IF NOT EXISTS chunks (
+       id TEXT PRIMARY KEY,
+       document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+       chunk_index INTEGER NOT NULL,
+       content TEXT NOT NULL,
+       char_start INTEGER NOT NULL,
+       char_end INTEGER NOT NULL,
+       context_prefix TEXT NOT NULL DEFAULT '',
+       UNIQUE(document_id, chunk_index)
+     )`,
+  );
+  db.db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id)",
+  );
+}
+
+/**
+ * Stub Reranker — matches the public surface of `Reranker.score()` but returns
+ * a fixed score map. The recall tool sets `rerank: true` internally, so wiring
+ * a stub avoids the ~580 MB ONNX model download (same pattern as `index.test.ts`).
+ */
+class StubReranker {
+  constructor(public readonly scoreMap: Map<string, number>) {}
+  async score(
+    _query: string,
+    docs: Array<{ id: string; text: string }>,
+  ): Promise<Map<string, number>> {
+    const out = new Map<string, number>();
+    for (const d of docs) {
+      if (this.scoreMap.has(d.id)) out.set(d.id, this.scoreMap.get(d.id)!);
+    }
+    return out;
+  }
+}
+
+describe("knowledge_recall tool registration", () => {
+  it("registers knowledge_recall alongside knowledge_search", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const registered = (server as unknown as Record<string, unknown>)
+      ._registeredTools as Record<string, unknown>;
+    expect(registered).toHaveProperty("knowledge_recall");
+    expect(registered).toHaveProperty("knowledge_search"); // sibling still exists
+  });
+
+  it("knowledge_recall schema requires query + role; accepts optional limit/type/tags", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const registered = (server as unknown as Record<string, unknown>)
+      ._registeredTools as Record<string, { inputSchema?: { parse: (v: unknown) => unknown } }>;
+    const schema = registered.knowledge_recall?.inputSchema;
+    expect(schema).toBeDefined();
+
+    // Valid minimum: query + role.
+    expect(() => schema!.parse({ query: "hello", role: "researcher" })).not.toThrow();
+    // All five roles accepted.
+    for (const role of ["researcher", "planner", "implementer", "reviewer", "triager"]) {
+      expect(() => schema!.parse({ query: "x", role })).not.toThrow();
+    }
+    // Invalid role rejected.
+    expect(() => schema!.parse({ query: "x", role: "philosopher" })).toThrow();
+    // role is required.
+    expect(() => schema!.parse({ query: "x" })).toThrow();
+    // Optionals accepted.
+    expect(() =>
+      schema!.parse({
+        query: "x",
+        role: "planner",
+        limit: 5,
+        type: "research",
+        tags: ["alpha"],
+        includeSuperseded: true,
+        brief: true,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("knowledge_recall role-tier policy fan-out", () => {
+  /**
+   * Builds a server whose `HybridSearch` is replaced with a spy that records
+   * each `search` invocation's `memoryTier`. We achieve this by hooking the
+   * server's tool registration but keeping the real `createServer` — instead
+   * of mocking the entire module, we seed the DB with tier-labeled docs and
+   * inspect which tiers the returned results came from.
+   */
+  async function seedThreeTierCorpus(): Promise<{
+    server: McpServer;
+    db: KnowledgeDB;
+  }> {
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", {
+      embedFn: mockEmbedFn,
+      // Stub reranker — recall always passes rerank=true; the stub returns
+      // a fixed score map per id so we can predict ordering.
+      rerankerFactory: () =>
+        new StubReranker(
+          new Map([
+            ["doc-1", 2.0],
+            ["raw-1", 3.0],
+            ["reflect-1", 1.0],
+            ["wiki-1", 0.5],
+          ]),
+        ) as unknown as import("../reranker.js").Reranker,
+    });
+    ensureV3Schema(db);
+
+    // One doc per tier so we can prove which tiers a role retrieved from.
+    db.upsertDocument({
+      id: "doc-1",
+      path: "doc-1.md",
+      title: "Curated Doc",
+      date: "2026-04-01",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "Curated document about retrieval orchestration policies.",
+    });
+    db.upsertDocument({
+      id: "raw-1",
+      path: "raw-1.md",
+      title: "Raw Memory",
+      date: "2026-04-02",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Raw ingest note about retrieval orchestration policies.",
+    });
+    db.upsertDocument({
+      id: "reflect-1",
+      path: "reflect-1.md",
+      title: "Reflection",
+      date: "2026-04-03",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Synthesized reflection on retrieval orchestration policies.",
+    });
+    db.upsertDocument({
+      id: "wiki-1",
+      path: "wiki-1.md",
+      title: "Wiki Entry",
+      date: "2026-04-04",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Wiki-tier curated note on retrieval orchestration policies.",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "doc-1");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("raw", "raw-1");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("reflection", "reflect-1");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("wiki", "wiki-1");
+    fts.rebuildIndex();
+
+    vec.createIndex();
+    const qEmb = await mockEmbedFn("retrieval orchestration policies");
+    vec.upsertEmbedding("doc-1", qEmb);
+    vec.upsertEmbedding("raw-1", qEmb);
+    vec.upsertEmbedding("reflect-1", qEmb);
+    vec.upsertEmbedding("wiki-1", qEmb);
+
+    return { server, db };
+  }
+
+  it("role='researcher' surfaces raw + reflection + doc, never wiki", async () => {
+    const { server } = await seedThreeTierCorpus();
+    const result = await callTool(server, "knowledge_recall", {
+      query: "retrieval orchestration policies",
+      role: "researcher",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const ids = payload.map((r) => r.id);
+    expect(ids).toContain("raw-1");
+    expect(ids).toContain("reflect-1");
+    expect(ids).toContain("doc-1");
+    expect(ids).not.toContain("wiki-1");
+  });
+
+  it("role='planner' surfaces reflection + wiki + doc, never raw", async () => {
+    const { server } = await seedThreeTierCorpus();
+    const result = await callTool(server, "knowledge_recall", {
+      query: "retrieval orchestration policies",
+      role: "planner",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const ids = payload.map((r) => r.id);
+    expect(ids).toContain("reflect-1");
+    expect(ids).toContain("wiki-1");
+    expect(ids).toContain("doc-1");
+    expect(ids).not.toContain("raw-1");
+  });
+
+  it("role='implementer' surfaces only wiki + doc — no raw leak", async () => {
+    const { server } = await seedThreeTierCorpus();
+    const result = await callTool(server, "knowledge_recall", {
+      query: "retrieval orchestration policies",
+      role: "implementer",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const ids = payload.map((r) => r.id);
+    expect(ids).toContain("wiki-1");
+    expect(ids).toContain("doc-1");
+    expect(ids).not.toContain("raw-1");
+    expect(ids).not.toContain("reflect-1");
+  });
+
+  it("role='reviewer' surfaces only wiki + doc — no raw or reflection leak", async () => {
+    const { server } = await seedThreeTierCorpus();
+    const result = await callTool(server, "knowledge_recall", {
+      query: "retrieval orchestration policies",
+      role: "reviewer",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const ids = payload.map((r) => r.id);
+    expect(ids).toContain("wiki-1");
+    expect(ids).toContain("doc-1");
+    expect(ids).not.toContain("raw-1");
+    expect(ids).not.toContain("reflect-1");
+  });
+
+  it("role='triager' surfaces only doc + wiki — no raw or reflection leak", async () => {
+    const { server } = await seedThreeTierCorpus();
+    const result = await callTool(server, "knowledge_recall", {
+      query: "retrieval orchestration policies",
+      role: "triager",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const ids = payload.map((r) => r.id);
+    expect(ids).toContain("doc-1");
+    expect(ids).toContain("wiki-1");
+    expect(ids).not.toContain("raw-1");
+    expect(ids).not.toContain("reflect-1");
+  });
+});
+
+describe("knowledge_recall merge + dedup behavior", () => {
+  it("dedups by id when the same doc appears in multiple tier sub-queries", async () => {
+    // Seed a single reflection doc and confirm the planner role (which spans
+    // reflection + wiki + doc) returns it exactly once. Even though
+    // hybrid.search is called three times, the merge layer dedups.
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", {
+      embedFn: mockEmbedFn,
+      rerankerFactory: () =>
+        new StubReranker(new Map([["only-reflect", 5.0]])) as unknown as import("../reranker.js").Reranker,
+    });
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "only-reflect",
+      path: "only-reflect.md",
+      title: "Sole Reflection",
+      date: "2026-05-01",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "The only reflection in this fixture about idempotent merges.",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("reflection", "only-reflect");
+    fts.rebuildIndex();
+    vec.createIndex();
+    vec.upsertEmbedding("only-reflect", await mockEmbedFn("idempotent merges"));
+
+    const result = await callTool(server, "knowledge_recall", {
+      query: "idempotent merges",
+      role: "planner",
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    const matches = payload.filter((r) => r.id === "only-reflect");
+    expect(matches.length).toBe(1);
+  });
+
+  it("respects the `limit` parameter after merging across tiers", async () => {
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", {
+      embedFn: mockEmbedFn,
+      rerankerFactory: () =>
+        new StubReranker(
+          new Map([
+            ["limit-doc-1", 5.0],
+            ["limit-doc-2", 4.0],
+            ["limit-doc-3", 3.0],
+            ["limit-doc-4", 2.0],
+          ]),
+        ) as unknown as import("../reranker.js").Reranker,
+    });
+    ensureV3Schema(db);
+
+    for (let i = 1; i <= 4; i++) {
+      db.upsertDocument({
+        id: `limit-doc-${i}`,
+        path: `limit-doc-${i}.md`,
+        title: `Curated Limit Doc ${i}`,
+        date: `2026-05-0${i}`,
+        type: "research",
+        status: "draft",
+        githubIssue: null,
+        content: "Curated limit doc about consolidated reranking checkpoints.",
+      });
+      db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", `limit-doc-${i}`);
+    }
+    fts.rebuildIndex();
+    vec.createIndex();
+    const qEmb = await mockEmbedFn("consolidated reranking checkpoints");
+    for (let i = 1; i <= 4; i++) {
+      vec.upsertEmbedding(`limit-doc-${i}`, qEmb);
+    }
+
+    const result = await callTool(server, "knowledge_recall", {
+      query: "consolidated reranking checkpoints",
+      role: "triager", // policy: [doc, wiki]
+      limit: 2,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    // Exactly 2 results — even though 4 doc-tier docs match, the limit caps.
+    expect(payload.length).toBe(2);
+  });
+
+  it("merges and re-ranks by rerank score descending", async () => {
+    // Two doc-tier docs; the reranker gives doc-B a higher score than doc-A.
+    // Confirm doc-B sorts first in the merged output.
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", {
+      embedFn: mockEmbedFn,
+      rerankerFactory: () =>
+        new StubReranker(
+          new Map([
+            ["rank-a", 1.0],
+            ["rank-b", 10.0],
+          ]),
+        ) as unknown as import("../reranker.js").Reranker,
+    });
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "rank-a",
+      path: "rank-a.md",
+      title: "Lower Rank",
+      date: "2026-05-10",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "Lower-rank doc about merge ordering during cross-tier recall.",
+    });
+    db.upsertDocument({
+      id: "rank-b",
+      path: "rank-b.md",
+      title: "Higher Rank",
+      date: "2026-05-11",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "Higher-rank doc about merge ordering during cross-tier recall.",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "rank-a");
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "rank-b");
+    fts.rebuildIndex();
+    vec.createIndex();
+    const qEmb = await mockEmbedFn("merge ordering cross tier");
+    vec.upsertEmbedding("rank-a", qEmb);
+    vec.upsertEmbedding("rank-b", qEmb);
+
+    const result = await callTool(server, "knowledge_recall", {
+      query: "merge ordering cross tier",
+      role: "implementer", // policy: [wiki, doc]
+      limit: 10,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    // The fusion blend can re-order against the raw rerank logit, but the
+    // higher-logit doc should still appear before the lower-logit doc.
+    const idxA = payload.findIndex((r) => r.id === "rank-a");
+    const idxB = payload.findIndex((r) => r.id === "rank-b");
+    expect(idxB).toBeGreaterThanOrEqual(0);
+    expect(idxA).toBeGreaterThanOrEqual(0);
+    expect(idxB).toBeLessThan(idxA);
+  });
+});
+
+describe("knowledge_recall payload shape parity with knowledge_search", () => {
+  it("returns the same per-hit shape as knowledge_search (id, path, title, type, status, date, score, snippet, tags)", async () => {
+    const mod = await import("../index.js");
+    const { server, db, fts, vec } = mod.createServer(":memory:", {
+      embedFn: mockEmbedFn,
+      rerankerFactory: () =>
+        new StubReranker(new Map([["parity-doc", 4.0]])) as unknown as import("../reranker.js").Reranker,
+    });
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "parity-doc",
+      path: "parity-doc.md",
+      title: "Parity Probe",
+      date: "2026-05-12",
+      type: "research",
+      status: "draft",
+      githubIssue: null,
+      content: "Parity probe content about payload shape comparison.",
+    });
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("doc", "parity-doc");
+    db.setTags("parity-doc", ["parity", "probe"]);
+    fts.rebuildIndex();
+    vec.createIndex();
+    vec.upsertEmbedding("parity-doc", await mockEmbedFn("payload shape comparison"));
+
+    const recall = await callTool(server, "knowledge_recall", {
+      query: "payload shape comparison",
+      role: "triager",
+      limit: 5,
+    });
+    expect(recall.isError).not.toBe(true);
+    const payload = JSON.parse(recall.content[0].text) as Array<Record<string, unknown>>;
+    const hit = payload.find((r) => r.id === "parity-doc");
+    expect(hit).toBeDefined();
+    expect(typeof hit!.path).toBe("string");
+    expect(typeof hit!.title).toBe("string");
+    expect(hit!.type).toBe("research");
+    expect(hit!.status).toBe("draft");
+    expect(hit!.date).toBe("2026-05-12");
+    expect(typeof hit!.score).toBe("number");
+    expect(typeof hit!.snippet).toBe("string");
+    expect(Array.isArray(hit!.tags)).toBe(true);
+    expect(hit!.tags).toEqual(expect.arrayContaining(["parity", "probe"]));
+    // Recall intentionally hides chunk/diag/rerank diagnostic fields — power
+    // users who want those call knowledge_search directly.
+    expect(hit!.chunk_index).toBeUndefined();
+    expect(hit!.fts_score).toBeUndefined();
+    expect(hit!.rerank_score).toBeUndefined();
+  });
+});
+
+describe("knowledge_recall degraded-but-not-failed behavior", () => {
+  it("continues across tiers when a single tier sub-query throws", async () => {
+    // Construct a server, then monkey-patch the hybrid search the registered
+    // tool will reach via the McpServer registry. We replace `hybrid.search`
+    // to throw on the first tier and return one hit on subsequent calls.
+    const mod = await import("../index.js");
+    const created = mod.createServer(":memory:", {
+      embedFn: mockEmbedFn,
+      // Stub reranker — without it, hybrid.search lazy-loads the real ONNX
+      // model on the second tier call, blowing the 5s test budget.
+      rerankerFactory: () =>
+        new StubReranker(
+          new Map([["degraded-doc", 1.0]]),
+        ) as unknown as import("../reranker.js").Reranker,
+    });
+    const { server, db, fts, vec } = created;
+    ensureV3Schema(db);
+
+    db.upsertDocument({
+      id: "degraded-doc",
+      path: "degraded-doc.md",
+      title: "Degraded Doc",
+      date: "2026-05-12",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Degraded path doc — survives a partial tier failure.",
+    });
+    // Tier matches the SECOND tier in the triager policy (wiki), so when the
+    // first tier (doc) sub-query throws, the second tier still returns the doc.
+    db.db.prepare("UPDATE documents SET memory_tier = ? WHERE id = ?").run("wiki", "degraded-doc");
+    fts.rebuildIndex();
+    vec.createIndex();
+    vec.upsertEmbedding("degraded-doc", await mockEmbedFn("survives partial tier failure"));
+
+    // Monkey-patch the hybrid instance to fail on the first call only.
+    let callCount = 0;
+    const realSearch = created.hybrid.search.bind(created.hybrid);
+    created.hybrid.search = (async (q: string, opts: unknown) => {
+      callCount++;
+      if (callCount === 1) throw new Error("synthetic tier-1 failure");
+      return realSearch(q, opts as Parameters<typeof realSearch>[1]);
+    }) as typeof created.hybrid.search;
+
+    const result = await callTool(server, "knowledge_recall", {
+      query: "survives partial tier failure",
+      role: "triager", // policy = [doc, wiki] -> 2 tiers; doc throws, wiki survives.
+      limit: 5,
+    });
+    // The first tier sub-query throws; the second one returns the doc.
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Array<{ id: string }>;
+    expect(payload.some((r) => r.id === "degraded-doc")).toBe(true);
+    // Both tiers were attempted.
+    expect(callCount).toBe(2);
+  });
+});

--- a/plugin/ralph-knowledge/src/index.ts
+++ b/plugin/ralph-knowledge/src/index.ts
@@ -196,6 +196,149 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
     },
   );
 
+  // ---------------------------------------------------------------------
+  // knowledge_recall — Phase 2 (GH-1204) role-aware retrieval wrapper.
+  //
+  // A policy layer on top of `knowledge_search`. Agents declare their *role*
+  // and the tool fans out one rerank-enabled `hybrid.search()` per tier in
+  // the role's policy, then merges and re-ranks by rerank score (falling back
+  // to RRF `score` when rerank is unavailable).
+  //
+  // Role -> tier policy (immutable map; see plan thoughts/shared/plans/
+  // 2026-05-12-group-GH-1203-1207-memory-tier-productization.md, Phase 2):
+  //   researcher  -> [raw, reflection, doc]
+  //   planner     -> [reflection, wiki, doc]
+  //   implementer -> [wiki, doc]
+  //   reviewer    -> [wiki, doc]
+  //   triager     -> [doc, wiki]
+  //
+  // Returns the same payload shape as `knowledge_search`. Power users keep
+  // direct `knowledge_search` access for explicit tier control.
+  // ---------------------------------------------------------------------
+  const ROLE_TIER_POLICY: Record<
+    "researcher" | "planner" | "implementer" | "reviewer" | "triager",
+    Array<"doc" | "raw" | "reflection" | "wiki">
+  > = {
+    researcher: ["raw", "reflection", "doc"],
+    planner: ["reflection", "wiki", "doc"],
+    implementer: ["wiki", "doc"],
+    reviewer: ["wiki", "doc"],
+    triager: ["doc", "wiki"],
+  };
+
+  server.tool(
+    "knowledge_recall",
+    "Role-aware retrieval over the knowledge base. Fans out one rerank-enabled hybrid.search() per memory tier in the role's policy and merges results. Use when you want tier-appropriate memory automatically; use knowledge_search when you need explicit tier control.",
+    {
+      query: z.string().describe("Search query (keywords or natural language)"),
+      role: z
+        .enum(["researcher", "planner", "implementer", "reviewer", "triager"])
+        .describe(
+          "Agent role driving tier policy. researcher=[raw,reflection,doc]; planner=[reflection,wiki,doc]; implementer=[wiki,doc]; reviewer=[wiki,doc]; triager=[doc,wiki]",
+        ),
+      limit: z.number().optional().describe("Max results (default: 10)"),
+      type: z.string().optional().describe("Filter by document type (research, plan, review, idea, report)"),
+      tags: z.array(z.string()).optional().describe("Filter by tags"),
+      includeSuperseded: z.boolean().optional().describe("Include superseded documents (default: false)"),
+      brief: z.boolean().optional().describe("Return minimal metadata only (default: false)"),
+    },
+    async (args) => {
+      try {
+        const tiers = ROLE_TIER_POLICY[args.role];
+        const limit = args.limit ?? 10;
+        // Fan out per-tier search. Run sequentially to keep behavior
+        // deterministic in tests; the cost dominated by the embed call is
+        // amortized across tiers because hybrid.search caches the query
+        // embedding inside its loop body (one embed per search() invocation,
+        // but the SQL is cheap on a warm DB).
+        type Hit = Awaited<ReturnType<typeof hybrid.search>>[number];
+        const byId = new Map<string, Hit>();
+        for (const tier of tiers) {
+          try {
+            const tierResults = await hybrid.search(args.query, {
+              tags: args.tags,
+              type: args.type,
+              limit,
+              includeSuperseded: args.includeSuperseded,
+              memoryTier: tier,
+              rerank: true,
+            });
+            for (const r of tierResults) {
+              // Dedup by document id; first occurrence wins. Because tiers
+              // are listed in priority order in the policy, the higher-priority
+              // tier's score is preserved on tie.
+              const existing = byId.get(r.id);
+              if (!existing) {
+                byId.set(r.id, r);
+                continue;
+              }
+              // Keep the entry with the higher rerank score (fall back to
+              // RRF score). This lets a doc that appears in multiple tiers
+              // (legitimately rare since tiers partition documents) ride the
+              // best signal.
+              const existingScore = existing.rerankScore ?? existing.score;
+              const candidateScore = r.rerankScore ?? r.score;
+              if (candidateScore > existingScore) {
+                byId.set(r.id, r);
+              }
+            }
+          } catch (e) {
+            // Degraded but not failed — log to stderr and continue with the
+            // remaining tiers. A single tier sub-query failure must not
+            // poison the entire recall call.
+            console.error(
+              `knowledge_recall: tier=${tier} sub-query failed: ${(e as Error).message}`,
+            );
+          }
+        }
+
+        // Merge and re-rank globally by rerank score (descending) with RRF
+        // score as the tie-breaker. Then truncate to the requested limit.
+        const merged = Array.from(byId.values()).sort((a, b) => {
+          const aScore = a.rerankScore ?? a.score;
+          const bScore = b.rerankScore ?? b.score;
+          if (bScore !== aScore) return bScore - aScore;
+          return b.score - a.score;
+        });
+        const top = merged.slice(0, limit);
+
+        const enriched = top.map((r) => {
+          // Mirror knowledge_search enrichment: strip internal-only fields,
+          // attach tags + outcome summary. We do NOT surface chunk_meta /
+          // diagnostic fields here because the recall API is intentionally
+          // minimal — power users who need that detail call knowledge_search.
+          const {
+            chunkIndex: _chunkIndex,
+            charStart: _charStart,
+            charEnd: _charEnd,
+            contextPrefix: _contextPrefix,
+            bestChunkId: _bestChunkId,
+            ftsScore: _ftsScore,
+            vecDistance: _vecDistance,
+            hitSources: _hitSources,
+            rerankScore: _rerankScore,
+            ...rest
+          } = r;
+          const base: Record<string, unknown> = { ...rest, tags: db.getTags(r.id) };
+          const doc = db.getDocument(r.id);
+          if (doc?.githubIssue) {
+            const outcomes = db.getOutcomeSummary(doc.githubIssue);
+            if (outcomes) base.outcomes_summary = outcomes;
+          }
+          return base;
+        });
+
+        const formatted = formatSearchResults(
+          enriched as unknown as Parameters<typeof formatSearchResults>[0],
+          args.brief ?? false,
+        );
+        return { content: [{ type: "text" as const, text: JSON.stringify(formatted, null, 2) }] };
+      } catch (e) {
+        return { content: [{ type: "text" as const, text: `Error: ${(e as Error).message}` }], isError: true };
+      }
+    },
+  );
+
   server.tool(
     "knowledge_traverse",
     "Walk typed and untyped relationship edges from a document.",

--- a/thoughts/shared/plans/2026-05-12-group-GH-1203-1207-memory-tier-productization.md
+++ b/thoughts/shared/plans/2026-05-12-group-GH-1203-1207-memory-tier-productization.md
@@ -248,10 +248,10 @@ Wrap `knowledge_search` in a policy layer keyed by agent role. Add `knowledge_re
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build --prefix plugin/ralph-knowledge` — no errors (new tool registration type-checks)
-- [ ] `npm test --prefix plugin/ralph-knowledge -- recall` — new policy-fanout tests pass
-- [ ] `grep -r "knowledge_recall" plugin/ralph-knowledge/src/index.ts` returns a match
-- [ ] `grep -l "knowledge_recall" plugin/ralph-hero/skills/{research,ralph-research,plan,ralph-plan,ralph-impl,retro}/SKILL.md | wc -l` returns 6
+- [x] `npm run build --prefix plugin/ralph-knowledge` — no errors (new tool registration type-checks)
+- [x] `npm test --prefix plugin/ralph-knowledge -- recall` — new policy-fanout tests pass (12/12)
+- [x] `grep -r "knowledge_recall" plugin/ralph-knowledge/src/index.ts` returns a match
+- [x] `grep -l "knowledge_recall" plugin/ralph-hero/skills/{research,ralph-research,plan,ralph-plan,ralph-impl,retro}/SKILL.md | wc -l` returns 6
 
 #### Manual Verification:
 - [ ] `/ralph-hero:research` on a topic with known raw/reflection memory returns results from `raw` and `reflection` tiers


### PR DESCRIPTION
## Summary

Add a `knowledge_recall(query, role)` MCP tool that wraps `knowledge_search` with role-driven tier policy. Wire it into 6 skills (`research`, `ralph-research`, `plan`, `ralph-plan`, `ralph-impl`, `retro`) so agents declare their role and get tier-appropriate memory automatically.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-group-GH-1203-1207-memory-tier-productization.md#phase-2-gh-1204--role-based-retrieval-knowledge_recall--wire-6-skills

Phases shipped: 2 of 5

## Test plan

- [x] `npm run build --prefix plugin/ralph-knowledge` — no errors (new tool registration type-checks)
- [x] `npm test --prefix plugin/ralph-knowledge -- recall` — new policy-fanout tests pass
- [x] `grep -r "knowledge_recall" plugin/ralph-knowledge/src/index.ts` returns a match
- [x] `grep -l "knowledge_recall" plugin/ralph-hero/skills/{research,ralph-research,plan,ralph-plan,ralph-impl,retro}/SKILL.md | wc -l` returns 6
- [ ] `/ralph-hero:research` on a topic with known raw/reflection memory returns results from `raw` and `reflection` tiers
- [ ] `/ralph-hero:plan` on the same topic returns results biased toward `wiki`+`reflection`+`doc`
- [ ] `/ralph-hero:impl` on the same topic returns ONLY `wiki`+`doc` results (no `raw` leak)

Closes #1204