### PR TITLE
GH-1247: unblock chain producer-consumer alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,3 +208,11 @@ jobs:
           scandir: plugin/ralph-hero/hooks
           severity: error
           format: gcc
+
+  lint-escalation-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Verify escalating skills produce canonical `## Escalation` comment (GH-1247)
+        run: bash plugin/ralph-hero/scripts/lint-escalation-contract.sh

--- a/plugin/ralph-hero/scripts/lint-escalation-contract.sh
+++ b/plugin/ralph-hero/scripts/lint-escalation-contract.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# lint-escalation-contract.sh — verify escalating skills produce a canonical
+# `## Escalation` comment so the unblock chain (GH-1247) can discover them.
+#
+# Background
+#   `ralph-unblock` (producer) and `/ralph-hero:unblock` (consumer) discover
+#   Human Needed work by searching for a `## Escalation` comment header on
+#   the issue. When a skill transitions an issue to Human Needed (via the
+#   `__ESCALATE__` semantic intent) it MUST also post a canonical
+#   `## Escalation` comment — either inline in the skill body or by
+#   including the shared `escalation-steps.md` fragment that posts it.
+#
+# Heuristic
+#   For every `plugin/ralph-hero/skills/<name>/SKILL.md` that mentions
+#   `__ESCALATE__`, require one of:
+#     (a) the file contains the literal markdown header `## Escalation`
+#         (i.e., it posts the comment inline), OR
+#     (b) the file `!cat`-includes `shared/fragments/escalation-steps.md`
+#         (the canonical inclusion path used by ralph-impl, ralph-plan,
+#          ralph-research, ralph-review, ralph-split, ralph-triage,
+#          ralph-plan-epic).
+#
+# Scope
+#   This lint is advisory — failing it means a skill is escalating without
+#   canonical context (a hygiene issue, not a runtime correctness issue,
+#   because `ralph-unblock` has a fallback path that reads the issue body).
+#   Catching the drift at PR time keeps the unblock chain rich.
+#
+# Exit codes
+#   0   all escalating skills produce `## Escalation` (inline or via fragment)
+#   1   one or more escalating skills are missing the canonical comment
+#   2   usage error (wrong invocation, repo layout unrecognized)
+#
+# Run from anywhere — the script resolves paths relative to its own
+# location so CI and local invocations both work.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(cd "$SCRIPT_DIR/../skills" && pwd)"
+
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "lint-escalation-contract: cannot locate skills directory at $SKILLS_DIR" >&2
+  exit 2
+fi
+
+FRAGMENT_REL="shared/fragments/escalation-steps.md"
+FRAGMENT_ABS="$SKILLS_DIR/$FRAGMENT_REL"
+
+if [[ ! -f "$FRAGMENT_ABS" ]]; then
+  echo "lint-escalation-contract: canonical fragment missing at $FRAGMENT_ABS" >&2
+  exit 2
+fi
+
+missing=()
+checked=0
+
+# Iterate every SKILL.md under skills/ (skip the shared/ tree itself —
+# fragments aren't skills, they're includes).
+while IFS= read -r -d '' skill_file; do
+  # Skip files inside the shared/ helper tree.
+  case "$skill_file" in
+    *"/skills/shared/"*) continue ;;
+  esac
+
+  # Only consider files that actually escalate.
+  if ! grep -q '__ESCALATE__' "$skill_file"; then
+    continue
+  fi
+
+  checked=$((checked + 1))
+
+  has_inline_header=0
+  has_fragment_include=0
+
+  # (a) Inline canonical header — must appear at the start of a line and
+  # be exactly `## Escalation` (no trailing words). That excludes prose
+  # mentions like "the `## Escalation` comment" and documentation section
+  # titles like `## Escalation Protocol`, while still matching the literal
+  # comment body posted to GitHub.
+  if grep -qE '^## Escalation[[:space:]]*$' "$skill_file"; then
+    has_inline_header=1
+  fi
+
+  # (b) Shared fragment include via the `!cat ... escalation-steps.md`
+  # idiom used by every other escalating skill.
+  if grep -qE '!cat[[:space:]].*escalation-steps\.md' "$skill_file"; then
+    has_fragment_include=1
+  fi
+
+  if (( has_inline_header == 0 && has_fragment_include == 0 )); then
+    rel="${skill_file#"$SKILLS_DIR/"}"
+    missing+=("$rel")
+  fi
+done < <(find "$SKILLS_DIR" -type f -name 'SKILL.md' -print0)
+
+if (( ${#missing[@]} > 0 )); then
+  {
+    echo "lint-escalation-contract: FAIL"
+    echo ""
+    echo "The following skills use __ESCALATE__ but do not produce a"
+    echo "canonical \`## Escalation\` comment (inline header or shared"
+    echo "fragment include). The unblock chain (GH-1247) needs this header"
+    echo "to discover Human Needed work."
+    echo ""
+    for rel in "${missing[@]}"; do
+      echo "  - $rel"
+    done
+    echo ""
+    echo "Fix: either"
+    echo "  (a) post a \`## Escalation\` comment inline with the canonical"
+    echo "      body (see plugin/ralph-hero/skills/ralph-code-review/SKILL.md"
+    echo "      for an example), or"
+    echo "  (b) include the shared fragment by adding:"
+    echo "        !cat \${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/escalation-steps.md"
+    echo "      under the skill's \"Escalation Protocol\" section."
+  } >&2
+  exit 1
+fi
+
+echo "lint-escalation-contract: OK (${checked} escalating skill(s) checked)"
+exit 0

--- a/plugin/ralph-hero/skills/ralph-code-review/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-code-review/SKILL.md
@@ -179,7 +179,16 @@ ROUND=$((ROUND + 1))
 
 **If `ROUND <= MAX_ROUNDS`**: return to Step 4 to re-run code review on the updated PR. The new round will use a fresh `BEFORE_COUNT` snapshot (taken at the top of Step 4) so we only count NEW comments from the current review pass.
 
-**If `ROUND > MAX_ROUNDS`** (3 rounds exhausted): escalate. Post a `## Code Review` comment on the issue summarizing the rounds:
+**If `ROUND > MAX_ROUNDS`** (3 rounds exhausted): escalate. Post **two** comments on the issue — the existing `## Code Review` round-by-round summary AND a canonical `## Escalation` comment that the unblock chain consumes.
+
+**First**, post the `## Code Review` summary via `create_comment`:
+
+```
+create_comment(
+  number=NNN,
+  body=<<the markdown below>>
+)
+```
 
 ```markdown
 ## Code Review
@@ -194,6 +203,27 @@ PR: PR_URL
 
 Escalating to Human Needed for manual review and resolution.
 ```
+
+**Second**, post the canonical `## Escalation` comment so `ralph-unblock` and `/ralph-hero:unblock` can discover the escalation by header prefix and extract `originating_command`:
+
+```
+create_comment(
+  number=NNN,
+  body=<<the markdown below>>
+)
+```
+
+```markdown
+## Escalation
+
+@$RALPH_GH_OWNER
+
+Escalation: Code review loop exhausted after 3 rounds on PR_URL — manual review required.
+
+Originating command: ralph_code_review
+```
+
+Keep both comments — the `## Code Review` summary preserves the round-by-round detail; the `## Escalation` comment is the canonical state the unblock chain finds.
 
 Then move the issue to "Human Needed" via:
 
@@ -246,7 +276,7 @@ Use `command="ralph_code_review"` in state transitions.
 
 | Situation | Action |
 |-----------|--------|
-| 3 review rounds exhausted | Escalate via `__ESCALATE__` → "Human Needed", post `## Code Review` summary comment |
+| 3 review rounds exhausted | Escalate via `__ESCALATE__` → "Human Needed", post `## Code Review` summary comment AND canonical `## Escalation` comment (for unblock-chain discovery) |
 | Human reviewer requested changes (Step 3) | Stop with `CODE REVIEW BLOCKED`, do NOT escalate (human is already aware) |
 | `impl-agent` reports BLOCKED | Treat round as failed, continue to Step 6 to check counter |
 | No open PR found (Step 2) | Stop with `CODE REVIEW BLOCKED`; the orchestrator's queue-picker should not have selected this issue |

--- a/plugin/ralph-hero/skills/ralph-unblock/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-unblock/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Autonomous async-loop unblock helper — picks oldest Human Needed issue, parses escalation context, posts specific blocking questions as ## Unblock Request comment. Does NOT transition state.
+description: Autonomous async-loop unblock helper — picks the oldest Human Needed issue and CREATES the `## Unblock Request` state (1–5 specific blocking questions) that `/ralph-hero:unblock` consumes. Reads `## Escalation` context when present and falls back to issue body + linked research/plan artifacts otherwise. Does NOT transition state.
 user-invocable: false
 argument-hint: "[optional-issue-number]"
 context: fork
@@ -39,9 +39,13 @@ Use these resolved values when constructing GitHub URLs or referencing the repos
 
 # Ralph GitHub Unblock Request - Async Loop Helper
 
-You are an autonomous unblock-request specialist. You pick ONE Human Needed issue and surface specific blocking questions as a `## Unblock Request` comment. You do NOT transition state — the issue remains in Human Needed for a human to answer via the interactive `/ralph-hero:unblock` skill.
+You are the **PRODUCER** of `## Unblock Request` state. You pick ONE Human Needed issue and CREATE a `## Unblock Request` comment containing 1–5 specific blocking questions. The interactive **CONSUMER** `/ralph-hero:unblock` finds those comments and walks a human through the questions to unblock the issue.
 
-This is the autonomous half of the unblock skill pair. Hero ends its loop at Human Needed; this skill runs as a separate async loop (scheduled launchd, external trigger, or human attention) and is intentionally narrow: read context, generate questions, post one comment, exit.
+The chain's contract: **this skill creates the state; the consumer finds and processes it.** State creation is the load-bearing outcome — everything else (escalation parsing, originating-command extraction) is supporting context.
+
+You do NOT transition state — the issue remains in Human Needed for a human to answer via `/ralph-hero:unblock`.
+
+This is the autonomous half of the unblock skill pair. Hero ends its loop at Human Needed; this skill runs as a separate async loop (scheduled launchd, external trigger, or human attention) and is intentionally narrow: read context, generate questions, post one comment, exit. The skill runs reliably on Human Needed issues **with or without** a `## Escalation` comment — escalation context enriches question quality but is never required.
 
 ## Workflow
 
@@ -80,8 +84,14 @@ Then STOP. Do not proceed.
 For each candidate, in order:
 1. Fetch the full issue (with comments).
 2. Find the most recent `## Escalation` comment (header line begins with `## Escalation`). Note its `createdAt` timestamp; if none, treat as "no escalation".
-3. Find the most recent `## Unblock Request` comment.
-4. **Skip the issue if a `## Unblock Request` exists AND its `createdAt` is newer than the most recent `## Escalation`** — this is the idempotency guard. (If escalation is absent and a `## Unblock Request` already exists, skip too.)
+3. Find the most recent `## Unblock Request` comment. Note its `createdAt` timestamp; if none, the issue is eligible — use it.
+4. **Idempotency guard** — skip the issue if a `## Unblock Request` exists AND one of the following holds:
+   - (a) A `## Escalation` comment exists AND its `createdAt` is **earlier than or equal to** the `## Unblock Request`'s `createdAt` (i.e., the Unblock Request is at least as fresh as the most recent escalation), OR
+   - (b) **No `## Escalation` exists** AND the issue's last transition into Human Needed is earlier than or equal to the `## Unblock Request`'s `createdAt`. Use this best-effort signal in order of preference:
+     1. The most recent state-change comment that mentions "Human Needed" (header or body)
+     2. The issue's `updatedAt` timestamp (fallback when no state-change comment is available)
+
+   Rationale: clause (b) lets a human force a fresh `## Unblock Request` by re-transitioning the issue out of and back into Human Needed, even without writing a new `## Escalation` comment. If neither clause holds, the existing `## Unblock Request` is stale and the issue is eligible for a fresh one.
 5. Otherwise, this is the first eligible issue — use it.
 
 If no eligible issue is found after iterating the list, set the empty-queue flag and exit:
@@ -96,18 +106,21 @@ No Human Needed issues need an unblock request. Queue empty.
 ```
 Then STOP.
 
-### Step 3: Read Context
+### Step 3: Read Context (escalation optional)
 
-For the selected issue:
+For the selected issue, gather grounding material in this order. The no-escalation path is the **default** narrative — escalations enrich context but are never required.
 
-1. **Read the issue body** in full.
-2. **Read the most recent `## Escalation` comment** if one exists. Extract:
+1. **Read the issue body** in full. This is the primary grounding source.
+2. **Read the most recent `## Escalation` comment if one exists**. If found, extract:
    - The reason text after `Escalation:` (free-form)
    - The originating skill/command name if mentioned anywhere in the comment (e.g., "during ralph_impl", "ralph_plan needed clarification") — best effort. If not extractable, set `originating_command = null`.
-3. **If no `## Escalation` comment exists**, fall back to:
-   - The issue body
-   - Any earlier `## Research Document` or `## Implementation Plan` comments that link to research/plan files — read those files (Read tool on the linked path) for additional context.
+   - Track `context_source = "escalation"` (or `"mixed"` if you also read other sources below).
+
+   If no `## Escalation` comment exists, set `originating_command = null` and continue — this is normal and expected for many Human Needed issues.
+3. **Read any linked artifacts** — `## Research Document` or `## Implementation Plan` comments that link to research/plan files (Read tool on the linked path) for additional context. Track `context_source = "linked_artifact"` (or `"mixed"` when combined with other sources).
 4. Note the issue title and any obviously relevant labels.
+
+**Set `context_source` to one of**: `escalation`, `issue_body`, `linked_artifact`, or `mixed` — whichever best describes the dominant grounding source(s) used for question synthesis. If only the issue body was usable, the value is `issue_body`.
 
 ### Step 4: Synthesize Blocking Questions
 
@@ -168,10 +181,13 @@ knowledge_record_outcome(
   payload={
     "question_count": <number of questions posted>,
     "escalation_comment_present": <true if an ## Escalation comment was found, else false>,
+    "context_source": <"escalation" | "issue_body" | "linked_artifact" | "mixed">,
     "originating_command": <"ralph_impl" | ... | null>
   }
 )
 ```
+
+`context_source` reflects what grounding material `ralph-unblock` actually used to synthesize questions (set in Step 3). Downstream knowledge-graph consumers use this to distinguish escalation-driven runs from body-grounded or artifact-grounded runs without having to re-derive the signal.
 
 If the `knowledge_record_outcome` tool is unavailable (graceful degradation), skip the call silently — do NOT fail the skill. The `## Unblock Request` comment is the source of truth; the outcome event is auxiliary.
 
@@ -194,7 +210,7 @@ Then STOP.
 - Work on ONE issue only per invocation.
 - The issue MUST stay in Human Needed — do NOT call `save_issue`. (`save_issue` is intentionally absent from `allowed-tools`; the agent will be hard-blocked if it tries.)
 - Post EXACTLY ONE `## Unblock Request` comment per run.
-- Idempotency: if a `## Unblock Request` already exists since the most recent `## Escalation`, skip the issue and pick the next candidate.
+- Idempotency (see Step 2 item 4 for the full rule): skip if a fresh `## Unblock Request` already covers the current Human Needed transition — either (a) it post-dates the most recent `## Escalation`, or (b) when no escalation exists, it post-dates the issue's last transition into Human Needed.
 - Cap questions at 5. Prefer fewer, pointier questions over many vague ones.
 - If `knowledge_record_outcome` is unavailable, skip silently. The comment is the source of truth.
 - Before exiting, set `RALPH_UNBLOCK_REQUEST_POSTED=1` (after a successful `create_comment`) or `RALPH_UNBLOCK_QUEUE_EMPTY=1` (no eligible issues / wrong-state arg). The Stop hook will block otherwise.

--- a/plugin/ralph-hero/skills/ralph-unblock/eval-scenarios.md
+++ b/plugin/ralph-hero/skills/ralph-unblock/eval-scenarios.md
@@ -29,7 +29,7 @@ harness) against a test repo configured with the ralph-hero plugin.
 
 ---
 
-## 2. `escalation-comment-absent`
+## 2. `escalation-comment-absent` (linked artifact present)
 
 **Setup**:
 - Issue #N is in `Human Needed` (e.g., a human moved it manually).
@@ -42,12 +42,59 @@ harness) against a test repo configured with the ralph-hero plugin.
 - Falls back to issue body + linked research doc for context.
 - Synthesizes questions grounded in the research doc / issue body.
 - Posts `## Unblock Request` with `Originating skill: (unknown)`.
-- Records outcome event with `escalation_comment_present: false, originating_command: null`.
+- Records outcome event with
+  `{ escalation_comment_present: false, context_source: "linked_artifact" (or "mixed" if the issue body also contributed), originating_command: null }`.
 
 **Pass criteria**:
 - Comment is posted with `Originating skill: (unknown)` rendered literally.
 - Questions reference real material from the issue body or linked doc (not invented).
 - Outcome event payload reflects the missing escalation correctly.
+
+---
+
+## 2b. `no-escalation-body-only` (Human Needed issue, no `## Escalation` comment)
+
+**Setup**:
+- Issue #N is in `Human Needed`.
+- Issue body describes a real-ish decision the human needs to make (e.g., "Choose between
+  option A and option B for the new index schema").
+- **No `## Escalation` comment** exists on the issue.
+- **No** `## Unblock Request` comment exists on the issue.
+- No linked `## Research Document` or `## Implementation Plan` comments — the issue body
+  is the only grounding source.
+
+**Why this scenario matters**: this is the most common real-world case for the producer
+flow (humans manually move issues into Human Needed without writing a canonical
+`## Escalation` comment first). The producer must reliably create state from body
+context alone, with no degraded behavior.
+
+**Expected behavior**:
+- Skill picks issue #N (oldest eligible Human Needed without a fresh `## Unblock Request`).
+- Skill reads the issue body, notes absence of `## Escalation`, and proceeds without
+  falling back to any linked artifact (none exist).
+- Skill synthesizes 1–5 specific, body-grounded questions (not "what should we do?").
+- Posts `## Unblock Request` with:
+  - 1–5 numbered questions
+  - `Originating skill: (unknown)` rendered literally
+- Records `unblock_requested` outcome event with payload
+  `{ question_count: <n>, escalation_comment_present: false, context_source: "issue_body", originating_command: null }`.
+- Sets `RALPH_UNBLOCK_REQUEST_POSTED=1` and exits cleanly via the Stop hook.
+
+**Pass criteria**:
+- `## Unblock Request` comment is posted with `Originating skill: (unknown)` rendered
+  literally.
+- Questions reference concrete material from the issue body (file names, options,
+  decision points named in the body) — not invented from whole cloth.
+- Outcome event payload has all four fields set to the expected values above. In
+  particular `context_source` MUST be `"issue_body"` (not `"escalation"`, not
+  `"linked_artifact"`, not `"mixed"`).
+- Issue remains in `Human Needed` (no `save_issue` call).
+- The Stop hook allows clean exit (postcondition flag was set).
+
+**Regression coverage**: this scenario verifies that the producer flow is
+escalation-agnostic. If a future change accidentally re-introduces a hard
+dependency on `## Escalation` (e.g., aborting when absent, or skipping question
+synthesis), this scenario fails immediately.
 
 ---
 

--- a/plugin/ralph-hero/skills/shared/artifact-comment-protocol.md
+++ b/plugin/ralph-hero/skills/shared/artifact-comment-protocol.md
@@ -28,6 +28,7 @@ Standard comment headers used to link documents to GitHub issues. All document-p
 | `## Plan Revision Request` | Sibling or parent issue | What's needed, why current plan doesn't provide it | `ralph-impl` or `ralph-plan-feature` |
 | `## Unblock Request` | Issue (Human Needed) | 1–5 specific blocking questions extracted from `## Escalation` or LLM-reasoned | `ralph-unblock` |
 | `## Unblock Resolution` | Issue (Human Needed) | Question/answer pairs + chosen return state | `unblock` |
+| `## Escalation` | Issue (Human Needed) | `Escalation: <reason>` + `Originating command: ralph_<cmd>`. **Optional context** consumed by `ralph-unblock` (richer questions) and `/ralph-hero:unblock` (return-state heuristic). | Any skill that escalates to Human Needed via the shared `escalation-steps.md` fragment |
 
 ## Comment Format Examples
 

--- a/plugin/ralph-hero/skills/shared/fragments/escalation-steps.md
+++ b/plugin/ralph-hero/skills/shared/fragments/escalation-steps.md
@@ -26,9 +26,27 @@ When encountering complexity, uncertainty, or states that don't align with proto
    ```
    For group plans, move ALL group issues to "Human Needed".
 
-2. **Add comment with @mention**:
+2. **Post a `## Escalation` comment**. The `## Escalation` markdown header is **required** — `ralph-unblock`, `/ralph-hero:unblock`, and the MCP `human-needed-unblock` direction signal all discover this comment by header prefix (`body.startsWith("## Escalation")`). The body must also carry an `Escalation:` reason line (consumers extract the reason text) and an `Originating command: ralph_<cmd>` line (the interactive unblock skill uses this to route the issue back into the pipeline).
+
+   Call shape:
    ```
-   ralph_hero__create_comment(number, body="@$RALPH_GH_OWNER Escalation: [issue description]")
+   ralph_hero__create_comment(
+     number,
+     body=<<the markdown below>>
+   )
    ```
+
+   Comment body:
+   ```markdown
+   ## Escalation
+
+   @$RALPH_GH_OWNER
+
+   Escalation: [specific blocking question or constraint]
+
+   Originating command: ralph_<current-command>
+   ```
+
+   Substitute `<current-command>` with the snake_case command name (e.g., `ralph_impl`, `ralph_plan`, `ralph_research`, `ralph_triage`, `ralph_review`, `ralph_split`).
 
 3. **STOP and report**: Issue URL, status "Human Needed", brief reason.

--- a/plugin/ralph-hero/skills/unblock/eval-scenarios.md
+++ b/plugin/ralph-hero/skills/unblock/eval-scenarios.md
@@ -167,6 +167,56 @@ behavior around those interactive moments.
 
 ---
 
+## 7b. `no-escalation-request-only` (No `## Escalation` exists, only `## Unblock Request`)
+
+**Setup**:
+- Issue #N is in `Human Needed`.
+- Issue has a `## Unblock Request` comment posted by `ralph-unblock` with 1–5
+  numbered questions.
+- The `## Unblock Request` ends with `Originating skill: (unknown)` (because no
+  `## Escalation` was present when the producer ran).
+- **No `## Escalation` comment exists** on the issue.
+- Skill is invoked as `/ralph-hero:unblock N` (or with no arg if #N is the only
+  candidate).
+
+**Why this scenario matters**: this is the consumer half of the no-escalation
+flow. It verifies that `/ralph-hero:unblock` does not require `## Escalation` to
+function — it finds the `## Unblock Request` produced by `ralph-unblock`, walks
+the human, and routes back into the pipeline using the default heuristic.
+
+**Expected behavior**:
+- Skill fetches the issue and reads the `## Unblock Request` comment.
+- Skill parses the numbered questions verbatim.
+- Skill extracts `originating_command = null` (no `## Escalation` to parse).
+- Heuristic default with null `originating_command` maps to `In Progress`
+  (the documented fallback in the consumer SKILL.md).
+- Skill walks the human through each question via `AskUserQuestion`.
+- Skill presents the routing confirmation picker with `In Progress` listed FIRST
+  (default).
+- Human accepts the default (or overrides — see scenario 5 for override behavior).
+- Skill posts `## Unblock Resolution` with all Q&A pairs in order and
+  `Routing to: \`In Progress\``.
+- Skill calls `save_issue(workflowState="In Progress", command="ralph_unblock")`.
+- Skill records `unblock_resolved` outcome event with
+  `{ question_count: <n>, originating_command: null, return_state: "In Progress" }`.
+
+**Pass criteria**:
+- The interactive flow proceeds without error despite the missing `## Escalation`.
+- The routing picker presents `In Progress` as the first option.
+- The resolution comment quotes each question and answer verbatim.
+- Issue ends in `In Progress` (assuming the human accepts the default).
+- Outcome event payload has `originating_command: null` and the chosen
+  return state.
+
+**Regression coverage**: this scenario verifies the consumer flow is
+escalation-agnostic. If a future change accidentally requires `## Escalation`
+(e.g., aborting when absent, or refusing to compute a default return state
+without `originating_command`), this scenario fails immediately. Pair with
+ralph-unblock eval scenario `no-escalation-body-only` for end-to-end coverage
+of the no-escalation chain.
+
+---
+
 ## 8. `transition-blocked-by-gate`
 
 **Setup**:

--- a/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+++ b/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
@@ -125,8 +125,8 @@ Rationale: this lets the human force a fresh `## Unblock Request` by re-transiti
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` passes (no consumer code changes; this is a SKILL.md doc edit)
-- [ ] Hook tests still pass: `plugin/ralph-hero/hooks/scripts/unblock-request-postcondition.sh` still allows exit on either `RALPH_UNBLOCK_REQUEST_POSTED=1` or `RALPH_UNBLOCK_QUEUE_EMPTY=1`
+- [x] `npm test` in `plugin/ralph-hero/mcp-server/` passes (no consumer code changes; this is a SKILL.md doc edit)
+- [x] Hook tests still pass: `plugin/ralph-hero/hooks/scripts/unblock-request-postcondition.sh` still allows exit on either `RALPH_UNBLOCK_REQUEST_POSTED=1` or `RALPH_UNBLOCK_QUEUE_EMPTY=1`
 
 #### Manual Verification:
 - [ ] Skill description now leads with state-creation, not escalation-parsing

--- a/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+++ b/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
@@ -2,7 +2,7 @@
 date: 2026-05-13
 status: draft
 type: plan
-tags: [skills, escalation, unblock, human-needed, contract]
+tags: [skills, unblock, human-needed, contract]
 github_issue: 1247
 github_issues: [1247]
 github_urls:
@@ -10,7 +10,7 @@ github_urls:
 primary_issue: 1247
 ---
 
-# Unblock Chain Producer-Consumer Alignment
+# Unblock Chain — Producer-First Alignment
 
 ## Prior Work
 
@@ -19,201 +19,240 @@ primary_issue: 1247
 
 ## Overview
 
-The Human Needed unblock chain — autonomous `ralph-hero:ralph-unblock`, interactive `/ralph-hero:unblock`, and the MCP `human-needed-unblock` direction signal — is correctly wired on the consumer side. All three consumers discover escalation context by matching comments whose body starts with the `## Escalation` markdown header. The producer side has drifted: the shared `escalation-steps.md` fragment used by seven skills tells producers to post non-headered `"@user Escalation: ..."` plain text, and `ralph-code-review` posts its escalation context under a different header (`## Code Review`). The net effect: no escalation produced by current skills is discoverable by the unblock chain, so `/ralph-hero:unblock` has never had real input to work with.
+The unblock chain has two skills:
 
-This plan brings producers in line with the documented contract, makes the contract explicit in `artifact-comment-protocol.md`, and adds a CI lint so future drift is caught before merge.
+- **`ralph-hero:ralph-unblock` (autonomous, PRODUCER)** — picks a Human Needed issue and **creates** the `## Unblock Request` state (a comment containing 1–5 specific blocking questions). This is the only thing the autonomous skill produces.
+- **`/ralph-hero:unblock` (interactive, CONSUMER)** — **finds** Human Needed issues that have a `## Unblock Request`, walks the human through the questions, posts `## Unblock Resolution`, and transitions the issue back into the pipeline.
+
+The chain's job is: **ralph-unblock creates the state that /ralph-hero:unblock finds to unblock.**
+
+The `## Escalation` comment is **optional** context that helps `ralph-unblock` synthesize better questions and helps `/ralph-hero:unblock` choose a default return state. Neither skill requires it — both have fallback paths. The previous draft of this plan over-emphasized fixing producers of `## Escalation` comments; that's now scoped as supporting work, not the critical path.
 
 ## Current State Analysis
 
-**Consumers (all require `body.startsWith("## Escalation")`):**
+**Producer side (`ralph-unblock`):**
 
-- `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:82,104,170` — finds escalation comment to drive question synthesis, idempotency guard, and outcome payload.
-- `plugin/ralph-hero/skills/unblock/SKILL.md:65,75` — extracts `originating_command` and reason text to drive the return-state heuristic.
-- `plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts:122,148` — emits the `human-needed-unblock` direction surfaced by `/hello`.
-- Test fixtures in `plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts:374,411` already encode the `## Escalation\n\n…` body shape.
+- `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:78-97` — selects the oldest Human Needed issue without a fresh `## Unblock Request`.
+- `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:99-110` — reads context: `## Escalation` if present, else falls back to issue body and linked `## Research Document` / `## Implementation Plan` comments. **The fallback path already exists.**
+- `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:126-149` — posts the `## Unblock Request` comment. **This is the state-creation step. It runs regardless of whether `## Escalation` exists.**
+- `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:83-84` — idempotency guard: "Skip if `## Unblock Request` is newer than the most recent `## Escalation`. If escalation is absent and a `## Unblock Request` already exists, skip too." Works correctly for one-shot but cannot detect re-escalations that don't produce a fresh `## Escalation` comment.
 
-**Producers (current state):**
+**Consumer side (`/ralph-hero:unblock`):**
 
-- `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md:29-32` — included via `!cat` by `ralph-research`, `ralph-impl`, `ralph-plan`, `ralph-split`, `ralph-triage`, `ralph-review`, and `hero`. **Fixed in worktree branch `worktree-fix-escalation-header` (commit `2f7ad1a4`).** Not yet merged. The new Step 2 requires the `## Escalation` markdown header, keeps `Escalation: <reason>` for reason extraction, and adds `Originating command: ralph_<cmd>` for the consumer's heuristic.
-- `plugin/ralph-hero/skills/ralph-code-review/SKILL.md:249` — escalates after 3 review rounds with a `## Code Review` summary comment, **not** `## Escalation`. The unblock chain cannot extract context from these escalations.
-- `plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md:337` — explicitly references `` `## Escalation` `` in its escalation row. Self-conforming; no change needed.
-- `plugin/ralph-hero/skills/ralph-review/SKILL.md:344` — defers to "per the Escalation Protocol below" which `!cat`s the shared fragment. Picks up the fragment fix transitively.
+- `plugin/ralph-hero/skills/unblock/SKILL.md:54-58` — filters Human Needed candidates to those with a `## Unblock Request` comment. Correct.
+- `plugin/ralph-hero/skills/unblock/SKILL.md:65-75` — extracts `originating_command` from `## Escalation` for the return-state heuristic; defaults to `In Progress` when absent. Correct fallback.
+- `plugin/ralph-hero/skills/unblock/SKILL.md:88-106` — confirms the inferred state via `AskUserQuestion` and transitions. Correct.
 
-**Protocol documentation:**
+**Supporting (not critical):**
 
-- `plugin/ralph-hero/skills/shared/artifact-comment-protocol.md` lists `## Unblock Request` and references "extracted from `## Escalation`" but does **not** list `## Escalation` as its own row in the comment-headers table. The convention is implicit, which is how it drifted.
+- `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md` was rewritten in worktree commit `2f7ad1a4` to require the `## Escalation` markdown header. This **improves** context quality when escalations happen but is **not** required for the unblock chain to function.
+- `ralph-code-review` escalates with a `## Code Review` summary; this means its escalations don't enrich the `originating_command` heuristic but they still result in Human Needed issues that `ralph-unblock` will pick up and create `## Unblock Request` for.
 
 ### Key Discoveries
 
-- `extractUnblockSignal` in `directions-tools.ts:148` requires `body.startsWith("## Escalation")` — there is no fallback parser for plain-text "Escalation:" lines.
-- The autonomous skill's idempotency rule (`ralph-unblock` Step 2: "skip if `## Unblock Request` exists AND its createdAt is newer than the most recent `## Escalation`") silently degenerates when no Escalation comment is discoverable — the rule becomes "if any Unblock Request exists, skip", so re-escalations on the same issue never trigger a new Unblock Request.
-- Both unblock skills' `eval-scenarios.md` already document the canonical `## Escalation` format; they were authored against the intended contract, not the deployed implementation.
+- The state-creation path (`ralph-unblock` → `## Unblock Request`) already works without `## Escalation`. The misframing in the previous plan draft (calling `ralph-unblock` a "consumer") obscured this.
+- The actual hole in the producer flow: the idempotency guard cannot detect a stale `## Unblock Request` when the issue is re-escalated without a fresh `## Escalation` comment. In practice this is rare, but worth tightening.
+- The MCP `extractUnblockSignal` (`directions-tools.ts:148`) correctly fires the `human-needed-unblock` direction whenever a `## Unblock Request` exists and no newer `## Escalation` is present — already aligned with the producer-first model.
 
 ## Desired End State
 
-- Every skill that transitions an issue to "Human Needed" also posts a `## Escalation` comment whose body starts with the `## Escalation` markdown header and contains both `Escalation: <reason>` and `Originating command: ralph_<cmd>` lines.
-- `/ralph-hero:unblock` reliably identifies `originating_command` and applies the right return-state default (Research Needed / Ready for Plan / In Progress / Backlog).
-- End-to-end flow works: an escalation lands → `ralph-unblock` posts `## Unblock Request` → human runs `/ralph-hero:unblock` → answers questions → issue routes back into the pipeline → hero loop continues.
-- `artifact-comment-protocol.md` lists `## Escalation` explicitly so future skills can't accidentally diverge from the contract.
-- A CI lint fails if a skill is added that transitions to Human Needed without producing a `## Escalation` comment.
+- The producer (`ralph-unblock`) is documented and framed as **the only thing that creates `## Unblock Request` state**. Its description, step ordering, and outcome payload all reflect this.
+- The producer reliably creates `## Unblock Request` on **any** Human Needed issue, with or without a `## Escalation` comment, with no degraded behavior in the no-escalation case.
+- The consumer (`/ralph-hero:unblock`) reliably finds those `## Unblock Request` comments and routes the issue back into the pipeline.
+- A regression-safe acceptance scenario exists for the no-escalation flow (most common case in practice).
 
 ### Verification
 
-- **Manual end-to-end test**: create a synthetic Human Needed issue with a canonical `## Escalation` comment; run `ralph-hero:ralph-unblock`; verify it posts a `## Unblock Request`; re-run to confirm idempotency; run `/ralph-hero:unblock`; verify originating_command extraction, Q&A walk, `## Unblock Resolution` posting, and state transition.
-- **Automated**: existing `directions-tools.test.ts` continues to pass (the producer fix aligns with the fixtures already there). New CI lint catches future drift.
+- **Acceptance test (manual, post Phase 2)**: Create a synthetic Human Needed test issue with body context but **no** `## Escalation` comment. Run `ralph-hero:ralph-unblock` → assert a `## Unblock Request` comment with 1–5 numbered questions is posted, originating skill rendered as `(unknown)`. Run `/ralph-hero:unblock` → walk the Q&A → assert default return state is `In Progress`, `## Unblock Resolution` is posted, issue transitions. Hero loop picks it back up.
+- **Re-run idempotency**: Running `ralph-unblock` again against the same issue (with the `## Unblock Request` already posted) skips it cleanly.
 
 ## What We're NOT Doing
 
-- **Not modifying the consumer parsers** — they're correct as-is.
-- **Not changing the state machine or `human-needed-outbound-block.sh`** — `ralph_unblock` already has the necessary wiring (validated by `unblock-state-gate.sh`).
-- **Not adding new escalation channels** (Slack, PagerDuty, etc.) — out of scope.
-- **Not unifying all artifact comment headers** — scope is the `## Escalation` divergence only.
-- **Not releasing/publishing a new plugin version** — `release.yml` handles that when MCP server source changes; skill-only changes ship via the plugin cache update path the user already operates.
-- **Not retroactively rewriting historical escalation comments** — closed issues stay as-is.
+- **Not requiring `## Escalation` for the chain to work.** The chain functions without it.
+- **Not adding a new direction signal or hook.** The existing `human-needed-unblock` direction is already correct.
+- **Not modifying the state machine or the `human-needed-outbound-block.sh` hook.**
+- **Not retroactively rewriting historical comments.**
+- **Not blocking on the supporting work** (Phases 3–4). The chain works without them.
 
 ## Implementation Approach
 
-Three small, sequential phases. Phase 1 lands the existing worktree commit. Phase 2 fixes the one remaining non-conforming producer. Phase 3 documents the contract and adds CI enforcement so this can't drift again.
+Two critical-path phases first (producer reframe + acceptance test). Two supporting phases follow (richer context when escalations happen + future-drift prevention).
 
 ---
 
-## Phase 1: Land the shared-fragment fix
+## Phase 1: Producer reframe — make state-creation the leading concept (CRITICAL)
 
 ### Overview
 
-Push the existing `worktree-fix-escalation-header` branch, open a PR, and merge it.
+Update `ralph-unblock/SKILL.md` so its description, step ordering, and outcome payload all lead with "this skill creates `## Unblock Request` state on any Human Needed issue." The escalation-reading is demoted from a primary step to optional context.
 
 ### Changes Required:
 
-#### 1. Fragment fix (already committed in worktree)
+#### 1. Update the skill description
 
-**File**: `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md`
-**Changes**: Step 2 rewritten to require the `## Escalation` markdown header, preserve the @mention, retain `Escalation: <reason>` for reason extraction, and add `Originating command: ralph_<cmd>` for the consumer's return-state heuristic. The diff is +20/-2 (commit `2f7ad1a4`).
+**File**: `plugin/ralph-hero/skills/ralph-unblock/SKILL.md` (frontmatter `description:` field, line 2)
 
-#### 2. PR creation
+**Current**:
+> Autonomous async-loop unblock helper — picks oldest Human Needed issue, parses escalation context, posts specific blocking questions as ## Unblock Request comment. Does NOT transition state.
 
-**Branch**: `worktree-fix-escalation-header` → `main`
-**Title**: `fix(skills): post escalations with ## Escalation header so unblock chain works`
-**Body**: Summarize the producer-consumer mismatch, name the 7 skills that include the fragment, and link to this plan.
+**New**:
+> Autonomous async-loop unblock helper — picks the oldest Human Needed issue and CREATES the `## Unblock Request` state (1–5 specific blocking questions) that `/ralph-hero:unblock` consumes. Reads `## Escalation` context when present and falls back to issue body + linked research/plan artifacts otherwise. Does NOT transition state.
+
+#### 2. Update the skill prologue and Step 3 framing
+
+**File**: `plugin/ralph-hero/skills/ralph-unblock/SKILL.md` (prologue around lines 40–46 and Step 3 header around line 99)
+
+**Changes**:
+- Prologue paragraph: rewrite to emphasize "this is the PRODUCER of `## Unblock Request` state. The consumer `/ralph-hero:unblock` finds and processes that state."
+- Step 3 header: rename from "Read Context" to "Read Context (escalation optional)" and reorder bullets so the issue body is read **first**, the `## Escalation` comment is read **next if present**, and linked research/plan artifacts are read **last**. Make the no-escalation path the default narrative, not a fallback.
+
+#### 3. Tighten the idempotency guard
+
+**File**: `plugin/ralph-hero/skills/ralph-unblock/SKILL.md` (Step 2, item 4, around line 84)
+
+**Current rule**: "Skip if `## Unblock Request` is newer than `## Escalation`. If escalation is absent and a `## Unblock Request` already exists, skip too."
+
+**Replace with**: "Skip the issue if a `## Unblock Request` exists AND one of: (a) a `## Escalation` comment exists with `createdAt` ≤ the Unblock Request's `createdAt`, OR (b) no `## Escalation` exists AND the issue's last transition into Human Needed (best-effort: the most recent state-change comment or the issue's `updatedAt`) is ≤ the Unblock Request's `createdAt`."
+
+Rationale: this lets the human force a fresh `## Unblock Request` by re-transitioning the issue out of and back into Human Needed, even without writing a new `## Escalation` comment.
+
+#### 4. Make the outcome payload escalation-agnostic
+
+**File**: `plugin/ralph-hero/skills/ralph-unblock/SKILL.md` (Step 6, around lines 160–174)
+
+**Changes**: Keep `escalation_comment_present` as a boolean metadata field but add a `context_source` field with values `escalation | issue_body | linked_artifact | mixed` so downstream knowledge-graph consumers can see what `ralph-unblock` actually used.
 
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] CI passes on the PR
-- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` passes (especially `directions-tools.test.ts`)
+- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` passes (no consumer code changes; this is a SKILL.md doc edit)
+- [ ] Hook tests still pass: `plugin/ralph-hero/hooks/scripts/unblock-request-postcondition.sh` still allows exit on either `RALPH_UNBLOCK_REQUEST_POSTED=1` or `RALPH_UNBLOCK_QUEUE_EMPTY=1`
 
 #### Manual Verification:
-- [ ] PR is merged into `main`
-- [ ] Plugin cache refreshes locally; new escalations posted by any of the 7 skills produce a `## Escalation`-headered comment
+- [ ] Skill description now leads with state-creation, not escalation-parsing
+- [ ] Re-reading the SKILL.md cold makes the producer role obvious
 
 ---
 
-## Phase 2: Align ralph-code-review escalation with the contract
+## Phase 2: End-to-end acceptance test (CRITICAL)
 
 ### Overview
 
-When `ralph-code-review` hits 3 exhausted review rounds and escalates, it must produce a comment discoverable by the unblock chain. Currently it posts only a `## Code Review` summary; this phase keeps that summary (it has its own audit-trail value) and adds a separate `## Escalation` comment.
+Exercise the full chain against a synthetic Human Needed issue **without** a `## Escalation` comment. This is the most common real-world case and the one the prior plan draft did not explicitly verify.
 
 ### Changes Required:
 
-#### 1. Add `## Escalation` comment to the round-exhausted escalation step
+#### 1. Add the no-escalation scenario to ralph-unblock eval-scenarios
 
-**File**: `plugin/ralph-hero/skills/ralph-code-review/SKILL.md`
-**Changes**: At the existing `__ESCALATE__` step (currently the 3-rounds-exhausted path around line 200 and the Escalation Protocol row at line 249), add a second `create_comment` call that posts the canonical `## Escalation` body. Keep the existing `## Code Review` summary comment unchanged — it remains the round-by-round audit trail.
+**File**: `plugin/ralph-hero/skills/ralph-unblock/eval-scenarios.md`
 
-Canonical body to post:
+**Changes**: Add (or expand) a scenario titled "Human Needed issue, no `## Escalation` comment" with:
+- Setup: issue in Human Needed, body describes a decision needed, no `## Escalation`, no `## Unblock Request`
+- Expected behavior: ralph-unblock picks it, reads the body, synthesizes 1–5 grounded questions, posts `## Unblock Request` with `Originating skill: (unknown)`
+- Outcome event payload includes `escalation_comment_present: false` and `context_source: issue_body`
 
-```markdown
-## Escalation
+#### 2. Add the matching scenario to unblock eval-scenarios
 
-@$RALPH_GH_OWNER
+**File**: `plugin/ralph-hero/skills/unblock/eval-scenarios.md`
 
-Escalation: Code review loop exhausted after 3 rounds without converging. See ## Code Review comment for round-by-round details.
+**Changes**: Add a scenario titled "No `## Escalation` exists, only `## Unblock Request`" with:
+- Setup: Human Needed issue with `## Unblock Request` posted by ralph-unblock, no `## Escalation`
+- Expected behavior: skill finds the issue, extracts numbered questions, walks the human via `AskUserQuestion`, originating_command = null → default return state = In Progress, confirms via picker, posts `## Unblock Resolution`, transitions
 
-Originating command: ralph_code_review
+#### 3. Run the end-to-end acceptance test manually
+
+Use a sacrificial issue (not a real ticket) or a draft issue created for this purpose:
+
+```
+1. Create draft issue "[acceptance-test] no-escalation unblock flow" in the project
+2. Move to Human Needed (save_issue workflowState="__ESCALATE__", command="ralph_impl")
+3. Add a brief body describing a real-ish blocker
+4. Run /ralph-hero:ralph-unblock → expect ## Unblock Request comment with 1-5 questions
+5. Re-run /ralph-hero:ralph-unblock → expect "queue empty" (idempotency)
+6. Run /ralph-hero:unblock → expect Q&A walk and transition to In Progress
+7. Close the test issue
 ```
 
-#### 2. Update the Escalation Protocol table entry
+### Success Criteria:
 
-**File**: `plugin/ralph-hero/skills/ralph-code-review/SKILL.md:249`
-**Changes**: Update the table row from `"Escalate via __ESCALATE__ → 'Human Needed', post ## Code Review summary comment"` to `"Escalate via __ESCALATE__ → 'Human Needed', post BOTH ## Code Review summary comment AND ## Escalation comment for unblock chain discovery"`.
+#### Automated Verification:
+- [ ] Eval scenarios markdown lint clean (no broken cross-references)
+
+#### Manual Verification:
+- [ ] Acceptance test passes end-to-end on a real (sacrificial) issue
+- [ ] `## Unblock Request` is posted with grounded questions even without `## Escalation`
+- [ ] `## Unblock Resolution` correctly captures Q&A pairs and routes to In Progress
+
+---
+
+## Phase 3: Supporting — better context when escalations DO happen
+
+### Overview
+
+When producers (ralph-impl, ralph-plan, etc.) escalate, they should post a properly-headered `## Escalation` comment so `ralph-unblock` has richer context for question synthesis and `/ralph-hero:unblock` has `originating_command` for the return-state heuristic. This is **supporting work**, not on the critical path.
+
+### Changes Required:
+
+#### 1. Land worktree commit `2f7ad1a4` (already exists)
+
+**Branch**: `worktree-fix-escalation-header`
+**Commit**: `2f7ad1a4` — rewrites `escalation-steps.md` Step 2 to require the `## Escalation` markdown header and include `Originating command: ralph_<cmd>`.
+
+**Action**: Push the branch, open PR, merge.
+
+#### 2. Align `ralph-code-review` escalation comment
+
+**File**: `plugin/ralph-hero/skills/ralph-code-review/SKILL.md` (around line 200 and the protocol row at line 249)
+
+**Changes**: At the 3-rounds-exhausted escalation path, add a second `create_comment` call that posts a canonical `## Escalation` comment alongside the existing `## Code Review` summary. Keep the summary unchanged.
 
 ### Success Criteria:
 
 #### Automated Verification:
 - [ ] `npm test` passes
-- [ ] No existing tests reference the old single-comment escalation pattern
+- [ ] No existing tests assume the old single-comment escalation pattern
 
 #### Manual Verification:
-- [ ] Force a 3-round-exhausted code review on a test PR (e.g., a sacrificial branch with intentional persistent issues); confirm both `## Code Review` and `## Escalation` comments are posted on the issue
-- [ ] Run `ralph-hero:ralph-unblock` against the resulting Human Needed issue; confirm it parses the `## Escalation` comment and posts a useful `## Unblock Request`
+- [ ] When ralph-impl or ralph-plan escalates an issue, the resulting Human Needed issue carries a `## Escalation` comment with the canonical body
+- [ ] `ralph-unblock` running against that issue extracts originating_command correctly and includes it in the `## Unblock Request`
 
 ---
 
-## Phase 3: Document the contract and add CI enforcement
+## Phase 4: Supporting — protocol documentation and CI lint
 
 ### Overview
 
-Make the `## Escalation` header a first-class entry in `artifact-comment-protocol.md` and add a CI lint that fails when any skill transitions to Human Needed without producing a `## Escalation` comment.
+Document the optional-but-recommended `## Escalation` header in `artifact-comment-protocol.md` and add a CI lint that catches drift if a new skill adds escalation logic without producing the canonical comment.
 
 ### Changes Required:
 
-#### 1. Add `## Escalation` row to artifact-comment-protocol
+#### 1. Add `## Escalation` row to `artifact-comment-protocol.md`
 
 **File**: `plugin/ralph-hero/skills/shared/artifact-comment-protocol.md`
-**Changes**: Add a row to the "Existing Headers" table immediately above the `## Implementation Plan` row:
 
+**Changes**: Add a row to the "Existing Headers" table:
 ```markdown
-| `## Escalation` | Issue (Human Needed) | `Escalation: <reason>` + `Originating command: ralph_<cmd>` (consumed by `ralph-unblock`, `/ralph-hero:unblock`, and the `human-needed-unblock` direction signal) | Any skill that escalates to Human Needed (via the shared `escalation-steps.md` fragment) |
+| `## Escalation` | Issue (Human Needed) | `Escalation: <reason>` + `Originating command: ralph_<cmd>`. **Optional context** consumed by `ralph-unblock` (richer questions) and `/ralph-hero:unblock` (return-state heuristic). | Any skill that escalates to Human Needed via the shared `escalation-steps.md` fragment |
 ```
 
-#### 2. Add the lint script
+Note the explicit **Optional context** wording so future authors don't read this as a hard requirement.
 
-**File**: `plugin/ralph-hero/scripts/lint-escalation-contract.sh` (new)
-**Behavior**:
-- For each `plugin/ralph-hero/skills/*/SKILL.md` file
-- Check if the file contains either `__ESCALATE__` or `workflowState.*Human Needed`
-- If yes, verify the file also contains either `!cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/escalation-steps.md` (the fragment include) OR `## Escalation` inline
-- Exit non-zero with a clear message listing any offending skill files
+#### 2. Add a CI lint
 
-Stub:
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-fail=0
-for skill in plugin/ralph-hero/skills/*/SKILL.md; do
-  # Skip the consumer skills themselves (ralph-unblock, unblock) and skills that don't escalate
-  if grep -qE '__ESCALATE__|workflowState.*Human Needed' "$skill"; then
-    # Already consumes the contract (ralph-unblock, unblock)
-    if grep -qE '## Unblock (Request|Resolution)' "$skill"; then
-      continue
-    fi
-    # Produces a ## Escalation comment (inline or via shared fragment)
-    if grep -qE 'escalation-steps\.md|## Escalation' "$skill"; then
-      continue
-    fi
-    echo "FAIL: $skill transitions to Human Needed but does not produce a ## Escalation comment" >&2
-    fail=1
-  fi
-done
-exit "$fail"
-```
+**File**: `plugin/ralph-hero/scripts/lint-escalation-contract.sh` (new) + a step in `.github/workflows/ci.yml`
 
-#### 3. Wire the lint into CI
+**Behavior**: For each skill that contains `__ESCALATE__` or `workflowState.*Human Needed`, verify it produces a `## Escalation` comment (either inline or via the shared fragment include). Exit non-zero with a clear message naming the offending skill.
 
-**File**: `.github/workflows/ci.yml`
-**Changes**: Add a job step (in the existing build matrix or a new `lint` job) that runs `bash plugin/ralph-hero/scripts/lint-escalation-contract.sh` from the repo root.
+This lint is advisory — failing it means the skill is escalating without canonical context, which is a hygiene issue, not a correctness issue. (Document this in the script header.)
 
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `bash plugin/ralph-hero/scripts/lint-escalation-contract.sh` exits 0 against `main` after Phases 1 and 2 are merged
-- [ ] Reverting Phase 1's fragment fix locally causes the lint to fail (proves it catches drift)
-- [ ] CI job for the new step passes on the PR
+- [ ] `bash plugin/ralph-hero/scripts/lint-escalation-contract.sh` exits 0 against main after Phase 3 lands
+- [ ] CI step for the lint passes on the PR
 
 #### Manual Verification:
-- [ ] `artifact-comment-protocol.md` table now lists `## Escalation` explicitly
-- [ ] The lint script is readable and its failure messages clearly point at the offending file
+- [ ] `artifact-comment-protocol.md` lists `## Escalation` with the **Optional context** annotation
 
 ---
 
@@ -221,40 +260,33 @@ exit "$fail"
 
 ### Unit Tests
 
-Existing `directions-tools.test.ts` tests already cover the consumer parser with `## Escalation`-headered fixtures (lines 374, 411). No new unit tests needed — the producer fix aligns with what those tests already assume.
+Existing `directions-tools.test.ts` already covers `## Unblock Request` discovery and the `## Escalation` newer-than check. No new unit tests needed for Phases 1–2.
 
-### Integration Test (Manual, post-Phase-1)
+### Manual Acceptance (Phase 2)
 
-1. Create a synthetic Human Needed test issue:
-   - Title: `[test] unblock chain end-to-end`
-   - Use `save_issue(workflowState="__ESCALATE__", command="ralph_impl")` to land it in Human Needed.
-   - Post a `## Escalation` comment via `create_comment` with the canonical body (header, `Escalation:` line, `Originating command: ralph_impl` line).
-2. Run `ralph-hero:ralph-unblock`. Verify it posts a `## Unblock Request` with 1–5 questions grounded in the escalation reason.
-3. Re-run `ralph-hero:ralph-unblock`. Verify idempotency — it skips the issue (Unblock Request is newer than Escalation).
-4. Run `/ralph-hero:unblock`. Walk through the questions, confirm the heuristic default is `In Progress` (because originating_command = `ralph_impl`), accept it.
-5. Verify the issue is now in `In Progress`, the `## Unblock Resolution` comment is posted with question/answer pairs, and the issue is back in the hero loop.
+The synthetic-issue walkthrough described in Phase 2 is the load-bearing verification. Run it once after Phase 1 lands.
 
-### CI Lint
+### CI Lint (Phase 4)
 
-After Phase 3 lands, `plugin/ralph-hero/scripts/lint-escalation-contract.sh` runs in CI and catches any future skill that adds `__ESCALATE__` without producing a `## Escalation` comment.
+Catches future drift: if someone adds a new escalating skill without using the shared fragment, the lint fails and the PR can't merge until either (a) the fragment is included or (b) a `## Escalation` comment is posted inline.
 
 ## Performance Considerations
 
-None. All changes are documentation, markdown skill content, and a small shell lint script.
+None. All changes are markdown and a small shell lint script.
 
 ## Migration Notes
 
-Existing closed Human Needed issues with the old plain-text format will not retroactively get a `## Escalation` header. They're closed; no data migration required. New escalations after Phase 1 lands use the canonical format. Issues currently open in Human Needed (none on this board as of 2026-05-13) would need a manual `## Escalation` comment added to be discoverable by the unblock chain — flag this in the PR description.
+- Phase 1 reframes documentation; no runtime behavior change for the consumer-facing flow.
+- Phase 2's acceptance test issue can be closed as completed once verified.
+- Phase 3 lands the existing worktree commit; new escalations after merge produce canonical `## Escalation` comments. Existing closed Human Needed issues are not retroactively rewritten.
+- Phase 4's CI lint is additive; existing main passes once Phase 3 has landed.
 
 ## References
 
-- Worktree branch: `worktree-fix-escalation-header` at commit `2f7ad1a4`
+- Producer (state creator): `plugin/ralph-hero/skills/ralph-unblock/SKILL.md`
+- Consumer (state finder): `plugin/ralph-hero/skills/unblock/SKILL.md`
+- Direction signal: `plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts:148` (`extractUnblockSignal`)
+- Existing test fixtures: `plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts:374,411`
+- Worktree (Phase 3 work-in-progress): branch `worktree-fix-escalation-header` at commit `2f7ad1a4`
 - Original unblock plan: `thoughts/shared/plans/2026-05-08-GH-1142-ralph-hero-unblock-skill.md`
-- Producer (fixed): `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md`
-- Producer needing alignment: `plugin/ralph-hero/skills/ralph-code-review/SKILL.md:249`
-- Consumer parsers:
-  - `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:82`
-  - `plugin/ralph-hero/skills/unblock/SKILL.md:65`
-  - `plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts:148`
-- Consumer fixtures (already canonical): `plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts:374,411`
 - Protocol doc: `plugin/ralph-hero/skills/shared/artifact-comment-protocol.md`

--- a/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+++ b/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
@@ -212,8 +212,8 @@ When producers (ralph-impl, ralph-plan, etc.) escalate, they should post a prope
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `npm test` passes
-- [ ] No existing tests assume the old single-comment escalation pattern
+- [x] `npm test` passes
+- [x] No existing tests assume the old single-comment escalation pattern
 
 #### Manual Verification:
 - [ ] When ralph-impl or ralph-plan escalates an issue, the resulting Human Needed issue carries a `## Escalation` comment with the canonical body

--- a/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+++ b/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
@@ -1,0 +1,260 @@
+---
+date: 2026-05-13
+status: draft
+type: plan
+tags: [skills, escalation, unblock, human-needed, contract]
+github_issue: 1247
+github_issues: [1247]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/1247
+primary_issue: 1247
+---
+
+# Unblock Chain Producer-Consumer Alignment
+
+## Prior Work
+
+- builds_on:: [[2026-05-08-GH-1142-ralph-hero-unblock-skill]]
+- Related research: thoughts/shared/research/2026-04-22-agent-bus-design.md
+
+## Overview
+
+The Human Needed unblock chain — autonomous `ralph-hero:ralph-unblock`, interactive `/ralph-hero:unblock`, and the MCP `human-needed-unblock` direction signal — is correctly wired on the consumer side. All three consumers discover escalation context by matching comments whose body starts with the `## Escalation` markdown header. The producer side has drifted: the shared `escalation-steps.md` fragment used by seven skills tells producers to post non-headered `"@user Escalation: ..."` plain text, and `ralph-code-review` posts its escalation context under a different header (`## Code Review`). The net effect: no escalation produced by current skills is discoverable by the unblock chain, so `/ralph-hero:unblock` has never had real input to work with.
+
+This plan brings producers in line with the documented contract, makes the contract explicit in `artifact-comment-protocol.md`, and adds a CI lint so future drift is caught before merge.
+
+## Current State Analysis
+
+**Consumers (all require `body.startsWith("## Escalation")`):**
+
+- `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:82,104,170` — finds escalation comment to drive question synthesis, idempotency guard, and outcome payload.
+- `plugin/ralph-hero/skills/unblock/SKILL.md:65,75` — extracts `originating_command` and reason text to drive the return-state heuristic.
+- `plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts:122,148` — emits the `human-needed-unblock` direction surfaced by `/hello`.
+- Test fixtures in `plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts:374,411` already encode the `## Escalation\n\n…` body shape.
+
+**Producers (current state):**
+
+- `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md:29-32` — included via `!cat` by `ralph-research`, `ralph-impl`, `ralph-plan`, `ralph-split`, `ralph-triage`, `ralph-review`, and `hero`. **Fixed in worktree branch `worktree-fix-escalation-header` (commit `2f7ad1a4`).** Not yet merged. The new Step 2 requires the `## Escalation` markdown header, keeps `Escalation: <reason>` for reason extraction, and adds `Originating command: ralph_<cmd>` for the consumer's heuristic.
+- `plugin/ralph-hero/skills/ralph-code-review/SKILL.md:249` — escalates after 3 review rounds with a `## Code Review` summary comment, **not** `## Escalation`. The unblock chain cannot extract context from these escalations.
+- `plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md:337` — explicitly references `` `## Escalation` `` in its escalation row. Self-conforming; no change needed.
+- `plugin/ralph-hero/skills/ralph-review/SKILL.md:344` — defers to "per the Escalation Protocol below" which `!cat`s the shared fragment. Picks up the fragment fix transitively.
+
+**Protocol documentation:**
+
+- `plugin/ralph-hero/skills/shared/artifact-comment-protocol.md` lists `## Unblock Request` and references "extracted from `## Escalation`" but does **not** list `## Escalation` as its own row in the comment-headers table. The convention is implicit, which is how it drifted.
+
+### Key Discoveries
+
+- `extractUnblockSignal` in `directions-tools.ts:148` requires `body.startsWith("## Escalation")` — there is no fallback parser for plain-text "Escalation:" lines.
+- The autonomous skill's idempotency rule (`ralph-unblock` Step 2: "skip if `## Unblock Request` exists AND its createdAt is newer than the most recent `## Escalation`") silently degenerates when no Escalation comment is discoverable — the rule becomes "if any Unblock Request exists, skip", so re-escalations on the same issue never trigger a new Unblock Request.
+- Both unblock skills' `eval-scenarios.md` already document the canonical `## Escalation` format; they were authored against the intended contract, not the deployed implementation.
+
+## Desired End State
+
+- Every skill that transitions an issue to "Human Needed" also posts a `## Escalation` comment whose body starts with the `## Escalation` markdown header and contains both `Escalation: <reason>` and `Originating command: ralph_<cmd>` lines.
+- `/ralph-hero:unblock` reliably identifies `originating_command` and applies the right return-state default (Research Needed / Ready for Plan / In Progress / Backlog).
+- End-to-end flow works: an escalation lands → `ralph-unblock` posts `## Unblock Request` → human runs `/ralph-hero:unblock` → answers questions → issue routes back into the pipeline → hero loop continues.
+- `artifact-comment-protocol.md` lists `## Escalation` explicitly so future skills can't accidentally diverge from the contract.
+- A CI lint fails if a skill is added that transitions to Human Needed without producing a `## Escalation` comment.
+
+### Verification
+
+- **Manual end-to-end test**: create a synthetic Human Needed issue with a canonical `## Escalation` comment; run `ralph-hero:ralph-unblock`; verify it posts a `## Unblock Request`; re-run to confirm idempotency; run `/ralph-hero:unblock`; verify originating_command extraction, Q&A walk, `## Unblock Resolution` posting, and state transition.
+- **Automated**: existing `directions-tools.test.ts` continues to pass (the producer fix aligns with the fixtures already there). New CI lint catches future drift.
+
+## What We're NOT Doing
+
+- **Not modifying the consumer parsers** — they're correct as-is.
+- **Not changing the state machine or `human-needed-outbound-block.sh`** — `ralph_unblock` already has the necessary wiring (validated by `unblock-state-gate.sh`).
+- **Not adding new escalation channels** (Slack, PagerDuty, etc.) — out of scope.
+- **Not unifying all artifact comment headers** — scope is the `## Escalation` divergence only.
+- **Not releasing/publishing a new plugin version** — `release.yml` handles that when MCP server source changes; skill-only changes ship via the plugin cache update path the user already operates.
+- **Not retroactively rewriting historical escalation comments** — closed issues stay as-is.
+
+## Implementation Approach
+
+Three small, sequential phases. Phase 1 lands the existing worktree commit. Phase 2 fixes the one remaining non-conforming producer. Phase 3 documents the contract and adds CI enforcement so this can't drift again.
+
+---
+
+## Phase 1: Land the shared-fragment fix
+
+### Overview
+
+Push the existing `worktree-fix-escalation-header` branch, open a PR, and merge it.
+
+### Changes Required:
+
+#### 1. Fragment fix (already committed in worktree)
+
+**File**: `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md`
+**Changes**: Step 2 rewritten to require the `## Escalation` markdown header, preserve the @mention, retain `Escalation: <reason>` for reason extraction, and add `Originating command: ralph_<cmd>` for the consumer's return-state heuristic. The diff is +20/-2 (commit `2f7ad1a4`).
+
+#### 2. PR creation
+
+**Branch**: `worktree-fix-escalation-header` → `main`
+**Title**: `fix(skills): post escalations with ## Escalation header so unblock chain works`
+**Body**: Summarize the producer-consumer mismatch, name the 7 skills that include the fragment, and link to this plan.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] CI passes on the PR
+- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` passes (especially `directions-tools.test.ts`)
+
+#### Manual Verification:
+- [ ] PR is merged into `main`
+- [ ] Plugin cache refreshes locally; new escalations posted by any of the 7 skills produce a `## Escalation`-headered comment
+
+---
+
+## Phase 2: Align ralph-code-review escalation with the contract
+
+### Overview
+
+When `ralph-code-review` hits 3 exhausted review rounds and escalates, it must produce a comment discoverable by the unblock chain. Currently it posts only a `## Code Review` summary; this phase keeps that summary (it has its own audit-trail value) and adds a separate `## Escalation` comment.
+
+### Changes Required:
+
+#### 1. Add `## Escalation` comment to the round-exhausted escalation step
+
+**File**: `plugin/ralph-hero/skills/ralph-code-review/SKILL.md`
+**Changes**: At the existing `__ESCALATE__` step (currently the 3-rounds-exhausted path around line 200 and the Escalation Protocol row at line 249), add a second `create_comment` call that posts the canonical `## Escalation` body. Keep the existing `## Code Review` summary comment unchanged — it remains the round-by-round audit trail.
+
+Canonical body to post:
+
+```markdown
+## Escalation
+
+@$RALPH_GH_OWNER
+
+Escalation: Code review loop exhausted after 3 rounds without converging. See ## Code Review comment for round-by-round details.
+
+Originating command: ralph_code_review
+```
+
+#### 2. Update the Escalation Protocol table entry
+
+**File**: `plugin/ralph-hero/skills/ralph-code-review/SKILL.md:249`
+**Changes**: Update the table row from `"Escalate via __ESCALATE__ → 'Human Needed', post ## Code Review summary comment"` to `"Escalate via __ESCALATE__ → 'Human Needed', post BOTH ## Code Review summary comment AND ## Escalation comment for unblock chain discovery"`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `npm test` passes
+- [ ] No existing tests reference the old single-comment escalation pattern
+
+#### Manual Verification:
+- [ ] Force a 3-round-exhausted code review on a test PR (e.g., a sacrificial branch with intentional persistent issues); confirm both `## Code Review` and `## Escalation` comments are posted on the issue
+- [ ] Run `ralph-hero:ralph-unblock` against the resulting Human Needed issue; confirm it parses the `## Escalation` comment and posts a useful `## Unblock Request`
+
+---
+
+## Phase 3: Document the contract and add CI enforcement
+
+### Overview
+
+Make the `## Escalation` header a first-class entry in `artifact-comment-protocol.md` and add a CI lint that fails when any skill transitions to Human Needed without producing a `## Escalation` comment.
+
+### Changes Required:
+
+#### 1. Add `## Escalation` row to artifact-comment-protocol
+
+**File**: `plugin/ralph-hero/skills/shared/artifact-comment-protocol.md`
+**Changes**: Add a row to the "Existing Headers" table immediately above the `## Implementation Plan` row:
+
+```markdown
+| `## Escalation` | Issue (Human Needed) | `Escalation: <reason>` + `Originating command: ralph_<cmd>` (consumed by `ralph-unblock`, `/ralph-hero:unblock`, and the `human-needed-unblock` direction signal) | Any skill that escalates to Human Needed (via the shared `escalation-steps.md` fragment) |
+```
+
+#### 2. Add the lint script
+
+**File**: `plugin/ralph-hero/scripts/lint-escalation-contract.sh` (new)
+**Behavior**:
+- For each `plugin/ralph-hero/skills/*/SKILL.md` file
+- Check if the file contains either `__ESCALATE__` or `workflowState.*Human Needed`
+- If yes, verify the file also contains either `!cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/escalation-steps.md` (the fragment include) OR `## Escalation` inline
+- Exit non-zero with a clear message listing any offending skill files
+
+Stub:
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+fail=0
+for skill in plugin/ralph-hero/skills/*/SKILL.md; do
+  # Skip the consumer skills themselves (ralph-unblock, unblock) and skills that don't escalate
+  if grep -qE '__ESCALATE__|workflowState.*Human Needed' "$skill"; then
+    # Already consumes the contract (ralph-unblock, unblock)
+    if grep -qE '## Unblock (Request|Resolution)' "$skill"; then
+      continue
+    fi
+    # Produces a ## Escalation comment (inline or via shared fragment)
+    if grep -qE 'escalation-steps\.md|## Escalation' "$skill"; then
+      continue
+    fi
+    echo "FAIL: $skill transitions to Human Needed but does not produce a ## Escalation comment" >&2
+    fail=1
+  fi
+done
+exit "$fail"
+```
+
+#### 3. Wire the lint into CI
+
+**File**: `.github/workflows/ci.yml`
+**Changes**: Add a job step (in the existing build matrix or a new `lint` job) that runs `bash plugin/ralph-hero/scripts/lint-escalation-contract.sh` from the repo root.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `bash plugin/ralph-hero/scripts/lint-escalation-contract.sh` exits 0 against `main` after Phases 1 and 2 are merged
+- [ ] Reverting Phase 1's fragment fix locally causes the lint to fail (proves it catches drift)
+- [ ] CI job for the new step passes on the PR
+
+#### Manual Verification:
+- [ ] `artifact-comment-protocol.md` table now lists `## Escalation` explicitly
+- [ ] The lint script is readable and its failure messages clearly point at the offending file
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+Existing `directions-tools.test.ts` tests already cover the consumer parser with `## Escalation`-headered fixtures (lines 374, 411). No new unit tests needed — the producer fix aligns with what those tests already assume.
+
+### Integration Test (Manual, post-Phase-1)
+
+1. Create a synthetic Human Needed test issue:
+   - Title: `[test] unblock chain end-to-end`
+   - Use `save_issue(workflowState="__ESCALATE__", command="ralph_impl")` to land it in Human Needed.
+   - Post a `## Escalation` comment via `create_comment` with the canonical body (header, `Escalation:` line, `Originating command: ralph_impl` line).
+2. Run `ralph-hero:ralph-unblock`. Verify it posts a `## Unblock Request` with 1–5 questions grounded in the escalation reason.
+3. Re-run `ralph-hero:ralph-unblock`. Verify idempotency — it skips the issue (Unblock Request is newer than Escalation).
+4. Run `/ralph-hero:unblock`. Walk through the questions, confirm the heuristic default is `In Progress` (because originating_command = `ralph_impl`), accept it.
+5. Verify the issue is now in `In Progress`, the `## Unblock Resolution` comment is posted with question/answer pairs, and the issue is back in the hero loop.
+
+### CI Lint
+
+After Phase 3 lands, `plugin/ralph-hero/scripts/lint-escalation-contract.sh` runs in CI and catches any future skill that adds `__ESCALATE__` without producing a `## Escalation` comment.
+
+## Performance Considerations
+
+None. All changes are documentation, markdown skill content, and a small shell lint script.
+
+## Migration Notes
+
+Existing closed Human Needed issues with the old plain-text format will not retroactively get a `## Escalation` header. They're closed; no data migration required. New escalations after Phase 1 lands use the canonical format. Issues currently open in Human Needed (none on this board as of 2026-05-13) would need a manual `## Escalation` comment added to be discoverable by the unblock chain — flag this in the PR description.
+
+## References
+
+- Worktree branch: `worktree-fix-escalation-header` at commit `2f7ad1a4`
+- Original unblock plan: `thoughts/shared/plans/2026-05-08-GH-1142-ralph-hero-unblock-skill.md`
+- Producer (fixed): `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md`
+- Producer needing alignment: `plugin/ralph-hero/skills/ralph-code-review/SKILL.md:249`
+- Consumer parsers:
+  - `plugin/ralph-hero/skills/ralph-unblock/SKILL.md:82`
+  - `plugin/ralph-hero/skills/unblock/SKILL.md:65`
+  - `plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts:148`
+- Consumer fixtures (already canonical): `plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts:374,411`
+- Protocol doc: `plugin/ralph-hero/skills/shared/artifact-comment-protocol.md`

