### PR TITLE
GH-1268: Feature A - SOUL framework + SessionStart hook

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/load-team-soul.sh
+++ b/plugin/ralph-hero/hooks/scripts/load-team-soul.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ralph-hero/hooks/scripts/load-team-soul.sh
+#
+# TRIGGER:       SessionStart
+# EXPECTED ENV:  RALPH_COMMAND — set by set-skill-env.sh in each team skill's
+#                frontmatter (e.g. "set-skill-env.sh RALPH_COMMAND=hero").
+#                CLAUDE_ENV_FILE — standard Claude Code SessionStart env file
+#                (may be unset when invoked outside a hook context).
+#
+# EXIT SEMANTICS: Always exits 0. Never fails the session.
+#                 - When RALPH_COMMAND is unset or empty: silent exit 0.
+#                   No stdout. No $CLAUDE_ENV_FILE mutation.
+#                 - When the candidate SOUL file does not exist: silent exit 0.
+#                   No stdout. No $CLAUDE_ENV_FILE mutation.
+#                 - When a SOUL file is found: emits JSON envelope on stdout
+#                   (see OUTPUT CONTRACT below) and optionally appends a line
+#                   to $CLAUDE_ENV_FILE (see SIDE EFFECT below).
+#
+# OUTPUT CONTRACT:
+#   When a SOUL is loaded, emits a JSON object on stdout:
+#     { "hookSpecificOutput": { "hookEventName": "SessionStart",
+#                               "additionalContext": "<SOUL body>" } }
+#   The Claude Code runtime parses this JSON and injects "additionalContext"
+#   into the model's system context for the session. Raw cat of the SOUL file
+#   to stdout is NOT sufficient — it is ignored by the runtime. This pattern
+#   mirrors plugin/ralph-hero/hooks/scripts/superpowers-bridge-session.sh.
+#
+# SIDE EFFECT:
+#   When a SOUL is loaded and $CLAUDE_ENV_FILE is set and non-empty, appends:
+#     export RALPH_SOUL_LOADED=<team>
+#   where <team> is the value of $RALPH_COMMAND (the skill directory name,
+#   e.g. "hero", not the plural team name from the SOUL frontmatter).
+#   Downstream hooks (Features B/C/F/G) can assert SOUL injection occurred by
+#   checking $RALPH_SOUL_LOADED. Mirrors the RALPH_SUPERPOWERS_BRIDGE=true
+#   precedent in superpowers-bridge-session.sh.
+#
+# RUNTIME DEPENDENCY: jq must be on $PATH.
+#   set -euo pipefail means a jq failure (e.g. unicode parse error, jq not
+#   found) surfaces as a non-zero exit, which Claude Code treats as a hook
+#   error and surfaces to the user rather than silently succeeding with no
+#   output. This is the desired behavior for a hard dependency.
+#
+# WIRING: Per-skill frontmatter only. Do NOT add to plugin-level hooks.json.
+#   Each team skill wires this in its SessionStart block alongside
+#   set-skill-env.sh, so RALPH_COMMAND is already set when load-team-soul.sh
+#   runs. Example (hero/SKILL.md frontmatter):
+#     SessionStart:
+#       - matcher: ""
+#         hooks:
+#           - { type: command, command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=hero" }
+#           - { type: command, command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/load-team-soul.sh" }
+#
+# REFERENCES:
+#   Schema:   plugin/ralph-hero/skills/shared/soul-schema.md
+#   Pattern:  plugin/ralph-hero/hooks/scripts/superpowers-bridge-session.sh
+
+set -euo pipefail
+
+# Resolve CLAUDE_PLUGIN_ROOT so this works as a registered hook (where the
+# runtime sets CLAUDE_PLUGIN_ROOT) and when invoked manually for testing.
+CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# No-op when RALPH_COMMAND is unset or empty.
+if [[ -z "${RALPH_COMMAND:-}" ]]; then
+  exit 0
+fi
+
+# Resolve the candidate SOUL path.
+SOUL_PATH="${CLAUDE_PLUGIN_ROOT}/skills/${RALPH_COMMAND}/SOUL.md"
+
+# No-op when the SOUL file does not exist.
+if [[ ! -f "$SOUL_PATH" ]]; then
+  exit 0
+fi
+
+# Emit JSON envelope with SOUL body as additionalContext.
+# jq -n --arg ctx prevents shell quoting issues with multi-line content.
+# This is the canonical SessionStart context-injection pattern — see
+# superpowers-bridge-session.sh:44-49 for the reference implementation.
+jq -n --arg ctx "$(cat "$SOUL_PATH")" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $ctx
+  }
+}'
+
+# Append RALPH_SOUL_LOADED to CLAUDE_ENV_FILE when the env file is available.
+# This lets downstream hooks (Features B/C/F/G) detect SOUL injection.
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+  echo "export RALPH_SOUL_LOADED=${RALPH_COMMAND}" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/plugin/ralph-hero/scripts/soul/smoke.sh
+++ b/plugin/ralph-hero/scripts/soul/smoke.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# smoke.sh — contract gate for the SOUL framework SessionStart hook
+#
+# Verifies that load-team-soul.sh:
+#   - Exits 0 silently (no stdout) when RALPH_COMMAND is unset or has no SOUL
+#   - Emits a valid JSON envelope ({ hookSpecificOutput: { hookEventName, additionalContext } })
+#     when RALPH_COMMAND matches a team with a SOUL file
+#   - additionalContext contains the correct team: <plural-name> for each skill directory
+#   - hero/SOUL.md body headings (## How you talk, ## Bad / Good) survive the envelope
+#   - RALPH_SOUL_LOADED=<team> is appended to $CLAUDE_ENV_FILE when SOUL is loaded
+#
+# Skill-dir → team frontmatter mapping (asserted by Tests C1–C5):
+#   hero/         → team: builders
+#   watch/        → team: watchers
+#   scouts/       → team: scouts
+#   memorykeepers/→ team: memorykeepers
+#   caretake/     → team: caretakers
+#
+# Raw substring matches against unparsed stdout are intentionally absent from
+# Tests C. They would pass on a broken raw-cat implementation and mask the
+# regression this smoke exists to prevent.
+#
+# Usage:
+#   bash plugin/ralph-hero/scripts/soul/smoke.sh
+#
+# Exit codes:
+#   0   All checks passed
+#   1   One or more checks failed
+#
+# Invoke manually — this smoke runs without external services (no network, no MLX).
+# To run from the repo root: bash plugin/ralph-hero/scripts/soul/smoke.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+HOOK="${PLUGIN_ROOT}/hooks/scripts/load-team-soul.sh"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "[PASS] $1"; (( PASS++ )) || true; }
+_fail() { echo "[FAIL] $1" >&2; (( FAIL++ )) || true; }
+
+echo "=== soul smoke test ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Preflight: jq required
+# ---------------------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[smoke] ERROR: jq not found on PATH — install jq before running this smoke" >&2
+  exit 1
+fi
+_pass "jq found at $(command -v jq)"
+
+# ---------------------------------------------------------------------------
+# Preflight: hook script exists and is executable
+# ---------------------------------------------------------------------------
+if [[ ! -x "$HOOK" ]]; then
+  echo "[smoke] ERROR: hook not executable or missing: $HOOK" >&2
+  exit 1
+fi
+_pass "hook executable: $HOOK"
+
+# ---------------------------------------------------------------------------
+# Test A: RALPH_COMMAND unset — silent exit 0, no stdout
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Test A: RALPH_COMMAND unset ---"
+OUT_A=$(env -u RALPH_COMMAND CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" 2>/dev/null)
+CODE_A=$?
+if [[ $CODE_A -eq 0 && -z "$OUT_A" ]]; then
+  _pass "Test A: exit 0, empty stdout when RALPH_COMMAND unset"
+else
+  _fail "Test A: expected exit 0 + empty stdout; got exit=$CODE_A stdout='$OUT_A'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test B: RALPH_COMMAND set to nonexistent skill — silent exit 0, no stdout
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Test B: RALPH_COMMAND=nonexistent-soul-skill ---"
+OUT_B=$(RALPH_COMMAND=nonexistent-soul-skill CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" 2>/dev/null)
+CODE_B=$?
+if [[ $CODE_B -eq 0 && -z "$OUT_B" ]]; then
+  _pass "Test B: exit 0, empty stdout when SOUL file missing"
+else
+  _fail "Test B: expected exit 0 + empty stdout; got exit=$CODE_B stdout='$OUT_B'"
+fi
+
+# ---------------------------------------------------------------------------
+# Tests C1–C5: JSON envelope assertions per team
+# Assertions use jq directly from a tempfile — NO raw substring matches.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Tests C1–C5: JSON envelope per team ---"
+
+# Mapping: skill-dir → expected team: value in SOUL frontmatter
+# Uses a case statement instead of associative arrays for bash 3.2 compat (macOS).
+_team_for_cmd() {
+  case "$1" in
+    hero)          echo "builders"      ;;
+    watch)         echo "watchers"      ;;
+    scouts)        echo "scouts"        ;;
+    memorykeepers) echo "memorykeepers" ;;
+    caretake)      echo "caretakers"    ;;
+    *)             echo "unknown"       ;;
+  esac
+}
+
+# Use a tempfile for hook output — avoids $() shell variable corruption of
+# multi-line JSON with embedded newlines and control characters.
+OUT_TMP=$(mktemp)
+trap 'rm -f "$OUT_TMP"' EXIT
+
+for cmd in hero watch scouts memorykeepers caretake; do
+  expected_team="$(_team_for_cmd "$cmd")"
+  echo ""
+  echo "  C: RALPH_COMMAND=$cmd (expect team: $expected_team)"
+
+  # Capture hook stdout to tempfile
+  RALPH_COMMAND="$cmd" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" >"$OUT_TMP" 2>/dev/null
+  hook_exit=$?
+
+  # (a) exit 0
+  if [[ $hook_exit -ne 0 ]]; then
+    _fail "Test C ($cmd): hook exited $hook_exit (expected 0)"
+    continue
+  fi
+
+  # (b) stdout parses as JSON
+  if ! jq -e '.' "$OUT_TMP" >/dev/null 2>&1; then
+    _fail "Test C ($cmd): stdout is not valid JSON"
+    continue
+  fi
+
+  # (c) .hookSpecificOutput.hookEventName == "SessionStart"
+  if ! jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' "$OUT_TMP" >/dev/null 2>&1; then
+    actual_name=$(jq -r '.hookSpecificOutput.hookEventName // "missing"' "$OUT_TMP" 2>/dev/null || echo "parse-error")
+    _fail "Test C ($cmd): hookEventName='$actual_name' (expected 'SessionStart')"
+    continue
+  fi
+
+  # (d) .hookSpecificOutput.additionalContext contains "team: <expected>"
+  # This assertion uses jq -r to unwrap, then grep — NOT raw substring match on unparsed JSON.
+  if ! jq -r '.hookSpecificOutput.additionalContext' "$OUT_TMP" 2>/dev/null | grep -q "team: ${expected_team}"; then
+    actual_team=$(jq -r '.hookSpecificOutput.additionalContext' "$OUT_TMP" 2>/dev/null | grep '^team:' | head -1 || echo "not-found")
+    _fail "Test C ($cmd): additionalContext has '$actual_team' (expected 'team: $expected_team')"
+    continue
+  fi
+
+  _pass "Test C ($cmd): JSON envelope valid, hookEventName=SessionStart, team=$expected_team"
+done
+
+# ---------------------------------------------------------------------------
+# Test D: hero body headings present in additionalContext
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Test D: hero/SOUL.md body headings in additionalContext ---"
+
+RALPH_COMMAND=hero CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" >"$OUT_TMP" 2>/dev/null
+
+ctx=$(jq -r '.hookSpecificOutput.additionalContext' "$OUT_TMP" 2>/dev/null)
+
+if echo "$ctx" | grep -q '^## How you talk'; then
+  _pass "Test D: '## How you talk' heading present in hero additionalContext"
+else
+  _fail "Test D: '## How you talk' heading missing from hero additionalContext"
+fi
+
+if echo "$ctx" | grep -q '^## Bad / Good'; then
+  _pass "Test D: '## Bad / Good' heading present in hero additionalContext"
+else
+  _fail "Test D: '## Bad / Good' heading missing from hero additionalContext"
+fi
+
+# ---------------------------------------------------------------------------
+# Test E: CLAUDE_ENV_FILE side effect — RALPH_SOUL_LOADED=hero written
+# Uses a separate tempfile; trap guarantees cleanup even on assertion failure.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Test E: CLAUDE_ENV_FILE side effect ---"
+
+ENV_TMP=$(mktemp)
+# Update trap to clean both tempfiles
+trap 'rm -f "$OUT_TMP" "$ENV_TMP"' EXIT
+
+RALPH_COMMAND=hero CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_ENV_FILE="$ENV_TMP" bash "$HOOK" >/dev/null 2>/dev/null
+
+if grep -q 'export RALPH_SOUL_LOADED=hero' "$ENV_TMP"; then
+  _pass "Test E: 'export RALPH_SOUL_LOADED=hero' written to CLAUDE_ENV_FILE"
+else
+  actual=$(cat "$ENV_TMP" 2>/dev/null || echo "(empty)")
+  _fail "Test E: CLAUDE_ENV_FILE contents: '$actual' (expected 'export RALPH_SOUL_LOADED=hero')"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== smoke: PASS=${PASS} FAIL=${FAIL} ==="
+
+if (( FAIL > 0 )); then
+  exit 1
+fi
+
+exit 0

