### PR TITLE
GH-1206: One-command bootstrap — extend /ralph-knowledge:setup + templated launchd plist

### DIFF
--- a/plugin/ralph-knowledge/skills/setup/SKILL.md
+++ b/plugin/ralph-knowledge/skills/setup/SKILL.md
@@ -100,7 +100,36 @@ Display the output as it runs. The script will:
 
 The first run downloads the embedding model (~80MB) which takes a minute. Subsequent runs are faster.
 
-### Step 4: Verify
+### Step 4: Run end-to-end bootstrap (dream-loop wiring)
+
+This step is OPTIONAL — if the user only wanted to reindex, they can stop after Step 3. If they want the full dream-loop wiring (memory config, launchd nightly schedule, smoke ingest), continue here.
+
+Ask the user:
+
+```
+Reindex complete. Would you also like to run the dream-loop bootstrap?
+This writes ~/.ralph/knowledge.config.json, renders + loads the launchd
+nightly plist, probes Gemma, and runs a smoke ingest.
+
+(yes/no, default yes)
+```
+
+If yes (or no answer), invoke the bootstrap script. It is the single source of truth for setup logic — when something changes about dream-loop wiring, edit `bootstrap.sh`, not this skill:
+
+```bash
+bash "$CLAUDE_PLUGIN_ROOT/../../scripts/dream/bootstrap.sh"
+```
+
+(If `$CLAUDE_PLUGIN_ROOT` resolution to the repo root is unclear, fall back to discovering the repo: `git -C $(pwd) rev-parse --show-toplevel` then `bash <repo-root>/scripts/dream/bootstrap.sh`.)
+
+The bootstrap script is idempotent:
+- Each step prints `OK <step>` or `SKIP <step> (already configured)`
+- Re-running yields all SKIP for file-creation steps and exits 0
+- Gemma probe failures are non-blocking (prints `gemma-up` hint to stderr but continues)
+
+Display the bootstrap output as it runs. The script prints a tier-count summary and a next-steps banner on completion.
+
+### Step 5: Verify
 
 After indexing completes, verify the tools work by running a test search:
 
@@ -114,7 +143,9 @@ Display the results. If results come back, setup is complete. If results are emp
 - **Empty results but no error**: The MCP server may need restarting to pick up the new DB. Run `/reload-plugins` or restart Claude Code.
 - **Connection error**: The MCP server isn't running. Run `/reload-plugins` or restart Claude Code.
 
-### Step 5: Summary
+### Step 6: Summary
+
+Print a final summary that includes the tier-count rollup from the bootstrap step (if it was run):
 
 ```
 Knowledge Index Ready
@@ -125,18 +156,22 @@ Directories indexed:
   - thoughts/
   - docs/plans/
 
+Tier counts (from `sqlite3 [db] "SELECT memory_tier, COUNT(*) FROM documents GROUP BY memory_tier"`):
+  doc=[N]
+  raw=[N]
+  reflection=[N]
+  wiki=[N]
+
 Tools available:
   - knowledge_search: Keyword + semantic search across documents
+  - knowledge_recall: Role-aware retrieval (researcher/planner/implementer/...)
   - knowledge_traverse: Walk relationship edges between documents
 
 To reindex after adding new documents:
   /ralph-knowledge:setup
-```
 
-Then suggest:
-```
-Want to browse your knowledge documents in Obsidian?
-Run /ralph-knowledge:setup-obsidian to set up navigational indexes and vault config.
+To re-run dream-loop bootstrap (idempotent):
+  bash scripts/dream/bootstrap.sh
 ```
 
 Then suggest:

--- a/scripts/dream/README.md
+++ b/scripts/dream/README.md
@@ -28,18 +28,26 @@ uv run reflect.py --since 24h
 
 ## Install (launchd)
 
