### PR TITLE
GH-1258: cos mode Phase 6 — nightly self-improvement loop

### DIFF
--- a/plugin/ralph-hero/scripts/cos/README.md
+++ b/plugin/ralph-hero/scripts/cos/README.md
@@ -413,6 +413,91 @@ remain unchanged.
 
 ---
 
+## Self-improvement loop (Phase 6)
+
+Phase 6 ([GH-1258](https://github.com/cdubiel08/ralph-hero/issues/1258)) ships a nightly launchd job that grades the last 7 morning briefs against a 5-dimension rubric (specificity, actionability, signal-vs-noise, novelty, brevity — each scored 1–5) and, when the mean score falls below 3.5, drafts a revised `system-prompt.md` via `cos.sh --role slow` and opens a GitHub PR labeled `cos-self-improvement` for human review. The script **never auto-merges** — the human is the gate, always.
+
+### Environment flags
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RALPH_COS_SELF_IMPROVE` | (unset) | **Safety gate.** Must be exactly `"1"` to enable. Unset or any other value → exits 0 immediately with a "quarantined" log line. |
+| `RALPH_COS_SELF_IMPROVE_DRY_RUN` | (unset) | Set to `"1"` to run the full grading + draft pipeline but skip `git push` and `gh pr create`. The branch and commit are created locally for inspection. Used by the smoke test and for first-time manual verification. |
+
+### Two-manual-verification policy
+
+**Do NOT set `RALPH_COS_SELF_IMPROVE=1` in the plist's EnvironmentVariables until you have manually invoked `self-improve.sh` twice with the env var set in your shell and confirmed both PRs are sensible.**
+
+Manual verification workflow:
+
+```bash
+# First manual run (dry-run — no push, no PR)
+RALPH_COS_SELF_IMPROVE=1 RALPH_COS_SELF_IMPROVE_DRY_RUN=1 \
+    plugin/ralph-hero/scripts/cos/self-improve.sh
+
+# Inspect the score table (stdout) and mean line (stderr)
+# If mean < 3.5: inspect the locally-created branch's system-prompt.md diff
+# git diff main plugin/ralph-hero/skills/cos/system-prompt.md
+
+# If the draft looks sensible, run without dry-run for real verification run #1:
+RALPH_COS_SELF_IMPROVE=1 plugin/ralph-hero/scripts/cos/self-improve.sh
+# → Opens a real PR. Review it on GitHub. If it looks good, close (do not merge yet).
+
+# Repeat for verification run #2. After two sensible PRs, set RALPH_COS_SELF_IMPROVE=1
+# in the launchd plist's EnvironmentVariables and reload:
+launchctl unload ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+launchctl load   ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+```
+
+The `cos-self-improvement` GitHub label is created idempotently by the script on first run. A future auto-merge integration (if ever introduced) would key off this label — but v1 intentionally has no such automation.
+
+### Smoke test
+
+```bash
+plugin/ralph-hero/scripts/cos/self-improve-smoke.sh
+```
+
+Creates a tmpdir with 7 synthetic low-quality briefs, runs `self-improve.sh` in dry-run mode, and asserts the expected score table and mean log line. Requires `pi` on PATH and `mlx-openai-server` running on `:8000`.
+
+### Install the launchd plist (optional — fires at 02:30 daily)
+
+```bash
+cp plugin/ralph-hero/scripts/cos/launchd/com.ralph.cos-self-improve.plist.template \
+   ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+
+# Hand-edit the plist if your checkout lives at a different path:
+# nano ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+# Replace /Users/dubiel/... with your actual path.
+
+# Do NOT set RALPH_COS_SELF_IMPROVE=1 yet — see two-manual-verification policy above.
+
+launchctl load ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+launchctl list | grep cos-self-improve
+# PID column shows "-" when idle; exit code "0" after a run (even when quarantined).
+```
+
+To unload:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+```
+
+Logs:
+- stdout: `/tmp/ralph-cos-self-improve.out`
+- stderr: `/tmp/ralph-cos-self-improve.err`
+
+### State directory
+
+Phase 6 writes transient grading artifacts (per-brief score files, draft system prompts) to:
+
+```
+~/.ralph-hero/cos/self-improve/run-YYYY-MM-DD/
+```
+
+Created automatically via `mkdir -p` on first run. The directory is safe to delete between runs — it is used only for intermediate files during a single grading session.
+
+---
+
 ## Directory layout
 
 ```
@@ -425,6 +510,8 @@ plugin/ralph-hero/scripts/cos/
 ├── cos-loop-smoke.sh             # End-to-end smoke for cos-loop.sh (manual; Phase 4)
 ├── cos-unattended.sh             # Dispatcher for scheduled unattended jobs (Phase 3)
 ├── morning-brief.sh              # Weekday 06:30 morning brief + ntfy push (Phase 3)
+├── self-improve.sh               # Nightly self-improvement loop (Phase 6)
+├── self-improve-smoke.sh         # Smoke test for self-improve.sh (manual; Phase 6)
 ├── mcp.json.example              # Template MCP config (placeholders substituted on install)
 ├── install-mcp-config.sh         # Idempotent installer for mcp.json.example
 ├── smoke.sh                      # End-to-end smoke test (manual; requires pi + MLX server)
@@ -436,7 +523,8 @@ plugin/ralph-hero/scripts/cos/
 │   ├── launch.sh                 # uv run streamlit run app.py ...
 │   └── pyproject.toml            # uv-managed deps (streamlit, pandas)
 └── launchd/
-    └── com.ralph.cos-morning-brief.plist.template   # launchd schedule template (Phase 3)
+    ├── com.ralph.cos-morning-brief.plist.template   # launchd schedule template (Phase 3)
+    └── com.ralph.cos-self-improve.plist.template    # launchd schedule template (Phase 6)
 ```
 
 ---
@@ -451,7 +539,7 @@ This foundation is consumed by:
 | 3 | [GH-1255](https://github.com/cdubiel08/ralph-hero/issues/1255) | Unattended morning brief + ntfy push |
 | 4 | [GH-1256](https://github.com/cdubiel08/ralph-hero/issues/1256) | oh-my-pi conventions: `cos-loop.sh` (count/duration loop), `gh-vfs.ts` pi extension (`issue://`, `pr://`, `thoughts://`), `ralph cos role` debug subcommand |
 | 5 | [GH-1257](https://github.com/cdubiel08/ralph-hero/issues/1257) | Streamlit desktop command surface at :8502 (six panels + chat) |
-| 6 | [GH-1258](https://github.com/cdubiel08/ralph-hero/issues/1258) | Nightly self-improvement loop |
+| 6 | [GH-1258](https://github.com/cdubiel08/ralph-hero/issues/1258) | Nightly self-improvement loop — shipped in this phase |
 
 The `cos.sh` CLI surface (positional prompt + `--role` flag + JSONL log shape) and
 `model-roles.sh` sourcing convention are **stable contracts**. Treat changes to these

--- a/plugin/ralph-hero/scripts/cos/launchd/com.ralph.cos-self-improve.plist.template
+++ b/plugin/ralph-hero/scripts/cos/launchd/com.ralph.cos-self-improve.plist.template
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.ralph.cos-self-improve.plist.template
+  =========================================
+  launchd plist for the nightly cos self-improvement loop (GH-1258).
+  Fires self-improve.sh at 02:30 daily (every day of the week).
+  Grades the last 7 morning briefs and opens a PR if mean score < 3.5.
+
+  Install workflow:
+  1. cp this template to ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+  2. Hand-edit /Users/dubiel/... paths below if your checkout lives elsewhere
+  3. Read the RALPH_COS_SELF_IMPROVE note below before editing EnvironmentVariables
+  4. launchctl load ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+  5. Verify: launchctl list | grep cos-self-improve
+     (PID column shows "-" when idle; exit code "0" after a successful run)
+
+  To fire manually for testing (without waiting for 02:30):
+    launchctl start com.ralph.cos-self-improve
+
+  To unload:
+    launchctl unload ~/Library/LaunchAgents/com.ralph.cos-self-improve.plist
+
+  Logs:
+    stdout: /tmp/ralph-cos-self-improve.out
+    stderr: /tmp/ralph-cos-self-improve.err
+-->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.ralph.cos-self-improve</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>cd /Users/dubiel/projects/ralph-hero/plugin/ralph-hero/scripts/cos &amp;&amp; ./self-improve.sh</string>
+	</array>
+
+	<!-- Fire at 02:30 every day (no Weekday key = all 7 days) -->
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>2</integer>
+		<key>Minute</key>
+		<integer>30</integer>
+	</dict>
+
+	<key>StandardOutPath</key>
+	<string>/tmp/ralph-cos-self-improve.out</string>
+
+	<key>StandardErrorPath</key>
+	<string>/tmp/ralph-cos-self-improve.err</string>
+
+	<key>EnvironmentVariables</key>
+	<dict>
+		<!-- Ensure pi, gh, git, awk, and other Homebrew tools are on PATH -->
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+
+		<!--
+		  RALPH_COS_SELF_IMPROVE: safety gate for the self-improvement loop.
+
+		  IMPORTANT — Two-manual-verification policy:
+		  Do NOT set this to "1" until you have manually invoked self-improve.sh
+		  twice with RALPH_COS_SELF_IMPROVE=1 set in your shell and confirmed both
+		  runs produced sensible revised prompts (or correctly skipped revision
+		  when mean >= 3.5). See plugin/ralph-hero/scripts/cos/README.md
+		  § Self-improvement loop for the full policy.
+
+		  Leave empty (default below) so the job fires but exits immediately with
+		  a "quarantined" log line in /tmp/ralph-cos-self-improve.err.
+		  Once you have completed two successful manual verification runs, change
+		  the empty string below to "1".
+		-->
+		<key>RALPH_COS_SELF_IMPROVE</key>
+		<string></string>
+	</dict>
+
+	<!-- Do not fire immediately on launchctl load — wait for 02:30 -->
+	<key>RunAtLoad</key>
+	<false/>
+</dict>
+</plist>

--- a/plugin/ralph-hero/scripts/cos/self-improve-smoke.sh
+++ b/plugin/ralph-hero/scripts/cos/self-improve-smoke.sh
@@ -25,7 +25,7 @@ SELF_IMPROVE="${SCRIPT_DIR}/self-improve.sh"
 # Usage
 # ---------------------------------------------------------------------------
 _usage() {
-    cat <<'EOF'
+    cat >&2 <<'EOF'
 self-improve-smoke.sh — manual end-to-end smoke test for self-improve.sh
 
 Usage:
@@ -48,7 +48,7 @@ for arg in "$@"; do
             ;;
         *)
             echo "[smoke] ERROR: Unknown flag: $arg" >&2
-            _usage >&2
+            _usage
             exit 2
             ;;
     esac
@@ -161,21 +161,19 @@ fi
 BRANCH_DATE="$(date -u +%F)"
 BRANCH_NAME="cos-self-improvement/${BRANCH_DATE}"
 
-if grep -qF "DRY RUN: skipping git push" "$STDERR_LOG"; then
-    echo "[smoke] Path: mean < 3.5 — draft prompt + branch created (dry-run skipped push/PR)"
-    # Verify the branch was created locally
+if grep -qF "DRY RUN: would create branch" "$STDERR_LOG"; then
+    echo "[smoke] Path: mean < 3.5 — dry-run gate fired before git mutation (no branch created)"
+    # Confirm no branch was left behind (dry-run now exits before git checkout -b)
     REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
     if git -C "$REPO_ROOT" rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
-        echo "[smoke] PASS: local branch '${BRANCH_NAME}' was created"
-        # Clean up the local branch
-        git -C "$REPO_ROOT" checkout main 2>/dev/null || git -C "$REPO_ROOT" checkout - 2>/dev/null || true
+        echo "[smoke] FAIL: local branch '${BRANCH_NAME}' was created despite dry-run (regression)" >&2
+        # Clean up the accidentally created branch
         git -C "$REPO_ROOT" branch -D "$BRANCH_NAME" 2>/dev/null || true
-        echo "[smoke] Cleaned up local branch: ${BRANCH_NAME}"
-    else
-        echo "[smoke] FAIL: local branch '${BRANCH_NAME}' was NOT created" >&2
         PASS=0
+    else
+        echo "[smoke] PASS: no local branch created (dry-run correctly exited before git mutation)"
     fi
-    echo "[smoke] Smoke test passed: low-quality briefs triggered draft prompt revision (branch cleaned up)"
+    echo "[smoke] Smoke test passed: low-quality briefs triggered dry-run path (no git state mutated)"
 elif grep -qF ">= 3.5; no revision needed" "$STDERR_LOG"; then
     MEAN_LINE="$(grep -oE "mean [0-9]+\.[0-9]+" "$STDERR_LOG" | head -1)"
     echo "[smoke] Path: mean >= 3.5 — no revision triggered"

--- a/plugin/ralph-hero/scripts/cos/self-improve-smoke.sh
+++ b/plugin/ralph-hero/scripts/cos/self-improve-smoke.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# self-improve-smoke.sh — manual smoke test for self-improve.sh (GH-1258)
+#
+# Creates a tmpdir with 7 synthetic morning-brief files (deliberately low-quality),
+# runs self-improve.sh in dry-run mode, and asserts expected outputs.
+#
+# This is a LOCAL-ONLY smoke test: it never pushes to origin, never calls gh pr create
+# (RALPH_COS_SELF_IMPROVE_DRY_RUN=1 is set automatically by this script).
+#
+# Prerequisites:
+#   - mlx-openai-server running on :8000 (pi + qwen3.5-27b)
+#   - pi on PATH
+#   - self-improve.sh in the same directory as this script
+#   - git in a working repo checkout
+#
+# Usage:
+#   plugin/ralph-hero/scripts/cos/self-improve-smoke.sh [--help|-h]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SELF_IMPROVE="${SCRIPT_DIR}/self-improve.sh"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+_usage() {
+    cat <<'EOF'
+self-improve-smoke.sh — manual end-to-end smoke test for self-improve.sh
+
+Usage:
+  self-improve-smoke.sh [--help|-h]
+
+Creates 7 synthetic low-quality morning brief files in a tmpdir, runs
+self-improve.sh with RALPH_COS_SELF_IMPROVE=1 and RALPH_COS_SELF_IMPROVE_DRY_RUN=1,
+then asserts expected stdout/stderr output.
+
+Does NOT push to origin or call gh pr create.
+Requires: pi on PATH, mlx-openai-server on :8000.
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+        *)
+            echo "[smoke] ERROR: Unknown flag: $arg" >&2
+            _usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Guard: self-improve.sh must exist and be executable
+# ---------------------------------------------------------------------------
+if [[ ! -x "$SELF_IMPROVE" ]]; then
+    echo "[smoke] ERROR: self-improve.sh not found or not executable at: $SELF_IMPROVE" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Create tmpdir; clean up on exit
+# ---------------------------------------------------------------------------
+SMOKE_TMPDIR="$(mktemp -d)"
+trap 'echo "[smoke] Cleaning up tmpdir: ${SMOKE_TMPDIR}"; rm -rf "${SMOKE_TMPDIR}"' EXIT
+
+RESEARCH_DIR="${SMOKE_TMPDIR}/shared/research"
+mkdir -p "$RESEARCH_DIR"
+
+echo "[smoke] tmpdir: ${SMOKE_TMPDIR}"
+echo "[smoke] Writing 7 synthetic low-quality morning briefs..."
+
+# ---------------------------------------------------------------------------
+# Write 7 synthetic briefs with deliberately low-quality content
+# (vague, no #NNN refs, no file paths, repetitive, long)
+# ---------------------------------------------------------------------------
+for i in $(seq 1 7); do
+    BRIEF_DATE="$(date -v-"${i}d" +%F 2>/dev/null || date -d "-${i} days" +%F 2>/dev/null || echo "2026-05-0${i}")"
+    BRIEF_FILE="${RESEARCH_DIR}/${BRIEF_DATE}-cos-morning-brief.md"
+
+    cat > "$BRIEF_FILE" <<EOF
+# Morning Brief — ${BRIEF_DATE}
+
+Here is a summary of what is happening with the project today. Things are generally moving forward. Some issues are in progress and some are waiting for review.
+
+There are several items that need attention. The team should look into the issues that are open and make sure everything is on track. It would be good to check in on the current work items.
+
+Some things were completed recently and other things are still pending. The overall status is okay but there is room for improvement in various areas. Moving forward we should continue to make progress on the open items.
+
+The pipeline looks reasonable. No major blockers at this time though some tasks could use more attention. The team is working on various things and progress is being made.
+
+In summary, things are progressing but there is work to be done. Stay focused and keep moving forward with the current priorities.
+EOF
+
+    echo "[smoke]   Wrote: $(basename "$BRIEF_FILE")"
+done
+
+# ---------------------------------------------------------------------------
+# Run self-improve.sh with dry-run flag
+# ---------------------------------------------------------------------------
+STDOUT_LOG="${SMOKE_TMPDIR}/stdout.log"
+STDERR_LOG="${SMOKE_TMPDIR}/stderr.log"
+
+echo "[smoke] Running self-improve.sh (RALPH_COS_SELF_IMPROVE=1 RALPH_COS_SELF_IMPROVE_DRY_RUN=1)..."
+echo "[smoke] (This invokes cos.sh --role slow 7+ times — expect it to take several minutes)"
+
+IMPROVE_EXIT=0
+RALPH_COS_SELF_IMPROVE=1 \
+RALPH_COS_SELF_IMPROVE_DRY_RUN=1 \
+RALPH_COS_THOUGHTS_DIR="${SMOKE_TMPDIR}" \
+    "$SELF_IMPROVE" > "$STDOUT_LOG" 2> "$STDERR_LOG" || IMPROVE_EXIT=$?
+
+echo "[smoke] self-improve.sh exited with code: ${IMPROVE_EXIT}"
+
+# ---------------------------------------------------------------------------
+# Display outputs
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== stdout ==="
+cat "$STDOUT_LOG"
+
+echo ""
+echo "=== stderr ==="
+cat "$STDERR_LOG"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+PASS=1
+
+# 1. stdout must contain the markdown table header
+if grep -qF "| Date | Brief |" "$STDOUT_LOG"; then
+    echo "[smoke] PASS: stdout contains markdown table header"
+else
+    echo "[smoke] FAIL: stdout does not contain '| Date | Brief |'" >&2
+    PASS=0
+fi
+
+# 2. stderr must mention the mean
+if grep -qE "mean [0-9]+\.[0-9]+" "$STDERR_LOG"; then
+    echo "[smoke] PASS: stderr contains mean line"
+else
+    echo "[smoke] FAIL: stderr does not contain a 'mean X.XX' line" >&2
+    PASS=0
+fi
+
+# 3. self-improve.sh must exit 0
+if [[ $IMPROVE_EXIT -eq 0 ]]; then
+    echo "[smoke] PASS: self-improve.sh exited 0"
+else
+    echo "[smoke] FAIL: self-improve.sh exited ${IMPROVE_EXIT} (expected 0)" >&2
+    PASS=0
+fi
+
+# 4. Determine which path fired
+BRANCH_DATE="$(date -u +%F)"
+BRANCH_NAME="cos-self-improvement/${BRANCH_DATE}"
+
+if grep -qF "DRY RUN: skipping git push" "$STDERR_LOG"; then
+    echo "[smoke] Path: mean < 3.5 — draft prompt + branch created (dry-run skipped push/PR)"
+    # Verify the branch was created locally
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
+    if git -C "$REPO_ROOT" rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
+        echo "[smoke] PASS: local branch '${BRANCH_NAME}' was created"
+        # Clean up the local branch
+        git -C "$REPO_ROOT" checkout main 2>/dev/null || git -C "$REPO_ROOT" checkout - 2>/dev/null || true
+        git -C "$REPO_ROOT" branch -D "$BRANCH_NAME" 2>/dev/null || true
+        echo "[smoke] Cleaned up local branch: ${BRANCH_NAME}"
+    else
+        echo "[smoke] FAIL: local branch '${BRANCH_NAME}' was NOT created" >&2
+        PASS=0
+    fi
+    echo "[smoke] Smoke test passed: low-quality briefs triggered draft prompt revision (branch cleaned up)"
+elif grep -qF ">= 3.5; no revision needed" "$STDERR_LOG"; then
+    MEAN_LINE="$(grep -oE "mean [0-9]+\.[0-9]+" "$STDERR_LOG" | head -1)"
+    echo "[smoke] Path: mean >= 3.5 — no revision triggered"
+    echo "[smoke] Smoke test passed: graded briefs but threshold not crossed (${MEAN_LINE})"
+elif grep -qF "insufficient briefs" "$STDERR_LOG"; then
+    echo "[smoke] FAIL: insufficient briefs detected (synthetic briefs may not have been found)" >&2
+    PASS=0
+elif grep -qF "too many parse failures" "$STDERR_LOG"; then
+    echo "[smoke] WARNING: too many parse failures — grader may be unavailable (mlx-openai-server running?)" >&2
+    # Not a hard failure for the smoke test — this can happen if the server is down
+    PASS=0
+else
+    echo "[smoke] FAIL: unexpected stderr output (no recognizable path taken)" >&2
+    PASS=0
+fi
+
+# ---------------------------------------------------------------------------
+# Final result
+# ---------------------------------------------------------------------------
+echo ""
+if [[ $PASS -eq 1 ]]; then
+    echo "[smoke] ALL ASSERTIONS PASSED"
+    exit 0
+else
+    echo "[smoke] SOME ASSERTIONS FAILED — review output above" >&2
+    exit 1
+fi

--- a/plugin/ralph-hero/scripts/cos/self-improve.sh
+++ b/plugin/ralph-hero/scripts/cos/self-improve.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+# self-improve.sh — nightly cos self-improvement loop (GH-1258)
+#
+# Grades the last 7 cos morning briefs against the 5-dimension rubric at
+# plugin/ralph-hero/skills/cos/rubric.md. When the mean score < 3.5, drafts
+# a revised system-prompt.md via cos.sh --role slow and opens a GitHub PR
+# labeled cos-self-improvement for human review.
+#
+# Usage:
+#   self-improve.sh [--help|-h]
+#
+# Environment:
+#   RALPH_COS_SELF_IMPROVE       MUST be "1" to enable; any other value (including
+#                                unset) exits 0 immediately with a "quarantined" log line.
+#   RALPH_COS_SELF_IMPROVE_DRY_RUN  Set to "1" to skip git push and gh pr create.
+#                                The script still creates the branch + commit locally,
+#                                which allows smoke testing and inspection without
+#                                touching the remote.
+#   RALPH_COS_THOUGHTS_DIR       Override for the thoughts/ corpus root directory.
+#                                Default: ~/projects/thoughts (same resolution as morning-brief.sh).
+#   RALPH_COS_DEBUG              Set to "1" for verbose stderr output.
+#
+# Exit codes:
+#   0   Normal exit (quarantined, insufficient briefs, mean >= 3.5, or PR opened)
+#   1   Fatal error: too many parse failures, or git/gh operation failed
+#   2   Usage error (--help exits 0, not 2)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# HARD GATE — must be the first executable statement after set -euo pipefail
+# ---------------------------------------------------------------------------
+if [[ "${RALPH_COS_SELF_IMPROVE:-}" != "1" ]]; then
+    echo "[self-improve] quarantined; set RALPH_COS_SELF_IMPROVE=1 to enable" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Defensive: ensure state directory exists for first-time installs
+# ---------------------------------------------------------------------------
+mkdir -p "${HOME}/.ralph-hero/cos/self-improve"
+
+# ---------------------------------------------------------------------------
+# Locate this script's directory robustly (works when symlinked)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+REPO_ROOT="$(cd "${PLUGIN_ROOT}/../.." && pwd -P)"
+
+COS_SH="${SCRIPT_DIR}/cos.sh"
+RUBRIC_FILE="${PLUGIN_ROOT}/skills/cos/rubric.md"
+SYSTEM_PROMPT_FILE="${PLUGIN_ROOT}/skills/cos/system-prompt.md"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+_usage() {
+    cat <<'EOF'
+self-improve.sh — nightly cos self-improvement loop
+
+Usage:
+  self-improve.sh [--help|-h]
+
+Grades the last 7 cos morning briefs against the 5-dimension rubric and,
+when the mean score < 3.5, opens a GitHub PR with a revised system prompt.
+
+Environment:
+  RALPH_COS_SELF_IMPROVE=1          Required to enable the script.
+  RALPH_COS_SELF_IMPROVE_DRY_RUN=1  Skip git push + gh pr create (local-only).
+  RALPH_COS_THOUGHTS_DIR            Override the thoughts/ corpus root.
+  RALPH_COS_DEBUG=1                 Verbose stderr output.
+
+See plugin/ralph-hero/skills/cos/rubric.md for the grading rubric.
+See plugin/ralph-hero/scripts/cos/README.md for the two-manual-verification policy.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+        *)
+            echo "[self-improve] ERROR: Unknown flag: $arg" >&2
+            _usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Debug helper
+# ---------------------------------------------------------------------------
+_debug() {
+    if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+        echo "[self-improve] DEBUG: $*" >&2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Guard: required tools
+# ---------------------------------------------------------------------------
+if [[ ! -f "$COS_SH" ]]; then
+    echo "[self-improve] ERROR: cos.sh not found at: $COS_SH" >&2
+    exit 1
+fi
+
+if [[ ! -f "$RUBRIC_FILE" ]]; then
+    echo "[self-improve] ERROR: rubric.md not found at: $RUBRIC_FILE" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SYSTEM_PROMPT_FILE" ]]; then
+    echo "[self-improve] ERROR: system-prompt.md not found at: $SYSTEM_PROMPT_FILE" >&2
+    exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "[self-improve] ERROR: git not found on PATH" >&2
+    exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "[self-improve] ERROR: gh CLI not found on PATH" >&2
+    exit 1
+fi
+
+if ! command -v awk >/dev/null 2>&1; then
+    echo "[self-improve] ERROR: awk not found on PATH" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the thoughts/ corpus root (mirrors morning-brief.sh resolution)
+# ---------------------------------------------------------------------------
+if [[ -n "${RALPH_COS_THOUGHTS_DIR:-}" ]]; then
+    THOUGHTS_DIR="${RALPH_COS_THOUGHTS_DIR}"
+else
+    THOUGHTS_DIR="${REPO_ROOT}/../thoughts"
+    THOUGHTS_DIR="$(cd "${THOUGHTS_DIR}" 2>/dev/null && pwd -P)" \
+        || THOUGHTS_DIR="${REPO_ROOT}/../thoughts"
+fi
+
+_debug "THOUGHTS_DIR=${THOUGHTS_DIR}"
+_debug "RUBRIC_FILE=${RUBRIC_FILE}"
+_debug "SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_FILE}"
+
+# ---------------------------------------------------------------------------
+# Glob morning brief files (sorted lexicographically = chronologically)
+# ---------------------------------------------------------------------------
+BRIEF_DIR="${THOUGHTS_DIR}/shared/research"
+
+if [[ ! -d "$BRIEF_DIR" ]]; then
+    echo "[self-improve] insufficient briefs (have 0, need 7); skipping run" >&2
+    exit 0
+fi
+
+# Build array of brief files sorted lexicographically (bash 3.2 compatible)
+BRIEF_FILES=()
+while IFS= read -r -d '' f; do
+    BRIEF_FILES+=("$f")
+done < <(find "$BRIEF_DIR" -maxdepth 1 -name '*-cos-morning-brief.md' -print0 | sort -z)
+
+BRIEF_COUNT="${#BRIEF_FILES[@]}"
+_debug "Found ${BRIEF_COUNT} brief files"
+
+if (( BRIEF_COUNT < 7 )); then
+    echo "[self-improve] insufficient briefs (have ${BRIEF_COUNT}, need 7); skipping run" >&2
+    exit 0
+fi
+
+# Take the LAST 7 (most recent by date prefix)
+START_IDX=$(( BRIEF_COUNT - 7 ))
+SELECTED_BRIEFS=("${BRIEF_FILES[@]:$START_IDX:7}")
+
+_debug "Grading ${#SELECTED_BRIEFS[@]} briefs"
+
+# ---------------------------------------------------------------------------
+# Load rubric content once
+# ---------------------------------------------------------------------------
+RUBRIC_CONTENT="$(cat "$RUBRIC_FILE")"
+
+# ---------------------------------------------------------------------------
+# Grade each brief
+# ---------------------------------------------------------------------------
+PARSE_FAILURES=0
+declare -a BRIEF_DATES
+declare -a BRIEF_BASENAMES
+declare -a BRIEF_SCORES_SPECIFICITY
+declare -a BRIEF_SCORES_ACTIONABILITY
+declare -a BRIEF_SCORES_SN
+declare -a BRIEF_SCORES_NOVELTY
+declare -a BRIEF_SCORES_BREVITY
+declare -a BRIEF_MEANS
+declare -a BRIEF_STATUS
+
+STATE_DIR="${HOME}/.ralph-hero/cos/self-improve"
+RUN_DATE="$(date -u +%F)"
+SCORE_TMPDIR="${STATE_DIR}/run-${RUN_DATE}"
+mkdir -p "$SCORE_TMPDIR"
+
+GRADE_IDX=0
+for BRIEF_FILE in "${SELECTED_BRIEFS[@]}"; do
+    BRIEF_BASENAME="$(basename "$BRIEF_FILE")"
+    # Extract date from filename: YYYY-MM-DD-cos-morning-brief.md
+    BRIEF_DATE="${BRIEF_BASENAME%%-cos-morning-brief.md}"
+
+    BRIEF_CONTENT="$(cat "$BRIEF_FILE")"
+
+    GRADE_PROMPT="$(cat <<EOF
+You are a grading assistant. Grade the following morning brief against the rubric below.
+
+## Morning Brief to Grade
+
+${BRIEF_CONTENT}
+
+## Rubric
+
+${RUBRIC_CONTENT}
+
+## Instructions
+
+Grade the brief above against each rubric dimension. Output EXACTLY 5 integers, one per line, with no other text, in this order:
+1. Specificity
+2. Actionability
+3. Signal-vs-noise
+4. Novelty
+5. Brevity
+
+Each integer must be between 1 and 5 inclusive. No explanations, no labels, no preamble.
+EOF
+)"
+
+    SCORE_FILE="${SCORE_TMPDIR}/scores-${BRIEF_DATE}.txt"
+    _debug "Grading ${BRIEF_BASENAME}..."
+
+    # Invoke cos.sh --role slow; capture stdout; failures are tolerated
+    GRADE_EXIT=0
+    "$COS_SH" --role slow "$GRADE_PROMPT" > "$SCORE_FILE" 2>/dev/null || GRADE_EXIT=$?
+
+    # Parse 5 integer scores from the output file
+    PARSE_OK=1
+    S1="" S2="" S3="" S4="" S5=""
+
+    LINE_NUM=0
+    while IFS= read -r line; do
+        # Strip whitespace
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        # Must be a single integer 1-5
+        if [[ "$line" =~ ^[1-5]$ ]]; then
+            LINE_NUM=$(( LINE_NUM + 1 ))
+            case $LINE_NUM in
+                1) S1="$line" ;;
+                2) S2="$line" ;;
+                3) S3="$line" ;;
+                4) S4="$line" ;;
+                5) S5="$line" ;;
+            esac
+        elif [[ -n "$line" ]]; then
+            # Non-empty non-integer line found — parse failure
+            PARSE_OK=0
+            break
+        fi
+    done < "$SCORE_FILE"
+
+    if [[ $PARSE_OK -eq 1 ]] && [[ $LINE_NUM -eq 5 ]]; then
+        BRIEF_DATES+=("$BRIEF_DATE")
+        BRIEF_BASENAMES+=("$BRIEF_BASENAME")
+        BRIEF_SCORES_SPECIFICITY+=("$S1")
+        BRIEF_SCORES_ACTIONABILITY+=("$S2")
+        BRIEF_SCORES_SN+=("$S3")
+        BRIEF_SCORES_NOVELTY+=("$S4")
+        BRIEF_SCORES_BREVITY+=("$S5")
+        BRIEF_MEAN="$(awk -v a="$S1" -v b="$S2" -v c="$S3" -v d="$S4" -v e="$S5" \
+            'BEGIN { printf "%.2f", (a+b+c+d+e)/5 }')"
+        BRIEF_MEANS+=("$BRIEF_MEAN")
+        BRIEF_STATUS+=("ok")
+        _debug "${BRIEF_BASENAME}: ${S1} ${S2} ${S3} ${S4} ${S5} mean=${BRIEF_MEAN}"
+    else
+        echo "[self-improve] WARNING: parse failed for ${BRIEF_BASENAME} (grade_exit=${GRADE_EXIT}, lines_parsed=${LINE_NUM})" >&2
+        BRIEF_DATES+=("$BRIEF_DATE")
+        BRIEF_BASENAMES+=("$BRIEF_BASENAME")
+        BRIEF_SCORES_SPECIFICITY+=("-")
+        BRIEF_SCORES_ACTIONABILITY+=("-")
+        BRIEF_SCORES_SN+=("-")
+        BRIEF_SCORES_NOVELTY+=("-")
+        BRIEF_SCORES_BREVITY+=("-")
+        BRIEF_MEANS+=("-")
+        BRIEF_STATUS+=("parse_failed")
+        PARSE_FAILURES=$(( PARSE_FAILURES + 1 ))
+    fi
+
+    GRADE_IDX=$(( GRADE_IDX + 1 ))
+done
+
+# ---------------------------------------------------------------------------
+# Abort if too many parse failures
+# ---------------------------------------------------------------------------
+if (( PARSE_FAILURES >= 3 )); then
+    echo "[self-improve] too many parse failures (${PARSE_FAILURES} of 7); aborting before PR" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Compute overall mean across all successful datapoints
+# ---------------------------------------------------------------------------
+TOTAL_SCORE=0
+TOTAL_COUNT=0
+for i in "${!BRIEF_STATUS[@]}"; do
+    if [[ "${BRIEF_STATUS[$i]}" == "ok" ]]; then
+        S1="${BRIEF_SCORES_SPECIFICITY[$i]}"
+        S2="${BRIEF_SCORES_ACTIONABILITY[$i]}"
+        S3="${BRIEF_SCORES_SN[$i]}"
+        S4="${BRIEF_SCORES_NOVELTY[$i]}"
+        S5="${BRIEF_SCORES_BREVITY[$i]}"
+        TOTAL_SCORE=$(( TOTAL_SCORE + S1 + S2 + S3 + S4 + S5 ))
+        TOTAL_COUNT=$(( TOTAL_COUNT + 5 ))
+    fi
+done
+
+if (( TOTAL_COUNT == 0 )); then
+    echo "[self-improve] no valid scores to compute mean; aborting" >&2
+    exit 1
+fi
+
+MEAN="$(awk -v t="$TOTAL_SCORE" -v n="$TOTAL_COUNT" 'BEGIN { printf "%.2f", t/n }')"
+
+# ---------------------------------------------------------------------------
+# Emit score table to stdout
+# ---------------------------------------------------------------------------
+echo "| Date | Brief | Specificity | Actionability | S/N | Novelty | Brevity | Mean |"
+echo "|------|-------|-------------|---------------|-----|---------|---------|------|"
+
+for i in "${!BRIEF_DATES[@]}"; do
+    DATE_COL="${BRIEF_DATES[$i]}"
+    NAME_COL="${BRIEF_BASENAMES[$i]}"
+    if [[ "${BRIEF_STATUS[$i]}" == "parse_failed" ]]; then
+        echo "| ${DATE_COL} | ${NAME_COL} | parse_failed | - | - | - | - | - |"
+    else
+        echo "| ${DATE_COL} | ${NAME_COL} | ${BRIEF_SCORES_SPECIFICITY[$i]} | ${BRIEF_SCORES_ACTIONABILITY[$i]} | ${BRIEF_SCORES_SN[$i]} | ${BRIEF_SCORES_NOVELTY[$i]} | ${BRIEF_SCORES_BREVITY[$i]} | ${BRIEF_MEANS[$i]} |"
+    fi
+done
+
+echo "| | **Overall mean** | | | | | | **${MEAN}** |"
+
+# ---------------------------------------------------------------------------
+# Decision: mean >= 3.5 → no revision needed
+# ---------------------------------------------------------------------------
+if awk -v m="$MEAN" 'BEGIN { exit !(m >= 3.5) }'; then
+    echo "[self-improve] mean ${MEAN} >= 3.5; no revision needed" >&2
+    exit 0
+fi
+
+echo "[self-improve] mean ${MEAN} < 3.5; drafting revised system prompt" >&2
+
+# ---------------------------------------------------------------------------
+# Branch guard: idempotent same-day re-run protection
+# ---------------------------------------------------------------------------
+BRANCH_NAME="cos-self-improvement/${RUN_DATE}"
+if git -C "$REPO_ROOT" rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
+    echo "[self-improve] branch already exists (${BRANCH_NAME}); aborting to avoid clobbering existing PR" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Draft revised system prompt via cos.sh --role slow
+# ---------------------------------------------------------------------------
+CURRENT_PROMPT_CONTENT="$(cat "$SYSTEM_PROMPT_FILE")"
+CURRENT_PROMPT_LEN="${#CURRENT_PROMPT_CONTENT}"
+
+# Build score table string for the revision prompt
+SCORE_TABLE=""
+for i in "${!BRIEF_DATES[@]}"; do
+    if [[ "${BRIEF_STATUS[$i]}" == "ok" ]]; then
+        SCORE_TABLE="${SCORE_TABLE}
+- ${BRIEF_DATES[$i]}: specificity=${BRIEF_SCORES_SPECIFICITY[$i]} actionability=${BRIEF_SCORES_ACTIONABILITY[$i]} signal-vs-noise=${BRIEF_SCORES_SN[$i]} novelty=${BRIEF_SCORES_NOVELTY[$i]} brevity=${BRIEF_SCORES_BREVITY[$i]} mean=${BRIEF_MEANS[$i]}"
+    else
+        SCORE_TABLE="${SCORE_TABLE}
+- ${BRIEF_DATES[$i]}: parse_failed"
+    fi
+done
+
+REVISION_PROMPT="$(cat <<EOF
+You are revising a chief-of-staff system prompt for a software project assistant.
+The current system prompt produced morning briefs that scored a mean of ${MEAN}/5.0 over the last 7 days.
+
+Per-brief scores (using the 5-dimension rubric):
+${SCORE_TABLE}
+
+The current system prompt is:
+
+${CURRENT_PROMPT_CONTENT}
+
+The rubric used for grading is:
+
+${RUBRIC_CONTENT}
+
+Based on the low scores, revise the system prompt to improve the areas where scores were low.
+Keep the same overall structure and intent of the prompt.
+Output ONLY the revised system-prompt.md content. No preamble, no explanation, no fenced code block.
+The output will be written directly to system-prompt.md.
+EOF
+)"
+
+DRAFT_PROMPT_FILE="${SCORE_TMPDIR}/draft-system-prompt-${RUN_DATE}.md"
+_debug "Requesting revised system prompt from cos.sh --role slow..."
+
+REVISION_EXIT=0
+"$COS_SH" --role slow "$REVISION_PROMPT" > "$DRAFT_PROMPT_FILE" 2>/dev/null || REVISION_EXIT=$?
+
+if [[ $REVISION_EXIT -ne 0 ]]; then
+    echo "[self-improve] ERROR: cos.sh failed during revision drafting (exit ${REVISION_EXIT})" >&2
+    exit 1
+fi
+
+DRAFT_CONTENT="$(cat "$DRAFT_PROMPT_FILE")"
+DRAFT_LEN="${#DRAFT_CONTENT}"
+
+if [[ -z "$DRAFT_CONTENT" ]]; then
+    echo "[self-improve] revised prompt indistinguishable from current (empty output); no PR" >&2
+    exit 0
+fi
+
+# Check for substantial difference: require either >5% length change OR different content
+if [[ "$DRAFT_CONTENT" == "$CURRENT_PROMPT_CONTENT" ]]; then
+    echo "[self-improve] revised prompt indistinguishable from current (identical content); no PR" >&2
+    exit 0
+fi
+
+# Float comparison for 5% threshold using awk
+if awk -v new_len="$DRAFT_LEN" -v old_len="$CURRENT_PROMPT_LEN" \
+    'BEGIN {
+        diff = (new_len > old_len) ? (new_len - old_len) : (old_len - new_len);
+        threshold = old_len * 0.05;
+        exit !(diff <= threshold)
+    }'; then
+    # Difference is <= 5% — do a sha256 check to see if content changed at all
+    OLD_HASH="$(printf '%s' "$CURRENT_PROMPT_CONTENT" | shasum -a 256 | cut -d' ' -f1)"
+    NEW_HASH="$(printf '%s' "$DRAFT_CONTENT" | shasum -a 256 | cut -d' ' -f1)"
+    if [[ "$OLD_HASH" == "$NEW_HASH" ]]; then
+        echo "[self-improve] revised prompt indistinguishable from current; no PR" >&2
+        exit 0
+    fi
+    _debug "Content changed (< 5% length diff but hashes differ) — proceeding with PR"
+fi
+
+# ---------------------------------------------------------------------------
+# Create branch, commit, push
+# ---------------------------------------------------------------------------
+git -C "$REPO_ROOT" checkout -b "$BRANCH_NAME"
+
+# Write the drafted prompt to system-prompt.md
+printf '%s' "$DRAFT_CONTENT" > "$SYSTEM_PROMPT_FILE"
+
+git -C "$REPO_ROOT" add "plugin/ralph-hero/skills/cos/system-prompt.md"
+git -C "$REPO_ROOT" commit -m "docs(cos): self-improvement revision ${RUN_DATE} (mean=${MEAN})"
+
+# ---------------------------------------------------------------------------
+# Dry-run gate: skip push + PR if RALPH_COS_SELF_IMPROVE_DRY_RUN=1
+# ---------------------------------------------------------------------------
+if [[ "${RALPH_COS_SELF_IMPROVE_DRY_RUN:-}" == "1" ]]; then
+    echo "[self-improve] DRY RUN: skipping git push and gh pr create" >&2
+    echo "[self-improve] Branch ${BRANCH_NAME} created locally with commit. Inspect then: git -C ${REPO_ROOT} branch -D ${BRANCH_NAME}" >&2
+    exit 0
+fi
+
+git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME"
+
+# ---------------------------------------------------------------------------
+# Idempotent label creation
+# ---------------------------------------------------------------------------
+gh label create cos-self-improvement \
+    --description 'Drafted by the nightly cos self-improvement loop' \
+    --color 'fbca04' \
+    --repo "$(git -C "$REPO_ROOT" remote get-url origin | sed 's|.*github.com[:/]\(.*\)\.git|\1|; s|.*github.com[:/]\(.*\)|\1|')" \
+    2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Build PR body
+# ---------------------------------------------------------------------------
+FILENAMES_LIST=""
+for BRIEF_FILE in "${SELECTED_BRIEFS[@]}"; do
+    FILENAMES_LIST="${FILENAMES_LIST}
+- $(basename "$BRIEF_FILE")"
+done
+
+PR_BODY="$(cat <<EOF
+## cos self-improvement revision — ${RUN_DATE}
+
+Mean score across last 7 morning briefs: **${MEAN}/5.0** (threshold: 3.5)
+
+### Per-brief scores
+
+| Date | Brief | Specificity | Actionability | S/N | Novelty | Brevity | Mean |
+|------|-------|-------------|---------------|-----|---------|---------|------|
+EOF
+)"
+
+for i in "${!BRIEF_DATES[@]}"; do
+    if [[ "${BRIEF_STATUS[$i]}" == "ok" ]]; then
+        PR_BODY="${PR_BODY}
+| ${BRIEF_DATES[$i]} | ${BRIEF_BASENAMES[$i]} | ${BRIEF_SCORES_SPECIFICITY[$i]} | ${BRIEF_SCORES_ACTIONABILITY[$i]} | ${BRIEF_SCORES_SN[$i]} | ${BRIEF_SCORES_NOVELTY[$i]} | ${BRIEF_SCORES_BREVITY[$i]} | ${BRIEF_MEANS[$i]} |"
+    else
+        PR_BODY="${PR_BODY}
+| ${BRIEF_DATES[$i]} | ${BRIEF_BASENAMES[$i]} | parse_failed | - | - | - | - | - |"
+    fi
+done
+
+PR_BODY="${PR_BODY}
+| | **Overall mean** | | | | | | **${MEAN}** |
+
+### Graded brief files
+${FILENAMES_LIST}
+
+### How to verify
+
+- [ ] Read the diff on this PR: confirm the revised prompt differs meaningfully from the current (not just whitespace).
+- [ ] Confirm the revised prompt remains a sensible chief-of-staff instruction set — it should still discourage fabrication, prefer brevity, and cite issue numbers.
+- [ ] Optionally: run \`RALPH_COS_SELF_IMPROVE=1 RALPH_COS_SELF_IMPROVE_DRY_RUN=1 plugin/ralph-hero/scripts/cos/self-improve.sh\` locally to reproduce the scores.
+- [ ] If the revision looks good, merge. If not, close this PR and adjust the rubric or system prompt manually.
+
+---
+
+*Generated by \`self-improve.sh\` — see \`plugin/ralph-hero/scripts/cos/README.md\` § Self-improvement loop for the two-manual-verification policy.*
+EOF
+"
+
+# ---------------------------------------------------------------------------
+# Open PR
+# ---------------------------------------------------------------------------
+PR_URL="$(gh pr create \
+    --title "cos: self-improvement revision ${RUN_DATE}" \
+    --body "$PR_BODY" \
+    --label "cos-self-improvement" \
+    --repo "$(git -C "$REPO_ROOT" remote get-url origin | sed 's|.*github.com[:/]\(.*\)\.git|\1|; s|.*github.com[:/]\(.*\)|\1|')")"
+
+echo "[self-improve] PR opened: ${PR_URL}" >&2
+echo "${PR_URL}"

--- a/plugin/ralph-hero/scripts/cos/self-improve.sh
+++ b/plugin/ralph-hero/scripts/cos/self-improve.sh
@@ -55,7 +55,7 @@ SYSTEM_PROMPT_FILE="${PLUGIN_ROOT}/skills/cos/system-prompt.md"
 # Usage
 # ---------------------------------------------------------------------------
 _usage() {
-    cat <<'EOF'
+    cat >&2 <<'EOF'
 self-improve.sh — nightly cos self-improvement loop
 
 Usage:
@@ -86,7 +86,7 @@ for arg in "$@"; do
             ;;
         *)
             echo "[self-improve] ERROR: Unknown flag: $arg" >&2
-            _usage >&2
+            _usage
             exit 2
             ;;
     esac
@@ -239,8 +239,9 @@ EOF
     _debug "Grading ${BRIEF_BASENAME}..."
 
     # Invoke cos.sh --role slow; capture stdout; failures are tolerated
+    # Restrict tools to read-only: grading only needs to inspect content, not write.
     GRADE_EXIT=0
-    "$COS_SH" --role slow "$GRADE_PROMPT" > "$SCORE_FILE" 2>/dev/null || GRADE_EXIT=$?
+    RALPH_COS_TOOLS=read,grep,find "$COS_SH" --role slow "$GRADE_PROMPT" > "$SCORE_FILE" 2>/dev/null || GRADE_EXIT=$?
 
     # Parse 5 integer scores from the output file
     PARSE_OK=1
@@ -368,6 +369,17 @@ if git -C "$REPO_ROOT" rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
+# Dry-run gate: must fire BEFORE any git mutation
+# ---------------------------------------------------------------------------
+# (Grading and revision drafting above are read-only. All git operations below
+# this point are mutations. Exit here so dry-run never creates a branch or commit.)
+if [[ "${RALPH_COS_SELF_IMPROVE_DRY_RUN:-}" == "1" ]]; then
+    echo "[self-improve] DRY RUN: would create branch ${BRANCH_NAME}, commit revised system-prompt.md, push, and open PR" >&2
+    echo "[self-improve] DRY RUN: mean=${MEAN} (below threshold 3.5); PR would be opened" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Draft revised system prompt via cos.sh --role slow
 # ---------------------------------------------------------------------------
 CURRENT_PROMPT_CONTENT="$(cat "$SYSTEM_PROMPT_FILE")"
@@ -411,7 +423,8 @@ DRAFT_PROMPT_FILE="${SCORE_TMPDIR}/draft-system-prompt-${RUN_DATE}.md"
 _debug "Requesting revised system prompt from cos.sh --role slow..."
 
 REVISION_EXIT=0
-"$COS_SH" --role slow "$REVISION_PROMPT" > "$DRAFT_PROMPT_FILE" 2>/dev/null || REVISION_EXIT=$?
+# Restrict tools to read-only: the revision LLM generates content to stdout, no write tool needed.
+RALPH_COS_TOOLS=read,grep,find "$COS_SH" --role slow "$REVISION_PROMPT" > "$DRAFT_PROMPT_FILE" 2>/dev/null || REVISION_EXIT=$?
 
 if [[ $REVISION_EXIT -ne 0 ]]; then
     echo "[self-improve] ERROR: cos.sh failed during revision drafting (exit ${REVISION_EXIT})" >&2
@@ -459,15 +472,6 @@ printf '%s' "$DRAFT_CONTENT" > "$SYSTEM_PROMPT_FILE"
 
 git -C "$REPO_ROOT" add "plugin/ralph-hero/skills/cos/system-prompt.md"
 git -C "$REPO_ROOT" commit -m "docs(cos): self-improvement revision ${RUN_DATE} (mean=${MEAN})"
-
-# ---------------------------------------------------------------------------
-# Dry-run gate: skip push + PR if RALPH_COS_SELF_IMPROVE_DRY_RUN=1
-# ---------------------------------------------------------------------------
-if [[ "${RALPH_COS_SELF_IMPROVE_DRY_RUN:-}" == "1" ]]; then
-    echo "[self-improve] DRY RUN: skipping git push and gh pr create" >&2
-    echo "[self-improve] Branch ${BRANCH_NAME} created locally with commit. Inspect then: git -C ${REPO_ROOT} branch -D ${BRANCH_NAME}" >&2
-    exit 0
-fi
 
 git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME"
 

--- a/plugin/ralph-hero/skills/cos/rubric.md
+++ b/plugin/ralph-hero/skills/cos/rubric.md
@@ -1,0 +1,88 @@
+# Cos Morning Brief Grading Rubric
+
+Five dimensions; each scored 1–5. Scores are integers only.
+
+---
+
+## Dimensions
+
+### 1. Specificity
+
+Does the brief ground every claim in a concrete reference (issue number, file path, commit, date)?
+
+| Score | Anchor |
+|-------|--------|
+| 1 | No concrete references — all vague ("some issues are in progress", "things are moving") |
+| 2 | 1–2 issue refs but most claims are unanchored |
+| 3 | Roughly half the claims are grounded; the other half are generalised |
+| 4 | Most claims anchored; one or two unanchored statements remain |
+| 5 | Every actionable claim is backed by a `#NNN`, a file path, or a verifiable date |
+
+### 2. Actionability
+
+Does the brief surface the single highest-priority next action clearly?
+
+| Score | Anchor |
+|-------|--------|
+| 1 | No next action stated — purely descriptive |
+| 2 | Vague next action ("look into the issues", "continue work") with no ownership or issue ref |
+| 3 | A next action is named but lacks the specific issue number or owner |
+| 4 | Next action named with issue ref; timing is implicit but inferable |
+| 5 | Explicit "next action: [verb] #NNN [by whom / before what]" with enough detail to act without follow-up |
+
+### 3. Signal-vs-noise
+
+Is the brief free of filler, repetition, and meta-commentary ("Here is your brief…")?
+
+| Score | Anchor |
+|-------|--------|
+| 1 | > 50% of word count is preamble, meta-narration, or repetition of prior content |
+| 2 | 30–50% filler |
+| 3 | 15–30% filler — some preamble or restated information present |
+| 4 | < 15% filler; minor hedging phrases remain |
+| 5 | Zero filler — every sentence carries new, actionable signal |
+
+### 4. Novelty
+
+Does the brief surface something that wasn't already in yesterday's brief (or is explicitly new)?
+
+| Score | Anchor |
+|-------|--------|
+| 1 | Verbatim or near-verbatim restatement of yesterday's brief |
+| 2 | Mostly old information with at most one new detail |
+| 3 | About half new, half repeated from prior briefs |
+| 4 | Mostly new; one or two recycled sentences |
+| 5 | Entirely new information (new events, new state changes, new risks surfaced) |
+
+### 5. Brevity
+
+Is the brief short enough to read in under 30 seconds on a phone?
+
+| Score | Anchor |
+|-------|--------|
+| 1 | > 300 words — requires scrolling |
+| 2 | 200–300 words |
+| 3 | 150–200 words |
+| 4 | 100–150 words |
+| 5 | ≤ 100 words — fits on a single phone screen without scrolling |
+
+---
+
+## Output contract
+
+When a grading script invokes `cos.sh --role slow` with this rubric, it passes a prompt that includes:
+
+1. The full text of the morning brief to grade.
+2. The full text of this rubric file.
+3. The following strict instruction:
+
+> "Grade the brief above against each rubric dimension. Output EXACTLY 5 integers, one per line, with no other text, in this order:
+> 1. Specificity
+> 2. Actionability
+> 3. Signal-vs-noise
+> 4. Novelty
+> 5. Brevity
+>
+> Each integer must be between 1 and 5 inclusive. No explanations, no labels, no preamble."
+
+The grading script parses exactly 5 lines of output. A response that does not contain exactly 5 lines, each a single integer in [1,5], is treated as a parse failure for that brief.

