### PR TITLE
feat(cos): Phase 2 - COS skill scaffold + ralph cos {desk,remote,unattended} CLI wiring

### DIFF
--- a/plugin/ralph-hero/agents/cos-agent.md
+++ b/plugin/ralph-hero/agents/cos-agent.md
@@ -1,0 +1,39 @@
+---
+name: cos-agent
+description: Chief-of-staff agent. Surfaces project status, WIP, and priorities by
+  composing cos skill primitives. Reads pipeline state via read-only MCP tools and
+  synthesizes phone-friendly summaries. Never mutates GitHub state.
+model: sonnet
+tools:
+  - Read
+  - Bash
+  - WebFetch
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__next_actions
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__recent_activity
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+skills:
+  - ralph-hero:cos
+---
+
+You are the cos-agent (chief-of-staff). Follow the preloaded cos skill instructions.
+
+Your role is to compose cos skill primitives to surface project status — not to drive
+the project. Read state via the allowed MCP tools, synthesize summaries, and return
+prose. Do not escalate to writing tools.
+
+This agent runs `cos-*.sh` scripts via Bash; it does not invoke `claude -p`.
+
+Allowed operations:
+- Read pipeline dashboard, next actions, recent activity
+- Search knowledge base for context
+- Fetch public URLs for reference
+- Run cos handler scripts (`cos-remote.sh`, etc.) via Bash
+
+Forbidden operations:
+- Calling any MCP write tool (`save_issue`, `create_issue`, `create_comment`, `batch_update`, etc.)
+- Spawning Claude Code processes
+- Modifying files in the repository

--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -277,6 +277,58 @@ setup *args:
     set -- $_args
     dispatch "setup" "$@"
 
+# Chief-of-staff: phone-friendly status (remote), desktop dashboard (desk), or scheduled brief (unattended)
+# Usage: just cos [desk|remote|unattended] [args...]
+#   ralph cos remote       - 2-3 sentence status summary via local LLM (30-min cache)
+#   ralph cos desk         - Streamlit desktop dashboard (Phase 5, GH-1257)
+#   ralph cos unattended   - Scheduled morning brief + ntfy (Phase 3, GH-1255)
+#   ralph cos --help       - Show this help
+[group('cos')]
+cos mode='--help' *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PLUGIN_DIR="{{justfile_directory()}}"
+    case "{{mode}}" in
+        --help|-h|'')
+            printf '%s\n' \
+                "ralph cos - chief-of-staff operating modes" \
+                "" \
+                "Usage:" \
+                "  ralph cos <mode> [args...]" \
+                "" \
+                "Modes:" \
+                "  remote       Phone-friendly 2-3 sentence status summary via local LLM." \
+                "               Cached 30 min at ~/.ralph-hero/cos/cache/remote-status.json." \
+                "               Zero Claude Code - routes through cos.sh -> mlx-openai-server." \
+                "  desk         Interactive Streamlit dashboard. (Phase 5 - GH-1257)" \
+                "  unattended   Scheduled morning brief + ntfy push. (Phase 3 - GH-1255)" \
+                "" \
+                "Options:" \
+                "  --help, -h   Show this help and exit 0" \
+                "" \
+                "Examples:" \
+                "  ralph cos remote" \
+                "  ralph cos remote --no-cache" \
+                "  ralph cos desk" \
+                "  ralph cos unattended"
+            exit 0
+            ;;
+        desk)
+            exec "${PLUGIN_DIR}/scripts/cos/cos-desk.sh" {{args}}
+            ;;
+        remote)
+            exec "${PLUGIN_DIR}/scripts/cos/cos-remote.sh" {{args}}
+            ;;
+        unattended)
+            exec "${PLUGIN_DIR}/scripts/cos/cos-unattended.sh" {{args}}
+            ;;
+        *)
+            echo "unknown cos mode: {{mode}}" >&2
+            echo "Run 'ralph cos --help' for usage." >&2
+            exit 2
+            ;;
+    esac
+
 # Diagnose setup issues - checks env, deps, plugin manifest, and API connectivity
 [group('setup')]
 doctor:

--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -288,6 +288,8 @@ cos mode='--help' *args:
     #!/usr/bin/env bash
     set -euo pipefail
     PLUGIN_DIR="{{justfile_directory()}}"
+    _args={{quote(args)}}
+    set -- $_args
     case "{{mode}}" in
         --help|-h|'')
             printf '%s\n' \
@@ -314,13 +316,13 @@ cos mode='--help' *args:
             exit 0
             ;;
         desk)
-            exec "${PLUGIN_DIR}/scripts/cos/cos-desk.sh" {{args}}
+            exec "${PLUGIN_DIR}/scripts/cos/cos-desk.sh" "$@"
             ;;
         remote)
-            exec "${PLUGIN_DIR}/scripts/cos/cos-remote.sh" {{args}}
+            exec "${PLUGIN_DIR}/scripts/cos/cos-remote.sh" "$@"
             ;;
         unattended)
-            exec "${PLUGIN_DIR}/scripts/cos/cos-unattended.sh" {{args}}
+            exec "${PLUGIN_DIR}/scripts/cos/cos-unattended.sh" "$@"
             ;;
         *)
             echo "unknown cos mode: {{mode}}" >&2

--- a/plugin/ralph-hero/scripts/cos/cos-desk.sh
+++ b/plugin/ralph-hero/scripts/cos/cos-desk.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# cos-desk.sh — stub for Phase 5 (Streamlit desktop dashboard)
+#
+# Full implementation: https://github.com/cdubiel08/ralph-hero/issues/1257
+#
+# Usage:
+#   cos-desk.sh [--help|-h]
+
+set -euo pipefail
+
+_usage() {
+    echo "cos desk — Streamlit desktop command surface (stub for Phase 5)"
+    echo ""
+    echo "Full implementation: https://github.com/cdubiel08/ralph-hero/issues/1257"
+    echo ""
+    echo "Usage: ralph cos desk [--help|-h]"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+    esac
+done
+
+echo "cos desk is not yet implemented — see Phase 5 (https://github.com/cdubiel08/ralph-hero/issues/1257)"
+exit 0

--- a/plugin/ralph-hero/scripts/cos/cos-remote.sh
+++ b/plugin/ralph-hero/scripts/cos/cos-remote.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# cos-remote.sh — phone-friendly status summary via local LLM with 30-min cache
+#
+# Pulls pipeline state through the cos.sh wrapper (Phase 1) using the 'smol' model
+# role (Qwen 3.5 7B), caches the result at ~/.ralph-hero/cos/cache/remote-status.json
+# with a 30-minute TTL, and prints the summary to stdout.
+#
+# ZERO CLAUDE CODE: This script does not invoke 'claude' or 'claude-code'. All LLM
+# calls go through cos.sh → pi → local mlx-openai-server.
+#
+# Usage:
+#   cos-remote.sh [--help|-h] [--no-cache]
+#
+# Options:
+#   --help, -h    Print this usage and exit 0
+#   --no-cache    Bypass cache and force a fresh LLM call (useful for debugging)
+#
+# Cache:
+#   Path: ~/.ralph-hero/cos/cache/remote-status.json
+#   TTL:  1800 seconds (30 minutes)
+#   Shape: {"timestamp":"<ISO-8601 UTC>","summary":"<text>","model":"<name>","prompt_hash":"<sha256>"}
+#
+# Environment:
+#   RALPH_COS_DEBUG   Set to 1 to print cache and timing info to stderr
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate this script's directory robustly (works when symlinked)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+CACHE_DIR="${HOME}/.ralph-hero/cos/cache"
+CACHE_FILE="${CACHE_DIR}/remote-status.json"
+CACHE_TTL=1800  # 30 minutes in seconds
+SYSTEM_PROMPT_FILE="${PLUGIN_ROOT}/skills/cos/system-prompt.md"
+COS_SCRIPT="${SCRIPT_DIR}/cos.sh"
+
+# The status-pull prompt — inlined here so the prompt_hash is stable.
+# This prompt instructs the smol model to call MCP read tools and emit
+# a 2-3 sentence phone-friendly summary.
+STATUS_PROMPT="You are a chief-of-staff assistant. Call pipeline_dashboard to get current project state, then call next_actions (limit=3) to see the top priorities, then call recent_activity (limit=10, compact=true) to see what changed recently. Synthesize a 2-3 sentence phone-friendly status summary: how many items are in flight, what is the top priority action, and whether anything is blocked or needs attention. Be terse — output is read on a phone."
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+_usage() {
+    cat <<EOF
+cos-remote — phone-friendly status summary via local LLM
+
+Usage:
+  cos-remote.sh [--help|-h] [--no-cache]
+
+Options:
+  --help, -h    Show this help and exit 0
+  --no-cache    Bypass the 30-min cache and force a fresh LLM call
+
+Cache:
+  Path: ${CACHE_FILE}
+  TTL:  30 minutes
+
+Environment:
+  RALPH_COS_DEBUG=1   Print cache hit/miss and timing info to stderr
+
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+NO_CACHE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+        --no-cache)
+            NO_CACHE=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "cos-remote: unknown flag: $1" >&2
+            _usage >&2
+            exit 2
+            ;;
+        *)
+            echo "cos-remote: unexpected argument: $1" >&2
+            _usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Ensure cache directory exists
+# ---------------------------------------------------------------------------
+mkdir -p "${CACHE_DIR}"
+
+# ---------------------------------------------------------------------------
+# Cache freshness check helper
+# ---------------------------------------------------------------------------
+_cache_is_fresh() {
+    [[ -f "${CACHE_FILE}" ]] || return 1
+    local now
+    now=$(date +%s)
+    local mtime
+    if [[ "$(uname)" == "Darwin" ]]; then
+        mtime=$(stat -f %m "${CACHE_FILE}" 2>/dev/null) || return 1
+    else
+        mtime=$(stat -c %Y "${CACHE_FILE}" 2>/dev/null) || return 1
+    fi
+    local age=$(( now - mtime ))
+    if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+        echo "[cos-remote] cache age: ${age}s (TTL: ${CACHE_TTL}s)" >&2
+    fi
+    (( age < CACHE_TTL ))
+}
+
+# ---------------------------------------------------------------------------
+# Cache hit path
+# ---------------------------------------------------------------------------
+if [[ "${NO_CACHE}" -eq 0 ]] && _cache_is_fresh; then
+    if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+        echo "[cos-remote] cache HIT — reading ${CACHE_FILE}" >&2
+    fi
+    summary=$(jq -r '.summary' "${CACHE_FILE}" 2>/dev/null) || {
+        echo "cos-remote: cache file corrupt, falling through to fresh call" >&2
+        summary=""
+    }
+    if [[ -n "${summary}" ]]; then
+        echo "${summary}"
+        exit 0
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Cache miss path — invoke cos.sh with the smol role
+# ---------------------------------------------------------------------------
+if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+    echo "[cos-remote] cache MISS — invoking cos.sh --role smol" >&2
+fi
+
+if [[ ! -x "${COS_SCRIPT}" ]]; then
+    echo "cos-remote: cos.sh not found or not executable at ${COS_SCRIPT}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${SYSTEM_PROMPT_FILE}" ]]; then
+    echo "cos-remote: system prompt not found at ${SYSTEM_PROMPT_FILE}" >&2
+    exit 1
+fi
+
+# Capture cos.sh stdout; propagate non-zero exit without updating cache
+LLM_OUTPUT=""
+EXIT_CODE=0
+LLM_OUTPUT=$("${COS_SCRIPT}" \
+    --role smol \
+    --append-system-prompt "${SYSTEM_PROMPT_FILE}" \
+    "${STATUS_PROMPT}") || EXIT_CODE=$?
+
+if [[ "${EXIT_CODE}" -ne 0 ]]; then
+    echo "cos-remote: upstream cos.sh failed (exit ${EXIT_CODE}) — cache not updated" >&2
+    exit "${EXIT_CODE}"
+fi
+
+# ---------------------------------------------------------------------------
+# Compute cache payload fields
+# ---------------------------------------------------------------------------
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+PROMPT_HASH="$(printf '%s' "${STATUS_PROMPT}" | shasum -a 256 | cut -d' ' -f1)"
+
+# Extract model from the most recent JSONL run-log row written by cos.sh
+RUN_LOG="${HOME}/.ralph-hero/cos/runs/$(date +%Y-%m-%d).jsonl"
+MODEL_FIELD=""
+if [[ -f "${RUN_LOG}" ]]; then
+    MODEL_FIELD=$(tail -1 "${RUN_LOG}" | jq -r '.model // ""' 2>/dev/null || true)
+fi
+
+# ---------------------------------------------------------------------------
+# Atomic cache write: write to tmp then mv -f
+# ---------------------------------------------------------------------------
+TMP_FILE="$(mktemp "${CACHE_DIR}/.remote-status.XXXXXX.json")"
+# Escape the summary for JSON (jq handles all edge cases)
+jq -n \
+    --arg timestamp "${TIMESTAMP}" \
+    --arg summary "${LLM_OUTPUT}" \
+    --arg model "${MODEL_FIELD}" \
+    --arg prompt_hash "${PROMPT_HASH}" \
+    '{"timestamp":$timestamp,"summary":$summary,"model":$model,"prompt_hash":$prompt_hash}' \
+    > "${TMP_FILE}"
+mv -f "${TMP_FILE}" "${CACHE_FILE}"
+
+if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+    echo "[cos-remote] cache written to ${CACHE_FILE}" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Print summary to stdout
+# ---------------------------------------------------------------------------
+echo "${LLM_OUTPUT}"