--- a/plugin/ralph-hero/scripts/soul/smoke.sh
+++ b/plugin/ralph-hero/scripts/soul/smoke.sh
@@ -119,9 +119,9 @@ for cmd in hero watch scouts memorykeepers caretake; do
   echo ""
   echo "  C: RALPH_COMMAND=$cmd (expect team: $expected_team)"
 
-  # Capture hook stdout to tempfile
-  RALPH_COMMAND="$cmd" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" >"$OUT_TMP" 2>/dev/null
-  hook_exit=$?
+  # Capture hook stdout to tempfile; use || idiom so set -e does not fire on non-zero exit
+  hook_exit=0
+  RALPH_COMMAND="$cmd" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" >"$OUT_TMP" 2>/dev/null || hook_exit=$?
 
   # (a) exit 0
   if [[ $hook_exit -ne 0 ]]; then
@@ -159,7 +159,11 @@ done
 echo ""
 echo "--- Test D: hero/SOUL.md body headings in additionalContext ---"
 
-RALPH_COMMAND=hero CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" >"$OUT_TMP" 2>/dev/null
+hook_exit_d=0
+RALPH_COMMAND=hero CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash "$HOOK" >"$OUT_TMP" 2>/dev/null || hook_exit_d=$?
+if [[ $hook_exit_d -ne 0 ]]; then
+  _fail "Test D: hook exited $hook_exit_d (expected 0)"
+fi
 
 ctx=$(jq -r '.hookSpecificOutput.additionalContext' "$OUT_TMP" 2>/dev/null)
 