--- a/plugin/ralph-hero/skills/cos/system-prompt.md
+++ b/plugin/ralph-hero/skills/cos/system-prompt.md
@@ -33,3 +33,7 @@ Brief, factual, no narration of internal steps. One paragraph maximum. No preamb
 ## Example Output (remote mode)
 
 > **3 items in flight.** #1254 (cos Phase 2) and #1255 (cos Phase 3) are both In Progress — Phase 2 merged 2026-05-14, Phase 3 unblocked. No PRs awaiting review. Next action: advance #1255 to Plan in Progress.
+
+## Grading rubric
+
+Morning briefs are graded nightly against the 5-dimension rubric at `plugin/ralph-hero/skills/cos/rubric.md` (specificity, actionability, signal-vs-noise, novelty, brevity — each scored 1–5). Consistently low scores (mean < 3.5 over the last 7 briefs) trigger a self-improvement PR with a revised version of this system prompt for human review.


### PR DESCRIPTION
## Summary

Ships the nightly self-improvement loop: an env-flag-gated 02:30 launchd job that grades the last 7 morning briefs against a 5-dimension rubric, computes the mean score, and opens a PR with a revised system prompt when the mean falls below 3.5.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-15-GH-1258-cos-phase6-self-improvement.md

Phase 1 of 1 (single-phase plan).

## Test plan

- [ ] Automated verification per plan Success Criteria
- [ ] Manual verification per plan Success Criteria

## What shipped

| Artifact | Description |
|----------|-------------|
| `plugin/ralph-hero/skills/cos/rubric.md` | 5-dimension rubric (specificity, actionability, signal-vs-noise, novelty, brevity) with 1-5 scoring anchors |
| `plugin/ralph-hero/scripts/cos/self-improve.sh` | End-to-end nightly grading script (env-gated, globs briefs, grades, computes mean, opens PR when mean < 3.5) |
| `plugin/ralph-hero/scripts/cos/self-improve-smoke.sh` | Local smoke test with synthetic briefs |
| `plugin/ralph-hero/scripts/cos/launchd/com.ralph.cos-self-improve.plist.template` | launchd template (fires 02:30 daily) |
| `plugin/ralph-hero/scripts/cos/README.md` | Phase 6 section with two-manual-verification policy |
| `plugin/ralph-hero/skills/cos/system-prompt.md` | Appended rubric cross-reference |

Closes #1258
