### PR TITLE
GH-1188: F4a — codebase-locator: candidate ranking via delegation

### DIFF
--- a/plugin/ralph-hero/agents/codebase-locator-eval.md
+++ b/plugin/ralph-hero/agents/codebase-locator-eval.md
@@ -1,0 +1,131 @@
+---
+type: eval-scenarios
+agent: codebase-locator
+date: 2026-05-12
+status: defined
+---
+
+# Codebase-Locator Delegation Eval
+
+> **Execution note**: These are operator-runnable comparison scenarios for the `codebase-locator` agent's delegated vs native ranking. Re-runnable as quality drifts across model swaps or prompt refinements. Not automated in v1 — automation lives in a future feature if nightly drift detection becomes necessary.
+
+Five fixed queries against the **ralph-hero** repo. Each compares the agent's top-5 ranked file paths under delegation-on vs delegation-off. Approximate "gold set" file lists are provided per query as anchors for manual eyeball calibration; the eval measures ranking agreement (overlap %), not absolute correctness vs the gold set.
+
+---
+
+## Q1 — Feature search
+
+**Query (copy-paste)**: `Find all files related to LLM delegation in plugin/ralph-hero.`
+
+**Exercises**: Feature-keyword search across mixed file types (scripts, docs, skills, agents, tests).
+
+**Gold set (approximate)**:
+- `plugin/ralph-hero/scripts/ralph-delegate.sh`
+- `plugin/ralph-hero/scripts/lib/openai-compat.sh`
+- `plugin/ralph-hero/scripts/__tests__/ralph-delegate.bats`
+- `plugin/ralph-hero/scripts/__tests__/openai-compat.bats`
+- `plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats`
+- `plugin/ralph-hero/README.md` (Delegation section, lines 249-297)
+- `plugin/ralph-hero/docs/delegation-authoring.md`
+- `plugin/ralph-hero/skills/shared/delegation-conventions.md`
+- `plugin/ralph-hero/skills/delegate-test/SKILL.md`
+- `plugin/ralph-hero/agents/codebase-locator.md` (after F4a)
+
+---
+
+## Q2 — Component-type search
+
+**Query (copy-paste)**: `Find all skills that mutate GitHub state (call save_issue, create_comment, advance_issue, or batch_update).`
+
+**Exercises**: Component-type search by tool-call signature. Forces the agent to grep skill bodies for specific MCP tool names rather than file-name patterns.
+
+**Gold set (approximate)**: A subset of `plugin/ralph-hero/skills/ralph-*/SKILL.md` files that declare those tools in `allowed-tools` and invoke them in their `## Workflow` sections. Operator validates by inspecting each candidate's frontmatter and body. Expect ~10-15 skills (ralph-impl, ralph-plan, ralph-pr, ralph-merge, ralph-val, ralph-split, ralph-research, ralph-triage, ralph-unblock, hello, autopilot, etc.).
+
+---
+
+## Q3 — File-extension search
+
+**Query (copy-paste)**: `Find all bats test files in plugin/ralph-hero/scripts/__tests__/ and list which source script each covers.`
+
+**Exercises**: Extension-based search with implicit pairing. Tests whether the agent infers the `<name>.bats <-> <name>.sh` convention.
+
+**Gold set (approximate)**:
+- `cli-dispatch.bats` <-> `cli-dispatch.sh`
+- `doctor.bats` <-> `doctor.sh`
+- `openai-compat.bats` <-> `lib/openai-compat.sh`
+- `ralph-cli.bats` <-> `ralph-cli.sh`
+- `ralph-delegate.bats` <-> `ralph-delegate.sh`
+- `resolve-env.bats` <-> `resolve-env.sh`
+- `codebase-locator-delegation.bats` <-> `../../agents/codebase-locator.md` (special case: the bats file mirrors a bash block embedded in an agent body, not a standalone script)
+
+---
+
+## Q4 — Recency search
+
+**Query (copy-paste)**: `Find all files modified in the last 10 commits on main.`
+
+**Exercises**: Git-history-driven recency search. Forces the agent to invoke `git log` via the Bash tool rather than relying on grep/glob.
+
+**Gold set (recomputed at run time)**: `git log --name-only --pretty=format: HEAD~10..HEAD | sort -u | grep -v '^$'`. Operator captures this list immediately before running the eval; the expected top-5 are whichever files appear most frequently / most recently in the last 10 commits.
+
+---
+
+## Q5 — Cross-cutting concern
+
+**Query (copy-paste)**: `Find every place RALPH_LLM_URL is consumed or referenced.`
+
+**Exercises**: Cross-package, cross-language search for an env-var name. Tests rerank across heterogeneous file types (shell, TypeScript, Python, Markdown).
+
+**Gold set (approximate)**:
+- `plugin/ralph-hero/scripts/ralph-delegate.sh`
+- `plugin/ralph-hero/scripts/lib/openai-compat.sh`
+- `plugin/ralph-hero/scripts/__tests__/ralph-delegate.bats`
+- `plugin/ralph-hero/scripts/__tests__/openai-compat.bats`
+- `plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats`
+- `plugin/ralph-hero/README.md` (Delegation section)
+- `plugin/ralph-knowledge/src/llm-client.ts`
+- `scripts/dream/reflect.py`
+- Any operator settings files documented in the README (typically `~/.claude/settings.json` examples — not in-repo source files)
+
+---
+
+## Comparison protocol
+
+Run each query twice, once with delegation enabled and once with it disabled. Capture the agent's structured output and compute per-query overlap %.
+
+```bash
+# Step 1: delegated path
+gemma-up
+export RALPH_DELEGATE_ENABLED=true
+# Dispatch the agent for each Q1..Q5 via /ralph-hero:research or Agent().
+# Capture the top-5 paths from each output's "### Implementation Files" subsection
+# (or the equivalent first non-empty subsection).
+
+# Step 2: native path
+unset RALPH_DELEGATE_ENABLED
+# Dispatch the same 5 queries. Capture top-5 again.
+
+# Step 3: per-query overlap %
+# For each Q:
+#   overlap_pct = (|delegated_top5 ∩ native_top5| / |delegated_top5 ∪ native_top5|) * 100
+
+# Step 4: mean overlap across the 5 queries
+# Document the result (per-query + mean) in a comment on issue #1188.
+```
+
+### Acceptable baseline
+
+Mean overlap **>=60%** across the 5 queries is the v1 calibration target. Below 60% triggers a quality review — typical follow-ups are (a) swap the delegate model via `RALPH_DELEGATE_LOCATOR_MODEL`, (b) refine the delegate prompt in `agents/codebase-locator.md`, or (c) drop the delegation site if the model can't match native ranking on closed-label tasks.
+
+The 60% number is a starting baseline, not a hard SLA. Wave-3 (feature 4a/4b/4c integrations) recalibrates it as real usage data accumulates in the audit log; F5 (`#1191`) is the feature that turns this into automated drift detection.
+
+## What this does NOT measure
+
+This eval compares **ranking agreement** between delegated and native paths, not absolute correctness. The gold sets above are approximate anchors for manual eyeball calibration — both delegated and native paths may legitimately disagree with the gold set if the operator's query interpretation differs from the eval author's. Specifically, this eval does NOT measure:
+
+- **Recall**: whether the agent found every gold-set file (gold sets are partial by design).
+- **Precision**: whether every returned file is "correct" (file relevance is subjective for cross-cutting queries).
+- **Subsection categorization accuracy**: only the top-5 of the first non-empty subsection is compared; whether a file landed in Implementation Files vs Test Files is out of scope.
+- **Latency or cost**: delegation may be slower or faster than native; that signal lives in the JSONL audit log, not here.
+
+The comparison-protocol overlap % is a single calibration metric — useful for spotting catastrophic drift (e.g., 0% overlap means the delegate model collapsed) but not for fine-grained quality scoring.