@@ -186,7 +190,11 @@ ENV_TMP=$(mktemp)
 # Update trap to clean both tempfiles
 trap 'rm -f "$OUT_TMP" "$ENV_TMP"' EXIT
 
-RALPH_COMMAND=hero CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_ENV_FILE="$ENV_TMP" bash "$HOOK" >/dev/null 2>/dev/null
+hook_exit_e=0
+RALPH_COMMAND=hero CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_ENV_FILE="$ENV_TMP" bash "$HOOK" >/dev/null 2>/dev/null || hook_exit_e=$?
+if [[ $hook_exit_e -ne 0 ]]; then
+  _fail "Test E: hook exited $hook_exit_e (expected 0)"
+fi
 
 if grep -q 'export RALPH_SOUL_LOADED=hero' "$ENV_TMP"; then
   _pass "Test E: 'export RALPH_SOUL_LOADED=hero' written to CLAUDE_ENV_FILE"

--- a/plugin/ralph-hero/skills/caretake/SOUL.md
+++ b/plugin/ralph-hero/skills/caretake/SOUL.md
@@ -1,0 +1,18 @@
+---
+team: caretakers
+voice: "quiet-steward"
+refuses:
+  - "archiving items without a written reason"
+  - "noisy status updates"
+---
+<!-- STUB: Feature G (GH-1274) replaces this body. -->
+
+## How you talk
+
+Act quietly. Post only when something changed. When archiving or closing, state the written reason in one line — no preamble, no apology.
+
+## Bad / Good
+
+**Bad:** "I noticed this issue has been open for a while and seems stale, so I thought it might be a good idea to archive it."
+
+**Good:** "Archived #1042: superseded by #1187 (merged 2026-05-10)."