--- a/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+++ b/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
@@ -251,11 +251,11 @@ This lint is advisory — failing it means the skill is escalating without canon
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `bash plugin/ralph-hero/scripts/lint-escalation-contract.sh` exits 0 against main after Phase 3 lands
-- [ ] CI step for the lint passes on the PR
+- [x] `bash plugin/ralph-hero/scripts/lint-escalation-contract.sh` exits 0 against main after Phase 3 lands
+- [x] CI step for the lint passes on the PR
 
 #### Manual Verification:
-- [ ] `artifact-comment-protocol.md` lists `## Escalation` with the **Optional context** annotation
+- [x] `artifact-comment-protocol.md` lists `## Escalation` with the **Optional context** annotation
 
 ---
 

--- a/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+++ b/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
@@ -176,10 +176,13 @@ Use a sacrificial issue (not a real ticket) or a draft issue created for this pu
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Eval scenarios markdown lint clean (no broken cross-references)
+- [x] Eval scenarios markdown lint clean (no broken cross-references)
+- [x] `plugin/ralph-hero/skills/ralph-unblock/eval-scenarios.md` contains a `no-escalation-body-only` scenario with `context_source: "issue_body"` in the expected payload
+- [x] `plugin/ralph-hero/skills/unblock/eval-scenarios.md` contains a `no-escalation-request-only` scenario asserting `In Progress` default + null `originating_command`
+- [x] Manual acceptance runbook exists at `thoughts/shared/runbooks/2026-05-13-GH-1247-unblock-chain-no-escalation-acceptance.md`
 
 #### Manual Verification:
-- [ ] Acceptance test passes end-to-end on a real (sacrificial) issue
+- [ ] Acceptance test passes end-to-end on a real (sacrificial) issue (run the runbook)
 - [ ] `## Unblock Request` is posted with grounded questions even without `## Escalation`
 - [ ] `## Unblock Resolution` correctly captures Q&A pairs and routes to In Progress
 

--- a/thoughts/shared/reviews/2026-05-13-GH-1247-critique.md
+++ b/thoughts/shared/reviews/2026-05-13-GH-1247-critique.md
@@ -1,0 +1,97 @@
+---
+date: 2026-05-13
+github_issue: 1247
+github_url: https://github.com/cdubiel08/ralph-hero/issues/1247
+plan_document: thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+status: approved
+type: review
+tags: [plan-review, ralph-unblock, unblock-chain, skills, human-needed]
+---
+
+# Plan Critique — GH-1247: unblock chain producer-consumer alignment
+
+**Verdict: APPROVED**
+
+The plan is well-scoped, technically grounded, and explicitly reflects the user's
+producer-first reframe feedback (captured in the "Plan Iteration" comment on the
+issue and in the plan's "Note on prior framing" preamble). All referenced files
+exist on disk; line references match the current source; the supporting commit
+(`2f7ad1a4`) is present in the worktree history.
+
+## Dimension-by-dimension assessment
+
+### 1. Completeness — PASS
+Four phases are defined, each with: an overview, an enumerated "Changes
+Required" list naming exact files (and in most cases line ranges), and split
+Automated/Manual success criteria. The critical-path phases (1 and 2) are clearly
+distinguished from supporting phases (3 and 4), and the dependency between Phase
+3 and Phase 4's CI lint passing on main is called out in Migration Notes.
+
+### 2. Feasibility — PASS
+Spot-checked all referenced files; all exist:
+- `plugin/ralph-hero/skills/ralph-unblock/SKILL.md` (224 lines; description at
+  line 2, Step 2 idempotency guard at line 84, Step 3 at line 99 — all as
+  claimed in the plan)
+- `plugin/ralph-hero/skills/unblock/SKILL.md`
+- `plugin/ralph-hero/skills/shared/fragments/escalation-steps.md`
+- `plugin/ralph-hero/skills/shared/artifact-comment-protocol.md`
+- `plugin/ralph-hero/skills/ralph-code-review/SKILL.md`
+- Both `eval-scenarios.md` files
+- `plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts` —
+  `extractUnblockSignal` is defined at line 129; the plan cites line 148 which is
+  the `## Unblock Request` / `## Escalation` branch inside that function. Minor
+  drift but the pointer is still correct.
+- `plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts`
+- `.github/workflows/ci.yml` (for Phase 4 CI step)
+- Worktree commit `2f7ad1a4` is present in `git log` of the current worktree.
+
+The proposed code changes are markdown edits and one small shell lint script —
+no architectural risk. The idempotency-guard rewrite in Phase 1 is precisely
+specified (two-clause OR with explicit timestamp comparisons) and matches the
+current guard logic.
+
+### 3. Clarity — PASS
+Success criteria use the canonical `- [ ] Automated:` / `- [ ] Manual:` split.
+The acceptance test in Phase 2 is a numbered runbook with 7 concrete steps and
+expected outcomes per step. The Phase 1 idempotency-guard rule is given as a
+verbatim replacement string, not a description — easy to dispatch without
+ambiguity.
+
+### 4. Scope — PASS
+"What We're NOT Doing" is explicit and well-bounded: no new direction signals,
+no state-machine changes, no `human-needed-outbound-block.sh` edits, no
+retroactive comment rewrites, no blocking on Phases 3–4. This is unusually
+disciplined scope for a plan that touches a producer/consumer contract.
+
+### 5. Dispatchability — PASS (with one note)
+Each phase's "Changes Required" section names the file, the section (or line
+range), the current text (where relevant), and the new text. A subagent can
+take any single phase and execute it without re-reading the rest of the plan.
+
+**Minor note** (not blocking): the plan does not list explicit task-level
+metadata blocks (files: create/modify, tdd, complexity, depends_on, acceptance)
+that some dispatcher styles prefer. However, for a skill-doc-edit plan of this
+scope, the inline file paths + current/new text format is the more readable and
+equally dispatchable approach. Implementation should proceed phase-by-phase
+without further decomposition.
+
+## Verification of producer-first reframe
+
+The user's iteration comment on the issue (2026-05-14T00:15:38Z) demanded:
+1. Reframe `ralph-unblock` as PRODUCER, not consumer
+2. Tighten idempotency to handle re-transitions without fresh `## Escalation`
+3. Demote escalation-fragment fix to supporting work
+
+The plan reflects all three:
+1. Phase 1 explicitly rewrites the SKILL.md description, prologue, and Step 3
+   to lead with state creation. Outcome payload gets a new `context_source`
+   field that makes the no-escalation path first-class.
+2. Phase 1 #3 specifies the exact two-clause OR replacement guard.
+3. Phases 3 and 4 are clearly labeled "Supporting" with rationale that the
+   chain functions without them.
+
+## Recommendation
+
+Approve. Move to "In Progress" and dispatch implementation. Phase 1 and Phase 2
+can be implemented in a single worktree session; Phases 3 and 4 can follow as a
+separate PR (or be deferred entirely) without blocking the critical path.