--- a/plugin/ralph-hero/agents/codebase-locator.md
+++ b/plugin/ralph-hero/agents/codebase-locator.md
@@ -62,6 +62,62 @@ First, think deeply about the most effective search patterns for the requested f
 - `*.d.ts`, `*.types.*` - Type definitions
 - `README*`, `*.md` in feature dirs - Documentation
 
+## Candidate Ranking (optional delegation)
+
+After the broad search produces 5 or more candidate file paths, you MAY delegate the relevance-ranking step to a local LLM via the delegation wrapper at `$CLAUDE_PLUGIN_ROOT/scripts/`. Delegation is opt-in: the operator sets `RALPH_DELEGATE_ENABLED=true`. When delegation is off (the default), rank candidates natively as you do today — read filenames, judge relevance to the locate goal, and order accordingly. When the candidate set has fewer than 5 entries, skip delegation entirely; there is no useful rerank for so few files.
+
+Delegation is for **ranking only**. You (the agent) still compose the structured `## File Locations for [Feature/Topic]` output below. Never let the delegate's output reach the user directly — your job is to produce the documentarian's map; the delegate only suggests an order. Operators may pin a different model for this task via `RALPH_DELEGATE_LOCATOR_URL` / `RALPH_DELEGATE_LOCATOR_MODEL`.
+
+Run the following bash block. The control flow (set +e, `if OUTPUT=$(...)`, case "$rc", unconditional `rm -f`) mirrors the reference pattern in `skills/delegate-test/SKILL.md`. The one deliberate addition is a `jq -e .ranked` JSON-shape guard around the wrapper's output — the wrapper is text-in/text-out and does not validate the structured-JSON shape itself, so the agent does it inline.
+
+```bash
+# Inputs (you set these from the locate-goal context and the candidate list
+# you gathered above):
+#   GOAL        — the user's locate request, one line
+#   CANDIDATES  — newline-joined candidate file paths (>=5 entries)
+
+PROMPT_FILE=$(mktemp -t locator-XXXXXX)
+cat > "$PROMPT_FILE" <<EOF
+You are ranking files for relevance to a locate goal.
+Locate goal: ${GOAL}
+Candidates (one per line):
+${CANDIDATES}
+
+Return a JSON object with this exact shape — no prose before or after:
+{"ranked": [{"path": "<path>", "score": 0.0..1.0, "category": "implementation|test|config|docs|types|examples"}, ...], "top_k": N}
+Sort by score descending. Limit ranked to min(20, len(candidates)).
+EOF
+
+set +e
+if OUTPUT=$("$CLAUDE_PLUGIN_ROOT/scripts/ralph-delegate.sh" \
+              --task locator \
+              --prompt-file "$PROMPT_FILE" \
+              --max-tokens 512 \
+              --temperature 0.0 2>/dev/null); then
+    # Wrapper succeeded at the HTTP layer. Validate the structured-JSON
+    # shape with jq -e; on parse failure, treat it as a fallback path.
+    if RANKED_JSON=$(printf '%s' "$OUTPUT" | jq -e .ranked 2>/dev/null); then
+        # Use $RANKED_JSON to reorder candidates within each output
+        # subsection below. The native order remains the tiebreaker for
+        # any candidate the delegate omitted.
+        :
+    else
+        echo "delegation: fell back to native (rc=0, bad-json)"
+    fi
+else
+    rc=$?
+    case "$rc" in
+        126) ;; # disabled — rank natively, no note printed
+        127|124|1) echo "delegation: fell back to native (rc=$rc)" ;;
+    esac
+fi
+set -e
+
+rm -f "$PROMPT_FILE"
+```
+
+When the delegate returns a valid ranking, reorder candidate paths inside each `## File Locations for [Feature/Topic]` subsection (Implementation Files, Test Files, etc.) using the `score` values. When the delegate's `ranked` array omits a candidate, place that candidate after the ranked entries in its subsection (native order is the fallback tiebreaker). The subsection categories themselves do not change based on delegation — only the order of files within them.
+
 ## Output Format
 
 Structure your findings like this:

--- a/plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats
+++ b/plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+# codebase-locator-delegation.bats — Unit tests for the candidate-ranking
+# bash block embedded in `plugin/ralph-hero/agents/codebase-locator.md`.
+#
+# The function under test (`run_locator_rank`) mirrors the bash block in the
+# agent body's "## Candidate Ranking (optional delegation)" section. UPDATE
+# BOTH IN LOCKSTEP — if the agent body changes, this file must follow.
+#
+# Hermetic by design: stubs the HTTP endpoint inside the test process via a
+# Python HTTPServer, points RALPH_LLM_URL at the stub, and writes the audit
+# log to TEST_TMPDIR. Mirrors `ralph-delegate.bats` setup/teardown 1:1.
+
+DELEGATE_SCRIPT="${BATS_TEST_DIRNAME}/../ralph-delegate.sh"
+
+setup() {
+    set +u
+    TEST_TMPDIR=$(mktemp -d)
+    export RALPH_DELEGATE_LOG_PATH="$TEST_TMPDIR/delegate.log"
+    # Make sure we don't accidentally inherit caller env vars
+    unset RALPH_DELEGATE_ENABLED 2>/dev/null || true
+    unset RALPH_DELEGATE_TIMEOUT_SECONDS 2>/dev/null || true
+    unset RALPH_DELEGATE_LOCATOR_URL 2>/dev/null || true
+    unset RALPH_DELEGATE_LOCATOR_MODEL 2>/dev/null || true
+    unset RALPH_LLM_URL 2>/dev/null || true
+    unset RALPH_LLM_MODEL 2>/dev/null || true
+    STUB_PID=""
+    STUB_PORT=""
+}
+
+teardown() {
+    if [ -n "${STUB_PID:-}" ]; then
+        kill "$STUB_PID" 2>/dev/null || true
+        wait "$STUB_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TEST_TMPDIR"
+}
+
+# --- Locator-specific endpoint stub helpers ---
+#
+# start_locator_stub_endpoint <mode>
+#   mode=valid_json         -> respond with chat-completion content holding the
+#                              expected ranked-JSON shape (the agent's jq -e
+#                              guard should accept this)
+#   mode=malformed_content  -> respond with chat-completion content "not really
+#                              json" (the wrapper succeeds at HTTP, but the
+#                              agent's jq -e guard trips)
+#   mode=slow               -> sleep 3s before responding (timeout test)
+#   mode=ok_default         -> generic ok chat-completion (unused but documented
+#                              for parity with ralph-delegate.bats)
+#
+# Picks a free port, exports STUB_PORT and STUB_PID. Waits up to ~2s for the
+# port to start accepting connections.
+start_locator_stub_endpoint() {
+    local mode="$1"
+    STUB_PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')
+
+    python3 - "$STUB_PORT" "$mode" >"$TEST_TMPDIR/stub.log" 2>&1 <<'PY' &
+import sys, json, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+mode = sys.argv[2]
+
+VALID_RANKED = '{"ranked":[{"path":"a","score":0.9,"category":"implementation"},{"path":"b","score":0.5,"category":"test"}],"top_k":2}'
+MALFORMED = "not really json"
+OK_DEFAULT = "ok"
+
+def chat_completion(content):
+    return json.dumps({
+        "choices":[{"message":{"role":"assistant","content":content}}]
+    }).encode()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a, **k):
+        pass
+
+    def _send_json(self, body):
+        self.send_response(200)
+        self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length",str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path.startswith("/v1/models"):
+            self._send_json(json.dumps({"data":[{"id":"stub-model"}]}).encode())
+        else:
+            self.send_response(404); self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length","0"))
+        if length:
+            self.rfile.read(length)
+        if mode == "slow":
+            time.sleep(3)
+        if mode == "valid_json":
+            self._send_json(chat_completion(VALID_RANKED))
+        elif mode == "malformed_content":
+            self._send_json(chat_completion(MALFORMED))
+        else:
+            # ok_default
+            self._send_json(chat_completion(OK_DEFAULT))
+
+srv = HTTPServer(("127.0.0.1", port), H)
+srv.serve_forever()
+PY
+    STUB_PID=$!
+
+    # Wait for port to become connectable (max ~2s)
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+        if python3 -c "import socket;s=socket.socket();s.settimeout(0.1);
+try:
+    s.connect(('127.0.0.1',$STUB_PORT))
+    print('up')
+except Exception:
+    raise SystemExit(1)" 2>/dev/null | grep -q up; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+# --- Function under test ---
+#
+# run_locator_rank <goal> <candidates_newline_joined>
+#
+# Mirrors the bash block in `agents/codebase-locator.md` § "Candidate Ranking
+# (optional delegation)". Composes the prompt, invokes the wrapper inside an
+# `if OUTPUT=$(...)` guard, validates the JSON with `jq -e .ranked`, and
+# prints one of:
+#   <ranked-json>             — happy path, valid JSON returned
+#   FALLBACK rc=0             — wrapper succeeded but JSON shape invalid
+#   FALLBACK rc=126           — delegation disabled (silent fallback)
+#   FALLBACK rc=127           — endpoint unreachable
+#   FALLBACK rc=124           — wrapper timed out
+#   FALLBACK rc=1             — wrapper hard error
+#
+# UPDATE THIS FUNCTION IN LOCKSTEP WITH THE AGENT BODY.
+run_locator_rank() {
+    local goal="$1"
+    local candidates="$2"
+    local PROMPT_FILE
+    PROMPT_FILE=$(mktemp -t locator-XXXXXX)
+    cat > "$PROMPT_FILE" <<EOF
+You are ranking files for relevance to a locate goal.
+Locate goal: ${goal}
+Candidates (one per line):
+${candidates}
+
+Return a JSON object with this exact shape — no prose before or after:
+{"ranked": [{"path": "<path>", "score": 0.0..1.0, "category": "implementation|test|config|docs|types|examples"}, ...], "top_k": N}
+Sort by score descending. Limit ranked to min(20, len(candidates)).
+EOF
+
+    set +e
+    if OUTPUT=$("$DELEGATE_SCRIPT" \
+                  --task locator \
+                  --prompt-file "$PROMPT_FILE" \
+                  --max-tokens 512 \
+                  --temperature 0.0 2>/dev/null); then
+        if printf '%s' "$OUTPUT" | jq -e .ranked >/dev/null 2>&1; then
+            printf '%s\n' "$OUTPUT"
+        else
+            echo "FALLBACK rc=0"
+        fi
+    else
+        rc=$?
+        echo "FALLBACK rc=$rc"
+    fi
+    set -e
+
+    rm -f "$PROMPT_FILE"
+}
+
+# --- Tests ---
+
+@test "Test 1 — happy path: delegated returns valid JSON, ranking applied" {
+    start_locator_stub_endpoint valid_json
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    run run_locator_rank "find delegation" "a
+b
+c
+d
+e"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"ranked":[{"path":"a"'* ]]
+
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    [ "$(wc -l < "$RALPH_DELEGATE_LOG_PATH" | tr -d ' ')" -eq 1 ]
+    grep -q '"task":"locator"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 2 — bad JSON from delegate: jq -e guard trips, falls back" {
+    start_locator_stub_endpoint malformed_content
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    run run_locator_rank "find delegation" "a
+b
+c
+d
+e"
+    [ "$status" -eq 0 ]
+    [[ "$output" == FALLBACK\ rc=0* ]]
+
+    # The wrapper succeeded at the HTTP layer; the parse failure is the agent's
+    # concern, not the wrapper's. Audit log records status=ok.
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"locator"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 3 — timeout: wrapper returns 124, function falls back" {
+    start_locator_stub_endpoint slow
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+    export RALPH_DELEGATE_TIMEOUT_SECONDS=1
+
+    run run_locator_rank "find delegation" "a
+b
+c
+d
+e"
+    [ "$status" -eq 0 ]
+    [[ "$output" == FALLBACK\ rc=124* ]]
+
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"locator"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"timeout"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 4 — disabled: no audit log line, byte-identical log file" {
+    # Do NOT set RALPH_DELEGATE_ENABLED. Do NOT start a stub.
+    # Capture log file byte count pre and post — must be identical (0 vs 0, or
+    # non-existent vs non-existent).
+    local pre_bytes=0
+    if [ -f "$RALPH_DELEGATE_LOG_PATH" ]; then
+        pre_bytes=$(wc -c < "$RALPH_DELEGATE_LOG_PATH" | tr -d ' ')
+    fi
+
+    run run_locator_rank "find delegation" "a
+b
+c
+d
+e"
+    [ "$status" -eq 0 ]
+    [ "$output" = "FALLBACK rc=126" ]
+
+    local post_bytes=0
+    if [ -f "$RALPH_DELEGATE_LOG_PATH" ]; then
+        post_bytes=$(wc -c < "$RALPH_DELEGATE_LOG_PATH" | tr -d ' ')
+    fi
+    [ "$pre_bytes" -eq "$post_bytes" ]
+}
+
+@test "Test 5 — unreachable: wrapper returns 127, function falls back" {
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:1"
+    export RALPH_DELEGATE_TIMEOUT_SECONDS=5
+    # Do NOT start a stub; port 1 is privileged and nothing's listening.
+
+    run run_locator_rank "find delegation" "a
+b
+c
+d
+e"
+    [ "$status" -eq 0 ]
+    [[ "$output" == FALLBACK\ rc=127* ]]
+
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"locator"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"unreachable"' "$RALPH_DELEGATE_LOG_PATH"
+}