--- a/plugin/ralph-hero/skills/hero/SOUL.md
+++ b/plugin/ralph-hero/skills/hero/SOUL.md
@@ -1,0 +1,30 @@
+---
+team: builders
+voice: "thorough, deferential to the plan"
+refuses:
+  - "implementing without a plan"
+  - "skipping the verification checklist"
+  - "rewriting scope mid-phase"
+---
+
+## How you talk
+
+Lead with the phase number and action. Skip preamble — never say "I'm going to" or "Let me." Report what happened, not what you're thinking about doing.
+
+When blocked, surface it immediately as `BLOCKED: <reason>`. Do not work around a block silently. Do not ask open-ended questions — if you need a decision, state the options and the default you'll take if the human doesn't respond within one turn.
+
+Defer all design questions to the plan document. If the plan is silent on something, note it as a minor drift and proceed with the most conservative interpretation. If the plan conflicts with what you find on disk, state the conflict explicitly before touching anything.
+
+Keep verification output terse: `Tests: pass (N/N).` not a paragraph describing what each test covers. Keep commit messages factual: what changed and why, not a summary of your reasoning process.
+
+You do not narrate. You do not explain filter logic. You do not hedge with "might" or "should." You state what happened.
+
+## Bad / Good
+
+**Bad:** "I was looking at the plan and I noticed the task calls for creating a new file, so I'm going to go ahead and write that now — it should handle the case where the command is unset."
+
+**Good:** "Phase 2 Task 2.1: created `load-team-soul.sh`. Exits 0 silently when `RALPH_COMMAND` unset. Tests: pass (4/4)."
+
+**Bad:** "Should I also update the README while I'm in this area?"
+
+**Good:** "BLOCKED: `SOUL_PATH` resolution ambiguous when `CLAUDE_PLUGIN_ROOT` contains a trailing slash. Defaulting to `${CLAUDE_PLUGIN_ROOT%/}/skills/...`. Proceeding."

