### PR TITLE
feat(event-shims): Feature D — alerts / langfuse / dream-loop to board (#1271)

### DIFF
--- a/plugin/ralph-hero/scripts/monitoring-bridge/README.md
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/README.md
@@ -1,0 +1,113 @@
+# monitoring-bridge
+
+Cloud Monitoring → GitHub Projects board bridge. Pulls messages from a Cloud
+Monitoring → Pub/Sub subscription and normalises each alert payload into a
+`watcher-auto`-labeled draft issue on the GitHub Projects V2 board.
+
+Part of **Feature D** of the Unified Agent System epic (GH-1271). The Director
+skill (Feature B) routes `watcher-auto` issues to the Watcher team; this
+script is the producer side.
+
+## How it works
+
+1. On each launchd tick (every 5 minutes), `subscribe.py` pulls up to 10
+   messages from the configured Pub/Sub subscription.
+2. Each message is decoded and normalised into a GitHub issue payload:
+   - Title: `[gcp-alert] <condition displayName>`
+   - Labels: `["watcher-auto"]`
+   - Body: iOS-friendly one-paragraph summary, `## Source` block with the
+     alert console URL and policy id, `## Suggested Team: watchers`, and the
+     full alert JSON in a collapsed `<details>` block.
+   - Marker: `<!-- gcp-policy: <policy-id> -->` in the body — matches the
+     shape that `gcp-incident-triage` already keys off.
+3. Before creating an issue, the subscriber checks for an existing open issue
+   with the same `<!-- gcp-policy: <id> -->` marker (via `gh issue list
+   --search`). Duplicate alerts are skipped.
+4. On successful creation, the Pub/Sub message is acknowledged so it is not
+   re-delivered.
+
+No LLM calls are made. The mapping from alert fields to issue fields is
+deterministic.
+
+## Setup
+
+### Prerequisites
+
+- Python ≥ 3.11 (managed by `uv`)
+- `uv` installed (`brew install uv` or `pip install uv`)
+- `gh` CLI authenticated (`gh auth login -s repo,project,read:org`)
+- GCP credentials with `pubsub.subscriptions.consume` permission
+  (`gcloud auth application-default login`)
+- Environment variables set (see Configuration below)
+
+### Install
+
+```bash
+cd plugin/ralph-hero/scripts/monitoring-bridge
+uv sync
+```
+
+### Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RALPH_MONITORING_SUBSCRIPTION` | Yes | Pub/Sub subscription name or full resource path |
+| `GOOGLE_CLOUD_PROJECT` | Yes | GCP project id |
+
+Set these in your shell profile or in the launchd plist's `EnvironmentVariables`
+block before loading the agent.
+
+## Install launchd agent
+
+```bash
+cp plugin/ralph-hero/scripts/monitoring-bridge/launchd/com.ralph.monitoring-bridge.plist.template \
+   ~/Library/LaunchAgents/com.ralph.monitoring-bridge.plist
+# Edit the plist to set RALPH_MONITORING_SUBSCRIPTION and GOOGLE_CLOUD_PROJECT
+launchctl load ~/Library/LaunchAgents/com.ralph.monitoring-bridge.plist
+```
+
+The agent fires every 300 seconds (5 minutes) via `StartInterval`. It does not
+run at load time (`RunAtLoad = false`).
+
+## Verification
+
+```bash
+# Confirm the launchd job is registered (PID column "-" when idle)
+launchctl list | grep monitoring-bridge
+
+# Tail output and error logs
+tail -f /tmp/ralph-monitoring-bridge.out
+tail -f /tmp/ralph-monitoring-bridge.err
+
+# Run a dry-run against the fixture (no Pub/Sub or GitHub access needed)
+cd plugin/ralph-hero/scripts/monitoring-bridge
+python3 subscribe.py --dry-run --subscription dummy --project dummy
+
+# Full smoke test (static assertions + dry-run)
+bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
+```
+
+## Dry-run mode
+
+`--dry-run` reads from `fixtures/sample-alert.json` instead of Pub/Sub and
+prints the normalised issue payload to stdout without creating any GitHub
+issues. Use this to verify the normalisation logic and the `<!-- gcp-policy:
+... -->` marker shape before enabling the live launchd agent.
+
+## Relation to gcp-incident-triage
+
+This subscriber is **not** a replacement for the `gcp-incident-triage` skill.
+The skill performs delta analysis, deduplication against existing issues, and
+root-cause triage. The subscriber's role is narrower: ensure issues exist on
+the board so the Director → Watch pipeline can act on them even when no human
+is at the terminal. The `<!-- gcp-policy: <id> -->` marker shape is shared so
+`gcp-incident-triage` can pick up subscriber-created issues and enrich them.
+
+## What is NOT done here
+
+- No new alert policies or Pub/Sub topics are created. Those are
+  terraform-managed; this script reads from an existing topic.
+- No Cloud Run deployment. The launchd-scheduled pull model is preferred for
+  parity with the dream-loop. A Cloud Run path is a valid follow-up if
+  multi-machine reliability is needed.
+- No LLM calls. The mapping is deterministic.

--- a/plugin/ralph-hero/scripts/monitoring-bridge/fixtures/sample-alert.json
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/fixtures/sample-alert.json
@@ -1,0 +1,45 @@
+{
+  "message": {
+    "data": "eyJpbmNpZGVudCI6IHsiaW5jaWRlbnRfaWQiOiAiMDEyMzQ1NjgtYWJjZC1lZjEyLTM0NTYtNzg5MGFiY2RlZjEyIiwgInJlc291cmNlX25hbWUiOiAicHJvamVjdHMvbXktcHJvamVjdC1pZCIsICJyZXNvdXJjZSI6IHsidHlwZSI6ICJnYWVfYXBwIiwgImxhYmVscyI6IHsibW9kdWxlX2lkIjogImRlZmF1bHQiLCAicHJvamVjdF9pZCI6ICJteS1wcm9qZWN0LWlkIn19LCAibWV0cmljIjogeyJ0eXBlIjogImFwcGVuZ2luZS5nb29nbGVhcGlzLmNvbS9odHRwL3NlcnZlcl9lcnJvcl9jb3VudCIsICJkaXNwbGF5TmFtZSI6ICJIVFRQIHNlcnZlciBlcnJvciBjb3VudCJ9LCAibWV0YWRhdGEiOiB7InN5c3RlbV9sYWJlbHMiOiB7ImxpbmtzIjogW3sicmVsIjogImh0dHBzOi8vc2NoZW1hcy5nb29nbGUuY29tL3NlcnZpY2UvcG9saWN5IiwgImhyZWYiOiAiaHR0cHM6Ly9jb25zb2xlLmNsb3VkLmdvb2dsZS5jb20vbW9uaXRvcmluZy9hbGVydHBvbGljaWVzL2RldGFpbC8xMjM0NTY3ODkwMTIzNDU2In1dfX0sICJwb2xpY3lfbmFtZSI6ICJwcm9qZWN0cy8xMjM0NTY3ODkwL2FsZXJ0UG9saWNpZXMvMTIzNDU2Nzg5MDEyMzQ1NiIsICJjb25kaXRpb25fbmFtZSI6ICJIaWdoIGVycm9yIHJhdGUgb24gcHJvZHVjdGlvbiBBUEkiLCAidXJsIjogImh0dHBzOi8vY29uc29sZS5jbG91ZC5nb29nbGUuY29tL21vbml0b3JpbmcvYWxlcnRzL2luY2lkZW50cy8wMTIzNDU2OC1hYmNkLWVmMTItMzQ1Ni03ODkwYWJjZGVmMTIiLCAic3RhcnRlZF9hdCI6IDE3NDc0MDAwMDAsICJlbmRlZF9hdCI6IG51bGwsICJzdGF0ZSI6ICJvcGVuIiwgInN1bW1hcnkiOiAiSFRUUCBzZXJ2ZXIgZXJyb3IgY291bnQgZm9yIHByb2plY3QgbXktcHJvamVjdC1pZCBleGNlZWRzIHRocmVzaG9sZCJ9LCAidmVyc2lvbiI6ICIxLjIiLCAiYWxlcnRfcG9saWN5X25hbWUiOiAiSGlnaCBlcnJvciByYXRlIG9uIHByb2R1Y3Rpb24gQVBJIiwgImNvbmRpdGlvbl9uYW1lIjogIkhpZ2ggZXJyb3IgcmF0ZSBvbiBwcm9kdWN0aW9uIEFQSSJ9",
+    "messageId": "1234567890123456",
+    "publishTime": "2026-05-16T10:00:00Z"
+  },
+  "subscription": "projects/my-project-id/subscriptions/monitoring-alerts-sub",
+  "_decoded": {
+    "incident": {
+      "incident_id": "01234568-abcd-ef12-3456-7890abcdef12",
+      "resource_name": "projects/my-project-id",
+      "resource": {
+        "type": "gae_app",
+        "labels": {
+          "module_id": "default",
+          "project_id": "my-project-id"
+        }
+      },
+      "metric": {
+        "type": "appengine.googleapis.com/http/server_error_count",
+        "displayName": "HTTP server error count"
+      },
+      "metadata": {
+        "system_labels": {
+          "links": [
+            {
+              "rel": "https://schemas.google.com/service/policy",
+              "href": "https://console.cloud.google.com/monitoring/alertpolicies/detail/12345678901234567890"
+            }
+          ]
+        }
+      },
+      "policy_name": "projects/1234567890/alertPolicies/12345678901234567890",
+      "condition_name": "High error rate on production API",
+      "url": "https://console.cloud.google.com/monitoring/alerts/incidents/01234568-abcd-ef12-3456-7890abcdef12",
+      "started_at": 1747400000,
+      "ended_at": null,
+      "state": "open",
+      "summary": "HTTP server error count for project my-project-id exceeds threshold"
+    },
+    "version": "1.2",
+    "alert_policy_name": "High error rate on production API",
+    "condition_name": "High error rate on production API"
+  }
+}

--- a/plugin/ralph-hero/scripts/monitoring-bridge/launchd/com.ralph.monitoring-bridge.plist.template
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/launchd/com.ralph.monitoring-bridge.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.ralph.monitoring-bridge</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>cd /Users/dubiel/projects/ralph-hero/plugin/ralph-hero/scripts/monitoring-bridge &amp;&amp; uv run subscribe.py --subscription "$RALPH_MONITORING_SUBSCRIPTION" --project "$GOOGLE_CLOUD_PROJECT"</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>StandardOutPath</key>
+	<string>/tmp/ralph-monitoring-bridge.out</string>
+	<key>StandardErrorPath</key>
+	<string>/tmp/ralph-monitoring-bridge.err</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+</dict>
+</plist>

--- a/plugin/ralph-hero/scripts/monitoring-bridge/pyproject.toml
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "monitoring-bridge"
+version = "0.1.0"
+description = "Cloud Monitoring → GitHub Projects board bridge (Pub/Sub subscriber)"
+requires-python = ">=3.11"
+dependencies = [
+    "google-cloud-pubsub>=2.21.0",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "ruff>=0.4.0",
+    "pytest>=8.0.0",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]

--- a/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
@@ -9,7 +9,8 @@
 #   5. Dry-run mode: runs subscribe.py --dry-run and asserts required tokens
 #      present in stdout:
 #        - watcher-auto
-#        - <!-- gcp-policy:
+#        - <!-- gcp-policy:  (HTML comment, preserved for gcp-incident-triage)
+#        - gcp-policy/       (plain-text marker, indexed by GitHub search)
 #        - [gcp-alert]
 #        - ## Source
 #        - ## Suggested Team: watchers
@@ -113,6 +114,7 @@ if [[ -f "$SUBSCRIBE_PY" && -f "$FIXTURE" ]]; then
         REQUIRED_TOKENS=(
             "watcher-auto"
             "<!-- gcp-policy:"
+            "gcp-policy/"
             "[gcp-alert]"
             "## Source"
             "## Suggested Team: watchers"

--- a/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# smoke.sh — static + dry-run assertions for the monitoring-bridge subscriber
+#
+# Checks:
+#   1. subscribe.py exists and is syntactically valid Python
+#   2. fixtures/sample-alert.json exists and parses as JSON
+#   3. pyproject.toml exists and contains google-cloud-pubsub dependency
+#   4. launchd plist template is well-formed (plutil -lint)
+#   5. Dry-run mode: runs subscribe.py --dry-run and asserts required tokens
+#      present in stdout:
+#        - watcher-auto
+#        - <!-- gcp-policy:
+#        - [gcp-alert]
+#        - ## Source
+#        - ## Suggested Team: watchers
+#
+# Usage (from repo root):
+#   bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
+#
+# Exit codes:
+#   0   All checks passed
+#   1   One or more assertions failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "[PASS] $1"; (( PASS++ )) || true; }
+_fail() { echo "[FAIL] $1" >&2; (( FAIL++ )) || true; }
+
+echo "=== monitoring-bridge smoke test ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. subscribe.py exists and parses as valid Python
+# ---------------------------------------------------------------------------
+SUBSCRIBE_PY="${SCRIPT_DIR}/subscribe.py"
+if [[ ! -f "$SUBSCRIBE_PY" ]]; then
+    _fail "subscribe.py not found: ${SUBSCRIBE_PY}"
+else
+    if python3 -c "import ast; ast.parse(open('${SUBSCRIBE_PY}').read())" 2>/dev/null; then
+        _pass "subscribe.py is syntactically valid Python"
+    else
+        _fail "subscribe.py has syntax errors"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. fixtures/sample-alert.json exists and parses as JSON
+# ---------------------------------------------------------------------------
+FIXTURE="${SCRIPT_DIR}/fixtures/sample-alert.json"
+if [[ ! -f "$FIXTURE" ]]; then
+    _fail "fixtures/sample-alert.json not found: ${FIXTURE}"
+else
+    if python3 -c "import json; json.load(open('${FIXTURE}'))" 2>/dev/null; then
+        _pass "fixtures/sample-alert.json is valid JSON"
+    else
+        _fail "fixtures/sample-alert.json is invalid JSON"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. pyproject.toml contains google-cloud-pubsub dependency
+# ---------------------------------------------------------------------------
+PYPROJECT="${SCRIPT_DIR}/pyproject.toml"
+if [[ ! -f "$PYPROJECT" ]]; then
+    _fail "pyproject.toml not found: ${PYPROJECT}"
+else
+    if grep -q "google-cloud-pubsub" "$PYPROJECT"; then
+        _pass "pyproject.toml declares google-cloud-pubsub dependency"
+    else
+        _fail "pyproject.toml missing google-cloud-pubsub dependency"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4. launchd plist template is well-formed
+# ---------------------------------------------------------------------------
+PLIST="${SCRIPT_DIR}/launchd/com.ralph.monitoring-bridge.plist.template"
+if [[ ! -f "$PLIST" ]]; then
+    _fail "launchd plist template not found: ${PLIST}"
+else
+    if plutil -lint "$PLIST" >/dev/null 2>&1; then
+        _pass "launchd plist template is well-formed (plutil -lint)"
+    else
+        _fail "launchd plist template is malformed (plutil -lint failed)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Dry-run mode: subscribe.py --dry-run emits expected tokens
+# ---------------------------------------------------------------------------
+if [[ -f "$SUBSCRIBE_PY" && -f "$FIXTURE" ]]; then
+    # Run dry-run directly with python3 (no uv sync required for dry-run path
+    # since google-cloud-pubsub is NOT imported in --dry-run mode)
+    DRY_RUN_OUTPUT=$(
+        cd "$SCRIPT_DIR" &&
+        python3 subscribe.py \
+            --dry-run \
+            --subscription dummy \
+            --project dummy \
+            --max-messages 1 \
+            2>/dev/null
+    ) || {
+        _fail "subscribe.py --dry-run exited non-zero"
+        DRY_RUN_OUTPUT=""
+    }
+
+    if [[ -n "$DRY_RUN_OUTPUT" ]]; then
+        REQUIRED_TOKENS=(
+            "watcher-auto"
+            "<!-- gcp-policy:"
+            "[gcp-alert]"
+            "## Source"
+            "## Suggested Team: watchers"
+        )
+        ALL_PRESENT=true
+        for token in "${REQUIRED_TOKENS[@]}"; do
+            if echo "$DRY_RUN_OUTPUT" | grep -qF "$token"; then
+                _pass "dry-run output contains: ${token}"
+            else
+                _fail "dry-run output MISSING: ${token}"
+                ALL_PRESENT=false
+            fi
+        done
+
+        if [[ "$ALL_PRESENT" == "true" ]]; then
+            _pass "dry-run output contains all required tokens"
+        fi
+    fi
+else
+    _fail "Skipping dry-run assertion (subscribe.py or fixture missing)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if (( FAIL > 0 )); then
+    exit 1
+fi
+
+echo "Smoke test PASSED."
+exit 0

--- a/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
@@ -1,0 +1,518 @@
+"""Cloud Monitoring → GitHub Projects board bridge.
+
+Pulls messages from a Cloud Monitoring → Pub/Sub subscription and
+normalises each alert payload into a ``watcher-auto``-labeled draft
+issue on the GitHub Projects V2 board.
+
+Design constraints (from Feature D shared constraints):
+- NO LLM calls. Mapping is deterministic: alert fields → issue fields.
+- The ``<!-- gcp-policy: <id> -->`` marker shape matches what
+  ``gcp-incident-triage`` already keys off — keeping the Director →
+  Watch handoff stable without coordination.
+- Idempotency: pre-flight checks for an open issue with the same
+  policy-id marker via ``gh issue list``; skips creation if found.
+- iOS-friendly issue body: one-paragraph summary, ``## Source``,
+  ``## Suggested Team: watchers``, full alert JSON in ``<details>``.
+
+Run via ``uv run subscribe.py --help`` for options.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import logging
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("ralph.monitoring-bridge.subscribe")
+
+# ---------------------------------------------------------------------------
+# Alert payload normalisation
+# ---------------------------------------------------------------------------
+
+_POLICY_ID_RE = re.compile(
+    r"alertPolicies/([^/\"'\s]+)",
+)
+
+
+def _extract_policy_id(incident: dict[str, Any]) -> str:
+    """Extract a stable policy id from the incident dict.
+
+    Tries (in order):
+    1. ``incident.policy_name`` — ``projects/<proj>/alertPolicies/<id>``
+    2. ``incident.metadata.system_labels.links[].href`` — alert console URL
+    3. ``incident.incident_id`` — fallback (unique per alert occurrence)
+    """
+    policy_name = incident.get("policy_name", "")
+    m = _POLICY_ID_RE.search(policy_name)
+    if m:
+        return m.group(1)
+
+    # Try the links array in system_labels
+    links = (
+        incident.get("metadata", {})
+        .get("system_labels", {})
+        .get("links", [])
+    )
+    for link in links:
+        href = link.get("href", "")
+        m = re.search(r"alertpolicies/detail/([^/?&#]+)", href, re.IGNORECASE)
+        if m:
+            return m.group(1)
+
+    # Last resort: use the incident_id (unique per occurrence, not per policy)
+    incident_id = incident.get("incident_id", "")
+    if incident_id:
+        return incident_id
+
+    # Absolute fallback: deterministic hash of the whole incident JSON
+    return hashlib.sha256(
+        json.dumps(incident, sort_keys=True).encode()
+    ).hexdigest()[:16]
+
+
+def _build_alert_url(incident: dict[str, Any]) -> str:
+    """Return the Cloud Console alert URL or a synthetic one."""
+    url = incident.get("url", "")
+    if url:
+        return url
+    incident_id = incident.get("incident_id", "unknown")
+    return (
+        f"https://console.cloud.google.com/monitoring/alerts/incidents/{incident_id}"
+    )
+
+
+def _format_timestamp(epoch: int | None) -> str:
+    if epoch is None:
+        return "unknown"
+    try:
+        dt = datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+        return dt.isoformat()
+    except (ValueError, OSError):
+        return str(epoch)
+
+
+def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
+    """Decode a Pub/Sub message and normalise it into an issue payload.
+
+    Input: a single Pub/Sub message dict (the ``message`` key of a pull
+    response item or a push payload). Expected shape::
+
+        {
+          "data": "<base64-encoded JSON>",
+          "messageId": "...",
+          "publishTime": "..."
+        }
+
+    Returns a dict with ``title``, ``labels``, ``body``, and ``policy_id``.
+    On any parse error the function returns a best-effort payload rather than
+    raising — downstream idempotency checks will de-dup duplicates.
+    """
+    # Decode the base64 data field
+    data_b64 = raw_message.get("data", "")
+    try:
+        alert_json = base64.b64decode(data_b64).decode("utf-8")
+        alert: dict[str, Any] = json.loads(alert_json)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Failed to decode Pub/Sub message data: %s", exc)
+        alert = {}
+
+    incident: dict[str, Any] = alert.get("incident", {})
+    condition_name: str = incident.get("condition_name", "") or alert.get(
+        "condition_name", "Unknown condition"
+    )
+    policy_id = _extract_policy_id(incident)
+    alert_url = _build_alert_url(incident)
+    state = incident.get("state", "unknown")
+    started_at = _format_timestamp(incident.get("started_at"))
+    summary = incident.get("summary", condition_name)
+    resource_type = incident.get("resource", {}).get("type", "")
+    project_id = (
+        incident.get("resource", {}).get("labels", {}).get("project_id", "")
+        or incident.get("resource_name", "").replace("projects/", "")
+    )
+
+    # iOS-friendly title: prefix + condition name (short, scannable)
+    title = f"[gcp-alert] {condition_name}"
+
+    # One-paragraph summary for the issue body (iOS-friendly, above the fold)
+    para = (
+        f"GCP Cloud Monitoring alert: **{condition_name}**"
+        f"{' on ' + resource_type if resource_type else ''}."
+        f" Alert state: `{state}`."
+        f" Started: `{started_at}`."
+    )
+    if summary and summary != condition_name:
+        para += f" {summary}"
+
+    # Full alert JSON in a collapsed <details> block
+    full_json = json.dumps(alert, indent=2, default=str)
+
+    body = (
+        f"{para}\n"
+        f"\n"
+        f"## Source\n"
+        f"\n"
+        f"- Alert: {alert_url}\n"
+        f"- Policy id: `{policy_id}`\n"
+        f"- Project: `{project_id}`\n"
+        f"- State: `{state}` | Started: `{started_at}`\n"
+        f"\n"
+        f"## Suggested Team: watchers\n"
+        f"\n"
+        f"<!-- gcp-policy: {policy_id} -->\n"
+        f"\n"
+        f"<details>\n"
+        f"<summary>Full alert JSON</summary>\n"
+        f"\n"
+        f"```json\n"
+        f"{full_json}\n"
+        f"```\n"
+        f"\n"
+        f"</details>\n"
+    )
+
+    return {
+        "title": title,
+        "labels": ["watcher-auto"],
+        "body": body,
+        "policy_id": policy_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Idempotency check — skip if issue already exists for this policy
+# ---------------------------------------------------------------------------
+
+
+def _issue_exists_for_policy(policy_id: str, repo: str | None) -> bool:
+    """Return True if an open issue with ``<!-- gcp-policy: <id> -->`` exists.
+
+    Uses ``gh issue list`` with a search query; no external API calls.
+    Returns False (allow creation) on any gh CLI error so a missing/
+    misconfigured CLI does not silently drop alerts.
+    """
+    marker = f"gcp-policy: {policy_id}"
+    cmd = [
+        "gh", "issue", "list",
+        "--state", "open",
+        "--search", marker,
+        "--json", "number,title",
+        "--limit", "5",
+    ]
+    if repo:
+        cmd += ["--repo", repo]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            log.warning(
+                "gh issue list failed (rc=%d): %s",
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return False
+        issues = json.loads(result.stdout or "[]")
+        return len(issues) > 0
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Idempotency check failed: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Issue creation
+# ---------------------------------------------------------------------------
+
+
+def _create_issue(
+    payload: dict[str, Any],
+    repo: str | None,
+) -> str | None:
+    """Create a GitHub issue via the ``gh`` CLI. Returns the issue URL or None."""
+    cmd = [
+        "gh", "issue", "create",
+        "--title", payload["title"],
+        "--body", payload["body"],
+    ]
+    for label in payload.get("labels", []):
+        cmd += ["--label", label]
+    if repo:
+        cmd += ["--repo", repo]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            log.error(
+                "gh issue create failed (rc=%d): %s",
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return None
+        url = result.stdout.strip()
+        return url
+    except Exception as exc:  # noqa: BLE001
+        log.error("Issue creation failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Pub/Sub pull
+# ---------------------------------------------------------------------------
+
+
+def _pull_messages(
+    subscription: str,
+    project: str,
+    max_messages: int,
+    timeout: int,
+) -> list[dict[str, Any]]:
+    """Pull messages from a Pub/Sub subscription via the gcloud CLI.
+
+    Returns a list of raw message dicts (the ``message`` field of each
+    receivedMessage). Acknowledges each message after a successful pull so
+    re-runs don't re-process the same alert (idempotency guard provides the
+    second line of defence).
+    """
+    try:
+        from google.cloud import pubsub_v1  # type: ignore[import-untyped]
+    except ImportError:
+        log.error(
+            "google-cloud-pubsub is required; run `uv sync` inside "
+            "plugin/ralph-hero/scripts/monitoring-bridge/"
+        )
+        return []
+
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = (
+        subscription
+        if subscription.startswith("projects/")
+        else f"projects/{project}/subscriptions/{subscription}"
+    )
+
+    try:
+        response = subscriber.pull(
+            request={
+                "subscription": subscription_path,
+                "max_messages": max_messages,
+            },
+            timeout=float(timeout),
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.error("Pub/Sub pull failed: %s", exc)
+        return []
+
+    messages = []
+    ack_ids = []
+    for received_message in response.received_messages:
+        msg = received_message.message
+        raw = {
+            "data": base64.b64encode(msg.data).decode("utf-8"),
+            "messageId": msg.message_id,
+            "publishTime": str(msg.publish_time),
+        }
+        messages.append(raw)
+        ack_ids.append(received_message.ack_id)
+
+    if ack_ids:
+        try:
+            subscriber.acknowledge(
+                request={
+                    "subscription": subscription_path,
+                    "ack_ids": ack_ids,
+                }
+            )
+            log.info("Acknowledged %d message(s)", len(ack_ids))
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Acknowledge failed (messages will be re-delivered): %s", exc)
+
+    subscriber.close()
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Fixture-based dry-run
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(fixture_path: Path) -> list[dict[str, Any]]:
+    """Load the sample-alert.json fixture as a single-item message list.
+
+    The fixture stores the full Pub/Sub push payload shape; we extract
+    the ``message`` sub-key. If the JSON has a ``_decoded`` key (the
+    human-readable companion) we re-encode the raw incident as base64 so
+    the normaliser's decode path runs normally.
+    """
+    with fixture_path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    msg = data.get("message", data)
+
+    # If the fixture has a ``_decoded`` companion, re-encode it so we
+    # exercise the base64 → JSON decode path in normalise_alert.
+    if "_decoded" in data and "data" in msg:
+        decoded = data["_decoded"]
+        msg = dict(msg)  # shallow copy
+        msg["data"] = base64.b64encode(
+            json.dumps(decoded).encode("utf-8")
+        ).decode("utf-8")
+
+    return [msg]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="subscribe.py",
+        description=(
+            "Cloud Monitoring → GitHub Projects board bridge. "
+            "Pulls Pub/Sub messages and creates watcher-auto-labeled "
+            "issues on the GitHub Projects V2 board."
+        ),
+    )
+    parser.add_argument(
+        "--subscription",
+        required=True,
+        help=(
+            "Pub/Sub subscription name or full resource path "
+            "(projects/<proj>/subscriptions/<name>)."
+        ),
+    )
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="GCP project id (used to resolve short subscription names).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Read from the fixture file instead of Pub/Sub and print "
+            "the normalised issue payload to stdout. Does NOT create issues."
+        ),
+    )
+    parser.add_argument(
+        "--max-messages",
+        type=int,
+        default=10,
+        help="Maximum number of messages to pull per run (default: 10).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="Pull timeout in seconds (default: 30).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help=(
+            "GitHub repo in owner/name format. Defaults to the current "
+            "repo inferred by gh CLI from git context."
+        ),
+    )
+    parser.add_argument(
+        "--fixture",
+        default=None,
+        help=(
+            "Path to the fixture JSON file for dry-run mode. "
+            "Defaults to fixtures/sample-alert.json next to this script."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (default: INFO).",
+    )
+
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.dry_run:
+        fixture_path = (
+            Path(args.fixture)
+            if args.fixture
+            else Path(__file__).resolve().parent / "fixtures" / "sample-alert.json"
+        )
+        if not fixture_path.exists():
+            log.error("Fixture file not found: %s", fixture_path)
+            return 1
+        messages = _load_fixture(fixture_path)
+        log.info("Dry-run mode: loaded %d message(s) from fixture", len(messages))
+    else:
+        messages = _pull_messages(
+            args.subscription,
+            args.project,
+            args.max_messages,
+            args.timeout,
+        )
+        log.info("Pulled %d message(s) from Pub/Sub", len(messages))
+
+    if not messages:
+        print("No messages to process.")
+        return 0
+
+    created = 0
+    skipped = 0
+    failed = 0
+
+    for i, msg in enumerate(messages, start=1):
+        payload = normalise_alert(msg)
+        policy_id = payload["policy_id"]
+
+        if args.dry_run:
+            print(f"\n--- Message {i} ---")
+            print(f"title: {payload['title']}")
+            print(f"labels: {payload['labels']}")
+            print(f"policy_id: {policy_id}")
+            print("body:")
+            print(payload["body"])
+            created += 1
+            continue
+
+        # Idempotency check
+        if _issue_exists_for_policy(policy_id, args.repo):
+            log.info(
+                "Skipping policy_id=%s — open issue already exists", policy_id
+            )
+            skipped += 1
+            continue
+
+        url = _create_issue(payload, args.repo)
+        if url:
+            print(f"Created issue: {url}  [policy_id={policy_id}]")
+            created += 1
+        else:
+            log.error("Failed to create issue for policy_id=%s", policy_id)
+            failed += 1
+
+    print(
+        f"\nResult: {created} created, {skipped} skipped (duplicate), "
+        f"{failed} failed."
+    )
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
@@ -164,6 +164,8 @@ def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
         f"- Project: `{project_id}`\n"
         f"- State: `{state}` | Started: `{started_at}`\n"
         f"\n"
+        f"**Policy ID:** `gcp-policy/{policy_id}`\n"
+        f"\n"
         f"## Suggested Team: watchers\n"
         f"\n"
         f"<!-- gcp-policy: {policy_id} -->\n"
@@ -192,13 +194,17 @@ def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
 
 
 def _issue_exists_for_policy(policy_id: str, repo: str | None) -> bool:
-    """Return True if an open issue with ``<!-- gcp-policy: <id> -->`` exists.
+    """Return True if an open issue with the plain-text policy marker exists.
+
+    Searches for the plain-text line ``gcp-policy/<id>`` which is indexed by
+    GitHub's search API (HTML comments are stripped before indexing and would
+    always return zero matches).
 
     Uses ``gh issue list`` with a search query; no external API calls.
     Returns False (allow creation) on any gh CLI error so a missing/
     misconfigured CLI does not silently drop alerts.
     """
-    marker = f"gcp-policy: {policy_id}"
+    marker = f"gcp-policy/{policy_id}"
     cmd = [
         "gh", "issue", "list",
         "--state", "open",
@@ -279,13 +285,22 @@ def _pull_messages(
     project: str,
     max_messages: int,
     timeout: int,
-) -> list[dict[str, Any]]:
-    """Pull messages from a Pub/Sub subscription via the gcloud CLI.
+) -> tuple[list[dict[str, Any]], list[str], "pubsub_v1.SubscriberClient", str]:
+    """Pull messages from a Pub/Sub subscription via the Pub/Sub client library.
 
-    Returns a list of raw message dicts (the ``message`` field of each
-    receivedMessage). Acknowledges each message after a successful pull so
-    re-runs don't re-process the same alert (idempotency guard provides the
-    second line of defence).
+    Returns a 4-tuple of:
+    - list of raw message dicts (the ``message`` field of each receivedMessage)
+    - list of ack_ids in the same order as the messages
+    - the open SubscriberClient (caller must close it)
+    - the resolved subscription path
+
+    The caller is responsible for ACKing each message individually AFTER
+    successfully processing it (at-least-once delivery). Messages that fail
+    processing are NOT ACKed and will be re-delivered by Pub/Sub after the
+    ack deadline expires.
+
+    Returns an empty tuple-of-empties on error so the caller can do a simple
+    ``if not messages`` guard.
     """
     try:
         from google.cloud import pubsub_v1  # type: ignore[import-untyped]
@@ -294,7 +309,7 @@ def _pull_messages(
             "google-cloud-pubsub is required; run `uv sync` inside "
             "plugin/ralph-hero/scripts/monitoring-bridge/"
         )
-        return []
+        return [], [], None, ""  # type: ignore[return-value]
 
     subscriber = pubsub_v1.SubscriberClient()
     subscription_path = (
@@ -313,7 +328,8 @@ def _pull_messages(
         )
     except Exception as exc:  # noqa: BLE001
         log.error("Pub/Sub pull failed: %s", exc)
-        return []
+        subscriber.close()
+        return [], [], None, ""  # type: ignore[return-value]
 
     messages = []
     ack_ids = []
@@ -327,20 +343,29 @@ def _pull_messages(
         messages.append(raw)
         ack_ids.append(received_message.ack_id)
 
-    if ack_ids:
-        try:
-            subscriber.acknowledge(
-                request={
-                    "subscription": subscription_path,
-                    "ack_ids": ack_ids,
-                }
-            )
-            log.info("Acknowledged %d message(s)", len(ack_ids))
-        except Exception as exc:  # noqa: BLE001
-            log.warning("Acknowledge failed (messages will be re-delivered): %s", exc)
+    return messages, ack_ids, subscriber, subscription_path
 
-    subscriber.close()
-    return messages
+
+def _ack_message(
+    subscriber: "pubsub_v1.SubscriberClient",
+    subscription_path: str,
+    ack_id: str,
+) -> None:
+    """ACK a single Pub/Sub message. Logs a warning on failure (non-fatal)."""
+    try:
+        subscriber.acknowledge(
+            request={
+                "subscription": subscription_path,
+                "ack_ids": [ack_id],
+            }
+        )
+        log.debug("Acknowledged message ack_id=%s…", ack_id[:16])
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "Acknowledge failed for ack_id=%s… (will be re-delivered): %s",
+            ack_id[:16],
+            exc,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -459,9 +484,12 @@ def main(argv: list[str] | None = None) -> int:
             log.error("Fixture file not found: %s", fixture_path)
             return 1
         messages = _load_fixture(fixture_path)
+        ack_ids: list[str] = []
+        subscriber = None
+        subscription_path = ""
         log.info("Dry-run mode: loaded %d message(s) from fixture", len(messages))
     else:
-        messages = _pull_messages(
+        messages, ack_ids, subscriber, subscription_path = _pull_messages(
             args.subscription,
             args.project,
             args.max_messages,
@@ -471,41 +499,52 @@ def main(argv: list[str] | None = None) -> int:
 
     if not messages:
         print("No messages to process.")
+        if subscriber is not None:
+            subscriber.close()
         return 0
 
     created = 0
     skipped = 0
     failed = 0
 
-    for i, msg in enumerate(messages, start=1):
-        payload = normalise_alert(msg)
-        policy_id = payload["policy_id"]
+    try:
+        for i, msg in enumerate(messages, start=1):
+            payload = normalise_alert(msg)
+            policy_id = payload["policy_id"]
 
-        if args.dry_run:
-            print(f"\n--- Message {i} ---")
-            print(f"title: {payload['title']}")
-            print(f"labels: {payload['labels']}")
-            print(f"policy_id: {policy_id}")
-            print("body:")
-            print(payload["body"])
-            created += 1
-            continue
+            if args.dry_run:
+                print(f"\n--- Message {i} ---")
+                print(f"title: {payload['title']}")
+                print(f"labels: {payload['labels']}")
+                print(f"policy_id: {policy_id}")
+                print("body:")
+                print(payload["body"])
+                created += 1
+                continue
 
-        # Idempotency check
-        if _issue_exists_for_policy(policy_id, args.repo):
-            log.info(
-                "Skipping policy_id=%s — open issue already exists", policy_id
-            )
-            skipped += 1
-            continue
+            # Idempotency check — duplicate alerts are ACKed (already handled)
+            if _issue_exists_for_policy(policy_id, args.repo):
+                log.info(
+                    "Skipping policy_id=%s — open issue already exists", policy_id
+                )
+                skipped += 1
+                # ACK the duplicate so it isn't re-delivered on the next run
+                _ack_message(subscriber, subscription_path, ack_ids[i - 1])
+                continue
 
-        url = _create_issue(payload, args.repo)
-        if url:
-            print(f"Created issue: {url}  [policy_id={policy_id}]")
-            created += 1
-        else:
-            log.error("Failed to create issue for policy_id=%s", policy_id)
-            failed += 1
+            url = _create_issue(payload, args.repo)
+            if url:
+                print(f"Created issue: {url}  [policy_id={policy_id}]")
+                created += 1
+                # ACK only after successful issue creation (at-least-once delivery)
+                _ack_message(subscriber, subscription_path, ack_ids[i - 1])
+            else:
+                log.error("Failed to create issue for policy_id=%s", policy_id)
+                failed += 1
+                # Do NOT ACK — Pub/Sub will re-deliver after the ack deadline
+    finally:
+        if subscriber is not None:
+            subscriber.close()
 
     print(
         f"\nResult: {created} created, {skipped} skipped (duplicate), "

--- a/plugin/ralph-hero/scripts/watch/smoke.sh
+++ b/plugin/ralph-hero/scripts/watch/smoke.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# smoke.sh — static assertions for the Watcher team artifact set
+#
+# Checks:
+#   1. SOUL.md frontmatter has team, voice, refuses keys
+#   2. SOUL.md body word count is in [150, 250]
+#   3. log-reader.md tools: field excludes write/mutation tools
+#   4. sre-fixit.md body contains the four kubectl shapes and no --force/--cascade
+#   5. watch/SKILL.md SessionStart hook references both set-skill-env.sh and load-team-soul.sh
+#   6. watch/SKILL.md contains at least three TODO(GH-1272) markers
+#   7. sre-allowlist-gate.sh: positive test (permitted kubectl shape passes)
+#   8. sre-allowlist-gate.sh: negative test (disallowed command is blocked)
+#   9. Heartbeat patch (Feature D, GH-1271): SKILL.md contains --auto-confirm step
+#  10. ralph-debug-collate/SKILL.md documents --auto-confirm flag (Feature D)
+#
+# Checks 1-8 are Feature C (GH-1270) artifacts. When running from a worktree
+# that predates Feature C's merge, absent files are skipped (not failed) so the
+# Feature D assertions (9-10) can be validated independently.
+#
+# Usage:
+#   bash plugin/ralph-hero/scripts/watch/smoke.sh
+#
+# Exit codes:
+#   0   All checks passed (or skipped due to absent Feature C artifacts)
+#   1   One or more assertions failed (first failure emits to stderr)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd -P)"
+PLUGIN_ROOT="${REPO_ROOT}/plugin/ralph-hero"
+
+SOUL_MD="${PLUGIN_ROOT}/skills/watch/SOUL.md"
+LOG_READER_MD="${PLUGIN_ROOT}/agents/log-reader.md"
+SRE_FIXIT_MD="${PLUGIN_ROOT}/agents/sre-fixit.md"
+SKILL_MD="${PLUGIN_ROOT}/skills/watch/SKILL.md"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+_pass() { echo "[PASS] $1"; (( PASS++ )) || true; }
+_fail() { echo "[FAIL] $1" >&2; (( FAIL++ )) || true; }
+_skip() { echo "[SKIP] $1 (Feature C artifact absent — pending GH-1270 merge)"; (( SKIP++ )) || true; }
+
+echo "=== watch smoke test ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. SOUL.md frontmatter has team, voice, refuses keys
+# ---------------------------------------------------------------------------
+if [[ ! -f "$SOUL_MD" ]]; then
+  _skip "SOUL.md not found: ${SOUL_MD}"
+else
+  KEY_COUNT=$(grep -cE '^(team|voice|refuses):' "$SOUL_MD" || true)
+  if [[ "$KEY_COUNT" -eq 3 ]]; then
+    _pass "SOUL.md frontmatter has team, voice, refuses keys (found ${KEY_COUNT})"
+  else
+    _fail "SOUL.md frontmatter missing keys — expected 3 of (team|voice|refuses), found ${KEY_COUNT}"
+  fi
+
+  # Validate frontmatter YAML is parseable
+  if python3 -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]).read().split("---")[1])' "$SOUL_MD" 2>/dev/null; then
+    _pass "SOUL.md frontmatter YAML is valid"
+  else
+    _fail "SOUL.md frontmatter YAML is invalid"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. SOUL.md body word count is in [150, 250]
+#    (Feature C ships the full SOUL body; stub from Feature A is < 150 words)
+# ---------------------------------------------------------------------------
+if [[ ! -f "$SOUL_MD" ]]; then
+  _skip "SOUL.md body word count (file absent)"
+else
+  WORD_COUNT=$(awk '/^---$/{n++; next} n==2' "$SOUL_MD" | wc -w | tr -d ' ')
+  if [[ "$WORD_COUNT" -ge 150 && "$WORD_COUNT" -le 250 ]]; then
+    _pass "SOUL.md body word count ${WORD_COUNT} is in [150, 250]"
+  elif [[ "$WORD_COUNT" -lt 150 ]]; then
+    _skip "SOUL.md body word count ${WORD_COUNT} < 150 — Feature C stub (full SOUL ships with GH-1270)"
+  else
+    _fail "SOUL.md body word count ${WORD_COUNT} is outside [150, 250]"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. log-reader.md tools: field excludes write/mutation tools
+# ---------------------------------------------------------------------------
+if [[ ! -f "$LOG_READER_MD" ]]; then
+  _skip "log-reader.md not found: ${LOG_READER_MD}"
+else
+  if python3 -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]).read().split("---")[1])' "$LOG_READER_MD" 2>/dev/null; then
+    _pass "log-reader.md frontmatter YAML is valid"
+  else
+    _fail "log-reader.md frontmatter YAML is invalid"
+  fi
+
+  TOOLS_LINE=$(grep -E '^tools:' "$LOG_READER_MD" || true)
+  FORBIDDEN='(Edit|Write|save_issue|create_issue|add_dependency|add_sub_issue|batch_update|advance_issue|archive_items)'
+  if echo "$TOOLS_LINE" | grep -Eq "$FORBIDDEN"; then
+    _fail "log-reader.md tools: field contains a forbidden write/mutation tool — line: '${TOOLS_LINE}'"
+  else
+    _pass "log-reader.md tools: field contains no write/mutation tools"
+  fi
+
+  if grep -qE '^model: haiku$' "$LOG_READER_MD"; then
+    _pass "log-reader.md model is haiku"
+  else
+    _fail "log-reader.md model is not haiku"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4a. sre-fixit.md body contains all four kubectl shapes
+# ---------------------------------------------------------------------------
+if [[ ! -f "$SRE_FIXIT_MD" ]]; then
+  _skip "sre-fixit.md not found: ${SRE_FIXIT_MD}"
+else
+  if python3 -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]).read().split("---")[1])' "$SRE_FIXIT_MD" 2>/dev/null; then
+    _pass "sre-fixit.md frontmatter YAML is valid"
+  else
+    _fail "sre-fixit.md frontmatter YAML is invalid"
+  fi
+
+  KUBECTL_COUNT=$(grep -cE 'kubectl (scale|drain|rollout|delete pod)' "$SRE_FIXIT_MD" || true)
+  if [[ "$KUBECTL_COUNT" -ge 4 ]]; then
+    _pass "sre-fixit.md contains at least 4 kubectl allowlist shapes (found ${KUBECTL_COUNT})"
+  else
+    _fail "sre-fixit.md missing kubectl allowlist shapes — expected >=4, found ${KUBECTL_COUNT}"
+  fi
+
+  # 4b. No --force or --cascade=foreground
+  if grep -qE '(--force|--cascade=foreground)' "$SRE_FIXIT_MD"; then
+    _fail "sre-fixit.md contains forbidden flags (--force or --cascade=foreground)"
+  else
+    _pass "sre-fixit.md has no --force or --cascade=foreground flags"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. watch/SKILL.md SessionStart hook references both scripts
+# ---------------------------------------------------------------------------
+if [[ ! -f "$SKILL_MD" ]]; then
+  _fail "watch/SKILL.md not found: ${SKILL_MD}"
+else
+  if python3 -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]).read().split("---")[1])' "$SKILL_MD" 2>/dev/null; then
+    _pass "watch/SKILL.md frontmatter YAML is valid"
+  else
+    _fail "watch/SKILL.md frontmatter YAML is invalid"
+  fi
+
+  HOOK_COUNT=$(grep -cE '(set-skill-env\.sh|load-team-soul\.sh)' "$SKILL_MD" || true)
+  if [[ "$HOOK_COUNT" -ge 2 ]]; then
+    _pass "watch/SKILL.md SessionStart hook references both set-skill-env.sh and load-team-soul.sh (found ${HOOK_COUNT})"
+  else
+    _fail "watch/SKILL.md SessionStart hook missing one or both scripts — expected >=2 matches, found ${HOOK_COUNT}"
+  fi
+
+  # argument-hint check
+  if grep -qE '^argument-hint: "\[--issue NNN\]"$' "$SKILL_MD"; then
+    _pass "watch/SKILL.md argument-hint is exactly \"[--issue NNN]\""
+  else
+    _fail "watch/SKILL.md argument-hint does not match expected value \"[--issue NNN]\""
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 6. watch/SKILL.md contains at least three TODO(GH-1272) markers
+# ---------------------------------------------------------------------------
+if [[ -f "$SKILL_MD" ]]; then
+  TODO_COUNT=$(grep -c 'TODO(GH-1272)' "$SKILL_MD" || true)
+  if [[ "$TODO_COUNT" -ge 3 ]]; then
+    _pass "watch/SKILL.md contains ${TODO_COUNT} TODO(GH-1272) markers (>= 3 required)"
+  else
+    _fail "watch/SKILL.md has only ${TODO_COUNT} TODO(GH-1272) markers — expected at least 3"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 7. sre-allowlist-gate.sh: positive test (permitted kubectl shape passes)
+# ---------------------------------------------------------------------------
+GATE_SCRIPT="${PLUGIN_ROOT}/hooks/scripts/sre-allowlist-gate.sh"
+
+if [[ ! -f "$GATE_SCRIPT" ]]; then
+  _skip "sre-allowlist-gate.sh not found: ${GATE_SCRIPT}"
+else
+  if [[ -x "$GATE_SCRIPT" ]]; then
+    _pass "sre-allowlist-gate.sh is executable"
+  else
+    _fail "sre-allowlist-gate.sh is not executable"
+  fi
+
+  # Positive: kubectl scale deployment (allowed shape) must exit 0
+  POSITIVE_PAYLOAD='{"hook_event_name":"PreToolUse","tool_name":"Bash","agent_type":"ralph-hero:sre-fixit","tool_input":{"command":"kubectl scale deployment api --replicas=3"}}'
+  if echo "$POSITIVE_PAYLOAD" | bash "$GATE_SCRIPT" >/dev/null 2>&1; then
+    _pass "sre-allowlist-gate.sh: permitted kubectl shape exits 0 (positive test)"
+  else
+    _fail "sre-allowlist-gate.sh: permitted kubectl shape was blocked — positive test FAILED"
+  fi
+
+  # ---------------------------------------------------------------------------
+  # 8. sre-allowlist-gate.sh: negative test (disallowed command is blocked)
+  # ---------------------------------------------------------------------------
+  # kubectl delete deployment is NOT in the allowlist (only 'delete pod' is)
+  NEGATIVE_PAYLOAD='{"hook_event_name":"PreToolUse","tool_name":"Bash","agent_type":"ralph-hero:sre-fixit","tool_input":{"command":"kubectl delete deployment api"}}'
+  if echo "$NEGATIVE_PAYLOAD" | bash "$GATE_SCRIPT" >/dev/null 2>&1; then
+    _fail "sre-allowlist-gate.sh: disallowed command was NOT blocked — negative test FAILED"
+  else
+    EXIT_CODE=$?
+    if [[ "$EXIT_CODE" -eq 2 ]]; then
+      _pass "sre-allowlist-gate.sh: disallowed kubectl command blocked with exit 2 (negative test)"
+    else
+      _pass "sre-allowlist-gate.sh: disallowed kubectl command blocked (exit ${EXIT_CODE}) (negative test)"
+    fi
+  fi
+
+  # log-reader positive: gcloud logging read (allowed shape) must exit 0
+  LOG_POSITIVE_PAYLOAD='{"hook_event_name":"PreToolUse","tool_name":"Bash","agent_type":"ralph-hero:log-reader","tool_input":{"command":"gcloud logging read '\''severity>=ERROR'\'' --limit=50 --project=my-proj --format=json"}}'
+  if echo "$LOG_POSITIVE_PAYLOAD" | bash "$GATE_SCRIPT" >/dev/null 2>&1; then
+    _pass "sre-allowlist-gate.sh: permitted gcloud logging read exits 0 (log-reader positive test)"
+  else
+    _fail "sre-allowlist-gate.sh: permitted gcloud logging read was blocked — log-reader positive test FAILED"
+  fi
+
+  # log-reader negative: arbitrary shell command must be blocked
+  LOG_NEGATIVE_PAYLOAD='{"hook_event_name":"PreToolUse","tool_name":"Bash","agent_type":"ralph-hero:log-reader","tool_input":{"command":"gcloud projects delete my-proj"}}'
+  if echo "$LOG_NEGATIVE_PAYLOAD" | bash "$GATE_SCRIPT" >/dev/null 2>&1; then
+    _fail "sre-allowlist-gate.sh: disallowed gcloud subcommand was NOT blocked — log-reader negative test FAILED"
+  else
+    _pass "sre-allowlist-gate.sh: disallowed gcloud subcommand blocked (log-reader negative test)"
+  fi
+
+  # non-restricted agent: any command must pass through (exit 0)
+  OTHER_PAYLOAD='{"hook_event_name":"PreToolUse","tool_name":"Bash","agent_type":"ralph-hero:impl-agent","tool_input":{"command":"echo hello"}}'
+  if echo "$OTHER_PAYLOAD" | bash "$GATE_SCRIPT" >/dev/null 2>&1; then
+    _pass "sre-allowlist-gate.sh: non-restricted agent_type passes through (exit 0)"
+  else
+    _fail "sre-allowlist-gate.sh: non-restricted agent_type was incorrectly blocked"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 9. Heartbeat patch (Feature D, GH-1271): SKILL.md contains auto-confirm step
+# ---------------------------------------------------------------------------
+if [[ -f "$SKILL_MD" ]]; then
+  if grep -q 'auto-confirm' "$SKILL_MD"; then
+    _pass "watch/SKILL.md heartbeat contains --auto-confirm step (Feature D)"
+  else
+    _fail "watch/SKILL.md heartbeat missing --auto-confirm step — Feature D patch not applied"
+  fi
+
+  if grep -q 'RALPH_DEBUG=true' "$SKILL_MD" && grep -q 'debug-collate skipped' "$SKILL_MD"; then
+    _pass "watch/SKILL.md heartbeat has RALPH_DEBUG preflight check with skip warning"
+  else
+    _fail "watch/SKILL.md heartbeat missing RALPH_DEBUG preflight check or 'debug-collate skipped' warning"
+  fi
+
+  if grep -qE 'result: heartbeat:.*debug-collate issues filed' "$SKILL_MD"; then
+    _pass "watch/SKILL.md heartbeat result: line includes debug-collate counter"
+  else
+    _fail "watch/SKILL.md heartbeat result: line missing debug-collate counter"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 10. ralph-debug-collate/SKILL.md contains --auto-confirm flag (Feature D)
+# ---------------------------------------------------------------------------
+DEBUG_COLLATE_MD="${PLUGIN_ROOT}/skills/ralph-debug-collate/SKILL.md"
+if [[ ! -f "$DEBUG_COLLATE_MD" ]]; then
+  _fail "ralph-debug-collate/SKILL.md not found: ${DEBUG_COLLATE_MD}"
+else
+  if grep -q 'auto-confirm' "$DEBUG_COLLATE_MD"; then
+    _pass "ralph-debug-collate/SKILL.md documents --auto-confirm flag"
+  else
+    _fail "ralph-debug-collate/SKILL.md missing --auto-confirm flag documentation"
+  fi
+
+  if grep -q 'argument-hint' "$DEBUG_COLLATE_MD" && grep -E 'argument-hint.*auto-confirm' "$DEBUG_COLLATE_MD" >/dev/null 2>&1; then
+    _pass "ralph-debug-collate/SKILL.md argument-hint includes --auto-confirm"
+  else
+    _fail "ralph-debug-collate/SKILL.md argument-hint missing --auto-confirm"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped (Feature C pending) ==="
+
+if (( FAIL > 0 )); then
+  exit 1
+fi
+
+echo "Smoke test PASSED."
+exit 0

--- a/plugin/ralph-hero/skills/director/event-classes.md
+++ b/plugin/ralph-hero/skills/director/event-classes.md
@@ -24,9 +24,10 @@ These labels are written by automated producers (event shims, dream-loop classif
 
 | workflow_state | labels | team | notes |
 |----------------|--------|------|-------|
-| any | `watcher-auto` | watchers | Label written by Cloud Monitoring → board bridge. Producer ships in Feature D (GH-1271). Feature C ships the `ralph-hero:watch` entrypoint. |
+| any | `watcher-auto` | watchers | Label written by Cloud Monitoring → board bridge (`plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py`). Feature C ships the `ralph-hero:watch` entrypoint. |
+| any | `debug-auto` | watchers | Label written by `ralph-debug-collate` (invoked from Watcher heartbeat). Observability follow-ups are owned by watchers. |
 | any | `scout-auto` | scouts | Label written by Scout scheduling hook (on-PR + nightly). Producer ships in Feature F (GH-1273). Feature F also ships `ralph-hero:scouts`. |
-| any | `process-improvement` | caretakers | Label written by dream-loop cluster classifier output. Producer ships in Feature D (GH-1271). Feature G ships `ralph-hero:caretake`. |
+| any | `process-improvement` | caretakers | Label written by dream-loop cluster classifier (`scripts/dream/reflect.py::emit_process_improvement_issue`). Feature G ships `ralph-hero:caretake`. |
 
 ## Priority 3 — Workflow state (fallback routing)
 
@@ -66,6 +67,18 @@ Director evaluates in this order:
 
 1. Fetch the candidate issue's labels array.
 2. Check for any `trigger:*` label (Priority 1). First match wins.
-3. Check for any automation label: `watcher-auto`, `scout-auto`, `process-improvement` (Priority 2). First match wins.
+3. Check for any automation label: `watcher-auto`, `debug-auto`, `scout-auto`, `process-improvement` (Priority 2). First match wins.
 4. Fall through to `workflow_state` lookup (Priority 3).
 5. If the resolved team's entrypoint does not yet exist, emit `needs input: team <name> not yet implemented (Feature <X>); skipping dispatch` and continue to the next event.
+
+---
+
+## Producers
+
+This table is the canonical inventory of automated label producers as of Feature D (GH-1271). New producers should add a row here when they land.
+
+| Label | Producer file | Trigger condition |
+|-------|---------------|-------------------|
+| `watcher-auto` | `plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py` | GCP Cloud Monitoring alert delivered to the configured Pub/Sub subscription |
+| `debug-auto` | `plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md` (invoked from Watcher heartbeat) | Langfuse error grouping with ≥ N occurrences in window (default: 3) |
+| `process-improvement` | `scripts/dream/reflect.py::emit_process_improvement_issue` | Dream-loop cluster of size ≥ threshold (default: 5) with ≥ N% `tool_use_error` or `verdict: BLOCKED` signals (default: 30%) |

--- a/plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Collate debug errors from Langfuse — run a dry-run, present grouped error signatures, and on confirmation file `debug-auto` issues (or comment on existing ones) for self-healing observability. Closes the OTel → Langfuse → GitHub feedback loop with a single command.
-argument-hint: "[optional: --since 24h] [--min-occurrences 3]"
+argument-hint: "[optional: --since 24h] [--min-occurrences 3] [--auto-confirm]"
 context: fork
 model: sonnet
 hooks:
@@ -59,6 +59,7 @@ Parse the argument string for optional flags:
 
 - `--since <window>`: Lower bound for the trace window. Accepts ISO dates (e.g., `2026-05-01`) or shorthand (`24h`, `7d`). Default: `24h`.
 - `--min-occurrences <n>`: Minimum number of occurrences for a signature to be reported. Default: `3`.
+- `--auto-confirm`: Skip the human confirmation prompt in Step 5 and proceed directly to filing issues. Used by the Watcher heartbeat (`plugin/ralph-hero/skills/watch/SKILL.md`) for unattended scheduled runs.
 
 Resolve `--since` to an ISO timestamp before calling the tool (e.g., `24h` → 24 hours before now).
 
@@ -128,13 +129,21 @@ If there are more than 5 groups, append:
 
 ### Step 5: Confirm
 
-Ask the user explicitly:
+If `--auto-confirm` is present, skip the human prompt and proceed directly to Step 6 (File Issues). Emit a result line listing each issue that will be filed:
+
+```
+result: auto-confirm active — filing debug-auto issues for <errorGroups> signature(s)
+```
+
+This path is used by the Watcher heartbeat (`plugin/ralph-hero/skills/watch/SKILL.md`). Do not use `--auto-confirm` in interactive sessions.
+
+Otherwise, ask the user explicitly:
 
 ```
 File `debug-auto` issues for these <errorGroups> signatures? [y/N]
 ```
 
-This skill is **interactive** — it is not part of autopilot and must not auto-confirm. If the user declines (any answer that is not `y` / `yes`), exit cleanly:
+This skill is **interactive** — it is not part of autopilot and must not auto-confirm unless the `--auto-confirm` flag is explicitly passed. If the user declines (any answer that is not `y` / `yes`), exit cleanly:
 
 ```
 Skipped — no issues filed.
@@ -186,7 +195,8 @@ Next: run `/ralph-hero:ralph-triage` to prioritize the freshly-filed `debug-auto
 
 ## Constraints
 
-- Interactive only — do not run from autopilot or unattended loops.
+- Interactive by default — do not run from autopilot or unattended loops without the `--auto-confirm` flag.
+- `--auto-confirm` is the path used by the Watcher heartbeat (`plugin/ralph-hero/skills/watch/SKILL.md`). When invoked with this flag the skill skips the human prompt and files issues automatically. Human sessions must not pass `--auto-confirm` unless the intent is truly unattended.
 - Read-only on Langfuse — the tool only queries observations, never mutates traces.
 - Tool-gated by `RALPH_DEBUG=true`. If the tool is not registered, the skill cannot proceed (Step 1 handles this).
 - One Langfuse host: defaults to `http://localhost:3100`. To target a different host, set `LANGFUSE_HOST` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` in the MCP-server environment.

--- a/plugin/ralph-hero/skills/watch/HEARTBEAT.md
+++ b/plugin/ralph-hero/skills/watch/HEARTBEAT.md
@@ -1,0 +1,114 @@
+---
+description: Heartbeat registration guide for the Watcher team entrypoint. Documents /schedule installation, cadence configuration, and troubleshooting.
+---
+
+# Watcher Heartbeat — Registration Guide
+
+The Watcher heartbeat runs `ralph-hero:watch` on a recurring schedule. When invoked with no argument, Watch queries the board for open `watcher-auto`, `watcher-investigate`, and `watcher-remediate` labelled issues and dispatches the appropriate sub-skill or subagent for each.
+
+## Registration
+
+### Interactive (recommended for first-time setup)
+
+```
+Skill("schedule", "every ${RALPH_WATCH_HEARTBEAT_MIN:-15}m /ralph-hero:watch")
+```
+
+### Cron syntax
+
+```
+Skill("schedule", "cron */15 * * * * /ralph-hero:watch")
+```
+
+Replace `15` with your preferred cadence in minutes (must be a positive integer).
+
+### With a custom cadence
+
+Set `RALPH_WATCH_HEARTBEAT_MIN` in your Claude Code settings before registering:
+
+```json
+{
+  "env": {
+    "RALPH_WATCH_HEARTBEAT_MIN": "30"
+  }
+}
+```
+
+Then register:
+
+```
+Skill("schedule", "every 30m /ralph-hero:watch")
+```
+
+## Cadence configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RALPH_WATCH_HEARTBEAT_MIN` | `15` | Heartbeat interval in minutes. Accepts a positive integer. The schedule registration command must use this value explicitly — the env var is not read by the `/schedule` runtime itself. |
+
+## Verifying the routine is registered
+
+After registration, confirm the entry appears in the schedule list:
+
+```
+Skill("schedule", "list")
+```
+
+Expected entry shape:
+
+```
+id: watch-heartbeat
+schedule: every 15m
+skill: /ralph-hero:watch
+last_run: <timestamp or "never">
+next_run: <timestamp>
+```
+
+The `id` field is assigned by the `/schedule` runtime. Note it for pause/delete operations.
+
+## Pausing and disabling
+
+To pause the heartbeat temporarily:
+
+```
+Skill("schedule", "pause <id>")
+```
+
+To delete the heartbeat entirely:
+
+```
+Skill("schedule", "delete <id>")
+```
+
+Where `<id>` is the value from `Skill("schedule", "list")`.
+
+## Troubleshooting
+
+### Feature A hook not installed (SOUL not loaded)
+
+**Symptom**: Watch runs but the paranoid-but-disciplined refusals are absent — the orchestrator accepts claims without trace IDs.
+
+**Cause**: `load-team-soul.sh` is not present at `${CLAUDE_PLUGIN_ROOT}/hooks/scripts/load-team-soul.sh`, or the SessionStart hook did not fire.
+
+**Fix**: Verify Feature A (GH-1268) has landed:
+
+```bash
+ls "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/load-team-soul.sh"
+ls "${CLAUDE_PLUGIN_ROOT}/skills/shared/soul-schema.md"
+```
+
+If either file is missing, the SOUL framework (Feature A) has not been installed. Re-run the GH-1268 implementation before using Watch.
+
+### gcp-incident-triage skill not present
+
+**Symptom**: Watch dispatches to `gcp-incident-triage` but the skill invocation fails with "skill not found".
+
+**Cause**: `gcp-incident-triage` is an operator-local skill installed at `~/.claude/skills/gcp-incident-triage/`. It is not part of this repository.
+
+**Fix**: Confirm the skill is installed:
+
+```bash
+ls ~/.claude/skills/gcp-incident-triage/SKILL.md
+```
+
+If missing, install the skill from its source. The Watch orchestrator wraps but does not include it.

--- a/plugin/ralph-hero/skills/watch/SKILL.md
+++ b/plugin/ralph-hero/skills/watch/SKILL.md
@@ -1,0 +1,142 @@
+---
+description: Watcher team orchestrator. Dispatches gcp-incident-triage, ralph-debug-collate, log-reader, and sre-fixit based on issue markers. Accepts --issue NNN (direct) or no arg (heartbeat every RALPH_WATCH_HEARTBEAT_MIN minutes). Reads team SOUL via SessionStart hook.
+argument-hint: "[--issue NNN]"
+context: inline
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=watch RALPH_REQUIRED_BRANCH=main"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/load-team-soul.sh"
+allowed-tools:
+  - Skill
+  - Agent
+  - Bash
+  - Read
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+---
+
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+- Heartbeat cadence (minutes): !`echo ${RALPH_WATCH_HEARTBEAT_MIN:-15}`
+
+# Ralph Watch — Watcher Team Orchestrator
+
+Single entrypoint for the Watcher team. Wraps `gcp-incident-triage`, `ralph-debug-collate`, `log-reader`, and `sre-fixit` behind one skill. Director (Feature B, GH-1269) dispatches this skill via `Skill("ralph-hero:watch", args="<issue-number>")` using a bare issue number. The canonical invocation form from Director is a bare number (e.g. `"42"`); `--issue NNN` is also accepted for direct human use. Both forms are equivalent.
+
+<!-- internal: Shared Constraint 6 — Director, not Watch, consumes `trigger:watch` labels and decides when to dispatch. Watch only accepts --issue NNN (direct) or no arg (heartbeat). Watch never reads trigger: labels itself. -->
+
+<!-- internal: Shared Constraint 7 — On every terminal state, Watch must call outcome-recorder. Feature E (GH-1272) builds the actual wrapper. Until then, every terminal handler contains a TODO(GH-1272) stub that Feature E follows when wiring. The stub comment is non-optional. -->
+
+## Argument parsing
+
+Parse `$ARGUMENTS` on entry:
+
+```
+if [[ "$ARGUMENTS" =~ ^--issue[[:space:]]+([0-9]+)$ ]]; then
+  WATCH_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+  WATCH_MODE=direct
+elif [[ "$ARGUMENTS" =~ ^([0-9]+)$ ]]; then
+  # Bare number — canonical Director dispatch form
+  WATCH_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+  WATCH_MODE=direct
+elif [[ -z "$ARGUMENTS" ]]; then
+  WATCH_MODE=heartbeat
+else
+  echo "needs input: unrecognised argument '${ARGUMENTS}'. Expected --issue NNN, a bare issue number, or no argument for heartbeat mode."
+  exit 1
+fi
+```
+
+**Direct mode** (`--issue NNN` or bare number): fetch the single issue and dispatch per the table below.
+
+**Heartbeat mode** (no arg): query the board for all open `watcher-auto`, `watcher-investigate`, and `watcher-remediate` labelled issues in Backlog, then dispatch per the table for each. Stop when the queue is empty.
+
+## SOUL refusal enforcement
+
+The SOUL (loaded via `load-team-soul.sh`) refuses claims without a trace ID and claims without a literal LQL/log-query snippet. Enforce this at the orchestrator level too: before dispatching any sub-skill or subagent, verify the issue body contains at least one of:
+- A trace ID matching `projects/[^/]+/traces/[a-f0-9]+`
+- A literal `gcloud logging read ...` snippet
+
+If neither is present AND the issue does not carry a `<!-- gcp-policy: ... -->` marker (which implies an upstream alert source that gcp-incident-triage will query), post a `needs input:` comment and escalate to Human Needed:
+
+```
+needs input: issue #NNN has no trace ID and no LQL snippet. Provide a trace ID (projects/<proj>/traces/<id>) or a gcloud logging read query before Watch can proceed.
+```
+
+## Dispatch table
+
+Inspect the fetched issue and route to the first matching row:
+
+| Condition | Action |
+|-----------|--------|
+| Issue body contains `<!-- gcp-policy: ... -->` marker | `Skill("gcp-incident-triage", "--issue NNN")` |
+| Issue body contains a `langfuse-trace:` URL | `Skill("ralph-hero:ralph-debug-collate", "--issue NNN")` |
+| Issue has label `watcher-investigate` | `Agent(subagent_type="ralph-hero:log-reader", prompt="Investigate issue #NNN: <issue title>. <issue body>")` |
+| Issue has label `watcher-remediate` AND proposed action matches the sre-fixit allowlist | `Agent(subagent_type="ralph-hero:sre-fixit", prompt="Remediate issue #NNN: <issue title>. <issue body>")` |
+| No row matches | Escalate to `Human Needed` with a `needs input:` comment explaining which marker or label is missing |
+
+<!-- internal: Dispatch rows must not overlap. A single issue should match at most one row. Priority is top-to-bottom: gcp-policy wins over langfuse-trace wins over labels. If an issue has both a gcp-policy marker and a watcher-investigate label, gcp-incident-triage is dispatched (first match wins). -->
+
+### sre-fixit pre-check
+
+Before dispatching `sre-fixit`, confirm the requested kubectl action from the issue body matches one of the four allowlisted shapes:
+- `kubectl scale deployment <name> --replicas=<N>`
+- `kubectl drain node <name>`
+- `kubectl rollout restart deployment/<name>`
+- `kubectl delete pod <name>`
+
+If the requested action is not in the list, do NOT dispatch sre-fixit. Escalate directly to Human Needed.
+
+## Heartbeat mode
+
+When invoked with no argument:
+
+1. Call `list_issues({labels: ["watcher-auto", "watcher-investigate", "watcher-remediate"], workflowState: "Backlog"})`.
+2. If the result is empty, emit `result: queue empty` and stop.
+3. For each issue in the result, dispatch per the dispatch table above (sequential — one issue at a time to avoid race conditions on shared board state).
+4. **Langfuse error collation** (Feature D, GH-1271): Run debug-collate in auto-confirm mode:
+   - Preflight: check `RALPH_DEBUG=true` is set. If not, log a single warning `debug-collate skipped: RALPH_DEBUG unset` and continue to step 5 without failing the heartbeat.
+   - If `RALPH_DEBUG=true`, invoke: `Skill("ralph-hero:ralph-debug-collate", "--auto-confirm --since 24h --min-occurrences 3")`
+   - The `--auto-confirm` flag bypasses the interactive confirmation prompt and files issues automatically. See `plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md` Step 5 for the auto-confirm path.
+   - Capture the count of filed issues from the result line for inclusion in the heartbeat summary.
+5. After all issues are processed and debug-collate runs, emit:
+   ```
+   result: heartbeat: N alerts dispatched, M debug-collate issues filed, K stale comments
+   ```
+
+The heartbeat loop is bounded: it processes only the issues returned by the initial `list_issues` call. It does not re-query mid-loop. New issues that arrive during the run are picked up on the next heartbeat invocation.
+
+## Terminal handlers
+
+After each sub-skill or subagent dispatch completes, emit a terminal result line and stub the outcome-recorder call:
+
+**On success (sub-skill/agent returned a result):**
+```
+result: #NNN dispatched to <sub-skill> — outcome: <outcome-summary>
+# TODO(GH-1272): wire outcome-recorder(decision=watch-dispatched, result=<outcome>, trace_id=<trace-id-if-known>)
+```
+
+**On escalation (no dispatch row matched or sre-fixit pre-check failed):**
+```
+result: #NNN escalated to Human Needed — no matching dispatch condition
+# TODO(GH-1272): wire outcome-recorder(decision=watch-escalated, result=human-needed, trace_id=<trace-id-if-known>)
+```
+
+**On SOUL refusal (no trace ID or LQL snippet):**
+```
+result: #NNN blocked — SOUL refusal: no trace ID or LQL snippet present
+# TODO(GH-1272): wire outcome-recorder(decision=watch-refused, result=missing-evidence, trace_id=none)
+```
+
+## Shared constraints (referenced)
+
+- **Constraint 6**: Director consumes `trigger:watch` labels and dispatches Watch. Watch never reads `trigger:` labels directly.
+- **Constraint 7** (GH-1272): All terminal handlers stub `outcome-recorder` with a `# TODO(GH-1272)` comment. Feature E wires the actual call.

--- a/scripts/dream/reflect.py
+++ b/scripts/dream/reflect.py
@@ -25,12 +25,13 @@ Run via ``uv run reflect.py --since 24h`` (see ``--help`` for options).
 from __future__ import annotations
 
 import argparse
-import json
+import hashlib
 import logging
 import os
 import re
 import sqlite3
 import struct
+import subprocess
 import sys
 import unicodedata
 from dataclasses import dataclass
@@ -65,6 +66,24 @@ PROMPT_CONTENT_CLIP = 800
 # timed out non-deterministically. Override with
 # ``RALPH_DREAM_LLM_TIMEOUT_S`` if your hardware needs longer.
 DEFAULT_LLM_TIMEOUT_S = int(os.environ.get("RALPH_DREAM_LLM_TIMEOUT_S", "180"))
+
+# ---------------------------------------------------------------------------
+# Process-improvement cluster classifier constants (Feature D, GH-1271)
+# ---------------------------------------------------------------------------
+
+# Minimum cluster size to consider for process-improvement issue filing.
+# Clusters smaller than this threshold are skipped regardless of signal
+# fraction. Overridable via RALPH_DREAM_PROCESS_IMPROVEMENT_MIN_CLUSTER.
+DEFAULT_CLUSTER_SIZE_THRESHOLD = int(
+    os.environ.get("RALPH_DREAM_PROCESS_IMPROVEMENT_MIN_CLUSTER", "5")
+)
+
+# Fraction of cluster members that must carry a failure signal
+# (tool_use_error or verdict: BLOCKED) before an issue is filed.
+# Overridable via RALPH_DREAM_PROCESS_IMPROVEMENT_SIGNAL_FRACTION.
+DEFAULT_SIGNAL_FRACTION_THRESHOLD = float(
+    os.environ.get("RALPH_DREAM_PROCESS_IMPROVEMENT_SIGNAL_FRACTION", "0.3")
+)
 
 # Reuse the parent plan's A-Mem prompt header verbatim so the prompt is
 # traceable to the spec. See:
@@ -331,6 +350,202 @@ def cluster_memories(
 
     # Sort by cluster size desc so "biggest theme" comes first in logs.
     return sorted(bucket.values(), key=len, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Process-improvement cluster classifier (Feature D, GH-1271)
+# ---------------------------------------------------------------------------
+
+_VERDICT_BLOCKED_RE = re.compile(r"verdict\s*:\s*BLOCKED", re.IGNORECASE)
+
+
+def detect_signals(memory: RawMemoryRow) -> set[str]:
+    """Return the subset of known failure signals present in a raw memory.
+
+    Signals detected:
+    - ``"tool_use_error"``: case-insensitive substring match in content
+    - ``"verdict_blocked"``: regex match for ``verdict:\\s*BLOCKED``
+
+    Pure function — no I/O, no MCP calls.
+    """
+    found: set[str] = set()
+    content = memory.content or ""
+    if "tool_use_error" in content.lower():
+        found.add("tool_use_error")
+    if _VERDICT_BLOCKED_RE.search(content):
+        found.add("verdict_blocked")
+    return found
+
+
+def classify_clusters(
+    clusters: list[list[RawMemoryRow]],
+    size_threshold: int = DEFAULT_CLUSTER_SIZE_THRESHOLD,
+    signal_fraction_threshold: float = DEFAULT_SIGNAL_FRACTION_THRESHOLD,
+) -> list[dict[str, Any]]:
+    """Return classification dicts for clusters that meet both thresholds.
+
+    A cluster is classified when:
+    1. ``len(cluster) >= size_threshold``
+    2. The fraction of members carrying at least one failure signal
+       (``tool_use_error`` or ``verdict_blocked``) >=
+       ``signal_fraction_threshold``
+
+    Returns a list of dicts with keys:
+    - ``cluster_index``: 0-based index into ``clusters``
+    - ``size``: number of members
+    - ``signal_counts``: ``{"tool_use_error": N, "verdict_blocked": M}``
+    - ``sample_ids``: list of member ids (all members, for dedup hashing)
+    - ``theme_hint``: most common signal name, or "mixed" if tied
+
+    Pure function — no I/O, no MCP calls. A failing caller (e.g. unreachable
+    MCP endpoint) must not affect the reflection pipeline; callers wrap this
+    in try/except and log a warning on failure.
+    """
+    results: list[dict[str, Any]] = []
+    for idx, cluster in enumerate(clusters):
+        if len(cluster) < size_threshold:
+            continue
+
+        signal_counts: dict[str, int] = {"tool_use_error": 0, "verdict_blocked": 0}
+        signalled = 0
+        for mem in cluster:
+            sigs = detect_signals(mem)
+            if sigs:
+                signalled += 1
+            for sig in sigs:
+                signal_counts[sig] = signal_counts.get(sig, 0) + 1
+
+        fraction = signalled / len(cluster)
+        if fraction < signal_fraction_threshold:
+            continue
+
+        # Determine a simple theme hint from the dominant signal
+        if signal_counts["tool_use_error"] > signal_counts["verdict_blocked"]:
+            theme_hint = "tool_use_error"
+        elif signal_counts["verdict_blocked"] > signal_counts["tool_use_error"]:
+            theme_hint = "verdict_blocked"
+        elif signal_counts["tool_use_error"] > 0:
+            theme_hint = "mixed"
+        else:
+            theme_hint = "unknown"
+
+        results.append(
+            {
+                "cluster_index": idx,
+                "size": len(cluster),
+                "signal_counts": signal_counts,
+                "sample_ids": [m.id for m in cluster],
+                "theme_hint": theme_hint,
+            }
+        )
+    return results
+
+
+def emit_process_improvement_issue(
+    classification: dict[str, Any],
+    dry_run: bool = False,
+    repo: str | None = None,
+) -> str | None:
+    """Build and file a ``process-improvement`` draft issue for a classified cluster.
+
+    In dry-run mode, prints the full payload to stdout and returns a truthy
+    string (``"<dry-run>"``). In live mode, calls ``gh issue create`` via
+    subprocess and returns the issue URL string, or ``None`` on failure.
+
+    On any subprocess/CLI failure the function logs a single warning and
+    returns ``None`` — the reflection pipeline keeps running.
+    """
+    size = classification["size"]
+    signal_counts = classification["signal_counts"]
+    sample_ids = classification["sample_ids"]
+    theme_hint = classification["theme_hint"]
+
+    tool_err_n = signal_counts.get("tool_use_error", 0)
+    blocked_n = signal_counts.get("verdict_blocked", 0)
+
+    title = (
+        f"[process-improvement] {theme_hint} cluster "
+        f"(cluster size={size}, blocked={blocked_n}, tool_errors={tool_err_n})"
+    )
+
+    # Deterministic cluster id from sorted member ids
+    cluster_id = hashlib.sha256(
+        "|".join(sorted(sample_ids)).encode()
+    ).hexdigest()[:12]
+
+    dominant = "tool errors" if tool_err_n >= blocked_n else "blocked verdicts"
+    para = (
+        f"Dream-loop detected a recurring failure cluster of {size} memories "
+        f"with {tool_err_n} `tool_use_error` signal(s) and "
+        f"{blocked_n} `verdict: BLOCKED` signal(s). "
+        f"Dominant signal: **{dominant}**. "
+        f"Theme: `{theme_hint}`. "
+        f"Cluster id: `{cluster_id}`."
+    )
+
+    ids_list = "\n".join(f"- {sid}" for sid in sample_ids)
+
+    body = (
+        f"{para}\n"
+        f"\n"
+        f"## Source\n"
+        f"\n"
+        f"- Cluster id: `{cluster_id}`\n"
+        f"- Cluster size: {size}\n"
+        f"- Tool errors: {tool_err_n}\n"
+        f"- Blocked verdicts: {blocked_n}\n"
+        f"\n"
+        f"## Suggested Team: caretakers\n"
+        f"\n"
+        f"<details>\n"
+        f"<summary>Source memory ids ({len(sample_ids)} total)</summary>\n"
+        f"\n"
+        f"{ids_list}\n"
+        f"\n"
+        f"</details>\n"
+    )
+
+    if dry_run:
+        print(f"title: {title}")
+        print("labels: ['process-improvement']")
+        print("body:")
+        print(body)
+        return "<dry-run>"
+
+    cmd = [
+        "gh", "issue", "create",
+        "--title", title,
+        "--body", body,
+        "--label", "process-improvement",
+    ]
+    if repo:
+        cmd += ["--repo", repo]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            log.warning(
+                "gh issue create failed for process-improvement cluster %s "
+                "(rc=%d): %s",
+                cluster_id,
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return None
+        url = result.stdout.strip()
+        return url
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "emit_process_improvement_issue failed for cluster %s: %s",
+            cluster_id,
+            exc,
+        )
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -760,7 +975,17 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help=(
             "Fetch + cluster + print counts and candidate titles but "
-            "do not call the LLM or write any files."
+            "do not call the LLM or write any files. Also skips "
+            "process-improvement issue creation (classifier runs but "
+            "prints payloads instead of calling gh issue create)."
+        ),
+    )
+    parser.add_argument(
+        "--gh-repo",
+        default=None,
+        help=(
+            "GitHub repo in owner/name format for process-improvement "
+            "issue creation. Defaults to repo inferred by gh CLI."
         ),
     )
     parser.add_argument(
@@ -812,6 +1037,34 @@ def main(argv: list[str] | None = None) -> int:
         ids_preview = ", ".join(m.id for m in cluster[:3])
         extra = "" if len(cluster) <= 3 else f" (+{len(cluster) - 3} more)"
         print(f"  Cluster {i}: size={len(cluster)} members=[{ids_preview}{extra}]")
+
+    # --- Process-improvement classifier (Feature D, GH-1271) ---
+    # Runs AFTER cluster_memories() and BEFORE _iter_reflections().
+    # The classifier is additive: it does not mutate clusters or affect
+    # the reflection-writing path. A failing classifier logs a warning
+    # and continues — the reflection pipeline keeps running.
+    classifications: list[dict[str, Any]] = []
+    try:
+        classifications = classify_clusters(clusters)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("classify_clusters failed (continuing): %s", exc)
+
+    pi_filed = 0
+    for cls in classifications:
+        result = emit_process_improvement_issue(
+            cls,
+            dry_run=args.dry_run,
+            repo=getattr(args, "gh_repo", None),
+        )
+        if result:
+            pi_filed += 1
+            if not args.dry_run:
+                log.info("Filed process-improvement issue: %s", result)
+
+    print(
+        f"Found {len(classifications)} process-improvement candidate(s); "
+        f"filed {pi_filed} issue(s)."
+    )
 
     if args.dry_run:
         print("Dry run; no LLM calls, no files written.")

--- a/scripts/dream/tests/test_reflect.py
+++ b/scripts/dream/tests/test_reflect.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import sqlite3
 import struct
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -827,3 +827,325 @@ class TestLlmTimeoutConfig:
         # regressions to the old 60s value.
         assert captured["timeout"] == reflect.DEFAULT_LLM_TIMEOUT_S
         assert reflect.DEFAULT_LLM_TIMEOUT_S >= 120
+
+
+# ---------------------------------------------------------------------------
+# Task 3.1 — detect_signals() and classify_clusters() (Feature D, GH-1271)
+# ---------------------------------------------------------------------------
+
+
+def _make_raw_row(
+    id: str,
+    content: str = "",
+) -> reflect.RawMemoryRow:
+    import numpy as np
+
+    return reflect.RawMemoryRow(
+        id=id,
+        content=content,
+        path=f"/tmp/{id}.md",
+        date="2026-05-16T10:00:00+00:00",
+        embedding=np.zeros(384, dtype=np.float32),
+    )
+
+
+class TestDetectSignals:
+    def test_no_signals_clean_content(self) -> None:
+        row = _make_raw_row("r1", "everything went fine")
+        assert reflect.detect_signals(row) == set()
+
+    def test_tool_use_error_detected_case_insensitive(self) -> None:
+        row = _make_raw_row("r2", "Got a TOOL_USE_ERROR from the API")
+        assert "tool_use_error" in reflect.detect_signals(row)
+
+    def test_verdict_blocked_detected(self) -> None:
+        row = _make_raw_row("r3", "result: verdict: BLOCKED on step 3")
+        assert "verdict_blocked" in reflect.detect_signals(row)
+
+    def test_verdict_blocked_with_spaces(self) -> None:
+        row = _make_raw_row("r4", "verdict :  BLOCKED (escalated)")
+        assert "verdict_blocked" in reflect.detect_signals(row)
+
+    def test_both_signals_detected(self) -> None:
+        row = _make_raw_row(
+            "r5",
+            "tool_use_error logged; verdict: BLOCKED by hook",
+        )
+        sigs = reflect.detect_signals(row)
+        assert "tool_use_error" in sigs
+        assert "verdict_blocked" in sigs
+
+    def test_empty_content(self) -> None:
+        row = _make_raw_row("r6", "")
+        assert reflect.detect_signals(row) == set()
+
+
+class TestClassifyClusters:
+    def test_cluster_below_size_threshold_not_classified(self) -> None:
+        # 3 members with 100% signal — below default threshold of 5
+        cluster = [
+            _make_raw_row(f"r{i}", "tool_use_error occurred") for i in range(3)
+        ]
+        results = reflect.classify_clusters([cluster], size_threshold=5)
+        assert results == []
+
+    def test_cluster_above_size_below_signal_fraction_not_classified(self) -> None:
+        # 6 members but only 1 has a signal → fraction 1/6 ≈ 0.17 < 0.3
+        members = [_make_raw_row(f"r{i}", "normal memory") for i in range(5)]
+        members.append(_make_raw_row("r5", "tool_use_error"))
+        results = reflect.classify_clusters(
+            [members], size_threshold=5, signal_fraction_threshold=0.3
+        )
+        assert results == []
+
+    def test_cluster_above_both_thresholds_tool_use_error_classified(self) -> None:
+        # 6 members, 3 with tool_use_error → fraction 0.5 >= 0.3
+        members = [
+            _make_raw_row(f"r{i}", "tool_use_error in step") for i in range(3)
+        ] + [_make_raw_row(f"clean{i}", "normal memory") for i in range(3)]
+        results = reflect.classify_clusters(
+            [members], size_threshold=5, signal_fraction_threshold=0.3
+        )
+        assert len(results) == 1
+        r = results[0]
+        assert r["cluster_index"] == 0
+        assert r["size"] == 6
+        assert r["signal_counts"]["tool_use_error"] == 3
+        assert r["signal_counts"]["verdict_blocked"] == 0
+        assert r["theme_hint"] == "tool_use_error"
+
+    def test_cluster_with_mixed_signals_classified(self) -> None:
+        # 6 members: 2 tool_use_error, 2 verdict_blocked, 2 clean
+        members = (
+            [_make_raw_row(f"te{i}", "tool_use_error") for i in range(2)]
+            + [_make_raw_row(f"vb{i}", "verdict: BLOCKED") for i in range(2)]
+            + [_make_raw_row(f"cl{i}", "normal") for i in range(2)]
+        )
+        results = reflect.classify_clusters(
+            [members], size_threshold=5, signal_fraction_threshold=0.3
+        )
+        assert len(results) == 1
+        r = results[0]
+        assert r["signal_counts"]["tool_use_error"] == 2
+        assert r["signal_counts"]["verdict_blocked"] == 2
+        assert r["theme_hint"] == "mixed"
+
+    def test_empty_cluster_list_returns_empty(self) -> None:
+        assert reflect.classify_clusters([]) == []
+
+    def test_env_var_override_applies(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RALPH_DREAM_PROCESS_IMPROVEMENT_MIN_CLUSTER", "3")
+        import importlib
+        importlib.reload(reflect)
+        assert reflect.DEFAULT_CLUSTER_SIZE_THRESHOLD == 3
+        # Restore for other tests
+        monkeypatch.delenv("RALPH_DREAM_PROCESS_IMPROVEMENT_MIN_CLUSTER")
+        importlib.reload(reflect)
+
+
+# ---------------------------------------------------------------------------
+# Task 3.2 — emit_process_improvement_issue() (Feature D, GH-1271)
+# ---------------------------------------------------------------------------
+
+
+def _make_classification(size: int = 6) -> dict[str, Any]:
+    return {
+        "cluster_index": 0,
+        "size": size,
+        "signal_counts": {"tool_use_error": 3, "verdict_blocked": 1},
+        "sample_ids": [f"raw-{i:02d}" for i in range(size)],
+        "theme_hint": "tool_use_error",
+    }
+
+
+class TestEmitProcessImprovementIssue:
+    def test_dry_run_prints_payload_returns_truthy(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cls = _make_classification()
+        result = reflect.emit_process_improvement_issue(cls, dry_run=True)
+        assert result  # truthy ("<dry-run>")
+        out = capsys.readouterr().out
+        assert "title:" in out
+        assert "[process-improvement]" in out
+        assert "labels:" in out
+        assert "## Source" in out
+        assert "## Suggested Team: caretakers" in out
+        assert "<details>" in out
+
+    def test_live_mode_monkeypatched_success_returns_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cls = _make_classification()
+        fake_url = "https://github.com/cdubiel08/ralph-hero/issues/9999"
+
+        def fake_run(cmd, **kwargs):  # noqa: ANN001, ARG001
+            class R:
+                returncode = 0
+                stdout = fake_url
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(reflect.subprocess, "run", fake_run)
+        result = reflect.emit_process_improvement_issue(cls, dry_run=False)
+        assert result == fake_url
+
+    def test_live_mode_monkeypatched_failure_logs_warning_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        cls = _make_classification()
+        caplog.set_level("WARNING", logger="ralph.dream.reflect")
+
+        def fake_run(cmd, **kwargs):  # noqa: ANN001, ARG001
+            class R:
+                returncode = 1
+                stdout = ""
+                stderr = "label not found"
+            return R()
+
+        monkeypatch.setattr(reflect.subprocess, "run", fake_run)
+        result = reflect.emit_process_improvement_issue(cls, dry_run=False)
+        assert result is None
+        assert any("failed" in r.message for r in caplog.records)
+
+    def test_payload_contains_all_required_sections(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cls = _make_classification()
+        reflect.emit_process_improvement_issue(cls, dry_run=True)
+        out = capsys.readouterr().out
+        for required in ("## Source", "## Suggested Team: caretakers", "<details>"):
+            assert required in out, f"Missing required section: {required!r}"
+
+
+# ---------------------------------------------------------------------------
+# Task 3.3 — main() integration: classifier threaded in (Feature D, GH-1271)
+# ---------------------------------------------------------------------------
+
+
+class TestMainClassifierIntegration:
+    def test_emit_called_and_reflections_still_run(
+        self,
+        tmp_path: Path,
+        patch_vec_loader: None,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Classifier fires, emit is called, and _iter_reflections still
+        processes the cluster (classifier is additive, not replacement)."""
+        import yaml as _yaml
+
+        db = tmp_path / "knowledge.db"
+        _seed_db(db, _orthogonal_cluster_fixture(n_per_cluster=8))
+
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            _yaml.safe_dump(
+                {
+                    "base_dir": str(tmp_path / "out"),
+                    "knowledge_db": str(db),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        emit_calls: list[dict[str, Any]] = []
+
+        def fake_emit(classification, dry_run=False, repo=None):  # noqa: ANN001
+            emit_calls.append({"classification": classification, "dry_run": dry_run})
+            return "<dry-run>" if dry_run else "https://github.com/test/issues/1"
+
+        iter_calls: list[int] = []
+
+        def fake_iter(clusters, llm_url, model, *, dry_run):  # noqa: ANN001
+            cluster_list = list(clusters)
+            iter_calls.append(len(cluster_list))
+            # Yield a fake reflection so main() doesn't trigger non-zero exit
+            fake_ref = {
+                "title": "t", "summary": "s", "insights": [],
+                "source_ids": [], "cluster_size": 1,
+            }
+            return iter([(cluster_list[0] if cluster_list else [], fake_ref)])
+
+        # Return a tool-error-heavy cluster so the classifier fires
+        heavy = [
+            _make_raw_row(f"raw-te-{i:02d}", "tool_use_error on step 3")
+            for i in range(8)
+        ]
+        # Stub fetch so main() doesn't short-circuit on empty DB
+        monkeypatch.setattr(reflect, "fetch_recent_raw_memories", lambda _db, _s: heavy)
+        monkeypatch.setattr(reflect, "cluster_memories", lambda _m: [heavy])
+        monkeypatch.setattr(reflect, "emit_process_improvement_issue", fake_emit)
+        monkeypatch.setattr(reflect, "_iter_reflections", fake_iter)
+        monkeypatch.setattr(reflect, "write_reflection", lambda r, base_dir, **kw: tmp_path / "fake.md")
+
+        rc = reflect.main(
+            [
+                "--config", str(cfg_path),
+                "--since", "2026-05-15",
+            ]
+        )
+        # emit was called for the classified cluster
+        assert len(emit_calls) >= 1
+        # _iter_reflections was called (reflection path kept running)
+        assert len(iter_calls) >= 1
+        out = capsys.readouterr().out
+        assert "process-improvement candidate" in out
+        assert rc == 0
+
+    def test_dry_run_skips_gh_calls(
+        self,
+        tmp_path: Path,
+        patch_vec_loader: None,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With --dry-run: no gh subprocess.run calls are made even when
+        a classifier-triggering cluster is present."""
+        import yaml as _yaml
+
+        db = tmp_path / "knowledge.db"
+        _seed_db(db, [])
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            _yaml.safe_dump(
+                {
+                    "base_dir": str(tmp_path / "out"),
+                    "knowledge_db": str(db),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        gh_calls: list[Any] = []
+
+        def fail_if_called(*args, **kwargs):  # noqa: ANN001, ARG001
+            gh_calls.append(args)
+            raise AssertionError("gh must not be called in dry-run")
+
+        # Inject memories and a heavy cluster so the classifier path runs
+        heavy = [
+            _make_raw_row(f"raw-dr-{i:02d}", "tool_use_error on step 3")
+            for i in range(8)
+        ]
+        monkeypatch.setattr(reflect, "fetch_recent_raw_memories", lambda _db, _s: heavy)
+        monkeypatch.setattr(reflect, "cluster_memories", lambda _m: [heavy])
+        monkeypatch.setattr(reflect.subprocess, "run", fail_if_called)
+
+        rc = reflect.main(
+            [
+                "--config", str(cfg_path),
+                "--since", "2026-05-15",
+                "--dry-run",
+            ]
+        )
+        assert rc == 0
+        # subprocess.run must not have been called (dry-run prints payload, no gh)
+        assert gh_calls == []
+        out = capsys.readouterr().out
+        assert "Dry run" in out
+        assert "process-improvement candidate" in out

--- a/thoughts/shared/plans/2026-05-16-GH-1271-event-shims.md
+++ b/thoughts/shared/plans/2026-05-16-GH-1271-event-shims.md
@@ -190,9 +190,9 @@ Build a launchd-scheduled Python subscriber that pulls messages from the existin
 
 #### Automated Verification:
 
-- [ ] `cd plugin/ralph-hero/scripts/monitoring-bridge && uv run ruff check .` — no errors
-- [ ] `bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh` — exits 0
-- [ ] `plutil -lint plugin/ralph-hero/scripts/monitoring-bridge/launchd/com.ralph.monitoring-bridge.plist.template` — well-formed plist
+- [x] `cd plugin/ralph-hero/scripts/monitoring-bridge && uv run ruff check .` — no errors
+- [x] `bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh` — exits 0
+- [x] `plutil -lint plugin/ralph-hero/scripts/monitoring-bridge/launchd/com.ralph.monitoring-bridge.plist.template` — well-formed plist
 
 #### Manual Verification:
 
@@ -258,7 +258,7 @@ Promote `ralph-debug-collate` from interactive to scheduled. Add a `--auto-confi
 
 #### Automated Verification:
 
-- [ ] `bash plugin/ralph-hero/scripts/watch/smoke.sh` — exits 0 with both new assertions passing
+- [x] `bash plugin/ralph-hero/scripts/watch/smoke.sh` — exits 0 with both new assertions passing
 
 #### Manual Verification:
 
@@ -331,8 +331,8 @@ Add a `classify_clusters()` step to `scripts/dream/reflect.py` that runs between
 
 #### Automated Verification:
 
-- [ ] `cd scripts/dream && uv run pytest` — all tests pass (including the new ones)
-- [ ] `cd scripts/dream && uv run ruff check .` — no errors
+- [x] `cd scripts/dream && uv run pytest` — all tests pass (including the new ones)
+- [x] `cd scripts/dream && uv run ruff check .` — no errors
 
 #### Manual Verification:
 
@@ -383,9 +383,9 @@ Edit `plugin/ralph-hero/skills/director/event-classes.md` to: (1) remove the `(p
 
 #### Automated Verification:
 
-- [ ] `grep -c 'placeholder' plugin/ralph-hero/skills/director/event-classes.md` — returns 0
-- [ ] `grep -c '## Producers' plugin/ralph-hero/skills/director/event-classes.md` — returns 1
-- [ ] File still parses as markdown (`head -20` shows valid frontmatter if present)
+- [x] `grep -c 'placeholder' plugin/ralph-hero/skills/director/event-classes.md` — returns 0
+- [x] `grep -c '## Producers' plugin/ralph-hero/skills/director/event-classes.md` — returns 1
+- [x] File still parses as markdown (`head -20` shows valid frontmatter if present)
 
 #### Manual Verification:
 


### PR DESCRIPTION
## Summary

Implements **Feature D: Event shims** — three producers that land non-issue events (Cloud Monitoring alerts, Langfuse error spikes, dream-loop recurring-failure clusters) directly on the board as labeled draft issues, eliminating the human ingestion step.

Closes #1271

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-16-GH-1271-event-shims.md

## Changes by phase

**Phase 1 — Cloud Monitoring → board** (`plugin/ralph-hero/scripts/monitoring-bridge/`)
- `subscribe.py` deterministic GCP alert → `watcher-auto` labeled issue; `--dry-run` reads fixture; idempotency marker `<!-- gcp-policy: <id> -->`; no LLM calls
- `pyproject.toml`, `smoke.sh` (10 checks), `launchd/com.ralph.monitoring-bridge.plist.template` (StartInterval=300)

**Phase 2 — Langfuse → board** (`plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md` + Watcher integration)
- `ralph-debug-collate` gains `--auto-confirm` flag (Step 5 confirm gate; plan cited Step 4 — corrected per reviewer nit)
- Watcher heartbeat invokes `ralph-debug-collate --auto-confirm --since 24h --min-occurrences 3` behind `RALPH_DEBUG=true` preflight (skip-warn if unset)
- `watch/smoke.sh` extended with 2 Feature D checks (9-10)

**Phase 3 — Dream-loop → board** (`scripts/dream/reflect.py`, `scripts/dream/tests/test_reflect.py`)
- `detect_signals()` pure-fn detection of `tool_use_error` / `verdict_blocked` in memory content
- `classify_clusters()` size + signal-fraction filter; env-var overridable thresholds
- `emit_process_improvement_issue()` iOS-friendly issue via `gh issue create`; dry-run mode; soft-fail on errors
- 43 pytest tests passing (18 new), ruff clean

**Phase 4 — Director taxonomy patch** (`plugin/ralph-hero/skills/director/event-classes.md`)
- Promoted `watcher-auto` and `process-improvement` rows from placeholder to live
- Added `debug-auto` row routing to watchers
- Appended `## Producers` section: label → producer file → trigger condition

## Forward-compatibility note (important for merge order)

Phase 2 wires the langfuse scheduled run into the Watcher heartbeat. **Feature C (#1270 PR #1278) is currently in Human Needed and unmerged.** The impl-agent authored Phase 2 against the GH-1270 worktree version of `plugin/ralph-hero/skills/watch/SKILL.md`, `HEARTBEAT.md`, and `scripts/watch/smoke.sh`, so this PR carries the **combined Feature C + Feature D content** on those three files.

Reviewer options:
1. **Merge GH-1270 first** → rebase this PR (clean diff, no Watcher files)
2. **Merge this PR first** → Watcher files land here; GH-1270 PR will need rebase/conflict-resolution against this PR's content
3. **Hold both until GH-1270 resolves** → coordinate as a single merge wave

`watch/smoke.sh` checks 9-10 (Feature D assertions) currently `_skip` the Feature C artifact pre-checks for forward-compat — smoke exits 0 (11 passed, 4 skipped).

## Test plan

- [x] `cd plugin/ralph-hero/scripts/monitoring-bridge && bash smoke.sh` — 10 checks pass
- [x] `cd scripts/dream && uv run pytest` — 43 tests pass (18 new for classifier)
- [x] `bash plugin/ralph-hero/scripts/watch/smoke.sh` — 11 passed, 4 skipped, exits 0
- [x] `ruff check scripts/dream/` clean
- [ ] Manual: deploy `monitoring-bridge` launchd plist; verify a synthetic alert lands as `watcher-auto` issue
- [ ] Manual: dream-loop nightly run with synthetic high-signal cluster → confirms `process-improvement` issue creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)