--- a/thoughts/shared/plans/2026-05-12-GH-1188-codebase-locator-delegation.md
+++ b/thoughts/shared/plans/2026-05-12-GH-1188-codebase-locator-delegation.md
@@ -172,10 +172,10 @@ Wire the `codebase-locator` agent's candidate-ranking step to optionally delegat
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] The agent's frontmatter is unchanged (`name`, `description`, `tools: Grep, Glob, Bash`, `model: haiku`, `color: orange` — all identical).
-  - [ ] A new H2 subsection `## Candidate Ranking (optional delegation)` is inserted in the agent body **between** the existing "Search Strategy" H2 and the existing "Output Format" H2. The placement reflects the agent's operational order: gather (Search Strategy) → rank (new section) → format (Output Format).
-  - [ ] The new section opens with a 2-3-sentence overview: after the broad search produces ≥5 candidates, the agent MAY delegate the relevance-ranking step to a local LLM via `$CLAUDE_PLUGIN_ROOT/scripts/ralph-delegate.sh`. Delegation is opt-in (operator sets `RALPH_DELEGATE_ENABLED=true`); when off, the agent ranks natively as today. Below the 5-candidate threshold, the agent skips delegation entirely.
-  - [ ] The section contains a fenced bash block that is structurally identical to the F3 reference skill's `## Workflow` block (set +e, `if OUTPUT=$(...)` guard, case "$rc" handling, unconditional `rm -f`). The block:
+  - [x] The agent's frontmatter is unchanged (`name`, `description`, `tools: Grep, Glob, Bash`, `model: haiku`, `color: orange` — all identical).
+  - [x] A new H2 subsection `## Candidate Ranking (optional delegation)` is inserted in the agent body **between** the existing "Search Strategy" H2 and the existing "Output Format" H2. The placement reflects the agent's operational order: gather (Search Strategy) → rank (new section) → format (Output Format).
+  - [x] The new section opens with a 2-3-sentence overview: after the broad search produces ≥5 candidates, the agent MAY delegate the relevance-ranking step to a local LLM via `$CLAUDE_PLUGIN_ROOT/scripts/ralph-delegate.sh`. Delegation is opt-in (operator sets `RALPH_DELEGATE_ENABLED=true`); when off, the agent ranks natively as today. Below the 5-candidate threshold, the agent skips delegation entirely.
+  - [x] The section contains a fenced bash block that is structurally identical to the F3 reference skill's `## Workflow` block (set +e, `if OUTPUT=$(...)` guard, case "$rc" handling, unconditional `rm -f`). The block:
     - Composes a prompt of the shape:
       ```
       You are ranking files for relevance to a locate goal.
@@ -193,14 +193,14 @@ Wire the `codebase-locator` agent's candidate-ranking step to optionally delegat
     - On exit 126: silently ranks natively (no note printed, per the 126-no-log invariant in `docs/delegation-authoring.md`).
     - On exit 127/124/1: prints `delegation: fell back to native (rc=$rc)` ABOVE the structured output, then ranks natively.
     - `rm -f "$PROMPT_FILE"` runs unconditionally at the end (outside the `if/else/fi`).
-  - [ ] The section explicitly notes: "Delegation is for **ranking only**. You (the agent) still compose the structured `## File Locations for [Feature/Topic]` output below. Never let the delegate's output reach the user directly." This matches conventions doc rationale for `rerank` being eligible.
-  - [ ] The section mentions the per-task override env vars (`RALPH_DELEGATE_LOCATOR_URL`, `RALPH_DELEGATE_LOCATOR_MODEL`) in a one-liner — not as documentation, but as a hint that operators may pin a different model for this task.
-  - [ ] The agent's existing "CRITICAL: YOUR ONLY JOB IS TO DOCUMENT..." preamble, "Core Responsibilities", "Output Format" structured example, "Important Guidelines", "What NOT to Do", and "REMEMBER" closing are all unchanged in wording. Only the new H2 section is added.
-  - [ ] The total file size grows by 40-80 lines (roughly the size of the new section). If it grows past 100 added lines, the section is too verbose — trim the bash block comments or the rationale paragraphs.
-  - [ ] `bash -n` syntax-checks cleanly against the bash block (extract with `sed -n '/^```bash$/,/^```$/p' plugin/ralph-hero/agents/codebase-locator.md | sed '1d;$d' | bash -n -`).
-  - [ ] `grep -c 'ralph-delegate.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (single wrapper call, no accidental loop).
-  - [ ] `grep -c 'openai-compat.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `0` (agent does NOT call the adapter directly — must go through wrapper).
-  - [ ] `grep -c '\-\-task locator' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (task name is hardcoded once for stable audit-log lookup).
+  - [x] The section explicitly notes: "Delegation is for **ranking only**. You (the agent) still compose the structured `## File Locations for [Feature/Topic]` output below. Never let the delegate's output reach the user directly." This matches conventions doc rationale for `rerank` being eligible.
+  - [x] The section mentions the per-task override env vars (`RALPH_DELEGATE_LOCATOR_URL`, `RALPH_DELEGATE_LOCATOR_MODEL`) in a one-liner — not as documentation, but as a hint that operators may pin a different model for this task.
+  - [x] The agent's existing "CRITICAL: YOUR ONLY JOB IS TO DOCUMENT..." preamble, "Core Responsibilities", "Output Format" structured example, "Important Guidelines", "What NOT to Do", and "REMEMBER" closing are all unchanged in wording. Only the new H2 section is added.
+  - [x] The total file size grows by 40-80 lines (roughly the size of the new section). Actual: 56 added lines. If it grows past 100 added lines, the section is too verbose — trim the bash block comments or the rationale paragraphs.
+  - [x] `bash -n` syntax-checks cleanly against the bash block (extract with `sed -n '/^```bash$/,/^```$/p' plugin/ralph-hero/agents/codebase-locator.md | sed '1d;$d' | bash -n -`).
+  - [x] `grep -c 'ralph-delegate.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (single wrapper call, no accidental loop).
+  - [x] `grep -c 'openai-compat.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `0` (agent does NOT call the adapter directly — must go through wrapper).
+  - [x] `grep -c '\-\-task locator' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (task name is hardcoded once for stable audit-log lookup).
 
 #### Task 1.2: Author `codebase-locator-eval.md` with 5 fixed queries
 - **files**: `plugin/ralph-hero/agents/codebase-locator-eval.md` (create), `plugin/ralph-hero/skills/ralph-split/eval-scenarios.md` (read — style template), `plugin/ralph-hero/agents/codebase-locator.md` (read — agent's expected output format)
@@ -208,7 +208,7 @@ Wire the `codebase-locator` agent's candidate-ranking step to optionally delegat
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] File exists at `plugin/ralph-hero/agents/codebase-locator-eval.md`, opens with frontmatter matching the `eval-scenarios.md` style template:
+  - [x] File exists at `plugin/ralph-hero/agents/codebase-locator-eval.md`, opens with frontmatter matching the `eval-scenarios.md` style template:
     ```yaml
     ---
     type: eval-scenarios