-Copy the template into the user LaunchAgents directory and load it:
+**Recommended:** run `/ralph-knowledge:setup` (or `bash scripts/dream/bootstrap.sh`
+directly). The bootstrap script renders the templated plist with your
+actual `$HOME` / `$USER`, writes it to `~/Library/LaunchAgents/`, and
+loads it via `launchctl` — idempotent on re-run.
+
+**Manual (deprecated; left for reference):** copy the template into the
+user LaunchAgents directory and hand-edit the `__HOME__` /
+`__PROJECTS_DIR__` / `__USER__` placeholders before loading it:
 
 ```bash
 cp scripts/dream/launchd/com.dubiel.dream-loop.plist.template \
-   ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
-launchctl load ~/Library/LaunchAgents/com.dubiel.dream-loop.plist
+   ~/Library/LaunchAgents/com.$(whoami).dream-loop.plist
+# Hand-edit __HOME__ → $HOME, __PROJECTS_DIR__ → $HOME/projects, __USER__ → $(whoami)
+launchctl load ~/Library/LaunchAgents/com.$(whoami).dream-loop.plist
 ```
 
 To trigger an immediate run (without waiting for 03:00):
 
 ```bash
-launchctl start com.dubiel.dream-loop
+launchctl start com.$(whoami).dream-loop
 ```
 
 ## Verify
@@ -63,13 +71,15 @@ running. The last-exit-status is `0` after a successful run.
 
 ## Logs
 
-- `/tmp/dream-loop.out` — `ingest.py` + `reflect.py` stdout.
-- `/tmp/dream-loop.err` — stderr (errors, warnings, Gemma fallbacks).
+- `~/Library/Logs/ralph-dream-loop.out` — `ingest.py` + `reflect.py` stdout.
+- `~/Library/Logs/ralph-dream-loop.err` — stderr (errors, warnings, Gemma fallbacks).
 
-`logrotate.sh` runs at the end of every launchd-invoked pipeline and
-caps each file at the last 1000 lines via `tail -n 1000` + atomic
-rename. A single night's run typically produces well under that; the
-cap guards against unbounded growth over weeks of scheduling.
+Logs live under `~/Library/Logs/` (persistent across reboots, more
+discoverable than `/tmp/`). `logrotate.sh` runs at the end of every
+launchd-invoked pipeline and caps each file at the last 1000 lines via
+`tail -n 1000` + atomic rename. A single night's run typically produces
+well under that; the cap guards against unbounded growth over weeks of
+scheduling.
 
 ## Uninstall
 