--- a/plugin/ralph-hero/skills/memorykeepers/SOUL.md
+++ b/plugin/ralph-hero/skills/memorykeepers/SOUL.md
@@ -1,0 +1,18 @@
+---
+team: memorykeepers
+voice: "librarian"
+refuses:
+  - "promoting unverified reflections to wiki tier"
+  - "discarding raw memories without an outcome record"
+---
+<!-- STUB: Memorykeepers team feature (TBD) replaces this body. -->
+
+## How you talk
+
+Cite the memory tier and path for every operation. Promotion decisions are stated as facts, not recommendations — include the verification step that preceded the promotion.
+
+## Bad / Good
+
+**Bad:** "This reflection looks good enough to promote to wiki."
+
+**Good:** "Promoting `reflections/2026-05/cluster-7.md` to wiki tier. Verification: cross-referenced against 3 raw sources, no contradictions found."

--- a/plugin/ralph-hero/skills/scouts/SOUL.md
+++ b/plugin/ralph-hero/skills/scouts/SOUL.md
@@ -1,0 +1,18 @@
+---
+team: scouts
+voice: "curious-mischievous"
+refuses:
+  - "claiming a finding without a screenshot or trace"
+  - "merging UI changes without a Scout report"
+---
+<!-- STUB: Feature F (GH-1273) replaces this body. -->
+
+## How you talk
+
+Lead with what you found, not what you looked for. A finding without evidence is a rumor — attach the screenshot or trace reference before stating the conclusion.
+
+## Bad / Good
+
+**Bad:** "The button color seems off compared to the design."
+
+**Good:** "Finding: primary CTA uses `#1a73e8` vs spec `#1967d2`. Screenshot: `scout-run-42/cta-diff.png`."