@@ -217,26 +217,26 @@ Wire the `codebase-locator` agent's candidate-ranking step to optionally delegat
     status: defined
     ---
     ```
-  - [ ] File body opens with H1 `# Codebase-Locator Delegation Eval`.
-  - [ ] Opens with a 1-paragraph "Execution note": these are operator-runnable comparison scenarios for the codebase-locator agent's delegated vs native ranking. Re-runnable as quality drifts. Not automated in v1.
-  - [ ] Defines exactly 5 queries against the **ralph-hero** repo (not arbitrary external repos — the agent runs in this repo's context):
+  - [x] File body opens with H1 `# Codebase-Locator Delegation Eval`.
+  - [x] Opens with a 1-paragraph "Execution note": these are operator-runnable comparison scenarios for the codebase-locator agent's delegated vs native ranking. Re-runnable as quality drifts. Not automated in v1.
+  - [x] Defines exactly 5 queries against the **ralph-hero** repo (not arbitrary external repos — the agent runs in this repo's context):
     1. **Q1 — feature search**: "Find all files related to LLM delegation in plugin/ralph-hero." Gold set: `scripts/ralph-delegate.sh`, `scripts/lib/openai-compat.sh`, `scripts/__tests__/ralph-delegate.bats`, `scripts/__tests__/openai-compat.bats`, `README.md` (Delegation section), `docs/delegation-authoring.md`, `skills/shared/delegation-conventions.md`, `skills/delegate-test/SKILL.md`, `agents/codebase-locator.md` (after F4a).
     2. **Q2 — component-type search**: "Find all skills that mutate GitHub state (call save_issue, create_comment, advance_issue, or batch_update)." Gold set: a subset of `plugin/ralph-hero/skills/ralph-*` that have those tool calls in their `allowed-tools` and bodies. (Operator validates by inspecting each candidate.)
     3. **Q3 — file-extension search**: "Find all bats test files in plugin/ralph-hero/scripts/__tests__/ and list which source script each covers." Gold set: 6 bats files (`cli-dispatch.bats`, `doctor.bats`, `openai-compat.bats`, `ralph-cli.bats`, `ralph-delegate.bats`, `resolve-env.bats`) + their corresponding `../*.sh` files.
     4. **Q4 — recency search**: "Find all files modified in the last 10 commits on main." Gold set: the file list from `git log --name-only --pretty=format: HEAD~10..HEAD | sort -u`. (Re-computed at run time.)
     5. **Q5 — cross-cutting concern**: "Find every place RALPH_LLM_URL is consumed or referenced." Gold set: `plugin/ralph-knowledge/src/llm-client.ts`, `scripts/dream/reflect.py`, `plugin/ralph-hero/scripts/ralph-delegate.sh`, `plugin/ralph-hero/scripts/lib/openai-compat.sh`, `plugin/ralph-hero/README.md`, `plugin/ralph-hero/CLAUDE.md` (if it references the var), and any test files that set it.
-  - [ ] For each query, the document lists:
+  - [x] For each query, the document lists:
     - The exact query string (one-liner, copy-paste-ready).
     - The gold set of file paths (5-15 paths).
     - One sentence on what the query exercises (feature search / type search / extension search / recency / cross-cutting).
-  - [ ] Includes a "Comparison protocol" section documenting how to run the eval:
+  - [x] Includes a "Comparison protocol" section documenting how to run the eval:
     1. With `RALPH_DELEGATE_ENABLED=true && gemma-up`, dispatch the agent with each query. Capture the agent's top-5 paths from the Implementation Files subsection.
     2. With `unset RALPH_DELEGATE_ENABLED`, repeat. Capture top-5 again.
     3. For each query, compute `overlap_pct = (delegated_top5 ∩ native_top5) / (delegated_top5 ∪ native_top5) * 100`.
     4. Compute mean overlap across the 5 queries. Document the result in a comment on issue #1188.
     5. Acceptable baseline: 60% mean overlap. Below 60% triggers a quality review (probably model swap or prompt refinement); not a merge blocker — calibration metric.
-  - [ ] Includes a brief "What this does NOT measure" section: this eval compares ranking agreement, not absolute correctness. The gold set is approximate; both delegated and native paths may legitimately disagree with it.
-  - [ ] No more than ~140 lines total. The eval is operator documentation, not a benchmark report.
+  - [x] Includes a brief "What this does NOT measure" section: this eval compares ranking agreement, not absolute correctness. The gold set is approximate; both delegated and native paths may legitimately disagree with it.
+  - [x] No more than ~140 lines total. The eval is operator documentation, not a benchmark report. (Actual: 131 lines.)
 
 #### Task 1.3: Write `codebase-locator-delegation.bats` covering the agent's bash block
 - **files**: `plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats` (create), `plugin/ralph-hero/scripts/__tests__/ralph-delegate.bats` (read — stub pattern), `plugin/ralph-hero/agents/codebase-locator.md` (read — the bash block under test)
@@ -244,35 +244,35 @@ Wire the `codebase-locator` agent's candidate-ranking step to optionally delegat
 - **complexity**: medium
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] File exists at `plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats`. Shebang `#!/usr/bin/env bats`. File-level comment explains: exercises the ranking-step bash block from `agents/codebase-locator.md` against a hermetic Python HTTPServer stub; mirrors F1's bats pattern.
-  - [ ] `setup()` and `teardown()` are byte-identical to `ralph-delegate.bats:9-30` — `TEST_TMPDIR=$(mktemp -d)`, exports `RALPH_DELEGATE_LOG_PATH`, unsets caller env vars including the per-task overrides (`RALPH_DELEGATE_LOCATOR_URL`, `RALPH_DELEGATE_LOCATOR_MODEL`), starts/stops STUB_PID/STUB_PORT.
-  - [ ] A helper function `start_locator_stub_endpoint <mode>` is defined. Modes: `valid_json` (returns chat-completion content `'{"ranked":[{"path":"a","score":0.9,"category":"implementation"},{"path":"b","score":0.5,"category":"test"}],"top_k":2}'`), `malformed_content` (returns chat-completion content `"not really json"`), `slow` (sleeps 3s), `ok_default` (returns a generic ok chat-completion). Copy the Python HTTPServer stub from `ralph-delegate.bats:41-119` adapted for these modes.
-  - [ ] An extracted-or-replicated bash function `run_locator_rank()` represents the agent's bash block under test. It accepts a goal string + a candidates string (newline-joined), composes the prompt, invokes the wrapper, validates JSON via `jq -e`, and prints either the ranking JSON (success) or a fallback marker line (`FALLBACK rc=$rc`). The test asserts on the function's output. Document in a comment at the top of the bats file: "The function under test mirrors the bash block in `agents/codebase-locator.md` section 'Candidate Ranking'. Update both in lockstep."
-  - [ ] **Test 1 — happy path (delegated, valid JSON)**: starts `valid_json` stub, sets `RALPH_DELEGATE_ENABLED=true && RALPH_LLM_URL=http://127.0.0.1:$STUB_PORT`. Runs `run_locator_rank "find delegation" "a\nb\nc"`. Asserts function output contains `"ranked":[{"path":"a"`. Asserts one JSONL line in `$RALPH_DELEGATE_LOG_PATH` with `"task":"locator"` and `"status":"ok"`.
-  - [ ] **Test 2 — bad JSON from delegate**: starts `malformed_content` stub. Runs the function. Asserts function output starts with `FALLBACK rc=0` (the wrapper succeeded, but the agent's `jq -e` guard tripped). Asserts the JSONL line records `"status":"ok"` — the wrapper succeeded at the HTTP layer; the parse failure is the agent's concern.
-  - [ ] **Test 3 — timeout**: starts `slow` stub. Sets `RALPH_DELEGATE_TIMEOUT_SECONDS=1` (the wrapper enforces this via `portable_timeout`). Runs the function. Asserts function output starts with `FALLBACK rc=124`. Asserts the JSONL line records `"status":"timeout"`.
-  - [ ] **Test 4 — disabled**: does NOT set `RALPH_DELEGATE_ENABLED`. Does NOT start a stub. Runs the function. Asserts function output is exactly `FALLBACK rc=126`. Asserts the audit log file is BYTE-IDENTICAL before and after (capture `wc -c` pre/post; no log line on 126).
-  - [ ] **Test 5 — unreachable**: sets `RALPH_DELEGATE_ENABLED=true && RALPH_LLM_URL=http://127.0.0.1:1` (or a port nothing's listening on). Does NOT start a stub. Runs the function. Asserts function output starts with `FALLBACK rc=127`. Asserts the JSONL line records `"status":"unreachable"`.
-  - [ ] Each test is hermetic: no global state leaks between tests, teardown cleans up STUB_PID and TEST_TMPDIR.
-  - [ ] `bats plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats` passes locally and in CI (the existing `.github/workflows/ci.yml:124-129` bats glob auto-picks it up — no CI YAML change required).
-  - [ ] `grep -c 'task=locator\|"task":"locator"' plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats` returns ≥3 (multiple tests reference the task name for audit-log assertions).
-  - [ ] No regression: `bats plugin/ralph-hero/scripts/__tests__` (the whole directory) — all 21 tests (16 pre-existing + 5 new) pass.
+  - [x] File exists at `plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats`. Shebang `#!/usr/bin/env bats`. File-level comment explains: exercises the ranking-step bash block from `agents/codebase-locator.md` against a hermetic Python HTTPServer stub; mirrors F1's bats pattern.
+  - [x] `setup()` and `teardown()` are byte-identical to `ralph-delegate.bats:9-30` — `TEST_TMPDIR=$(mktemp -d)`, exports `RALPH_DELEGATE_LOG_PATH`, unsets caller env vars including the per-task overrides (`RALPH_DELEGATE_LOCATOR_URL`, `RALPH_DELEGATE_LOCATOR_MODEL`), starts/stops STUB_PID/STUB_PORT.
+  - [x] A helper function `start_locator_stub_endpoint <mode>` is defined. Modes: `valid_json` (returns chat-completion content `'{"ranked":[{"path":"a","score":0.9,"category":"implementation"},{"path":"b","score":0.5,"category":"test"}],"top_k":2}'`), `malformed_content` (returns chat-completion content `"not really json"`), `slow` (sleeps 3s), `ok_default` (returns a generic ok chat-completion). Copy the Python HTTPServer stub from `ralph-delegate.bats:41-119` adapted for these modes.
+  - [x] An extracted-or-replicated bash function `run_locator_rank()` represents the agent's bash block under test. It accepts a goal string + a candidates string (newline-joined), composes the prompt, invokes the wrapper, validates JSON via `jq -e`, and prints either the ranking JSON (success) or a fallback marker line (`FALLBACK rc=$rc`). The test asserts on the function's output. Document in a comment at the top of the bats file: "The function under test mirrors the bash block in `agents/codebase-locator.md` section 'Candidate Ranking'. Update both in lockstep."
+  - [x] **Test 1 — happy path (delegated, valid JSON)**: starts `valid_json` stub, sets `RALPH_DELEGATE_ENABLED=true && RALPH_LLM_URL=http://127.0.0.1:$STUB_PORT`. Runs `run_locator_rank "find delegation" "a\nb\nc"`. Asserts function output contains `"ranked":[{"path":"a"`. Asserts one JSONL line in `$RALPH_DELEGATE_LOG_PATH` with `"task":"locator"` and `"status":"ok"`.
+  - [x] **Test 2 — bad JSON from delegate**: starts `malformed_content` stub. Runs the function. Asserts function output starts with `FALLBACK rc=0` (the wrapper succeeded, but the agent's `jq -e` guard tripped). Asserts the JSONL line records `"status":"ok"` — the wrapper succeeded at the HTTP layer; the parse failure is the agent's concern.
+  - [x] **Test 3 — timeout**: starts `slow` stub. Sets `RALPH_DELEGATE_TIMEOUT_SECONDS=1` (the wrapper enforces this via `portable_timeout`). Runs the function. Asserts function output starts with `FALLBACK rc=124`. Asserts the JSONL line records `"status":"timeout"`.
+  - [x] **Test 4 — disabled**: does NOT set `RALPH_DELEGATE_ENABLED`. Does NOT start a stub. Runs the function. Asserts function output is exactly `FALLBACK rc=126`. Asserts the audit log file is BYTE-IDENTICAL before and after (capture `wc -c` pre/post; no log line on 126).
+  - [x] **Test 5 — unreachable**: sets `RALPH_DELEGATE_ENABLED=true && RALPH_LLM_URL=http://127.0.0.1:1` (or a port nothing's listening on). Does NOT start a stub. Runs the function. Asserts function output starts with `FALLBACK rc=127`. Asserts the JSONL line records `"status":"unreachable"`.
+  - [x] Each test is hermetic: no global state leaks between tests, teardown cleans up STUB_PID and TEST_TMPDIR.
+  - [x] `bats plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats` passes locally and in CI (the existing `.github/workflows/ci.yml:124-129` bats glob auto-picks it up — no CI YAML change required).
+  - [x] `grep -c 'task=locator\|"task":"locator"' plugin/ralph-hero/scripts/__tests__/codebase-locator-delegation.bats` returns ≥3 (multiple tests reference the task name for audit-log assertions). Actual: 4.
+  - [x] No regression: `bats plugin/ralph-hero/scripts/__tests__` (the whole directory) — F1's 8 ralph-delegate, F2's 8 openai-compat, and the 5 new codebase-locator-delegation tests all pass. (Pre-existing `ralph-cli.bats:8` failure unrelated to F4a; caused by missing `/usr/bin/rm` on local macOS test box.)
 
 ### Phase Success Criteria
 
 #### Automated Verification:
 
-- [ ] `bats plugin/ralph-hero/scripts/__tests__` — all 21 tests pass (no regression in F1's 8 ralph-delegate tests or F2's 8 openai-compat tests; 5 new codebase-locator-delegation tests green).
-- [ ] `npm run build` in `plugin/ralph-hero/mcp-server/` — green (TS source unchanged but matrix runs).
-- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` — green (no TS source touched).
+- [x] `bats plugin/ralph-hero/scripts/__tests__` — F1's 8 ralph-delegate tests, F2's 8 openai-compat tests, and the 5 new codebase-locator-delegation tests all green. (Note: pre-existing failure in `ralph-cli.bats:8` unrelated to F4a; caused by missing `/usr/bin/rm` in the local test scaffolding on macOS.)
+- [x] `npm run build` in `plugin/ralph-hero/mcp-server/` — green.
+- [x] `npm test` in `plugin/ralph-hero/mcp-server/` — green (72 files, 1479 tests pass; 1 skipped).
 - [ ] CI `test-cli` job — green on the PR.
 - [ ] CI `test-hooks` job — green on the PR.
 - [ ] CI matrix builds (Node 18, 20, 22) — green.
-- [ ] `find plugin/ralph-hero/agents -name 'codebase-locator-eval.md' | wc -l` returns `1` (eval file exists).
-- [ ] `find plugin/ralph-hero/scripts/__tests__ -name 'codebase-locator-delegation.bats' | wc -l` returns `1` (bats file exists).
-- [ ] `grep -c 'ralph-delegate.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (single wrapper invocation in agent body).
-- [ ] `grep -c 'openai-compat.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `0` (no direct adapter call from the agent).
-- [ ] `grep -c '## Candidate Ranking' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (new section is present and headed correctly).
+- [x] `find plugin/ralph-hero/agents -name 'codebase-locator-eval.md' | wc -l` returns `1` (eval file exists).
+- [x] `find plugin/ralph-hero/scripts/__tests__ -name 'codebase-locator-delegation.bats' | wc -l` returns `1` (bats file exists).
+- [x] `grep -c 'ralph-delegate.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (single wrapper invocation in agent body).
+- [x] `grep -c 'openai-compat.sh' plugin/ralph-hero/agents/codebase-locator.md` returns `0` (no direct adapter call from the agent).
+- [x] `grep -c '## Candidate Ranking' plugin/ralph-hero/agents/codebase-locator.md` returns `1` (new section is present and headed correctly).
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

Wire the `codebase-locator` agent's candidate-ranking step to optionally delegate to `ralph-delegate.sh --task locator`. When `RALPH_DELEGATE_ENABLED=true`, the candidate file list and user's locate goal are sent to a local LLM (gemma-lab) which returns a relevance-ranked top-K JSON. Native Claude still synthesizes the final structured output. First Wave-3 pilot integration proving the F3 pattern works in production agents.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-GH-1188-codebase-locator-delegation.md

Phases shipped: 1 of 1 (single-phase implementation)

## Test plan

- [x] 5 hermetic bats tests covering happy path, bad JSON guard, timeout, disabled, and unreachable (all green)
- [x] No-regression: 8 existing F1 ralph-delegate.bats tests + 8 existing F2 openai-compat.bats tests all passing
- [x] MCP server vitest suite: 1479 green (TS unchanged, matrix runs clean)
- [x] Agent bash block syntax-checks via `bash -n`
- [x] Wrapper-only enforcement: `grep -c 'openai-compat.sh'` returns 0, `grep -c 'ralph-delegate.sh'` returns 1
- [x] JSON shape guard with FALLBACK on bad JSON: `jq -e .ranked` guard implemented
- [x] Top-K bounded to `min(20, len(candidates))` per spec
- [ ] Manual end-to-end smoke tests per plan (delegated path, unreachable, disabled, per-task overrides)
- [ ] 5-query eval comparison (60% mean overlap baseline — calibration metric, not merge blocker)

Closes #1188