### PR TITLE
GH-1190: F4c — val-agent: pass/fail classification via delegation

### DIFF
--- a/plugin/ralph-hero/agents/val-agent-eval.md
+++ b/plugin/ralph-hero/agents/val-agent-eval.md
@@ -1,0 +1,149 @@
+---
+type: eval-scenarios
+agent: val-agent
+date: 2026-05-12
+status: defined
+---
+
+# Val-Agent Delegation Eval
+
+> **Execution note**: These are operator-runnable comparison scenarios for the `ralph-val` skill's delegated vs native verdict-prefix classification. Re-runnable as quality drifts across model swaps or prompt refinements. Not automated in v1 — automation lives in a future feature (F5 / `#1191` telemetry, or a follow-up nightly drift detector) if needed.
+
+10 historic In Progress / In Review issues from the **ralph-hero** repo with known verdicts. For each issue, the operator runs `ralph-val` against the worktree with delegation on and off, then records whether the resulting verdict-prefix (`VALIDATION PASS|FIX|FAIL`) matches. The eval measures **prefix agreement** (Issue acceptance criterion #1, target ≥80% / 8 of 10), not absolute correctness — both delegated and native paths produce LLM-mediated classifications; the cross-check rule (Constraint #9) is the guarantee that the delegate never overrides ground truth from the automated checks.
+
+---
+
+## Issue selection criteria
+
+Pick **10 historic issues** from the ralph-hero repo (or any repo where val has been run on a real worktree). The selection must satisfy:
+
+- **Reachable worktree**: each issue's `worktrees/GH-NNN` is reproducible. Re-create via `git worktree add worktrees/GH-NNN feature/GH-NNN` if pruned post-merge.
+- **Verdict spread**: aim for 4-5 `VALIDATION PASS`, 3-4 `VALIDATION FAIL`, 1-2 `VALIDATION FIX`. FIX is rare in the historical corpus — a 1-2 representation is realistic, and a corpus with zero FIX issues is acceptable in v1.
+- **Complexity spread**: small (XS/S issues with 1-2 phases) and medium (S/M issues with 3-5 phases). Skip L/XL epics — the per-check count would dominate the prompt budget (Constraint #11) and trigger the truncation branch, distorting the comparison.
+- **Has a plan with `## Desired End State`**: issues without plans (or with plans missing `Automated Verification`) bypass Step 7.0 entirely (the threshold gate trips on `total_checks < 2`). Skip them.
+- **Has a reachable worktree branch**: skip issues whose `feature/GH-NNN` branch has been pruned from the remote.
+
+Three plausible candidate ranges from the current delegation epic (#965) as starting suggestions; the operator picks the actual 10 at run time:
+
+- **F1 (#1185)** — bash-heavy, multi-phase. Verdict PASS at merge time (bats green).
+- **F4a (#1188)** — agent-body integration. Verdict PASS at merge time.
+- **F4b (#1189)** — skill-body integration with threshold-gate test. Verdict PASS at merge time.
+- Older Phase-4 review-skill issues (mixed verdicts; F2's `#1186`, F3's `#1187`).
+
+Pad to 10 with any other recently-validated issues; non-delegation-epic issues are explicitly welcome (the eval is repo-wide, not epic-scoped).
+
+---
+
+## Agreement criterion
+
+Per issue: the **delegated verdict prefix** (`VALIDATION PASS|FIX|FAIL`) equals the **native verdict prefix**. The `### Automated Checks`, `### Drift Analysis`, and `### Cross-Phase Integration` blocks are NOT scored — they are composed natively in both paths and should be byte-identical. Only the gross verdict label is the comparison surface.
+
+The cross-check rule (Constraint #9) means that when delegate disagrees with the underlying check data, the skill falls back to native — so a "MATCH" in the table can be produced either by (a) the delegate agreeing with native or (b) the cross-check tripping and the skill falling back to native classification. Both are valid path-equivalences for the agreement metric.
+
+---
+
+## Comparison protocol
+
+Run the following steps for each of the 10 selected issues.
+
+```bash
+# Pre-flight
+gemma-up                                  # start local LLM
+export RALPH_DELEGATE_ENABLED=true
+ISSUE_NUMBER=1185                         # iterate over the 10 selected issues
+ROOT=$(git rev-parse --show-toplevel)
+WORKTREE="$ROOT/worktrees/GH-${ISSUE_NUMBER}"
+
+# Step 1: delegated path
+[ -d "$WORKTREE" ] || git worktree add "$WORKTREE" "feature/GH-${ISSUE_NUMBER}"
+cd "$WORKTREE"
+# Invoke the skill against this worktree via the dispatch path the operator
+# uses (Skill, Agent, or the loop runner). Capture the verdict-prefix from
+# the resulting `## Validation` comment OR the skill's stdout (the line
+# starting with `VALIDATION `).
+echo "=== Delegated verdict for issue #$ISSUE_NUMBER ==="
+# Capture the first VALIDATION line of the skill's stdout (or the posted
+# comment body) into DELEGATED_PREFIX.
+
+# Step 2: native path
+unset RALPH_DELEGATE_ENABLED
+# Re-run the skill against the same worktree without delegation.
+echo "=== Native verdict for issue #$ISSUE_NUMBER ==="
+# Capture the first VALIDATION line into NATIVE_PREFIX.
+
+# Step 3: record
+# Append a row to the 10-row agreement table: ISSUE_NUMBER | DELEGATED_PREFIX |
+# NATIVE_PREFIX | MATCH or DELEGATED=<x> NATIVE=<y>.
+
+# Step 4: aggregate
+# Count MATCH rows. Compute (MATCH / 10) * 100. Target: >=80% (>=8 of 10).
+
+# Step 5: post the 10-row table + aggregate rate as a comment on issue #1190.
+```
+
+### Example agreement table (illustrative — not actual data)
+
+| Issue   | Delegated         | Native             | Outcome |
+|---------|-------------------|--------------------|---------|
+| #1185   | VALIDATION PASS   | VALIDATION PASS    | MATCH   |
+| #1186   | VALIDATION PASS   | VALIDATION PASS    | MATCH   |
+| #1187   | VALIDATION PASS   | VALIDATION PASS    | MATCH   |
+| #1188   | VALIDATION PASS   | VALIDATION PASS    | MATCH   |
+| #1189   | VALIDATION FAIL   | VALIDATION FAIL    | MATCH   |
+| #1100   | VALIDATION FIX    | VALIDATION FIX     | MATCH   |
+| #1101   | VALIDATION FAIL   | VALIDATION FAIL    | MATCH   |
+| #1099   | VALIDATION PASS   | VALIDATION FAIL    | DELEGATED=PASS NATIVE=FAIL |
+| #1097   | VALIDATION FAIL   | VALIDATION FAIL    | MATCH   |
+| #1098   | VALIDATION PASS   | VALIDATION PASS    | MATCH   |
+
+**Aggregate:** 9/10 MATCH = 90%. Passes the soft baseline of 80%.
+
+### Acceptable baseline
+
+**≥80% agreement (≥8 of 10 MATCH)** per Issue acceptance criterion #1. Below 80% triggers a prompt-refinement review — typical follow-ups:
+
+- Tweak the prompt's classification rules (the `Rules:` block in Step 7.0's bash heredoc) to be more concrete about "ambiguous" cases.
+- Swap the model via `RALPH_DELEGATE_VAL_CLASSIFY_MODEL` (e.g., try Qwen instead of Gemma).
+- Tune the threshold gate (currently `>=2 checks AND >=1 failure`) if telemetry shows the wrong cut — e.g., raise to `>=3` if 2-check classifications are noisy.
+- Drop the delegation site if the model can't match native on closed-label tasks — but only if Wave-3 telemetry (F5) confirms the score is structurally low, not a one-off.
+
+The 80% number is a starting baseline, not a hard SLA. Wave-3 (Features 4a/4b/4c) recalibrates it as real usage data accumulates in `~/.ralph-hero/delegate.log`; F5 (`#1191`) is the feature that turns this into automated drift detection.
+
+---
+
+## What this does NOT measure
+
+This eval compares **verdict prefixes in isolation**. It does NOT measure:
+
+- **Absolute correctness** — the "gold" verdict is itself the native verdict, so this is a self-consistency check, not a ground-truth check. The cross-check rule (Constraint #9) is the actual ground-truth guard: it prevents the delegate from disagreeing with the automated-check data, which is the authoritative signal.
+- **The verdict body sections** — `### Automated Checks`, `### Drift Analysis`, `### Cross-Phase Integration`, the `Verdict:` line, fix-command lists, substantive-failure detail lists. All composed natively in both paths; out of scope.
+- **Whether `create_comment` succeeds** — covered by the existing `skills/ralph-val/eval-scenarios.md` (3 scenarios: PASS, FIX, FAIL).
+- **The cross-check rule's effectiveness** — the cross-check is a Constraint #9 invariant exercised by the bats suite (`scripts/__tests__/val-agent-delegation.bats`), not the eval.
+- **Latency or cost** — delegation may be slower or faster than native; that signal lives in the JSONL audit log at `~/.ralph-hero/delegate.log`, not here.
+
+---
+
+## Re-run cadence
+
+Re-run the 10-issue eval after:
+
+- **Model swaps** — when `RALPH_DELEGATE_VAL_CLASSIFY_MODEL` (or the default `RALPH_LLM_MODEL`) changes.
+- **Wrapper changes** — when `ralph-delegate.sh` or `lib/openai-compat.sh` is modified (F5, F6, or any future foundation work).
+- **Prompt refinements** — when the prompt template in `skills/ralph-val/SKILL.md` Step 7.0 is edited.
+- **Quarterly during Wave-4** — once telemetry (F5) ships, the operator may re-run quarterly to detect drift.
+
+Document each re-run as a follow-up comment on issue #1190 (or a fresh tracking issue if the cadence becomes frequent enough to warrant its own thread).
+
+---
+
+## Special cases
+
+How to handle edge cases during selection or scoring:
+
+- **Worktree pruned** — skip the issue and select a replacement. Re-creating the worktree from `feature/GH-NNN` is allowed if the branch still exists on the remote; otherwise skip.
+- **Plan no longer exists** — skip the issue and select a replacement. The `## Implementation Plan` comment URL must resolve.
+- **`Queue empty` verdict** — skip (not a real classification; produced by the queue-pick branch when no In Progress issue has a worktree).
+- **Threshold gate trips (all checks pass)** — MATCH is automatic because both paths produce `VALIDATION PASS` deterministically. Count as MATCH; no delegation invocation, no audit-log line written.
+- **Cross-check trips on the delegated path** — the skill falls back to native, so the recorded "delegated" prefix equals the native prefix → MATCH by construction. Annotate the row with `(cross-check fired)` for transparency but count as MATCH.
+- **Delegate timeout or unreachable on the delegated path** — falls back to native; same construction → MATCH. Annotate `(fallback rc=124)` or `(fallback rc=127)`.
+- **Stale worktree (behind origin/main)** — record `staleness` as a substantive failure note per Step 4's freshness check. The verdict prefix still classifies normally; the staleness annotation does not change the prefix.

--- a/plugin/ralph-hero/scripts/__tests__/val-agent-delegation.bats
+++ b/plugin/ralph-hero/scripts/__tests__/val-agent-delegation.bats
@@ -1,0 +1,434 @@
+#!/usr/bin/env bats
+# val-agent-delegation.bats — Unit tests for the verdict-classification bash
+# block embedded in `plugin/ralph-hero/skills/ralph-val/SKILL.md` (Step 7.0).
+#
+# The function under test (`run_val_classify`) mirrors the bash block in the
+# skill body's "Step 7.0: Classify Verdict (optional delegation)" section.
+# UPDATE BOTH IN LOCKSTEP — if the skill body changes, this file must follow.
+#
+# Hermetic by design: stubs the HTTP endpoint inside the test process via a
+# Python HTTPServer, points RALPH_LLM_URL at the stub, and writes the audit
+# log to TEST_TMPDIR. Mirrors `pr-agent-delegation.bats` (F4b) and
+# `codebase-locator-delegation.bats` (F4a) setup/teardown 1:1, with
+# task-specific stub modes and helper functions.
+#
+# Known gap: the symmetric cross-check branch (delegate=fail, failed_checks=0)
+# is documented in the skill body but not exercised here. It is unreachable in
+# practice because the threshold gate requires failed_checks>=1 before
+# delegation fires. Documented for completeness.
+
+DELEGATE_SCRIPT="${BATS_TEST_DIRNAME}/../ralph-delegate.sh"
+
+setup() {
+    set +u
+    TEST_TMPDIR=$(mktemp -d)
+    export RALPH_DELEGATE_LOG_PATH="$TEST_TMPDIR/delegate.log"
+    # Make sure we don't accidentally inherit caller env vars
+    unset RALPH_DELEGATE_ENABLED 2>/dev/null || true
+    unset RALPH_DELEGATE_TIMEOUT_SECONDS 2>/dev/null || true
+    unset RALPH_DELEGATE_VAL_CLASSIFY_URL 2>/dev/null || true
+    unset RALPH_DELEGATE_VAL_CLASSIFY_MODEL 2>/dev/null || true
+    unset RALPH_LLM_URL 2>/dev/null || true
+    unset RALPH_LLM_MODEL 2>/dev/null || true
+    STUB_PID=""
+    STUB_PORT=""
+}
+
+teardown() {
+    if [ -n "${STUB_PID:-}" ]; then
+        kill "$STUB_PID" 2>/dev/null || true
+        wait "$STUB_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TEST_TMPDIR"
+}
+
+# --- Val-classify-specific endpoint stub helpers ---
+#
+# start_val_classify_stub_endpoint <mode>
+#   mode=valid_pass        -> respond with chat-completion content holding a
+#                             well-formed `{"classification":"pass",...}` JSON
+#                             (valid enum, jq guard accepts)
+#   mode=valid_fail        -> respond with chat-completion content holding a
+#                             well-formed `{"classification":"fail",...}` JSON
+#   mode=needs_review      -> respond with chat-completion content holding a
+#                             well-formed `{"classification":"needs-review",...}` JSON
+#                             (delegate explicitly uncertain)
+#   mode=invalid_enum      -> respond with chat-completion content holding a
+#                             well-formed JSON whose classification is an
+#                             unexpected token (e.g. "maybe"); case-statement
+#                             guard trips
+#   mode=malformed_content -> respond with chat-completion content "not really
+#                             json" (the wrapper succeeds at HTTP, but the
+#                             skill's `jq -er .classification` guard trips)
+#   mode=slow              -> sleep 3s before responding (timeout test)
+#   mode=ok_default        -> generic ok chat-completion (unused but kept for
+#                             parity with F4a/F4b stubs)
+#
+# Picks a free port, exports STUB_PORT and STUB_PID. Waits up to ~2s for the
+# port to start accepting connections.
+start_val_classify_stub_endpoint() {
+    local mode="$1"
+    STUB_PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')
+
+    python3 - "$STUB_PORT" "$mode" >"$TEST_TMPDIR/stub.log" 2>&1 <<'PY' &
+import sys, json, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+mode = sys.argv[2]
+
+VALID_PASS = json.dumps({
+    "classification": "pass",
+    "rationale": "All four automated checks succeeded and the desired end state appears satisfied.",
+})
+VALID_FAIL = json.dumps({
+    "classification": "fail",
+    "rationale": "Two unit tests failed in the npm test run.",
+})
+NEEDS_REVIEW = json.dumps({
+    "classification": "needs-review",
+    "rationale": "One check could not be executed because the script was missing executable permissions.",
+})
+INVALID_ENUM = json.dumps({
+    "classification": "maybe",
+    "rationale": "Looks fine.",
+})
+MALFORMED = "not really json"
+OK_DEFAULT = "ok"
+
+def chat_completion(content):
+    return json.dumps({
+        "choices":[{"message":{"role":"assistant","content":content}}]
+    }).encode()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a, **k):
+        pass
+
+    def _send_json(self, body):
+        self.send_response(200)
+        self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length",str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path.startswith("/v1/models"):
+            self._send_json(json.dumps({"data":[{"id":"stub-model"}]}).encode())
+        else:
+            self.send_response(404); self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length","0"))
+        if length:
+            self.rfile.read(length)
+        if mode == "slow":
+            time.sleep(3)
+        if mode == "valid_pass":
+            self._send_json(chat_completion(VALID_PASS))
+        elif mode == "valid_fail":
+            self._send_json(chat_completion(VALID_FAIL))
+        elif mode == "needs_review":
+            self._send_json(chat_completion(NEEDS_REVIEW))
+        elif mode == "invalid_enum":
+            self._send_json(chat_completion(INVALID_ENUM))
+        elif mode == "malformed_content":
+            self._send_json(chat_completion(MALFORMED))
+        else:
+            # ok_default
+            self._send_json(chat_completion(OK_DEFAULT))
+
+srv = HTTPServer(("127.0.0.1", port), H)
+srv.serve_forever()
+PY
+    STUB_PID=$!
+
+    # Wait for port to become connectable (max ~2s)
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+        if python3 -c "import socket;s=socket.socket();s.settimeout(0.1);
+try:
+    s.connect(('127.0.0.1',$STUB_PORT))
+    print('up')
+except Exception:
+    raise SystemExit(1)" 2>/dev/null | grep -q up; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+# --- Function under test ---
+#
+# run_val_classify <total_checks> <failed_checks> <substantive_failures> \
+#                  <desired_end_state> <per_check_summary>
+#
+# Mirrors the bash block in `skills/ralph-val/SKILL.md` Step 7.0. Counts
+# accepted as inputs (the skill computes them from Step 6's check results).
+# Composes the prompt, runs the threshold gate, invokes the wrapper inside an
+# `if OUTPUT=$(...)` guard, validates the response with `jq -er .classification`
+# + bash case-statement enum guard, runs the cross-check (Constraint #9), maps
+# gross fail to FIX vs FAIL via mechanical/substantive routing (Constraint #13),
+# and prints one of:
+#   VALIDATION PASS                    — happy path, all-pass / delegate=pass
+#   VALIDATION FIX                     — happy path, delegate=fail + mechanical-only
+#   VALIDATION FAIL                    — happy path, delegate=fail + substantive
+#   FALLBACK rc=0,bad-shape            — wrapper succeeded but JSON/enum invalid
+#   FALLBACK rc=0,cross-check-pass     — delegate=pass but substantive failures present
+#   FALLBACK rc=0,cross-check-fail     — delegate=fail but failed_checks==0 (unreachable in practice)
+#   FALLBACK rc=0,needs-review         — delegate explicitly uncertain
+#   FALLBACK rc=126                    — delegation disabled (silent fallback)
+#   FALLBACK rc=127                    — endpoint unreachable
+#   FALLBACK rc=124                    — wrapper timed out
+#   FALLBACK rc=1                      — wrapper hard error
+#   BELOW_THRESHOLD                    — total_checks<2 || failed_checks==0 (threshold gate)
+#
+# UPDATE THIS FUNCTION IN LOCKSTEP WITH THE SKILL BODY.
+run_val_classify() {
+    local total_checks="$1"
+    local failed_checks="$2"
+    local substantive_failures="$3"
+    local desired_end_state="${4:-Plan desired end state snippet.}"
+    local per_check_summary="${5:-- npm test: PASS}"
+
+    # --- Threshold gate (Constraint #10: >=2 checks AND >=1 failure) ---
+    if [ "$total_checks" -lt 2 ] || [ "$failed_checks" -eq 0 ]; then
+        echo "BELOW_THRESHOLD"
+        return 0
+    fi
+
+    local PROMPT_FILE
+    PROMPT_FILE=$(mktemp -t val-classify-XXXXXX)
+    cat > "$PROMPT_FILE" <<EOF
+You are classifying the outcome of an automated validation run.
+
+Desired end state (from the plan):
+${desired_end_state}
+
+Per-check results (PASS|FAIL [reason]):
+${per_check_summary}
+
+Drift analysis summary:
+- Phase 1: 0 drifts
+
+Cross-phase integration:
+Single-phase plan — skipped
+
+Return a JSON object with this exact shape — no prose before or after:
+{"classification": "pass" | "fail" | "needs-review", "rationale": "<one-sentence>"}
+
+Rules:
+- "pass" when every check is PASS and the desired end state is satisfied.
+- "fail" when at least one check FAILed.
+- "needs-review" only if the result is genuinely ambiguous (e.g., a check
+  could not run or the desired end state is unclear).
+EOF
+
+    set +e
+    if OUTPUT=$("$DELEGATE_SCRIPT" \
+                  --task val_classify \
+                  --prompt-file "$PROMPT_FILE" \
+                  --max-tokens 128 \
+                  --temperature 0.0 2>/dev/null); then
+        local CLASSIFICATION jq_rc
+        CLASSIFICATION=$(printf '%s' "$OUTPUT" | jq -er .classification 2>/dev/null)
+        jq_rc=$?
+        if [ "$jq_rc" -ne 0 ]; then
+            echo "FALLBACK rc=0,bad-shape"
+        else
+            case "$CLASSIFICATION" in
+                pass)
+                    if [ "$substantive_failures" -gt 0 ]; then
+                        echo "FALLBACK rc=0,cross-check-pass"
+                    else
+                        echo "VALIDATION PASS"
+                    fi
+                    ;;
+                fail)
+                    if [ "$failed_checks" -eq 0 ]; then
+                        echo "FALLBACK rc=0,cross-check-fail"
+                    else
+                        if [ "$substantive_failures" -gt 0 ]; then
+                            echo "VALIDATION FAIL"
+                        else
+                            echo "VALIDATION FIX"
+                        fi
+                    fi
+                    ;;
+                needs-review)
+                    echo "FALLBACK rc=0,needs-review"
+                    ;;
+                *)
+                    echo "FALLBACK rc=0,bad-shape"
+                    ;;
+            esac
+        fi
+    else
+        rc=$?
+        echo "FALLBACK rc=$rc"
+    fi
+    set -e
+
+    rm -f "$PROMPT_FILE"
+}
+
+# --- Tests ---
+
+@test "Test 1 — threshold gate: all-pass deterministic, no wrapper call, byte-identical log" {
+    # Threshold: total_checks<2 || failed_checks==0 → below threshold → no delegation.
+    # All-pass case (failed_checks==0): deterministic VALIDATION PASS, no wrapper.
+    # Mirrors Constraint #10 and the early-return branch in the skill.
+    export RALPH_DELEGATE_ENABLED=true
+    # Do NOT start a stub; the threshold gate trips before any wrapper call.
+
+    local pre_bytes=0
+    if [ -f "$RALPH_DELEGATE_LOG_PATH" ]; then
+        pre_bytes=$(wc -c < "$RALPH_DELEGATE_LOG_PATH" | tr -d ' ')
+    fi
+
+    run run_val_classify 5 0 0 "End state." "- npm test: PASS"
+    [ "$status" -eq 0 ]
+    [ "$output" = "BELOW_THRESHOLD" ]
+
+    # No wrapper invocation → no audit-log line → byte-identical log file.
+    local post_bytes=0
+    if [ -f "$RALPH_DELEGATE_LOG_PATH" ]; then
+        post_bytes=$(wc -c < "$RALPH_DELEGATE_LOG_PATH" | tr -d ' ')
+    fi
+    [ "$pre_bytes" -eq "$post_bytes" ]
+}
+
+@test "Test 2 — happy path FAIL: delegate=fail + substantive failures → VALIDATION FAIL" {
+    start_val_classify_stub_endpoint valid_fail
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    run run_val_classify 5 2 2 "End state." "- npm test: FAIL [2 failures]
+- npm run build: PASS"
+    [ "$status" -eq 0 ]
+    [ "$output" = "VALIDATION FAIL" ]
+
+    # Audit log records the delegated invocation succeeded at HTTP.
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"val_classify"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 3 — happy path FIX: delegate=fail + mechanical-only failures → VALIDATION FIX" {
+    start_val_classify_stub_endpoint valid_fail
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    # 5 checks, 2 failed, 0 substantive → all failures are mechanical.
+    # Delegate=fail + cross-check passes (failed_checks>0) → routing maps to FIX.
+    run run_val_classify 5 2 0 "End state." "- prettier --check: FAIL [reformat needed]
+- npm test: PASS"
+    [ "$status" -eq 0 ]
+    [ "$output" = "VALIDATION FIX" ]
+
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"val_classify"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 4 — cross-check trip: delegate=pass + substantive failures present → fallback" {
+    start_val_classify_stub_endpoint valid_pass
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    # 5 checks, 3 failed, 2 substantive. Delegate=pass is inconsistent with
+    # substantive_failures>0 → cross-check trips → FALLBACK.
+    run run_val_classify 5 3 2 "End state." "- npm test: FAIL [2 substantive]
+- prettier --check: FAIL [mechanical]"
+    [ "$status" -eq 0 ]
+    [ "$output" = "FALLBACK rc=0,cross-check-pass" ]
+
+    # The wrapper succeeded at the HTTP layer; the cross-check failure is
+    # the skill's concern, not the wrapper's. Audit log records status=ok.
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"val_classify"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 5 — needs-review classification: delegate uncertain → fallback" {
+    start_val_classify_stub_endpoint needs_review
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    run run_val_classify 5 2 2 "End state." "- npm test: FAIL"
+    [ "$status" -eq 0 ]
+    [ "$output" = "FALLBACK rc=0,needs-review" ]
+
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"val_classify"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 6 — malformed JSON content: jq -er guard trips, falls back" {
+    start_val_classify_stub_endpoint malformed_content
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    run run_val_classify 5 2 2 "End state." "- npm test: FAIL"
+    [ "$status" -eq 0 ]
+    [ "$output" = "FALLBACK rc=0,bad-shape" ]
+
+    # The wrapper succeeded at the HTTP layer; the parse failure is the
+    # skill's concern, not the wrapper's. Audit log records status=ok.
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"val_classify"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 7 — invalid enum value: case-statement guard trips, falls back" {
+    start_val_classify_stub_endpoint invalid_enum
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+
+    run run_val_classify 5 2 2 "End state." "- npm test: FAIL"
+    [ "$status" -eq 0 ]
+    [ "$output" = "FALLBACK rc=0,bad-shape" ]
+
+    # The enum guard treats any value not in {pass, fail, needs-review} as
+    # bad-shape, indistinguishable from a missing-field case in the marker.
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"val_classify"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"ok"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 8 — timeout: wrapper returns 124, function falls back" {
+    start_val_classify_stub_endpoint slow
+    export RALPH_DELEGATE_ENABLED=true
+    export RALPH_LLM_URL="http://127.0.0.1:$STUB_PORT"
+    export RALPH_DELEGATE_TIMEOUT_SECONDS=1
+
+    run run_val_classify 5 2 2 "End state." "- npm test: FAIL"
+    [ "$status" -eq 0 ]
+    [[ "$output" == FALLBACK\ rc=124* ]]
+
+    [ -f "$RALPH_DELEGATE_LOG_PATH" ]
+    grep -q '"task":"val_classify"' "$RALPH_DELEGATE_LOG_PATH"
+    grep -q '"status":"timeout"' "$RALPH_DELEGATE_LOG_PATH"
+}
+
+@test "Test 9 — disabled: no audit log line, byte-identical log file" {
+    # Do NOT set RALPH_DELEGATE_ENABLED. Do NOT start a stub.
+    # Capture log file byte count pre and post — must be identical (0 vs 0,
+    # or non-existent vs non-existent). Mirrors F4a's Test 4 and F4b's
+    # Test 5 invariant.
+    local pre_bytes=0
+    if [ -f "$RALPH_DELEGATE_LOG_PATH" ]; then
+        pre_bytes=$(wc -c < "$RALPH_DELEGATE_LOG_PATH" | tr -d ' ')
+    fi
+
+    run run_val_classify 5 2 2 "End state." "- npm test: FAIL"
+    [ "$status" -eq 0 ]
+    [ "$output" = "FALLBACK rc=126" ]
+
+    local post_bytes=0
+    if [ -f "$RALPH_DELEGATE_LOG_PATH" ]; then
+        post_bytes=$(wc -c < "$RALPH_DELEGATE_LOG_PATH" | tr -d ' ')
+    fi
+    [ "$pre_bytes" -eq "$post_bytes" ]
+}

--- a/plugin/ralph-hero/skills/ralph-val/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-val/SKILL.md
@@ -237,15 +237,204 @@ Cross-Phase Integration:
 
 If the plan has only one phase, report: `Cross-Phase Integration: Single-phase plan — skipped`
 
+## Step 7.0: Classify Verdict (optional delegation)
+
+When delegation is enabled (`RALPH_DELEGATE_ENABLED=true`), the plan's `## Desired End State` snippet + the per-check summary (from Step 6) + the drift analysis summary (from Step 6.5) + the cross-phase integration result (from Step 6.6) are sent to a local LLM via the wrapper at `$CLAUDE_PLUGIN_ROOT/scripts/` (task name `val_classify`), which returns a strict 3-value enum (`pass`|`fail`|`needs-review`). The skill **cross-checks** the enum against the automated-check results — the delegate is advisory, not authoritative — and uses the result to inform the verdict-prefix selection in Step 7 below. Everything else (the `### Automated Checks` per-check list, the `### Drift Analysis`, the `### Cross-Phase Integration`, the `Verdict:` line, the failure-detail sections, the `create_comment` MCP call) is composed and invoked natively. Delegation is opt-in (operator sets the env var); when off, the skill classifies natively as today.
+
+**Delegation is for classification only.** The verdict body (per-check list, drift analysis, cross-phase integration, fix-command list, substantive-failure detail list) is composed natively in Step 7. The `create_comment` MCP call in Step 8 is invoked natively in all cases — the delegate's output is text-in for the verdict-prefix selection and nothing else. Never let delegated text reach the comment body or any GitHub mutation. (See `skills/shared/delegation-conventions.md` for the eligibility matrix and the no-mutation rule.)
+
+The `VERDICT_PREFIX` set here MUST be exactly one of `VALIDATION PASS`, `VALIDATION FIX`, or `VALIDATION FAIL` (the literal tokens the `val-postcondition.sh` Stop hook accepts). The skill MUST NOT substitute alternate vocabulary — see Step 7's "Verdict format (strict)" section. This guards against the delegate's `rationale` field leaking into the verdict prefix.
+
+Operators may pin a different model for this task via `RALPH_DELEGATE_VAL_CLASSIFY_URL` / `RALPH_DELEGATE_VAL_CLASSIFY_MODEL`. The wrapper resolves per-task overrides without code changes here (F1's `_resolve_task_var` upper-cases `val_classify` → `VAL_CLASSIFY`).
+
+Run the following bash block. The control flow (`set +e`, `if OUTPUT=$(...)`, `case "$rc"`, unconditional `rm -f`) mirrors the reference pattern in `skills/delegate-test/SKILL.md`, F4a's `agents/codebase-locator.md` § "Candidate Ranking", and F4b's `skills/ralph-pr/SKILL.md` § "Step 5.0". Task-specific deviations: (a) **threshold gate** counts checks (`total_checks >= 2 AND failed_checks >= 1`), (b) **strict 3-value enum JSON guard** via `jq -er .classification` + bash `case` statement instead of `jq -e .ranked` or byte-length prose guards, (c) **cross-check rule** — delegate is advisory; inconsistency with automated checks triggers native fallback, (d) `--max-tokens 128 --temperature 0.0` (small budget for the enum response).
+
+```bash
+# --- Inputs (set from the prior steps' context) ---
+#   TOTAL_CHECKS              — total automated checks run (Step 6)
+#   FAILED_CHECKS             — number of failed checks (Step 6)
+#   SUBSTANTIVE_FAILURES      — number of substantive failures (Step 7's
+#                               in-context mechanical/substantive classification,
+#                               which runs regardless of delegation)
+#   DESIRED_END_STATE_SNIPPET — first paragraph of the plan's ## Desired End State
+#   PER_CHECK_SUMMARY         — compact per-check summary, one line per check,
+#                               max 30 lines: "- <name>: PASS|FAIL [<reason>]"
+#   DRIFT_SUMMARY             — one line per phase from Step 6.5, max 10 lines
+#   CROSS_PHASE_RESULT        — one line summary from Step 6.6
+#
+# Output: VERDICT_PREFIX — exactly one of:
+#   VALIDATION PASS | VALIDATION FIX | VALIDATION FAIL
+
+TOTAL_CHECKS=${TOTAL_CHECKS:-0}
+FAILED_CHECKS=${FAILED_CHECKS:-0}
+SUBSTANTIVE_FAILURES=${SUBSTANTIVE_FAILURES:-0}
+
+# --- Threshold gate (Constraint #10: >=2 checks AND >=1 failure) ---
+if [ "$TOTAL_CHECKS" -lt 2 ] || [ "$FAILED_CHECKS" -eq 0 ]; then
+    # Below threshold — compose natively, skip delegation entirely. All-pass
+    # case is deterministic: VALIDATION PASS. No wrapper call, no tempfile,
+    # no audit-log line.
+    VERDICT_PREFIX="VALIDATION PASS"
+else
+    # --- Threshold met — build prompt and try delegation ---
+    PROMPT_FILE=$(mktemp -t val-classify-XXXXXX)
+    cat > "$PROMPT_FILE" <<EOF
+You are classifying the outcome of an automated validation run.
+
+Desired end state (from the plan):
+${DESIRED_END_STATE_SNIPPET}
+
+Per-check results (PASS|FAIL [reason]):
+${PER_CHECK_SUMMARY}
+
+Drift analysis summary:
+${DRIFT_SUMMARY}
+
+Cross-phase integration:
+${CROSS_PHASE_RESULT}
+
+Return a JSON object with this exact shape — no prose before or after:
+{"classification": "pass" | "fail" | "needs-review", "rationale": "<one-sentence>"}
+
+Rules:
+- "pass" when every check is PASS and the desired end state is satisfied.
+- "fail" when at least one check FAILed.
+- "needs-review" only if the result is genuinely ambiguous (e.g., a check
+  could not run or the desired end state is unclear).
+EOF
+
+    # 8 KB prompt size cap (Constraint #11). If over, truncate the per-check
+    # summary block (the longest typically) first. If still over after
+    # truncation, fall back to native.
+    PROMPT_BYTES=$(wc -c < "$PROMPT_FILE" | tr -d ' ')
+    if [ "$PROMPT_BYTES" -gt 8192 ]; then
+        TRUNCATED_PER_CHECK=$(printf '%s' "$PER_CHECK_SUMMARY" | head -c 4096)
+        cat > "$PROMPT_FILE" <<EOF
+You are classifying the outcome of an automated validation run.
+
+Desired end state (from the plan):
+${DESIRED_END_STATE_SNIPPET}
+
+Per-check results (PASS|FAIL [reason]):
+${TRUNCATED_PER_CHECK}
+
+Drift analysis summary:
+${DRIFT_SUMMARY}
+
+Cross-phase integration:
+${CROSS_PHASE_RESULT}
+
+Return a JSON object with this exact shape — no prose before or after:
+{"classification": "pass" | "fail" | "needs-review", "rationale": "<one-sentence>"}
+
+Rules:
+- "pass" when every check is PASS and the desired end state is satisfied.
+- "fail" when at least one check FAILed.
+- "needs-review" only if the result is genuinely ambiguous (e.g., a check
+  could not run or the desired end state is unclear).
+EOF
+        PROMPT_BYTES=$(wc -c < "$PROMPT_FILE" | tr -d ' ')
+    fi
+
+    if [ "$PROMPT_BYTES" -gt 8192 ]; then
+        # Still oversized — fall back to native without invoking the wrapper.
+        # Native classification: any substantive failure → FAIL; only
+        # mechanical failures → FIX; all pass → PASS (the existing Step 7
+        # logic).
+        if [ "$SUBSTANTIVE_FAILURES" -gt 0 ]; then
+            VERDICT_PREFIX="VALIDATION FAIL"
+        else
+            VERDICT_PREFIX="VALIDATION FIX"
+        fi
+        rm -f "$PROMPT_FILE"
+    else
+        # Default native value — overwritten only if the delegate path returns
+        # a shape-valid + cross-check-passing classification below.
+        if [ "$SUBSTANTIVE_FAILURES" -gt 0 ]; then
+            VERDICT_PREFIX="VALIDATION FAIL"
+        else
+            VERDICT_PREFIX="VALIDATION FIX"
+        fi
+
+        set +e
+        if OUTPUT=$("$CLAUDE_PLUGIN_ROOT/scripts/ralph-delegate.sh" \
+                      --task val_classify \
+                      --prompt-file "$PROMPT_FILE" \
+                      --max-tokens 128 \
+                      --temperature 0.0 2>/dev/null); then
+            # Wrapper succeeded at HTTP. Validate the response shape in two
+            # stages: (1) jq -er .classification extracts the field; (2) a
+            # bash case statement restricts the value to exactly the three
+            # accepted tokens (pass|fail|needs-review). Any other value is
+            # treated as bad-shape and falls back.
+            CLASSIFICATION=$(printf '%s' "$OUTPUT" | jq -er .classification 2>/dev/null)
+            jq_rc=$?
+            if [ "$jq_rc" -ne 0 ]; then
+                echo "delegation: fell back to native (rc=0, bad-shape)"
+            else
+                case "$CLASSIFICATION" in
+                    pass)
+                        # Cross-check (Constraint #9): delegate=pass is only
+                        # consistent when SUBSTANTIVE_FAILURES==0. If a
+                        # substantive failure was recorded, fall back.
+                        if [ "$SUBSTANTIVE_FAILURES" -gt 0 ]; then
+                            echo "delegation: cross-check failed (delegate=pass, substantive_failures=$SUBSTANTIVE_FAILURES) — falling back to native"
+                        else
+                            VERDICT_PREFIX="VALIDATION PASS"
+                        fi
+                        ;;
+                    fail)
+                        # Cross-check (Constraint #9): delegate=fail is only
+                        # consistent when FAILED_CHECKS>0 (which the threshold
+                        # gate already enforces). If somehow no checks failed,
+                        # fall back.
+                        if [ "$FAILED_CHECKS" -eq 0 ]; then
+                            echo "delegation: cross-check failed (delegate=fail, failed_checks=0) — falling back to native"
+                        else
+                            # Map gross fail to FIX vs FAIL via the native
+                            # mechanical/substantive routing (Constraint #13).
+                            if [ "$SUBSTANTIVE_FAILURES" -gt 0 ]; then
+                                VERDICT_PREFIX="VALIDATION FAIL"
+                            else
+                                VERDICT_PREFIX="VALIDATION FIX"
+                            fi
+                        fi
+                        ;;
+                    needs-review)
+                        # Delegate explicitly admitted uncertainty — fall back.
+                        echo "delegation: needs-review — falling back to native"
+                        ;;
+                    *)
+                        # Enum guard tripped — fall back.
+                        echo "delegation: fell back to native (rc=0, bad-shape)"
+                        ;;
+                esac
+            fi
+        else
+            rc=$?
+            case "$rc" in
+                126) ;; # disabled — compose natively, no note printed
+                127|124|1) echo "delegation: fell back to native (rc=$rc)" ;;
+            esac
+        fi
+        set -e
+
+        rm -f "$PROMPT_FILE"
+    fi
+fi
+```
+
+After this block, `VERDICT_PREFIX` holds exactly one of `VALIDATION PASS`, `VALIDATION FIX`, or `VALIDATION FAIL`. Step 7 below uses `${VERDICT_PREFIX}` as the first line of the verdict block; every other line of the verdict body is composed natively per the existing Step 7 templates.
+
 ## Step 7: Produce Verdict
 
-Classify each failure, then choose the verdict:
+Classify each failure (mechanical-vs-substantive) and use the `${VERDICT_PREFIX}` set by Step 7.0 as the first line of the verdict block. The mechanical-vs-substantive classification feeds the in-context routing that Step 7.0's bash block consumes via `SUBSTANTIVE_FAILURES`; the `${VERDICT_PREFIX}` value is what the verdict line starts with.
 
 **Failure classification:**
 - **Mechanical**: has a deterministic auto-fix — formatter (`prettier --write`), linter (`eslint --fix`), missing trailing newline, import sorting. No judgment needed.
 - **Substantive**: tests fail, missing functionality, wrong behavior, missing files the plan requires. Requires implementation work.
 
-**Verdict rules:**
+**Verdict rules** (these are the same rules Step 7.0's native fallback applies; Step 7.0's delegated path produces a `${VERDICT_PREFIX}` that is consistent with these rules after the cross-check guard):
 - All checks pass → `PASS`
 - Only mechanical failures → `FIX` (list the fix commands)
 - Any substantive failure → `FAIL`
@@ -260,12 +449,12 @@ VALIDATION FIX
 VALIDATION FAIL
 ```
 
-Do NOT substitute other status words (e.g. `BLOCKED`, `COMPLETE`, `Phase Assessment`, `Status: ❌`). These are not recognized by `val-postcondition.sh` and will cause the Stop hook to block. Use the literal `VALIDATION PASS|FIX|FAIL` prefix verbatim — no emoji, no bold, no alternate vocabulary.
+Do NOT substitute other status words (e.g. `BLOCKED`, `COMPLETE`, `Phase Assessment`, `Status: ❌`). These are not recognized by `val-postcondition.sh` and will cause the Stop hook to block. Use the literal `VALIDATION PASS|FIX|FAIL` prefix verbatim — no emoji, no bold, no alternate vocabulary. The first line of the verdict report MUST be `${VERDICT_PREFIX}` (set by Step 7.0); the skill MUST NOT recompute the prefix in-context.
 
 Output the validation report:
 
 ```
-VALIDATION [PASS/FIX/FAIL]
+${VERDICT_PREFIX}
 Issue: #NNN
 Plan: [plan path]
 Worktree: [worktree path]


### PR DESCRIPTION
## Summary

Wire \`val-agent\`'s pass/fail classification step to optionally delegate via \`ralph-delegate.sh\`. Adds Step 7.0 to \`skills/ralph-val/SKILL.md\` with strict 3-value enum (pass|fail|needs-review) JSON validation, cross-check against automated-check results, and threshold gate. Native Claude still composes the verdict comment and decides whether to advance the issue.

## Plan

[2026-05-12-GH-1190-val-agent-classification-delegation.md](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-12-GH-1190-val-agent-classification-delegation.md)

Phase shipped: 1 of 1

## Test plan

- [x] Automated verification per plan Success Criteria
  - 9/9 new F4c bats tests pass (threshold gate, happy paths, cross-check trip, needs-review, malformed JSON, invalid enum, timeout, disabled)
  - F1/F2/F4a/F4b regression-clean: all existing bats suites green
  - npm run build + test all green
- [x] Manual verification per plan Success Criteria
  - Wrapper-only: \`grep -c 'ralph-delegate.sh' skills/ralph-val/SKILL.md\` = 1
  - Mutation preserved: \`create_comment\` in Step 8 unchanged
  - FIX classification stays native (mechanical-vs-substantive routing in-skill)
  - No-regression: with \`RALPH_DELEGATE_ENABLED\` unset, bit-identical behavior to today

Closes #1190