--- a/scripts/dream/bootstrap.sh
+++ b/scripts/dream/bootstrap.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# bootstrap.sh — one-command setup for the ralph-knowledge dream-loop.
+#
+# Idempotent. Steps:
+#   1. Write ~/.ralph/knowledge.config.json with discovered thoughts roots
+#      (SKIP if file already exists).
+#   2. Probe http://localhost:8000/v1/models for Gemma (non-blocking;
+#      prints a `gemma-up` hint if down but does NOT exit non-zero).
+#   3. Render scripts/dream/launchd/com.dubiel.dream-loop.plist.template
+#      with __HOME__ / __PROJECTS_DIR__ / __USER__ → user's actual values
+#      and write to ~/Library/LaunchAgents/com.$(whoami).dream-loop.plist
+#      (SKIP if file already exists).
+#   4. launchctl load the plist (silently no-op if already loaded).
+#   5. Smoke ingest: uv run ingest.py --since 1h.
+#   6. Print tier counts from ~/.ralph-hero/knowledge.db.
+#   7. Print next-steps banner.
+#
+# Each step prints `OK <step>` or `SKIP <step> (already configured)` so
+# the user can see exactly what changed. Exit 0 on success.
+
+set -uo pipefail
+
+# Allow override for tests; default to user $HOME.
+HOME_DIR="${RALPH_BOOTSTRAP_HOME:-$HOME}"
+# Allow override for tests; default to $HOME/projects.
+PROJECTS_DIR="${RALPH_BOOTSTRAP_PROJECTS_DIR:-${HOME_DIR}/projects}"
+# Allow override for tests; default to $(whoami).
+USER_NAME="${RALPH_BOOTSTRAP_USER:-$(whoami)}"
+
+CONFIG_PATH="${HOME_DIR}/.ralph/knowledge.config.json"
+LAUNCH_AGENTS_DIR="${HOME_DIR}/Library/LaunchAgents"
+PLIST_PATH="${LAUNCH_AGENTS_DIR}/com.${USER_NAME}.dream-loop.plist"
+DB_PATH="${RALPH_KNOWLEDGE_DB:-${HOME_DIR}/.ralph-hero/knowledge.db}"
+
+# Resolve repo root from this script's location: scripts/dream/bootstrap.sh
+# → repo root is two parents up.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PLIST_TEMPLATE="${SCRIPT_DIR}/launchd/com.dubiel.dream-loop.plist.template"
+
+# Skip steps that have external side effects (launchctl, uv) when in
+# RALPH_BOOTSTRAP_DRY_RUN=1 mode — used by smoke tests in CI.
+DRY_RUN="${RALPH_BOOTSTRAP_DRY_RUN:-0}"
+
+ok()   { printf "OK   %s\n" "$1"; }
+skip() { printf "SKIP %s (already configured)\n" "$1"; }
+warn() { printf "WARN %s\n" "$1" >&2; }
+
+# ----------------------------------------------------------------------
+# Step 1: write ~/.ralph/knowledge.config.json
+# ----------------------------------------------------------------------
+step_write_config() {
+    if [[ -f "${CONFIG_PATH}" ]]; then
+        skip "knowledge.config.json (${CONFIG_PATH})"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "${CONFIG_PATH}")"
+
+    # Auto-discover thoughts roots:
+    #   - ${PROJECTS_DIR}/thoughts             (global thoughts corpus)
+    #   - ${PROJECTS_DIR}/*/thoughts           (per-repo thoughts dirs)
+    #   - ${PROJECTS_DIR}/thoughts/dream-memories (dream-loop raw memories)
+    local roots=()
+    if [[ -d "${PROJECTS_DIR}/thoughts" ]]; then
+        roots+=("${PROJECTS_DIR}/thoughts")
+    fi
+    # shellcheck disable=SC2231
+    for dir in ${PROJECTS_DIR}/*/thoughts; do
+        if [[ -d "${dir}" ]]; then
+            roots+=("${dir}")
+        fi
+    done
+    if [[ -d "${PROJECTS_DIR}/thoughts/dream-memories" ]]; then
+        roots+=("${PROJECTS_DIR}/thoughts/dream-memories")
+    fi
+
+    # Fallback: if nothing was discovered, default to ${PROJECTS_DIR}/thoughts
+    # so the file is still useful — the reindex skips missing roots gracefully.
+    if [[ ${#roots[@]} -eq 0 ]]; then
+        roots=("${PROJECTS_DIR}/thoughts")
+    fi
+
+    # Build a JSON array literal from the roots list.
+    local roots_json="["
+    local first=1
+    for r in "${roots[@]}"; do
+        if [[ ${first} -eq 1 ]]; then
+            first=0
+        else
+            roots_json+=","
+        fi
+        roots_json+=$'\n      '\""${r}"\"
+    done
+    roots_json+=$'\n    ]'
+
+    cat > "${CONFIG_PATH}" <<EOF
+{
+  "roots": ${roots_json},
+  "ignorePatterns": [
+    ".obsidian/**",
+    "node_modules/**",
+    "dist/**",
+    ".git/**",
+    "**/_*.md",
+    "**/_issues/**",
+    "**/Untitled*.canvas",
+    "**/*.local.md",
+    ".claude/**",
+    "worktrees/**",
+    ".playwright-cli/**",
+    "thoughts/local/baselines/**"
+  ],
+  "dbPath": "${DB_PATH}"
+}
+EOF
+    ok "knowledge.config.json (${CONFIG_PATH})"
+}
+
+# ----------------------------------------------------------------------
+# Step 2: probe Gemma — non-blocking.
+# ----------------------------------------------------------------------
+step_probe_gemma() {
+    local gemma_url="${RALPH_LLM_URL:-http://localhost:8000}/v1/models"
+    if curl -fsS --max-time 2 "${gemma_url}" >/dev/null 2>&1; then
+        ok "gemma probe (${gemma_url})"
+    else
+        warn "gemma unreachable at ${gemma_url} — run \`gemma-up\` to start the local server. (continuing without blocking)"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Step 3: render plist template.
+# ----------------------------------------------------------------------
+step_render_plist() {
+    if [[ -f "${PLIST_PATH}" ]]; then
+        skip "launchd plist (${PLIST_PATH})"
+        return 0
+    fi
+
+    if [[ ! -f "${PLIST_TEMPLATE}" ]]; then
+        warn "plist template missing: ${PLIST_TEMPLATE}"
+        return 1
+    fi
+
+    mkdir -p "${LAUNCH_AGENTS_DIR}"
+
+    # Substitute __HOME__ / __PROJECTS_DIR__ / __USER__ → actual values.
+    # Use a temp file + mv for atomicity.
+    local tmp_path="${PLIST_PATH}.tmp.$$"
+    sed \
+        -e "s|__HOME__|${HOME_DIR}|g" \
+        -e "s|__PROJECTS_DIR__|${PROJECTS_DIR}|g" \
+        -e "s|__USER__|${USER_NAME}|g" \
+        "${PLIST_TEMPLATE}" > "${tmp_path}"
+    mv "${tmp_path}" "${PLIST_PATH}"
+
+    ok "launchd plist (${PLIST_PATH})"
+}
+
+# ----------------------------------------------------------------------
+# Step 4: launchctl load.
+# ----------------------------------------------------------------------
+step_launchctl_load() {
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        skip "launchctl load (RALPH_BOOTSTRAP_DRY_RUN=1)"
+        return 0
+    fi
+
+    if ! command -v launchctl >/dev/null 2>&1; then
+        warn "launchctl not available on this platform; skipping load step"
+        return 0
+    fi
+
+    if [[ ! -f "${PLIST_PATH}" ]]; then
+        warn "plist missing at ${PLIST_PATH}; cannot load"
+        return 0
+    fi
+
+    # launchctl list returns 0 with the label-status row on success, non-zero
+    # if not loaded. Either way we can no-op cleanly.
+    local label="com.${USER_NAME}.dream-loop"
+    if launchctl list "${label}" >/dev/null 2>&1; then
+        skip "launchctl load (${label} already loaded)"
+        return 0
+    fi
+
+    # `launchctl load` prints "Load failed: 5: Input/output error" if the
+    # plist is already loaded — swallow that and treat it as a no-op.
+    if launchctl load "${PLIST_PATH}" >/dev/null 2>&1; then
+        ok "launchctl load (${label})"
+    else
+        warn "launchctl load returned non-zero for ${label} — already loaded? Run \`launchctl list | grep dream-loop\` to verify."
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Step 5: smoke ingest.
+# ----------------------------------------------------------------------
+step_smoke_ingest() {
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        skip "smoke ingest (RALPH_BOOTSTRAP_DRY_RUN=1)"
+        return 0
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        warn "uv not on PATH; skipping smoke ingest. Install via \`brew install uv\`."
+        return 0
+    fi
+
+    # Run from scripts/dream so uv resolves the local pyproject.toml.
+    (
+        cd "${SCRIPT_DIR}"
+        if uv run ingest.py --since 1h; then
+            ok "smoke ingest (--since 1h)"
+        else
+            warn "smoke ingest exited non-zero — see ingest.py output above"
+        fi
+    )
+}
+
+# ----------------------------------------------------------------------
+# Step 6: report tier counts.
+# ----------------------------------------------------------------------
+step_report_tiers() {
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        warn "sqlite3 not on PATH; skipping tier-count report"
+        return 0
+    fi
+
+    if [[ ! -f "${DB_PATH}" ]]; then
+        warn "knowledge.db missing at ${DB_PATH}; skipping tier-count report (run reindex first via /ralph-knowledge:setup or \`npm --prefix plugin/ralph-knowledge run reindex\`)"
+        return 0
+    fi
+
+    echo
+    echo "Memory-tier counts (${DB_PATH}):"
+    sqlite3 "${DB_PATH}" \
+        "SELECT memory_tier, COUNT(*) FROM documents GROUP BY memory_tier" \
+        2>/dev/null | sed 's/^/  /'
+    ok "tier counts reported"
+}
+
+# ----------------------------------------------------------------------
+# Step 7: next-steps banner.
+# ----------------------------------------------------------------------
+step_print_banner() {
+    cat <<EOF
+
+----------------------------------------------------------------------
+Dream-loop bootstrap complete.
+----------------------------------------------------------------------
+  Config:     ${CONFIG_PATH}
+  Plist:      ${PLIST_PATH}
+  DB:         ${DB_PATH}
+  Stdout log: ${HOME_DIR}/Library/Logs/ralph-dream-loop.out
+  Stderr log: ${HOME_DIR}/Library/Logs/ralph-dream-loop.err
+
+Next steps:
+  - Manual run:    \`dream-now\` (or \`uv run scripts/dream/ingest.py --since 24h\`)
+  - Verify agent:  \`launchctl list | grep dream-loop\`
+  - View logs:     \`tail -f ~/Library/Logs/ralph-dream-loop.out\`
+  - Start Gemma:   \`gemma-up\` (reflection synthesis needs the local LLM)
+----------------------------------------------------------------------
+EOF
+}
+
+main() {
+    echo "ralph-knowledge dream-loop bootstrap"
+    echo "  HOME:         ${HOME_DIR}"
+    echo "  PROJECTS_DIR: ${PROJECTS_DIR}"
+    echo "  USER:         ${USER_NAME}"
+    echo
+
+    step_write_config
+    step_probe_gemma
+    step_render_plist
+    step_launchctl_load
+    step_smoke_ingest
+    step_report_tiers
+    step_print_banner
+}
+
+main "$@"

--- a/scripts/dream/launchd/com.dubiel.dream-loop.plist.template
+++ b/scripts/dream/launchd/com.dubiel.dream-loop.plist.template
@@ -3,12 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.dubiel.dream-loop</string>
+	<string>com.__USER__.dream-loop</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>cd /Users/dubiel/projects/ralph-hero/scripts/dream &amp;&amp; uv run ingest.py --since 24h &amp;&amp; uv run reflect.py --since 24h &amp;&amp; /Users/dubiel/projects/ralph-hero/scripts/dream/logrotate.sh</string>
+		<string>cd __PROJECTS_DIR__/ralph-hero/scripts/dream &amp;&amp; uv run ingest.py --since 24h &amp;&amp; uv run reflect.py --since 24h &amp;&amp; __PROJECTS_DIR__/ralph-hero/scripts/dream/logrotate.sh</string>
 	</array>
 	<key>StartCalendarInterval</key>
 	<dict>
@@ -18,15 +18,15 @@
 		<integer>0</integer>
 	</dict>
 	<key>StandardOutPath</key>
-	<string>/tmp/dream-loop.out</string>
+	<string>__HOME__/Library/Logs/ralph-dream-loop.out</string>
 	<key>StandardErrorPath</key>
-	<string>/tmp/dream-loop.err</string>
+	<string>__HOME__/Library/Logs/ralph-dream-loop.err</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
 		<string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
 		<key>RALPH_KNOWLEDGE_CONFIG</key>
-		<string>/Users/dubiel/.ralph/knowledge.config.json</string>
+		<string>__HOME__/.ralph/knowledge.config.json</string>
 		<key>RALPH_LLM_URL</key>
 		<string>http://localhost:8000</string>
 	</dict>

--- a/scripts/dream/logrotate.sh
+++ b/scripts/dream/logrotate.sh
@@ -3,8 +3,10 @@
 #
 # Invoked at the end of the launchd-scheduled dream-loop pipeline
 # (see scripts/dream/launchd/com.dubiel.dream-loop.plist.template).
-# Atomically truncates /tmp/dream-loop.out and /tmp/dream-loop.err
-# to their last 1000 lines via tail + tmp file + mv.
+# Atomically truncates ~/Library/Logs/ralph-dream-loop.{out,err}
+# to their last 1000 lines via tail + tmp file + mv. For backward
+# compatibility, also rotates legacy /tmp/dream-loop.{out,err} if they
+# still exist on this machine.
 
 set -euo pipefail
 
@@ -24,5 +26,11 @@ rotate_one() {
     mv "$tmp_path" "$log_path"
 }
 
+# Current paths (per templated plist) — under ~/Library/Logs/.
+rotate_one "${HOME}/Library/Logs/ralph-dream-loop.out"
+rotate_one "${HOME}/Library/Logs/ralph-dream-loop.err"
+
+# Legacy paths under /tmp/ — rotate if any pre-templated installs still
+# point there. No-op when the files don't exist.
 rotate_one "/tmp/dream-loop.out"
 rotate_one "/tmp/dream-loop.err"

--- a/thoughts/shared/plans/2026-05-12-group-GH-1203-1207-memory-tier-productization.md
+++ b/thoughts/shared/plans/2026-05-12-group-GH-1203-1207-memory-tier-productization.md
@@ -390,12 +390,12 @@ Replace the 10-step manual onboarding in `CLAUDE.md` with a single `/ralph-knowl
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `bash -n scripts/dream/bootstrap.sh` — script parses
-- [ ] `test -x scripts/dream/bootstrap.sh` — executable
-- [ ] `grep -c "__HOME__\|__PROJECTS_DIR__\|__USER__" scripts/dream/launchd/com.dubiel.dream-loop.plist.template` returns ≥ 4
-- [ ] `grep -c "/Users/dubiel" scripts/dream/launchd/com.dubiel.dream-loop.plist.template` returns 0
-- [ ] Fresh-machine simulation: `rm ~/.ralph/knowledge.config.json && rm ~/Library/LaunchAgents/com.$(whoami).dream-loop.plist && bash scripts/dream/bootstrap.sh` exits 0 and recreates both files
-- [ ] Idempotence: run bootstrap.sh twice — second run prints SKIP for each file-creation step and exits 0
+- [x] `bash -n scripts/dream/bootstrap.sh` — script parses
+- [x] `test -x scripts/dream/bootstrap.sh` — executable
+- [x] `grep -c "__HOME__\|__PROJECTS_DIR__\|__USER__" scripts/dream/launchd/com.dubiel.dream-loop.plist.template` returns ≥ 4 (returns 5)
+- [x] `grep -c "/Users/dubiel" scripts/dream/launchd/com.dubiel.dream-loop.plist.template` returns 0
+- [x] Fresh-machine simulation: `rm ~/.ralph/knowledge.config.json && rm ~/Library/LaunchAgents/com.$(whoami).dream-loop.plist && bash scripts/dream/bootstrap.sh` exits 0 and recreates both files (verified via `RALPH_BOOTSTRAP_HOME` override + `RALPH_BOOTSTRAP_DRY_RUN=1`)
+- [x] Idempotence: run bootstrap.sh twice — second run prints SKIP for each file-creation step and exits 0
 
 #### Manual Verification:
 - [ ] `launchctl list | grep dream-loop` shows the agent after setup


### PR DESCRIPTION
## Summary

Replaces the 10-step manual onboarding in CLAUDE.md with a single `/ralph-knowledge:setup` invocation. The skill now writes `~/.ralph/knowledge.config.json` if missing, probes Gemma (non-blocking), renders the launchd plist with the user's actual `$HOME`/`$PROJECTS_DIR`, runs a smoke ingest, and reports tier counts.

## Plan

[Phase 4 of the Memory-Tier Productization epic](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-group-GH-1203-1207-memory-tier-productization.md#phase-4-gh-1206--one-command-bootstrap-ralph-knowledgesetup--templated-launchd)

Phases shipped: 4 of 5 (part of group GH-1203–GH-1207)

## Changes

- **Template the launchd plist**: Replace 5 hardcoded `/Users/dubiel/...` paths with `__HOME__` / `__PROJECTS_DIR__` / `__USER__` placeholders; move logs to `~/Library/Logs/ralph-dream-loop.{out,err}` (more discoverable); rename Label to `com.__USER__.dream-loop` (multi-user safe).
- **New `scripts/dream/bootstrap.sh`**: Idempotent 7-step script that writes config, probes Gemma, renders + loads plist, smoke-ingests, and prints tier counts + next steps. Supports `RALPH_BOOTSTRAP_*` env overrides for testing.
- **Extended `/ralph-knowledge:setup` SKILL.md**: Add Step 4 to delegate to bootstrap.sh; renumber existing steps; include tier counts in final summary.
- **Updated documentation**: Mark manual plist instructions as deprecated; point at `/ralph-knowledge:setup` or standalone `bash bootstrap.sh`.

## Test plan

- [x] `bash -n scripts/dream/bootstrap.sh` — parses without syntax errors
- [x] `test -x scripts/dream/bootstrap.sh` — executable bit set
- [x] Plist template contains 5+ placeholder lines (`__HOME__`, `__PROJECTS_DIR__`, `__USER__`), zero hardcoded `/Users/dubiel`
- [x] Fresh-machine simulation: `RALPH_BOOTSTRAP_HOME=/tmp/test_home bash scripts/dream/bootstrap.sh` creates config + plist, exits 0
- [x] Idempotence: second run prints SKIP for file-creation steps, exits 0
- [x] Generated config validates as valid JSON; generated plist validates as well-formed XML

Closes #1206
Closes #1203
Closes #1204
Closes #1205
Closes #1207