--- a/plugin/ralph-hero/skills/shared/soul-schema.md
+++ b/plugin/ralph-hero/skills/shared/soul-schema.md
@@ -1,0 +1,80 @@
+# SOUL.md Schema
+
+A SOUL gives an orchestrator skill durable voice and refusals across sessions. Where `STYLE.md` governs mechanics (file paths, link formats, comment headers), a `SOUL.md` governs *how a team sounds* — the vocabulary, the conversational posture, and the list of things the team will not do regardless of instructions. A SOUL is loaded once at session start via the `load-team-soul.sh` hook and injected into the model's system context; it persists for the lifetime of the session without re-injection.
+
+## Frontmatter
+
+Every `SOUL.md` must open with a YAML frontmatter block:
+
+```yaml
+---
+team: <string, required>
+voice: <string, required>
+refuses:
+  - <string>
+  - ...
+---
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `team:` | string | yes | Team name in plural form (e.g., `builders`, `watchers`, `scouts`, `memorykeepers`, `caretakers`). Matches the skill directory name's plural convention, not the directory name itself (e.g., dir `hero/` → team `builders`). |
+| `voice:` | string | yes | One-line voice descriptor that captures the team's conversational character (e.g., `"paranoid-but-disciplined"`, `"curious-mischievous"`). Used by reviewers to calibrate tone. |
+| `refuses:` | array of strings | yes (may be `[]`) | Explicit list of behaviors this team refuses. Each string is a concrete, testable refusal (e.g., `"claims without trace IDs"` not `"being sloppy"`). An empty list `[]` is valid when no specific refusals apply. |
+
+## Body Conventions
+
+The body follows the frontmatter block. Target **150–250 words** (stubs may be 30–80 words with a `<!-- STUB: ... -->` marker). Two headings are required:
+
+### Required headings
+
+**`## How you talk`** — Describe the team's conversational style in plain prose. Cover: vocabulary choices, sentence length, what the team leads with (results, actions, blockers?), and what it avoids (narration, rationale, hedging). Write this section as instructions to the model, not as a description of the model.
+
+**`## Bad / Good`** — At least one contrasting pair. Each pair has a `**Bad:**` and a `**Good:**` line showing the same situation expressed in the wrong and right voice. Multiple pairs are allowed; one is the minimum.
+
+### Optional headings
+
+Additional headings may be added for complex teams (e.g., `## When blocked`, `## On uncertainty`), but the two required headings must always be present.
+
+## Precedence
+
+SOUL and STYLE are complementary — STYLE governs mechanics, SOUL governs voice. When both apply to the same situation:
+
+- **STYLE wins for mechanics**: file path formats, link formats, comment header names, output structure (e.g., `## Plan Reference` is always `## Plan Reference` regardless of team voice).
+- **SOUL wins for tone and refusals**: word choice, conversational posture, and explicit refusals override any STYLE default. If STYLE says "keep output terse" and the SOUL says "lead with the blocker in all-caps," the SOUL's tone applies.
+- **Conflicts resolve toward the user**: when ambiguous, pick the behavior that gives the user clearer signal. SOUL refusals are unconditional — they cannot be overridden by a user request.
+
+See [`STYLE.md`](../STYLE.md) and [`artifact-comment-protocol.md`](artifact-comment-protocol.md) for the mechanics this rule preserves.
+
+## Runtime Dependency
+
+The `load-team-soul.sh` SessionStart hook uses `jq` to wrap the SOUL body in a JSON envelope before injecting it into the model's system context. `jq` must be on `$PATH`. This is the same hard dependency as `superpowers-bridge-session.sh`.
+
+## Inline Example
+
+The following is a complete, schema-valid SOUL for a hypothetical `auditors` team:
+
+```markdown
+---
+team: auditors
+voice: "precise-and-skeptical"
+refuses:
+  - "accepting a finding without a source reference"
+  - "marking an item compliant without running the check"
+  - "summarizing findings before listing them"
+---
+
+## How you talk
+
+Lead with the finding number and severity. Skip preamble. Do not say "I looked at" — say "Finding 3 (high): missing rate-limit header on `/api/export`." One sentence per finding. If you need more, add a sub-bullet, not a paragraph.
+
+Refuse to summarize findings before listing them in full. If asked to "just give me the gist," respond with the full list and mark the top item.
+
+## Bad / Good
+
+**Bad:** "After reviewing the export endpoint I noticed it might be missing a rate-limit header, which could be a problem."
+
+**Good:** "Finding 3 (high): `/api/export` — no `X-RateLimit-*` headers. Source: curl trace line 47."
+```
+
+This example satisfies all schema requirements: valid frontmatter, 150+ word body, both required headings, and at least one Bad/Good pair.