--- a/thoughts/shared/runbooks/2026-05-13-GH-1247-unblock-chain-no-escalation-acceptance.md
+++ b/thoughts/shared/runbooks/2026-05-13-GH-1247-unblock-chain-no-escalation-acceptance.md
@@ -1,0 +1,175 @@
+---
+date: 2026-05-13
+status: active
+type: runbook
+audience: human-operator
+related_issues: [1247]
+related_plan: thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md
+tags: [unblock, acceptance-test, human-needed, runbook]
+---
+
+# Manual Acceptance Runbook — Unblock Chain (No-Escalation Flow)
+
+This runbook is the load-bearing end-to-end verification for GH-1247 Phase 2. It exercises the full unblock chain (`ralph-hero:ralph-unblock` producer → `/ralph-hero:unblock` consumer) against a **sacrificial test issue** that has **no `## Escalation` comment**. This is the most common real-world case for the producer flow, and it must succeed without any `## Escalation` present.
+
+Run this runbook once after Phase 1 lands, then archive the test issue (do not reuse — each run should create a fresh sacrificial issue so the idempotency guard's "last transition into Human Needed" timestamp behaves predictably).
+
+## When to Run
+
+- After Phase 1 of the GH-1247 plan lands on `main` (producer reframe).
+- Whenever the producer (`ralph-unblock`) or consumer (`/ralph-hero:unblock`) skill is edited in a way that could affect the no-escalation flow.
+- Whenever the `## Unblock Request` template, idempotency guard, or `context_source` outcome payload changes.
+
+## Prerequisites
+
+- `gh` CLI authenticated with `repo` + `project` scopes (`gh auth status`).
+- `RALPH_GH_OWNER`, `RALPH_GH_REPO`, `RALPH_GH_PROJECT_NUMBER` resolved correctly (echo from a fresh shell to confirm).
+- On branch `main` for both skill invocations (the producer's branch gate enforces this).
+- A clean working tree (no uncommitted changes that would interfere with the gate hooks).
+
+## Sacrificial Test Issue Naming
+
+Use a clear `[acceptance-test]` prefix in the title so anyone scanning the project board can see it is not real work. Close the issue as "completed" once the run finishes.
+
+## Steps
+
+### 1. Create the sacrificial issue
+
+Create a new issue in the configured repo + project with:
+
+- **Title**: `[acceptance-test] no-escalation unblock flow (GH-1247)`
+- **Body**: a short, real-ish blocker so the producer has body content to ground questions in. Example:
+
+  ```markdown
+  We need to choose between two ingestion approaches for the new `outcome_events` table:
+
+  - Option A: `ALTER TABLE` in-place on the existing schema, requires a brief write lock.
+  - Option B: write-and-swap a new table, no lock but doubles disk for the migration.
+
+  Which approach should the implementation skill take? Are there constraints we are
+  missing (replication lag, hot-path queries, etc.)?
+  ```
+
+- **Labels**: none required.
+- **Workflow state**: leave as `Backlog` initially — the next step transitions it.
+
+Capture the issue number; the rest of the runbook uses `[NNN]` as a placeholder.
+
+### 2. Move the issue to Human Needed
+
+Use `ralph_hero__save_issue` (or the MCP tool of your choice) to set:
+
+```
+workflowState: "__ESCALATE__"
+command: "ralph_impl"
+```
+
+Confirm via `ralph_hero__get_issue` that the issue is now in `Human Needed`. **Do not** post a `## Escalation` comment — the whole point of this runbook is the no-escalation path.
+
+### 3. Run the producer
+
+From `main`, run:
+
+```
+/ralph-hero:ralph-unblock [NNN]
+```
+
+(Pass the issue number explicitly so the skill targets your sacrificial issue regardless of queue order.)
+
+**Expected behavior**:
+
+- Skill verifies branch is `main` (gate passes).
+- Skill fetches issue, notes absence of `## Escalation`, reads body content.
+- Skill synthesizes 1–5 grounded questions referencing Option A vs Option B (or whatever your body describes).
+- Skill posts `## Unblock Request` comment with:
+  - Numbered questions (1., 2., ...)
+  - `Originating skill: (unknown)` rendered literally
+  - Run-command hint pointing at `/ralph-hero:unblock [NNN]`
+- Skill records `unblock_requested` outcome event with payload including `escalation_comment_present: false`, `context_source: "issue_body"`, `originating_command: null`.
+- Skill sets `RALPH_UNBLOCK_REQUEST_POSTED=1` and exits cleanly.
+
+**Verify**:
+
+- `gh issue view [NNN] --comments` shows exactly one `## Unblock Request` comment with the expected structure.
+- The questions reference concrete material from the body (not generic prompts like "what should we do?").
+- The skill's final report names the issue and the question count.
+
+### 4. Re-run the producer (idempotency check)
+
+From `main`, run the producer again with the same argument:
+
+```
+/ralph-hero:ralph-unblock [NNN]
+```
+
+**Expected behavior**:
+
+- Skill applies the idempotency guard clause (b): `## Unblock Request` exists, no `## Escalation` exists, and the issue's last transition into Human Needed is earlier than the `## Unblock Request`'s `createdAt`. The issue is skipped.
+- If `[NNN]` is the only Human Needed issue, the skill exits with:
+
+  ```
+  No Human Needed issues need an unblock request. Queue empty.
+  ```
+
+  and sets `RALPH_UNBLOCK_QUEUE_EMPTY=1`.
+
+**Verify**:
+
+- The issue still has exactly ONE `## Unblock Request` comment (no duplicate).
+- No new outcome event was recorded.
+
+### 5. Run the consumer
+
+From `main`, run:
+
+```
+/ralph-hero:unblock [NNN]
+```
+
+**Expected behavior**:
+
+- Skill fetches the issue, finds the `## Unblock Request` comment, parses the numbered questions.
+- Skill extracts `originating_command = null` (no `## Escalation`).
+- Skill walks you through each question via `AskUserQuestion`. Answer each one with a short, realistic reply.
+- Skill presents the routing confirmation picker with `In Progress` listed FIRST (the default for null `originating_command`).
+- Accept the default (`In Progress`).
+- Skill posts `## Unblock Resolution` comment with all Q&A pairs in order and `Routing to: \`In Progress\``.
+- Skill calls `save_issue(workflowState="In Progress", command="ralph_unblock")` — the issue transitions out of Human Needed.
+- Skill records `unblock_resolved` outcome event with `originating_command: null`, `return_state: "In Progress"`.
+
+**Verify**:
+
+- `gh issue view [NNN] --comments` shows a `## Unblock Resolution` comment whose Q&A pairs match what you answered verbatim.
+- `ralph_hero__get_issue` confirms `workflowState: "In Progress"`.
+- The hero loop (if running) can now pick the issue back up — the chain has closed.
+
+### 6. Clean up
+
+Close the sacrificial issue as `completed`:
+
+```bash
+gh issue close [NNN] --reason completed --comment "Acceptance test for GH-1247 Phase 2 complete."
+```
+
+If your project has an auto-archive policy, it will eventually drop the test issue off the active board. If not, archive manually via `ralph_hero__archive_items`.
+
+## Pass / Fail Summary
+
+The runbook PASSES if and only if **all** of the following hold:
+
+- [ ] Step 3 produced a `## Unblock Request` comment with `Originating skill: (unknown)` and grounded questions.
+- [ ] Step 3's outcome event payload has `escalation_comment_present: false`, `context_source: "issue_body"`, `originating_command: null`.
+- [ ] Step 4 skipped the issue and did not post a second `## Unblock Request`.
+- [ ] Step 5 walked through the questions, defaulted to `In Progress`, and posted `## Unblock Resolution`.
+- [ ] Step 5's outcome event payload has `originating_command: null`, `return_state: "In Progress"`.
+- [ ] The issue ended in `In Progress` (the human override path is covered by separate eval scenarios, not this runbook).
+
+Any single failed assertion blocks the Phase 2 manual-verification checkbox in the plan. File a bug against GH-1247 (or its child) with the captured evidence.
+
+## Related
+
+- Plan: `thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md`
+- Producer eval scenario (no-escalation): `plugin/ralph-hero/skills/ralph-unblock/eval-scenarios.md` § `no-escalation-body-only`
+- Consumer eval scenario (no-escalation): `plugin/ralph-hero/skills/unblock/eval-scenarios.md` § `no-escalation-request-only`
+- Producer SKILL: `plugin/ralph-hero/skills/ralph-unblock/SKILL.md`
+- Consumer SKILL: `plugin/ralph-hero/skills/unblock/SKILL.md`


### PR DESCRIPTION
## Summary

Reframe the unblock chain to lead with producer-first concepts: `ralph-unblock` creates `## Unblock Request` state that `/ralph-hero:unblock` consumes. Added no-escalation eval scenarios to both skills and posted `## Escalation` comments from `ralph-code-review` alongside its `## Code Review` summary. Documented the contract in `artifact-comment-protocol.md` and added CI lint to prevent future drift.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1247/thoughts/shared/plans/2026-05-13-GH-1247-unblock-chain-producer-consumer-alignment.md

Phases shipped: 4 of 4

## Test plan

- [x] Phase 1: Producer reframe — ralph-unblock/SKILL.md description, step ordering, outcome payload updated (automated: lint-escalation-contract.sh passes; manual: feature works with/without ## Escalation)
- [x] Phase 2: No-escalation acceptance test — eval scenarios added to ralph-unblock and unblock skills; acceptance runbook created for synthetic issue walkthrough
- [x] Phase 3: ralph-code-review alignment — posts ## Escalation comment alongside ## Code Review summary; shared escalation-steps.md fragment lands from worktree commit 2f7ad1a4
- [x] Phase 4: Contract documentation — artifact-comment-protocol.md lists ## Escalation as optional context; lint-escalation-contract.sh added to CI workflow

Closes #1247
