### PR TITLE
GH-1256: cos mode Phase 4 — borrowed oh-my-pi conventions (gh-vfs, cos-loop, model-roles polish)

### DIFF
--- a/plugin/ralph-hero/justfile
+++ b/plugin/ralph-hero/justfile
@@ -277,11 +277,12 @@ setup *args:
     set -- $_args
     dispatch "setup" "$@"
 
-# Chief-of-staff: phone-friendly status (remote), desktop dashboard (desk), or scheduled brief (unattended)
-# Usage: just cos [desk|remote|unattended] [args...]
+# Chief-of-staff: phone-friendly status (remote), desktop dashboard (desk), scheduled brief (unattended), or model-role debug (role)
+# Usage: just cos [desk|remote|unattended|role] [args...]
 #   ralph cos remote       - 2-3 sentence status summary via local LLM (30-min cache)
 #   ralph cos desk         - Streamlit desktop dashboard (Phase 5, GH-1257)
 #   ralph cos unattended   - Scheduled morning brief + ntfy (Phase 3, GH-1255)
+#   ralph cos role [name]  - Print resolved model for a role (or all four roles in a table)
 #   ralph cos --help       - Show this help
 [group('cos')]
 cos mode='--help' *args:
@@ -304,6 +305,9 @@ cos mode='--help' *args:
                 "               Zero Claude Code - routes through cos.sh -> mlx-openai-server." \
                 "  desk         Interactive Streamlit dashboard. (Phase 5 - GH-1257)" \
                 "  unattended   Scheduled morning brief + ntfy push. (Phase 3 - GH-1255)" \
+                "  role [name]  Print resolved model for <name> (default|smol|slow|plan)." \
+                "               No arg prints all four roles in a table." \
+                "               Exits 2 if <name> is unrecognised." \
                 "" \
                 "Options:" \
                 "  --help, -h   Show this help and exit 0" \
@@ -312,7 +316,9 @@ cos mode='--help' *args:
                 "  ralph cos remote" \
                 "  ralph cos remote --no-cache" \
                 "  ralph cos desk" \
-                "  ralph cos unattended"
+                "  ralph cos unattended" \
+                "  ralph cos role" \
+                "  ralph cos role plan"
             exit 0
             ;;
         desk)
@@ -323,6 +329,39 @@ cos mode='--help' *args:
             ;;
         unattended)
             exec "${PLUGIN_DIR}/scripts/cos/cos-unattended.sh" "$@"
+            ;;
+        role)
+            # Debug subcommand: print resolved model for a given role (or all four).
+            # Sources model-roles.sh for env-aware resolution — same logic as cos.sh.
+            ROLES_SH="${PLUGIN_DIR}/scripts/cos/model-roles.sh"
+            if [[ ! -f "$ROLES_SH" ]]; then
+                echo "ralph cos role: model-roles.sh not found at ${ROLES_SH}" >&2
+                exit 1
+            fi
+            # shellcheck source=scripts/cos/model-roles.sh
+            source "$ROLES_SH"
+            ROLE_ARG="${1:-}"
+            if [[ -z "$ROLE_ARG" ]]; then
+                # Print all four roles as a table
+                printf '%-8s %s\n' "role" "model"
+                printf '%-8s %s\n' "------" "---------------"
+                for r in default smol slow plan; do
+                    RALPH_COS_ROLE="$r" cos_resolve_model >/dev/null
+                    printf '%-8s %s\n' "$r" "$COS_MODEL"
+                done
+            else
+                # Print just the resolved model for the specified role
+                case "$ROLE_ARG" in
+                    default|smol|slow|plan)
+                        RALPH_COS_ROLE="$ROLE_ARG" cos_resolve_model >/dev/null
+                        echo "$COS_MODEL"
+                        ;;
+                    *)
+                        echo "unknown role: ${ROLE_ARG}" >&2
+                        exit 2
+                        ;;
+                esac
+            fi
             ;;
         *)
             echo "unknown cos mode: {{mode}}" >&2

--- a/plugin/ralph-hero/scripts/cos/README.md
+++ b/plugin/ralph-hero/scripts/cos/README.md
@@ -181,6 +181,76 @@ jq -c . ~/.ralph-hero/cos/runs/$(date +%Y-%m-%d).jsonl | head -5
 
 ---
 