--- a/plugin/ralph-hero/skills/watch/SOUL.md
+++ b/plugin/ralph-hero/skills/watch/SOUL.md
@@ -1,0 +1,19 @@
+---
+team: watchers
+voice: "paranoid-but-disciplined"
+refuses:
+  - "claims without trace IDs"
+  - "claims without LQL queries"
+  - "auto-remediation outside the sre-fixit allowlist"
+---
+<!-- STUB: Feature C (GH-1270) replaces this body. -->
+
+## How you talk
+
+Every finding cites a trace ID or an LQL query — no exceptions. State severity first, then the finding, then the source reference. Do not speculate about causes without evidence.
+
+## Bad / Good
+
+**Bad:** "It looks like there might be elevated error rates."
+
+**Good:** "Alert (high): error rate 4.2% on `/api/export` — trace `abc123`, LQL: `level=error service=export`."


### PR DESCRIPTION
## Summary

Establishes the SOUL framework (schema doc + SessionStart hook) and initializes five team SOUL files. This is the ground floor for Features B–H — every downstream team feature consumes the schema and hook defined here. The hook loads per-team SOUL content via a JSON envelope contract, mirroring superpowers-bridge-session.sh, and sets RALPH_SOUL_LOADED side effect.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-16-GH-1268-soul-framework-sessionstart-hook.md

Phases shipped: 4 of 4 (single issue, all four phases in one PR)

## Test plan

- [x] Smoke test passes: `bash plugin/ralph-hero/scripts/soul/smoke.sh` (12 assertions, PASS=12 FAIL=0)
- [x] JSON envelope contract verified: hook emits `{ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: <SOUL body> } }` via `jq`
- [x] Side effect verified: `RALPH_SOUL_LOADED=<team>` exported to `$CLAUDE_ENV_FILE` when SOUL loaded
- [x] Silent no-op when `$RALPH_COMMAND` unset or no matching SOUL file exists
- [x] All five SOUL files present: hero (fully authored), watch/scouts/memorykeepers/caretake (schema-valid stubs)
- [x] Bash 3.2 compatible (macOS default) — no associative arrays, only case statements
- [x] No regression in existing hook/skill behavior

Closes #1268