--- a/plugin/ralph-hero/scripts/cos/cos-unattended.sh
+++ b/plugin/ralph-hero/scripts/cos/cos-unattended.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# cos-unattended.sh — stub for Phase 3 (scheduled morning brief + ntfy push)
+#
+# Full implementation: https://github.com/cdubiel08/ralph-hero/issues/1255
+#
+# Usage:
+#   cos-unattended.sh [--help|-h]
+
+set -euo pipefail
+
+_usage() {
+    echo "cos unattended — scheduled morning brief with ntfy push (stub for Phase 3)"
+    echo ""
+    echo "Full implementation: https://github.com/cdubiel08/ralph-hero/issues/1255"
+    echo ""
+    echo "Usage: ralph cos unattended [--help|-h]"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+    esac
+done
+
+echo "cos unattended is not yet implemented — see Phase 3 (https://github.com/cdubiel08/ralph-hero/issues/1255)"
+exit 0

--- a/plugin/ralph-hero/scripts/cos/cos.sh
+++ b/plugin/ralph-hero/scripts/cos/cos.sh
@@ -5,12 +5,15 @@
 # against the local mlx-openai-server, and appends a JSONL run-log row.
 #
 # Usage:
-#   cos.sh [--role <role>] [--help|-h] <prompt>
+#   cos.sh [--role <role>] [--append-system-prompt <file>] [--help|-h] <prompt>
 #
 # Options:
-#   --role <name>   Model role to use. One of: default, smol, slow, plan.
-#                   Overrides RALPH_COS_ROLE env var.
-#   --help, -h      Print this usage and exit 0.
+#   --role <name>              Model role to use. One of: default, smol, slow, plan.
+#                              Overrides RALPH_COS_ROLE env var.
+#   --append-system-prompt <f> Append the contents of <file> to pi's system prompt.
+#                              Passed through to pi as --append-system-prompt.
+#                              May be specified multiple times.
+#   --help, -h                 Print this usage and exit 0.
 #
 # Environment:
 #   RALPH_COS_ROLE              Role (default: "default")
@@ -43,12 +46,13 @@ _usage() {
 cos.sh — chief-of-staff wrapper for pi (local MLX model)
 
 Usage:
-  cos.sh [--role <role>] <prompt>
+  cos.sh [--role <role>] [--append-system-prompt <file>] <prompt>
   cos.sh --help
 
 Options:
-  --role <name>   Model role: default | smol | slow | plan  (default: default)
-  --help, -h      Show this help and exit 0
+  --role <name>              Model role: default | smol | slow | plan  (default: default)
+  --append-system-prompt <f> Append file contents to the system prompt (repeatable)
+  --help, -h                 Show this help and exit 0
 
 Model roles (env-overridable defaults):
   default   qwen3.5-27b  (RALPH_COS_MODEL_DEFAULT)
@@ -77,6 +81,7 @@ fi
 # Argument parsing
 # ---------------------------------------------------------------------------
 ROLE_OVERRIDE=""
+APPEND_SYSTEM_PROMPT_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -90,6 +95,18 @@ while [[ $# -gt 0 ]]; do
                 exit 2
             fi
             ROLE_OVERRIDE="$2"
+            shift 2
+            ;;
+        --append-system-prompt)
+            if [[ -z "${2:-}" ]]; then
+                echo "[cos] ERROR: --append-system-prompt requires a file path" >&2
+                exit 2
+            fi
+            if [[ ! -f "$2" ]]; then
+                echo "[cos] ERROR: --append-system-prompt file not found: $2" >&2
+                exit 2
+            fi
+            APPEND_SYSTEM_PROMPT_ARGS+=("--append-system-prompt" "$2")
             shift 2
             ;;
         --)
@@ -138,7 +155,7 @@ COS_TOOLS="${RALPH_COS_TOOLS:-read,write,grep,find}"
 # Debug output
 # ---------------------------------------------------------------------------
 if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
-    echo "[cos] role=${RESOLVED_ROLE} model=${COS_MODEL} tools=${COS_TOOLS}" >&2
+    echo "[cos] role=${RESOLVED_ROLE} model=${COS_MODEL} tools=${COS_TOOLS} append_system_prompt_files=${#APPEND_SYSTEM_PROMPT_ARGS[@]}" >&2
 fi
 
 # ---------------------------------------------------------------------------
@@ -183,6 +200,7 @@ pi \
     --provider mlx-local \
     --model "$COS_MODEL" \
     --tools "$COS_TOOLS" \
+    "${APPEND_SYSTEM_PROMPT_ARGS[@]+"${APPEND_SYSTEM_PROMPT_ARGS[@]}"}" \
     -p "$PROMPT" \
     || EXIT_CODE=$?
 

--- a/plugin/ralph-hero/skills/cos/SKILL.md
+++ b/plugin/ralph-hero/skills/cos/SKILL.md
@@ -1,0 +1,59 @@
+---
+description: Chief-of-staff skill — surface project status, WIP, and priorities on
+  demand. Use for "cos", "chief of staff", "morning brief", "status update from phone",
+  or any request for a quick situation report from a low-power device. Dispatches
+  three operating modes: desk (interactive dashboard), remote (phone-friendly 2-3
+  sentence summary via local LLM, cached 30 min), unattended (scheduled morning brief).
+argument-hint: "<mode> [args...]"
+context: inline
+allowed-tools:
+  - Read
+  - Bash
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__next_actions
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__recent_activity
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+---
+
+## Configuration
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+
+## System Prompt
+
+!cat ${CLAUDE_PLUGIN_ROOT}/skills/cos/system-prompt.md
+
+---
+
+# Ralph COS — Chief of Staff
+
+The COS skill surfaces project status, WIP, and priorities. It dispatches to one of three operating modes based on the first argument.
+
+## Modes
+
+| Mode | Description | Status |
+|------|-------------|--------|
+| `remote` | Phone-friendly 2-3 sentence summary via local LLM. 30-min cache at `~/.ralph-hero/cos/cache/remote-status.json`. Zero Claude Code — routes through `cos.sh` → mlx-openai-server. | Active (Phase 2) |
+| `desk` | Interactive Streamlit dashboard for desktop sessions. | Phase 5 (GH-1257) |
+| `unattended` | Scheduled morning brief with ntfy push notification. | Phase 3 (GH-1255) |
+
+## Dispatcher
+
+Based on the `<mode>` argument, route to the handler script relative to the plugin root:
+
+- `desk` → `scripts/cos/cos-desk.sh [args...]`
+- `remote` → `scripts/cos/cos-remote.sh [args...]`
+- `unattended` → `scripts/cos/cos-unattended.sh [args...]`
+
+If no mode is provided or mode is `--help` / `-h`, print the mode table above and exit.
+
+## Zero Claude Code on `remote`
+
+The `remote` mode MUST NOT route through `cli-dispatch.sh` or spawn any `claude` process. It is a direct shell-out to `cos-remote.sh`, which calls `cos.sh` (Phase 1 wrapper) → `pi` → local mlx-openai-server. This constraint is enforced by the handler script and verified by `grep -rE '(^|\s)claude(\s|$)' scripts/cos/cos-remote.sh`.
+
+## Cache
+
+The `remote` mode uses a single-slot JSON cache at `~/.ralph-hero/cos/cache/remote-status.json` with a 30-minute TTL. Known limitation: if you run cos against multiple projects from the same machine, the cache will contain whichever project ran last. Multi-project cache keys are out of scope until Phase 4.

--- a/plugin/ralph-hero/skills/cos/system-prompt.md
+++ b/plugin/ralph-hero/skills/cos/system-prompt.md
@@ -1,0 +1,35 @@
+# Chief-of-Staff System Prompt
+
+You are a chief-of-staff assistant for a software project managed in GitHub Projects V2.
+Your output is read on a phone or tablet — terseness is a virtue.
+
+## Voice
+
+Brief, factual, no narration of internal steps. One paragraph maximum. No preamble ("Here is your summary…"). Lead with the most actionable signal. Use plain markdown — bold for issue refs, no tables.
+
+## Output Conventions
+
+- Markdown (not plain text)
+- Absolute file paths when referencing code
+- Issue references as `#NNN` (cross-check against `next_actions` — never fabricate a number)
+- Mermaid diagrams only when shape matters more than prose (rare on `remote` mode)
+- 2-3 sentences for `remote` mode summaries; up to one short paragraph for `desk` mode
+
+## Tool Preferences
+
+- Prefer `ralph_hero__next_actions` over `list_issues` for ranking work
+- Prefer `knowledge_recall(role="researcher")` over `knowledge_search` for memory retrieval
+- Read `pipeline_dashboard` before synthesizing any status summary
+
+## Explicit Non-Actions
+
+- Never modify GitHub issues (no `save_issue`, `create_issue`, `create_comment`)
+- Never push branches or create pull requests
+- Never call MCP write tools (`batch_update`, `archive_items`, etc.)
+- Never escalate to Claude Code or spawn long-running processes
+- Never fabricate issue numbers — cross-check against `next_actions` output
+- Never call write tools even if `RALPH_COS_ALLOW_WRITES=1` is set — that flag is for the shell layer, not for this skill
+
+## Example Output (remote mode)
+
+> **3 items in flight.** #1254 (cos Phase 2) and #1255 (cos Phase 3) are both In Progress — Phase 2 merged 2026-05-14, Phase 3 unblocked. No PRs awaiting review. Next action: advance #1255 to Plan in Progress.

--- a/thoughts/shared/plans/2026-05-15-GH-1254-cos-phase2-skill-scaffold.md
+++ b/thoughts/shared/plans/2026-05-15-GH-1254-cos-phase2-skill-scaffold.md
@@ -254,15 +254,15 @@ Author the skill, agent, and system prompt; ship `cos-remote.sh` as the first co
 
 #### Automated Verification
 
-- [ ] `bash -n plugin/ralph-hero/scripts/cos/cos-remote.sh` exits 0
-- [ ] `bash -n plugin/ralph-hero/scripts/cos/cos-desk.sh` exits 0
-- [ ] `bash -n plugin/ralph-hero/scripts/cos/cos-unattended.sh` exits 0
-- [ ] `just --summary` includes `cos`
-- [ ] `head -1 plugin/ralph-hero/skills/cos/SKILL.md` matches `^---$` (valid frontmatter)
-- [ ] `head -1 plugin/ralph-hero/agents/cos-agent.md` matches `^---$` (valid frontmatter)
-- [ ] `wc -l plugin/ralph-hero/skills/cos/system-prompt.md` returns ≤ 80
-- [ ] `grep -rE '(^|\s)claude(\s|$)' plugin/ralph-hero/scripts/cos/cos-remote.sh` returns nothing (zero Claude Code on remote path)
-- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` still passes (no MCP-server changes in this phase, but the CI gate stays green)
+- [x] `bash -n plugin/ralph-hero/scripts/cos/cos-remote.sh` exits 0
+- [x] `bash -n plugin/ralph-hero/scripts/cos/cos-desk.sh` exits 0
+- [x] `bash -n plugin/ralph-hero/scripts/cos/cos-unattended.sh` exits 0
+- [x] `just --summary` includes `cos`
+- [x] `head -1 plugin/ralph-hero/skills/cos/SKILL.md` matches `^---$` (valid frontmatter)
+- [x] `head -1 plugin/ralph-hero/agents/cos-agent.md` matches `^---$` (valid frontmatter)
+- [x] `wc -l plugin/ralph-hero/skills/cos/system-prompt.md` returns ≤ 80 (35 lines)
+- [x] `grep -rE '(^|\s)claude(\s|$)' plugin/ralph-hero/scripts/cos/cos-remote.sh` returns nothing (zero Claude Code on remote path)
+- [x] `npm test` in `plugin/ralph-hero/mcp-server/` still passes (1505 passed, 3 skipped)
 
 #### Manual Verification
 


### PR DESCRIPTION
## Summary

- Scaffolds `plugin/ralph-hero/skills/cos/SKILL.md` with frontmatter, mode dispatcher, and `!cat` system-prompt include
- Adds `plugin/ralph-hero/agents/cos-agent.md` with read-only tool allowlist and `skills: [cos]` preload
- Adds `plugin/ralph-hero/skills/cos/system-prompt.md` (35 lines, voice + non-actions + remote example)
- Ships `plugin/ralph-hero/scripts/cos/cos-remote.sh` — 30-min JSON cache at `~/.ralph-hero/cos/cache/remote-status.json`, atomic write via tmp+mv, zero `claude` invocations, calls `cos.sh --role smol` with `--append-system-prompt`
- Adds `cos-desk.sh` and `cos-unattended.sh` as exit-0 stubs pointing at Phase 5 (GH-1257) and Phase 3 (GH-1255)
- Wires `cos` recipe into `plugin/ralph-hero/justfile` — bash mode-dispatcher, bypasses `cli-dispatch.sh`, uses `{{justfile_directory()}}` for path resolution
- Adds `--append-system-prompt` flag support to `cos.sh` (minimal addendum; stable CLI contract preserved — the flag is new, not a change to existing args)

Closes #1254.

## Test plan

- [x] `bash -n` exits 0 for `cos-remote.sh`, `cos-desk.sh`, `cos-unattended.sh`, `cos.sh`
- [x] `just --summary` includes `cos`
- [x] `head -1 plugin/ralph-hero/skills/cos/SKILL.md` matches `^---$`
- [x] `head -1 plugin/ralph-hero/agents/cos-agent.md` matches `^---$`
- [x] `wc -l plugin/ralph-hero/skills/cos/system-prompt.md` = 35 (≤ 80)
- [x] `grep -rE '(^|\s)claude(\s|$)' scripts/cos/cos-remote.sh` returns empty
- [x] `npm test` in `mcp-server/` — 1505 passed, 3 skipped, 0 failed
- [ ] `ralph cos remote` (with `pi` + mlx-openai-server running) — manual smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)