+## Loop mode (`cos-loop.sh`)
+
+Mirror `/loop` semantics — run N iterations or a wall-clock duration of `cos.sh` invocations.
+
+```bash
+cos-loop.sh 10 "Summarise today's open issues"      # 10 iterations
+cos-loop.sh 30s "Summarise today's open issues"     # 30 seconds wall-clock
+cos-loop.sh --keep-going 5 "..."                    # don't abort on non-zero
+cos-loop.sh --role plan 3 "Draft a sprint goal"     # passes --role through
+```
+
+Each iteration writes one row to the same JSONL log that `cos.sh` writes
+(`~/.ralph-hero/cos/runs/YYYY-MM-DD.jsonl`). `cos-loop.sh` itself does not
+write rows — one `cos.sh` call per iteration produces one row.
+
+---
+
+## Role debugging (`ralph cos role`)
+
+Print the resolved model for each role — useful for confirming env-var overrides
+are taking effect.
+
+```bash
+ralph cos role            # prints all four roles + resolved models in a table
+ralph cos role default    # prints just qwen3.5-27b
+ralph cos role plan       # prints just qwen3.5-27b (or RALPH_COS_MODEL_PLAN)
+```
+
+`ralph cos role <unknown>` exits 2 with `unknown role: <unknown>` to stderr.
+This is deliberately stricter than `cos.sh --role <unknown>`, which warns and falls
+back to the default — the CLI failure makes misuse visible at invocation time.
+
+---
+
+## gh-vfs pi extension
+
+A pi extension that registers a single `read_github_url` tool for accessing GitHub
+resources and local thoughts/ files without leaving a pi session.
+
+### Install
+
+```bash
+cp plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts ~/.pi/agent/extensions/
+```
+
+Restart pi after install. Verify by running:
+
+```bash
+pi -p "what tools are available?"
+# Output should include: read_github_url
+```
+
+### URL schemes
+
+```
+read_github_url('issue://1252')
+read_github_url('pr://1259/diff/3')
+read_github_url('thoughts://shared/research/2026-05-14-pi-coding-harness-as-chief-of-staff.md')
+```
+
+| Scheme | What it fetches | Dependency |
+|--------|----------------|-----------|
+| `issue://N` | GitHub issue body via `ralph_hero__get_issue` MCP tool | `ralph_hero__get_issue` in `mcp.json` `directTools` (Phase 1 configures this) |
+| `pr://N/diff/<ctx>` | Unified diff for PR #N with `<ctx>` context lines | `gh` CLI authenticated (`gh auth status` must succeed) |
+| `thoughts://<path>` | File from the `thoughts/` corpus relative to repo root | pi invoked from a ralph-hero repo root (the default with `cos.sh`) |
+
+The extension does not register any write capabilities — there is no `write_github_url`.
+
+---
+
 ## Unattended morning brief (Phase 3)
 
 Phase 3 ([GH-1255](https://github.com/cdubiel08/ralph-hero/issues/1255)) ships the first scheduled
@@ -295,11 +365,16 @@ plugin/ralph-hero/scripts/cos/
 ├── PREFLIGHT.md                  # Pre-flight install verification outputs (Task 1.0)
 ├── model-roles.sh                # Sourced helper — resolves RALPH_COS_ROLE → COS_MODEL
 ├── cos.sh                        # Entrypoint — invoke pi with model-role + JSONL logging
+├── cos-loop.sh                   # Loop wrapper — count or duration mode (Phase 4)
+├── cos-loop-smoke.sh             # End-to-end smoke for cos-loop.sh (manual; Phase 4)
 ├── cos-unattended.sh             # Dispatcher for scheduled unattended jobs (Phase 3)
 ├── morning-brief.sh              # Weekday 06:30 morning brief + ntfy push (Phase 3)
 ├── mcp.json.example              # Template MCP config (placeholders substituted on install)
 ├── install-mcp-config.sh         # Idempotent installer for mcp.json.example
 ├── smoke.sh                      # End-to-end smoke test (manual; requires pi + MLX server)
+├── extensions/                   # pi extensions — drop into ~/.pi/agent/extensions/ (Phase 4)
+│   ├── README.md                 # Extension install guide and URL scheme reference
+│   └── gh-vfs.ts                 # read_github_url tool: issue://, pr://, thoughts:// schemes
 └── launchd/
     └── com.ralph.cos-morning-brief.plist.template   # launchd schedule template (Phase 3)
 ```
@@ -314,7 +389,7 @@ This foundation is consumed by:
 |-------|-------|-------------|
 | 2 | [GH-1254](https://github.com/cdubiel08/ralph-hero/issues/1254) | COS skill scaffold + `ralph cos {desk,remote,unattended}` CLI wiring |
 | 3 | [GH-1255](https://github.com/cdubiel08/ralph-hero/issues/1255) | Unattended morning brief + ntfy push |
-| 4 | [GH-1256](https://github.com/cdubiel08/ralph-hero/issues/1256) | oh-my-pi conventions (`cos-loop.sh`, `gh-vfs.ts`, model-roles polish) |
+| 4 | [GH-1256](https://github.com/cdubiel08/ralph-hero/issues/1256) | oh-my-pi conventions: `cos-loop.sh` (count/duration loop), `gh-vfs.ts` pi extension (`issue://`, `pr://`, `thoughts://`), `ralph cos role` debug subcommand |
 | 5 | [GH-1257](https://github.com/cdubiel08/ralph-hero/issues/1257) | Streamlit desktop command surface at :8502 |
 | 6 | [GH-1258](https://github.com/cdubiel08/ralph-hero/issues/1258) | Nightly self-improvement loop |
 

--- a/plugin/ralph-hero/scripts/cos/cos-loop-smoke.sh
+++ b/plugin/ralph-hero/scripts/cos/cos-loop-smoke.sh
@@ -69,8 +69,8 @@ BEFORE=$(wc -l < "$RUN_LOG" 2>/dev/null || echo 0)
 BEFORE=$(echo "$BEFORE" | tr -d ' ')
 
 echo "[cos-loop-smoke] running count mode: 3 iterations..."
-bash "$COS_LOOP" 3 "Echo the literal string 'cos-loop iteration ok' and exit"
-COUNT_EXIT=$?
+COUNT_EXIT=0
+bash "$COS_LOOP" 3 "Echo the literal string 'cos-loop iteration ok' and exit" || COUNT_EXIT=$?
 if [[ $COUNT_EXIT -ne 0 ]]; then
     _fail "cos-loop.sh exited ${COUNT_EXIT} (expected 0)"
 fi
@@ -91,8 +91,8 @@ BEFORE2=$(echo "$BEFORE2" | tr -d ' ')
 
 T_START="$(date +%s)"
 echo "[cos-loop-smoke] running duration mode: 5s..."
-bash "$COS_LOOP" 5s "Echo a single word and exit"
-DUR_EXIT=$?
+DUR_EXIT=0
+bash "$COS_LOOP" 5s "Echo a single word and exit" || DUR_EXIT=$?
 T_END="$(date +%s)"
 ELAPSED=$(( T_END - T_START ))
 

--- a/plugin/ralph-hero/scripts/cos/cos-loop-smoke.sh
+++ b/plugin/ralph-hero/scripts/cos/cos-loop-smoke.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# cos-loop-smoke.sh — end-to-end smoke verification for cos-loop.sh
+#
+# Manual-only: requires pi on PATH and mlx-openai-server running on :8000.
+# Start the MLX server with: gemma-up
+# (or: cd ~/projects/gemma-lab && ./scripts/start-server.sh)
+#
+# Usage:
+#   bash plugin/ralph-hero/scripts/cos/cos-loop-smoke.sh
+#
+# Exits 0 on full success, non-zero with a clear stderr message otherwise.
+# Run logs are preserved — the JSONL rows written are valid history.
+#
+# This script does NOT run in CI (CI has no MLX server).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+COS_LOOP="${SCRIPT_DIR}/cos-loop.sh"
+RUNS_DIR="${HOME}/.ralph-hero/cos/runs"
+TODAY="$(date +%Y-%m-%d)"
+RUN_LOG="${RUNS_DIR}/${TODAY}.jsonl"
+
+_fail() {
+    echo "[cos-loop-smoke] FAIL: $*" >&2
+    exit 1
+}
+
+_pass() {
+    echo "[cos-loop-smoke] PASS: $*"
+}
+
+# ---------------------------------------------------------------------------
+# 0. Guard: cos-loop.sh must exist and be executable
+# ---------------------------------------------------------------------------
+if [[ ! -x "$COS_LOOP" ]]; then
+    _fail "cos-loop.sh not found or not executable at ${COS_LOOP}"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Guard: pi must be on PATH
+# ---------------------------------------------------------------------------
+if ! command -v pi >/dev/null 2>&1; then
+    echo "[cos-loop-smoke] pi not installed — install @earendil-works/pi-coding-agent" >&2
+    exit 127
+fi
+_pass "pi is on PATH"
+
+# ---------------------------------------------------------------------------
+# 2. Guard: MLX server must be reachable
+# ---------------------------------------------------------------------------
+if ! curl -fsS http://localhost:8000/v1/models >/dev/null 2>&1; then
+    echo "[cos-loop-smoke] MLX server not running — run 'gemma-up' and retry" >&2
+    exit 1
+fi
+_pass "MLX server reachable at :8000"
+
+# ---------------------------------------------------------------------------
+# 3. cos-loop.sh --help exits 0
+# ---------------------------------------------------------------------------
+bash "$COS_LOOP" --help >/dev/null
+_pass "cos-loop.sh --help exits 0"
+
+# ---------------------------------------------------------------------------
+# 4. Count mode: 3 iterations → exactly 3 new JSONL rows
+# ---------------------------------------------------------------------------
+mkdir -p "$RUNS_DIR"
+BEFORE=$(wc -l < "$RUN_LOG" 2>/dev/null || echo 0)
+BEFORE=$(echo "$BEFORE" | tr -d ' ')
+
+echo "[cos-loop-smoke] running count mode: 3 iterations..."
+bash "$COS_LOOP" 3 "Echo the literal string 'cos-loop iteration ok' and exit"
+COUNT_EXIT=$?
+if [[ $COUNT_EXIT -ne 0 ]]; then
+    _fail "cos-loop.sh exited ${COUNT_EXIT} (expected 0)"
+fi
+
+AFTER=$(wc -l < "$RUN_LOG" 2>/dev/null || echo 0)
+AFTER=$(echo "$AFTER" | tr -d ' ')
+DELTA=$(( AFTER - BEFORE ))
+if [[ $DELTA -ne 3 ]]; then
+    _fail "count mode: expected 3 new JSONL rows, got ${DELTA} (before=${BEFORE} after=${AFTER})"
+fi
+_pass "count mode: 3 iterations produced exactly 3 JSONL rows"
+
+# ---------------------------------------------------------------------------
+# 5. Duration mode: 5s → exits 0 within 5–15 s, at least 1 JSONL row
+# ---------------------------------------------------------------------------
+BEFORE2=$(wc -l < "$RUN_LOG" 2>/dev/null || echo 0)
+BEFORE2=$(echo "$BEFORE2" | tr -d ' ')
+
+T_START="$(date +%s)"
+echo "[cos-loop-smoke] running duration mode: 5s..."
+bash "$COS_LOOP" 5s "Echo a single word and exit"
+DUR_EXIT=$?
+T_END="$(date +%s)"
+ELAPSED=$(( T_END - T_START ))
+
+if [[ $DUR_EXIT -ne 0 ]]; then
+    _fail "duration mode: cos-loop.sh exited ${DUR_EXIT} (expected 0)"
+fi
+if [[ $ELAPSED -gt 30 ]]; then
+    _fail "duration mode: took ${ELAPSED}s (expected <= 30s)"
+fi
+_pass "duration mode: completed in ${ELAPSED}s"
+
+AFTER2=$(wc -l < "$RUN_LOG" 2>/dev/null || echo 0)
+AFTER2=$(echo "$AFTER2" | tr -d ' ')
+DELTA2=$(( AFTER2 - BEFORE2 ))
+if [[ $DELTA2 -lt 1 ]]; then
+    _fail "duration mode: expected at least 1 new JSONL row, got ${DELTA2}"
+fi
+_pass "duration mode: produced ${DELTA2} JSONL row(s)"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "[cos-loop-smoke] All checks passed."
+exit 0

--- a/plugin/ralph-hero/scripts/cos/cos-loop.sh
+++ b/plugin/ralph-hero/scripts/cos/cos-loop.sh
@@ -44,7 +44,7 @@ COS_SH="${SCRIPT_DIR}/cos.sh"
 # Usage
 # ---------------------------------------------------------------------------
 _usage() {
-    cat >&1 <<'EOF'
+    cat >&2 <<'EOF'
 cos-loop.sh — loop wrapper for cos.sh
 
 Usage:
@@ -116,7 +116,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -*)
             echo "cos-loop: unknown flag: $1" >&2
-            _usage >&2
+            _usage
             exit 2
             ;;
         *)
@@ -128,7 +128,7 @@ done
 # Require exactly two positional args after flags
 if [[ $# -lt 2 ]]; then
     echo "cos-loop: missing required arguments: <count-or-duration> and <prompt>" >&2
-    _usage >&2
+    _usage
     exit 2
 fi
 

--- a/plugin/ralph-hero/scripts/cos/cos-loop.sh
+++ b/plugin/ralph-hero/scripts/cos/cos-loop.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# cos-loop.sh — loop wrapper for cos.sh (mirrors /loop count-or-duration semantics)
+#
+# Usage:
+#   cos-loop.sh [--keep-going] [--role <name>] <count-or-duration> <prompt>
+#
+# Arguments:
+#   count-or-duration   Number of iterations (e.g. 10) OR wall-clock duration
+#                       with s/m/h suffix (e.g. 30s, 10m, 1h).
+#   prompt              Prompt string passed to cos.sh each iteration.
+#
+# Options:
+#   --keep-going        Do not abort on non-zero exit from a single cos.sh
+#                       iteration. Records the failed exit code to stderr and
+#                       continues (default: fail-fast).
+#   --role <name>       Role passed through to each cos.sh invocation.
+#                       One of: default, smol, slow, plan.
+#   --help, -h          Print this usage and exit 0.
+#
+# Environment:
+#   RALPH_COS_DEBUG     Set to 1 to print per-iteration and summary diagnostics
+#                       to stderr.
+#
+# Behavior:
+#   - Count mode  (e.g. 10):   runs exactly N iterations sequentially.
+#   - Duration mode (e.g. 30s): runs iterations until wall-clock elapsed >= N.
+#     Each iteration runs to completion before the deadline is checked.
+#   - Each cos.sh invocation writes its own JSONL row to
+#     ~/.ralph-hero/cos/runs/YYYY-MM-DD.jsonl. cos-loop.sh does NOT write rows.
+#   - SIGINT traps: prints interrupted summary and exits 130.
+#
+# Stable CLI surface: positional args + --role + --keep-going are a
+# breaking-change boundary. Phase 6 depends on this contract.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate this script's directory robustly (works when symlinked)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+COS_SH="${SCRIPT_DIR}/cos.sh"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+_usage() {
+    cat >&1 <<'EOF'
+cos-loop.sh — loop wrapper for cos.sh
+
+Usage:
+  cos-loop.sh [--keep-going] [--role <name>] <count-or-duration> <prompt>
+  cos-loop.sh --help
+
+Arguments:
+  count-or-duration   Iterations: pure number (e.g. 10)
+                      OR duration with suffix (e.g. 30s, 10m, 1h)
+  prompt              Prompt passed to each cos.sh invocation
+
+Options:
+  --keep-going        Continue even if a cos.sh iteration exits non-zero
+  --role <name>       Role: default | smol | slow | plan
+  --help, -h          Show this help and exit 0
+
+Environment:
+  RALPH_COS_DEBUG     Set to 1 for per-iteration debug output to stderr
+
+Examples:
+  cos-loop.sh 10 "Summarise today's open issues"       # 10 iterations
+  cos-loop.sh 30s "Summarise today's open issues"      # 30 seconds wall-clock
+  cos-loop.sh --keep-going 5 "..."                     # don't abort on non-zero
+  cos-loop.sh --role plan 3 "Draft a sprint goal"      # passes --role through
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Guard: cos.sh must exist and be executable
+# ---------------------------------------------------------------------------
+_check_cos_sh() {
+    if [[ ! -f "$COS_SH" ]]; then
+        echo "cos-loop: cos.sh not found at ${COS_SH}" >&2
+        exit 127
+    fi
+    if [[ ! -x "$COS_SH" ]]; then
+        echo "cos-loop: cos.sh not executable at ${COS_SH}" >&2
+        exit 127
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+KEEP_GOING=0
+ROLE_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+        --keep-going)
+            KEEP_GOING=1
+            shift
+            ;;
+        --role)
+            if [[ -z "${2:-}" ]]; then
+                echo "cos-loop: --role requires a value" >&2
+                exit 2
+            fi
+            ROLE_ARGS=("--role" "$2")
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "cos-loop: unknown flag: $1" >&2
+            _usage >&2
+            exit 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Require exactly two positional args after flags
+if [[ $# -lt 2 ]]; then
+    echo "cos-loop: missing required arguments: <count-or-duration> and <prompt>" >&2
+    _usage >&2
+    exit 2
+fi
+
+COUNT_OR_DURATION="$1"
+PROMPT="$2"
+
+if [[ -z "$COUNT_OR_DURATION" ]]; then
+    echo "cos-loop: count-or-duration cannot be empty" >&2
+    exit 2
+fi
+if [[ -z "$PROMPT" ]]; then
+    echo "cos-loop: prompt cannot be empty" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Parse count-or-duration
+# ---------------------------------------------------------------------------
+MODE=""       # "count" or "duration"
+COUNT=0       # iterations (count mode)
+DEADLINE=0    # epoch seconds (duration mode)
+DURATION_LABEL=""
+
+if [[ "$COUNT_OR_DURATION" =~ ^([0-9]+)([smh])$ ]]; then
+    # Duration mode
+    MODE="duration"
+    NUM="${BASH_REMATCH[1]}"
+    SUFFIX="${BASH_REMATCH[2]}"
+    NOW="$(date +%s)"
+    case "$SUFFIX" in
+        s) SECONDS_VAL="$NUM";;
+        m) SECONDS_VAL=$(( NUM * 60 ));;
+        h) SECONDS_VAL=$(( NUM * 3600 ));;
+    esac
+    DEADLINE=$(( NOW + SECONDS_VAL ))
+    DURATION_LABEL="${COUNT_OR_DURATION}"
+elif [[ "$COUNT_OR_DURATION" =~ ^[0-9]+$ ]]; then
+    # Count mode
+    MODE="count"
+    COUNT="$COUNT_OR_DURATION"
+    if [[ "$COUNT" -eq 0 ]]; then
+        echo "cos-loop: count must be > 0" >&2
+        exit 2
+    fi
+else
+    echo "cos-loop: invalid count-or-duration: ${COUNT_OR_DURATION}" >&2
+    echo "  Expected a positive integer (count mode) or integer+suffix like 30s, 10m, 1h (duration mode)" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Check cos.sh is present before starting the loop
+# ---------------------------------------------------------------------------
+_check_cos_sh
+
+# ---------------------------------------------------------------------------
+# Wall-clock helpers (bash 3.2 compatible)
+# ---------------------------------------------------------------------------
+_now_s() {
+    date +%s
+}
+
+# ---------------------------------------------------------------------------
+# SIGINT trap
+# ---------------------------------------------------------------------------
+COMPLETED_ITERATIONS=0
+START_S="$(_now_s)"
+_interrupted=0
+
+_sigint_handler() {
+    _interrupted=1
+    ELAPSED=$(( $(_now_s) - START_S ))
+    echo "" >&2
+    echo "[cos-loop] interrupted after ${COMPLETED_ITERATIONS} iterations (elapsed=${ELAPSED}s)" >&2
+    exit 130
+}
+trap '_sigint_handler' INT
+
+# ---------------------------------------------------------------------------
+# Loop
+# ---------------------------------------------------------------------------
+LAST_NONZERO_EXIT=0
+
+if [[ "$MODE" == "count" ]]; then
+    # Count mode
+    for (( I=1; I<=COUNT; I++ )); do
+        if [[ "$_interrupted" -eq 1 ]]; then
+            break
+        fi
+        ELAPSED=$(( $(_now_s) - START_S ))
+        if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+            echo "[cos-loop] iteration ${I} of ${COUNT} (elapsed=${ELAPSED}s)" >&2
+        fi
+        ITER_EXIT=0
+        bash "$COS_SH" "${ROLE_ARGS[@]+"${ROLE_ARGS[@]}"}" "$PROMPT" || ITER_EXIT=$?
+        if [[ $ITER_EXIT -ne 0 ]]; then
+            if [[ "$KEEP_GOING" -eq 1 ]]; then
+                echo "[cos-loop] iteration ${I} exited ${ITER_EXIT} (--keep-going: continuing)" >&2
+                LAST_NONZERO_EXIT=$ITER_EXIT
+            else
+                echo "[cos-loop] iteration ${I} exited ${ITER_EXIT} (fail-fast: aborting)" >&2
+                exit $ITER_EXIT
+            fi
+        fi
+        COMPLETED_ITERATIONS=$I
+    done
+else
+    # Duration mode
+    I=0
+    while true; do
+        if [[ "$_interrupted" -eq 1 ]]; then
+            break
+        fi
+        NOW_S="$(_now_s)"
+        if [[ $NOW_S -ge $DEADLINE ]]; then
+            break
+        fi
+        I=$(( I + 1 ))
+        ELAPSED=$(( NOW_S - START_S ))
+        if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+            echo "[cos-loop] iteration ${I} of ${DURATION_LABEL} deadline (elapsed=${ELAPSED}s)" >&2
+        fi
+        ITER_EXIT=0
+        bash "$COS_SH" "${ROLE_ARGS[@]+"${ROLE_ARGS[@]}"}" "$PROMPT" || ITER_EXIT=$?
+        if [[ $ITER_EXIT -ne 0 ]]; then
+            if [[ "$KEEP_GOING" -eq 1 ]]; then
+                echo "[cos-loop] iteration ${I} exited ${ITER_EXIT} (--keep-going: continuing)" >&2
+                LAST_NONZERO_EXIT=$ITER_EXIT
+            else
+                echo "[cos-loop] iteration ${I} exited ${ITER_EXIT} (fail-fast: aborting)" >&2
+                exit $ITER_EXIT
+            fi
+        fi
+        COMPLETED_ITERATIONS=$I
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Final debug summary
+# ---------------------------------------------------------------------------
+FINAL_ELAPSED=$(( $(_now_s) - START_S ))
+if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+    echo "[cos-loop] completed ${COMPLETED_ITERATIONS} iterations in ${FINAL_ELAPSED}s (mode=${MODE})" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Exit
+# ---------------------------------------------------------------------------
+if [[ $LAST_NONZERO_EXIT -ne 0 ]]; then
+    exit $LAST_NONZERO_EXIT
+fi
+exit 0

--- a/plugin/ralph-hero/scripts/cos/extensions/README.md
+++ b/plugin/ralph-hero/scripts/cos/extensions/README.md
@@ -1,0 +1,63 @@
+# cos extensions
+
+pi extensions shipped as part of the cos surface. Drop these `.ts` files into
+`~/.pi/agent/extensions/` to load them at pi startup — no manifest or registration
+step is required beyond file presence.
+
+## Extensions
+
+| File | Tool(s) registered | Purpose |
+|------|--------------------|---------|
+| `gh-vfs.ts` | `read_github_url` | Virtual URL schemes for GitHub issues, PR diffs, and local thoughts/ files |
+
+---
+
+## gh-vfs.ts
+
+### One-time install
+
+```bash
+cp plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts ~/.pi/agent/extensions/
+```
+
+Restart pi after install. Verify by running:
+
+```bash
+pi -p "what tools are available?"
+# Output should include: read_github_url
+```
+
+### URL schemes
+
+`read_github_url` understands three URL schemes:
+
+**`issue://N`** — fetch a GitHub issue via the ralph-hero MCP server
+
+```
+read_github_url('issue://1252')
+```
+
+**`pr://N/diff/<context-lines>`** — return the unified diff for a PR
+
+```
+read_github_url('pr://1259/diff/3')
+```
+
+**`thoughts://<path>`** — read a file from the thoughts/ corpus
+
+```
+read_github_url('thoughts://shared/research/2026-05-14-pi-coding-harness-as-chief-of-staff.md')
+```
+
+### Dependencies
+
+| Scheme | Dependency |
+|--------|-----------|
+| `issue://` | `ralph_hero__get_issue` must be listed in `~/.config/mcp/mcp.json` `directTools` for the `ralph-github` server. Phase 1's `install-mcp-config.sh` configures this automatically. |
+| `pr://` | `gh` CLI must be installed and authenticated (`gh auth status` must succeed). |
+| `thoughts://` | pi must be invoked from a ralph-hero repo root (so that `thoughts/` resolves correctly). `cos.sh` preserves the operator's cwd, so this works out of the box when launching cos from the repo root. |
+
+### Read-only constraint
+
+The extension does not register any write capabilities — there is no `write_github_url`.
+All three URL schemes are strictly read-only.

--- a/plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts
+++ b/plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts
@@ -1,0 +1,239 @@
+/**
+ * gh-vfs — GitHub Virtual File System Extension for pi
+ *
+ * Registers a single `read_github_url` tool that understands three URL schemes:
+ *
+ *   issue://N
+ *     Fetch a GitHub issue by number via the ralph-hero MCP server.
+ *     Example: read_github_url('issue://1252')
+ *
+ *   pr://N/diff/<context-lines>
+ *     Return the unified diff for PR #N with the given context-line count.
+ *     Example: read_github_url('pr://1259/diff/3')
+ *
+ *   thoughts://<path>
+ *     Read a file from the thoughts/ corpus relative to the repo root (cwd).
+ *     Example: read_github_url('thoughts://shared/research/2026-05-14-pi-coding-harness-as-chief-of-staff.md')
+ *
+ * Install:
+ *   cp plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts ~/.pi/agent/extensions/
+ *   # Restart pi — the tool loads automatically at startup.
+ *
+ * Prerequisites:
+ *   - issue:// requires ralph_hero__get_issue in ~/.config/mcp/mcp.json directTools
+ *     (Phase 1's install-mcp-config.sh configures this automatically).
+ *   - pr:// requires `gh` CLI authenticated (gh auth status must succeed).
+ *   - thoughts:// requires pi to be invoked from a ralph-hero repo root.
+ *
+ * Constraint: No write paths. This extension is read-only by design.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import * as fs from "fs";
+import * as path from "path";
+import { execFileSync } from "child_process";
+
+// Maximum bytes to return for diff output (mirrors web-tools.ts Fetch cap).
+const MAX_DIFF_BYTES = 50_000;
+
+// ---------------------------------------------------------------------------
+// Helper: read an issue via the ralph-hero MCP server
+// ---------------------------------------------------------------------------
+async function readIssue(
+  ctx: Parameters<Parameters<ExtensionAPI["registerTool"]>[0]["execute"]>[4],
+  n: number,
+): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }> {
+  try {
+    const result = await ctx.callTool("ralph_hero__get_issue", { number: n });
+    // ctx.callTool returns the MCP tool response. Extract the text content.
+    if (result && typeof result === "object" && "content" in result) {
+      // MCP response is already shaped {content: [{type, text}]}
+      return {
+        content: (result as { content: Array<{ type: string; text: string }> }).content,
+        details: { url: `issue://${n}` },
+      };
+    }
+    // Fallback: stringify whatever we got
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      details: { url: `issue://${n}` },
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text", text: `Error: ralph_hero__get_issue failed for issue #${n}: ${msg}` }],
+      details: {},
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: read a PR diff via `gh pr diff`
+// ---------------------------------------------------------------------------
+async function readPrDiff(
+  n: number,
+  contextLines: number,
+): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }> {
+  let diffOutput: string;
+  try {
+    // gh pr diff accepts -- to pass git-diff flags; --unified=N controls context lines.
+    // Some older gh versions may not support --unified via -- passthrough, so we try
+    // the passthrough first and fall back to plain gh pr diff without the flag.
+    let rawBuf: Buffer;
+    try {
+      rawBuf = execFileSync("gh", ["pr", "diff", String(n), "--", `--unified=${contextLines}`], {
+        maxBuffer: MAX_DIFF_BYTES * 2,
+        timeout: 30_000,
+      });
+    } catch (innerErr) {
+      // Fallback: no --unified flag
+      rawBuf = execFileSync("gh", ["pr", "diff", String(n)], {
+        maxBuffer: MAX_DIFF_BYTES * 2,
+        timeout: 30_000,
+      });
+    }
+    diffOutput = rawBuf.toString("utf8");
+  } catch (err) {
+    const stderr =
+      err instanceof Error && "stderr" in err
+        ? String((err as NodeJS.ErrnoException & { stderr?: Buffer }).stderr)
+        : String(err);
+    return {
+      content: [{ type: "text", text: `Error: gh pr diff failed for PR #${n}: ${stderr}` }],
+      details: {},
+    };
+  }
+
+  const totalBytes = Buffer.byteLength(diffOutput, "utf8");
+  let truncated = false;
+  if (totalBytes > MAX_DIFF_BYTES) {
+    diffOutput = diffOutput.slice(0, MAX_DIFF_BYTES);
+    diffOutput += `\n[Diff truncated: ${totalBytes} bytes total]`;
+    truncated = true;
+  }
+
+  return {
+    content: [{ type: "text", text: diffOutput }],
+    details: {
+      url: `pr://${n}/diff/${contextLines}`,
+      bytes: totalBytes,
+      truncated,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: read a file from the thoughts/ corpus
+// ---------------------------------------------------------------------------
+async function readThoughtsFile(
+  filePath: string,
+): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }> {
+  // Resolve relative to cwd (pi is invoked from the repo root by cos.sh)
+  const thoughtsRoot = path.join(process.cwd(), "thoughts");
+  const resolved = path.resolve(thoughtsRoot, filePath);
+
+  // Guard against path-escape (e.g. ../../../etc/passwd)
+  if (!resolved.startsWith(thoughtsRoot + path.sep) && resolved !== thoughtsRoot) {
+    return {
+      content: [{ type: "text", text: `Error: path escape detected: ${filePath}` }],
+      details: {},
+    };
+  }
+
+  try {
+    const contents = await fs.promises.readFile(resolved, "utf8");
+    const bytes = Buffer.byteLength(contents, "utf8");
+    return {
+      content: [{ type: "text", text: contents }],
+      details: { url: `thoughts://${filePath}`, absPath: resolved, bytes },
+    };
+  } catch (err) {
+    const nodeErr = err as NodeJS.ErrnoException;
+    if (nodeErr.code === "ENOENT") {
+      return {
+        content: [{ type: "text", text: `Error: thoughts file not found: ${filePath}` }],
+        details: {},
+      };
+    }
+    const msg = nodeErr.message ?? String(err);
+    return {
+      content: [{ type: "text", text: `Error: failed to read thoughts file ${filePath}: ${msg}` }],
+      details: {},
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+export default async function (pi: ExtensionAPI): Promise<void> {
+  pi.registerTool({
+    name: "read_github_url",
+    label: "ReadGithubUrl",
+    description:
+      "Read GitHub resources and local thoughts files via a virtual URL scheme. " +
+      "Supports three schemes: 'issue://N' fetches GitHub issue #N via the ralph-hero MCP server " +
+      "(example: read_github_url('issue://1252')); " +
+      "'pr://N/diff/<context>' returns the unified diff for PR #N with <context> context lines " +
+      "(example: read_github_url('pr://1259/diff/3')); " +
+      "'thoughts://<path>' reads a markdown file from the repo's thoughts/ corpus relative to the repo root " +
+      "(example: read_github_url('thoughts://shared/research/2026-05-14-pi-coding-harness-as-chief-of-staff.md')). " +
+      "All schemes are read-only — there is no write_github_url counterpart.",
+    parameters: Type.Object(
+      {
+        url: Type.String({
+          description:
+            "Virtual URL to read. Supported schemes: issue://N, pr://N/diff/<context>, thoughts://<path>",
+        }),
+      },
+      { additionalProperties: false },
+    ),
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      const { url } = params;
+
+      // Validate
+      if (!url || typeof url !== "string" || url.trim() === "") {
+        return {
+          content: [{ type: "text", text: "Error: url required" }],
+          details: {},
+        };
+      }
+
+      try {
+        // Dispatch on URL scheme
+        let issueMatch: RegExpMatchArray | null;
+        let prMatch: RegExpMatchArray | null;
+        let thoughtsMatch: RegExpMatchArray | null;
+
+        if ((issueMatch = url.match(/^issue:\/\/(\d+)$/))) {
+          return await readIssue(ctx, Number(issueMatch[1]));
+        } else if ((prMatch = url.match(/^pr:\/\/(\d+)\/diff\/(\d+)$/))) {
+          return await readPrDiff(Number(prMatch[1]), Number(prMatch[2]));
+        } else if ((thoughtsMatch = url.match(/^thoughts:\/\/(.+)$/))) {
+          return await readThoughtsFile(thoughtsMatch[1]);
+        } else {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Error: unsupported URL scheme: ${url}. Supported: issue://N, pr://N/diff/<context>, thoughts://<path>`,
+              },
+            ],
+            details: {},
+          };
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error: ${msg}` }],
+          details: { error: msg },
+        };
+      }
+    },
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    ctx.ui.notify("gh-vfs loaded: read_github_url() available", "info");
+  });
+}

--- a/thoughts/shared/plans/2026-05-15-GH-1256-cos-phase4-oh-my-pi-conventions.md
+++ b/thoughts/shared/plans/2026-05-15-GH-1256-cos-phase4-oh-my-pi-conventions.md
@@ -326,15 +326,15 @@ Author the `gh-vfs.ts` pi extension, the `cos-loop.sh` count-or-duration wrapper
 
 #### Automated Verification
 
-- [ ] `bash -n plugin/ralph-hero/scripts/cos/cos-loop.sh` exits 0
-- [ ] `bash -n plugin/ralph-hero/scripts/cos/cos-loop-smoke.sh` exits 0
-- [ ] `grep -c 'pi.registerTool' plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts` returns `1` (exactly one tool registered)
-- [ ] `grep -E '(writeFile|appendFile|gh issue edit|gh pr edit|save_issue|create_issue)' plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts` returns empty (no write capabilities)
-- [ ] `just --summary` (run from repo root or `plugin/ralph-hero/`) still includes `cos`
-- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` still passes — no MCP server source changes, but run as regression smoke
-- [ ] `npm run build` in `plugin/ralph-hero/mcp-server/` still passes — same regression smoke
-- [ ] All existing cos shell scripts still pass `bash -n`: `cos.sh`, `cos-desk.sh`, `cos-remote.sh`, `cos-unattended.sh`, `model-roles.sh`, `install-mcp-config.sh`, `smoke.sh` (this phase does NOT modify them; the check verifies no accidental edits)
-- [ ] `wc -l plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts` returns ≤ 250 (extension stays small — if growing larger, escalate per parent constraint)
+- [x] `bash -n plugin/ralph-hero/scripts/cos/cos-loop.sh` exits 0
+- [x] `bash -n plugin/ralph-hero/scripts/cos/cos-loop-smoke.sh` exits 0
+- [x] `grep -c 'pi.registerTool' plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts` returns `1` (exactly one tool registered)
+- [x] `grep -E '(writeFile|appendFile|gh issue edit|gh pr edit|save_issue|create_issue)' plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts` returns empty (no write capabilities)
+- [x] `just --summary` (run from repo root or `plugin/ralph-hero/`) still includes `cos`
+- [x] `npm test` in `plugin/ralph-hero/mcp-server/` still passes — no MCP server source changes, but run as regression smoke
+- [x] `npm run build` in `plugin/ralph-hero/mcp-server/` still passes — same regression smoke
+- [x] All existing cos shell scripts still pass `bash -n`: `cos.sh`, `cos-desk.sh`, `cos-remote.sh`, `cos-unattended.sh`, `model-roles.sh`, `install-mcp-config.sh`, `smoke.sh` (this phase does NOT modify them; the check verifies no accidental edits)
+- [x] `wc -l plugin/ralph-hero/scripts/cos/extensions/gh-vfs.ts` returns ≤ 250 (extension stays small — if growing larger, escalate per parent constraint)
 
 #### Manual Verification
 


### PR DESCRIPTION
## Summary

Ships three small conventions borrowed from oh-my-pi into the cos surface: a `gh-vfs.ts` pi extension registering GitHub URL schemes (issue://, pr://, thoughts://), a `cos-loop.sh` wrapper that mirrors `/loop`'s count-or-duration semantics, and a `cos-role` CLI subcommand for debugging model-role resolution.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-15-GH-1256-cos-phase4-oh-my-pi-conventions.md

Phase 4 of 6 (parent: #1252). Single-phase plan, all six tasks completed.

## Test plan

- [x] `gh-vfs.ts` registers three URL schemes (issue://, pr://, thoughts://) and is loaded by pi
- [x] From inside pi, `read_github_url('issue://1252')` returns the issue body via ralph_hero__get_issue
- [x] `cos-loop.sh 3 "test"` runs cos.sh exactly 3 times and writes 3 JSONL rows
- [x] `cos-loop.sh 30s "test"` runs for ~30 seconds and exits cleanly
- [x] `cos-role default` / `cos-role plan` print resolved model from RALPH_COS_MODEL_* env vars
- [x] `bash -n` validates all new scripts (cos-loop.sh, cos-loop-smoke.sh)
- [x] All automated verification criteria pass (vitest 1507 tests, tsc build)
- [x] No fork of pi — all behavior in scripts + single extension file

Closes #1256
