### PR TITLE
feat(ios-remote): Feature H — iOS remote-control integration (GH-1275)

### DIFF
--- a/plugin/ralph-hero/scripts/cos/README.md
+++ b/plugin/ralph-hero/scripts/cos/README.md
@@ -131,6 +131,26 @@ cat ~/.ralph-hero/cos/runs/$(date +%Y-%m-%d).jsonl
 
 ---
 
+## Five-team rollup
+
+Since Feature H (GH-1275), `cos` output covers all five teams in the unified agent organization: **Builders**, **Watchers**, **Scouts**, **Memorykeepers**, and **Caretakers**.
+
+Team attribution uses the Director event-classes taxonomy (see `plugin/ralph-hero/skills/director/event-classes.md` as the canonical source):
+
+| Team | Attribution method | Label / filter |
+|------|--------------------|----------------|
+| Builders | workflow state | `In Progress`, `In Review` (no automation label for builders) |
+| Watchers | label | `watcher-auto` (Priority 2, written by monitoring bridge) |
+| Scouts | label | `scout-auto` (Priority 2, written by scout scheduling hook) |
+| Memorykeepers | placeholder | no producer yet; reserved in event-classes.md |
+| Caretakers | label | `process-improvement` (Priority 2, written by dream-loop classifier) |
+
+Each section in the cos output shows: open issue count, titles of top 3 by priority, and a one-line WIP sentence.
+
+For the iOS workflow (trigger teams from your phone, receive ntfy pushes, open Drive artifacts), see [`../skills/director/IOS-REMOTE.md`](../skills/director/IOS-REMOTE.md).
+
+---
+
 ## Write gate
 
 Write tools (`save_issue`, `create_issue`, `batch_update`, etc.) are **deliberately omitted**

--- a/plugin/ralph-hero/scripts/cos/smoke.sh
+++ b/plugin/ralph-hero/scripts/cos/smoke.sh
@@ -95,7 +95,33 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 7. Clean up
+# 7. Five-team rollup assertion (Feature H, GH-1275)
+#    Gated on pi + mlx-openai-server being available (already checked above).
+#    Asks cos.sh to emit a five-team status rollup and asserts all five section
+#    headers appear in the output.
+# ---------------------------------------------------------------------------
+echo ""
+echo "Running five-team rollup assertion..."
+ROLLUP_FILE="/tmp/cos-smoke-rollup.txt"
+rm -f "$ROLLUP_FILE"
+
+"$COS_SH" --role smol "Output a five-team status rollup with sections for Builders, Watchers, Scouts, Memorykeepers, and Caretakers. Write the output to /tmp/cos-smoke-rollup.txt." || true
+
+if [[ -f "$ROLLUP_FILE" ]]; then
+    for section in "Builders" "Watchers" "Scouts" "Memorykeepers" "Caretakers"; do
+        if grep -q "$section" "$ROLLUP_FILE"; then
+            _pass "Five-team rollup contains '${section}' section"
+        else
+            _fail "Five-team rollup missing '${section}' section"
+        fi
+    done
+    rm -f "$ROLLUP_FILE"
+else
+    _fail "Five-team rollup file was not created at ${ROLLUP_FILE}"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Clean up
 # ---------------------------------------------------------------------------
 rm -f "$SMOKE_FILE"
 

--- a/plugin/ralph-hero/scripts/lib/push-artifact.sh
+++ b/plugin/ralph-hero/scripts/lib/push-artifact.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# push-artifact.sh — shared gdrive-push helper with iOS-mode sentinel awareness
+#
+# Feature H (GH-1275): iOS remote-control integration
+# Plan: thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md (Phase 3, Task 3.1)
+#
+# CLI signature:
+#   push-artifact.sh <path> [description] [--push-drive | --no-push-drive]
+#
+# Decision logic (evaluated in this exact order — explicit flags win first):
+#   1. If --no-push-drive was passed: SKIP (explicit operator opt-out always wins)
+#   2. Else if --push-drive was passed: PUSH (explicit operator opt-in always wins)
+#   3. Else if ${TMPDIR:-/tmp}/ralph-ios-mode exists: PUSH (Phase 0 sentinel)
+#   4. Else if RALPH_IOS_MODE is non-empty: PUSH (legacy env var manual override)
+#   5. Else: SKIP (desk-mode default OFF)
+#
+# On PUSH: invokes gdrive-push skill via `claude -p`, parses stdout for Drive URL.
+# On SKIP or failure: exits 0 with empty stdout (no warning for the expected default-OFF case).
+#
+# Returns:
+#   stdout: Drive URL (one line) on successful push; empty on skip or failure
+#   stderr: diagnostic messages (only on failure or RALPH_COS_DEBUG=1)
+#   exit:   always 0 (best-effort)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing — centralized; callers forward flags unparsed
+# ---------------------------------------------------------------------------
+ARTIFACT_PATH=""
+DESCRIPTION=""
+PUSH_FLAG=""   # "push" | "no-push" | "" (unset = use sentinel/env logic)
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --push-drive)    PUSH_FLAG="push";    shift ;;
+        --no-push-drive) PUSH_FLAG="no-push"; shift ;;
+        *)
+            if [[ -z "$ARTIFACT_PATH" ]]; then
+                ARTIFACT_PATH="$1"
+            elif [[ -z "$DESCRIPTION" ]]; then
+                DESCRIPTION="$1"
+            fi
+            shift ;;
+    esac
+done
+
+if [[ -z "$ARTIFACT_PATH" ]]; then
+    echo "[push-artifact] ERROR: no path provided" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Decision logic (rules 1–5)
+# ---------------------------------------------------------------------------
+DECISION="skip"
+RULE=5
+
+if [[ "$PUSH_FLAG" == "no-push" ]]; then
+    DECISION="skip"
+    RULE=1
+elif [[ "$PUSH_FLAG" == "push" ]]; then
+    DECISION="push"
+    RULE=2
+elif [[ -f "${TMPDIR:-/tmp}/ralph-ios-mode" ]]; then
+    DECISION="push"
+    RULE=3
+elif [[ -n "${RALPH_IOS_MODE:-}" ]]; then
+    DECISION="push"
+    RULE=4
+fi
+
+if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+    echo "[push-artifact] decision=${DECISION} rule=${RULE} path=${ARTIFACT_PATH}" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# SKIP path — silent exit (no warning; this is the expected desk-mode default)
+# ---------------------------------------------------------------------------
+if [[ "$DECISION" == "skip" ]]; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# PUSH path — invoke gdrive-push skill via claude -p
+# ---------------------------------------------------------------------------
+GDRIVE_CMD="'/gdrive-push ${ARTIFACT_PATH}'"
+if [[ -n "$DESCRIPTION" ]]; then
+    GDRIVE_CMD="'/gdrive-push ${ARTIFACT_PATH} \"${DESCRIPTION}\"'"
+fi
+
+GDRIVE_OUTPUT=""
+rc=0
+GDRIVE_OUTPUT=$(claude -p "/gdrive-push ${ARTIFACT_PATH}${DESCRIPTION:+ \"${DESCRIPTION}\"}" 2>&1) || rc=$?
+
+if [[ "$rc" -ne 0 ]]; then
+    echo "[push-artifact] gdrive-push failed — artifact still landed locally at ${ARTIFACT_PATH}" >&2
+    exit 0
+fi
+
+# Parse Drive URL from output (gdrive-push emits https://drive.google.com/file/d/... URLs)
+DRIVE_URL=$(printf '%s\n' "$GDRIVE_OUTPUT" | grep -oE 'https://drive\.google\.com/[^ ]+' | head -1 || true)
+
+if [[ -n "$DRIVE_URL" ]]; then
+    if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+        echo "[push-artifact] drive_url=${DRIVE_URL}" >&2
+    fi
+    printf '%s\n' "$DRIVE_URL"
+else
+    echo "[push-artifact] gdrive-push succeeded but no Drive URL found in output" >&2
+fi
+
+exit 0

--- a/plugin/ralph-hero/scripts/lib/push-on-completion.sh
+++ b/plugin/ralph-hero/scripts/lib/push-on-completion.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# push-on-completion.sh — shared ntfy completion-push helper
+#
+# Feature H (GH-1275): iOS remote-control integration
+# Plan: thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md (Phase 2, Task 2.1)
+#
+# Reuses the ntfy pattern from cos Phase 3 (GH-1255):
+#   - Topic: RALPH_COS_NTFY_TOPIC env var
+#   - Body:  "$message ($url)" truncated to 117 chars + "..."
+#   - Graceful degradation: missing ntfy binary or unset topic → warn + exit 0
+#
+# Usage (CLI form):
+#   push-on-completion.sh "message" "url"
+#
+# Usage (sourced form — exposes push_on_completion function):
+#   source push-on-completion.sh
+#   push_on_completion "message" "url"
+#
+# Exit codes:
+#   0  always (best-effort; the underlying operation already succeeded)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Core function — works whether sourced or exec'd
+# ---------------------------------------------------------------------------
+push_on_completion() {
+    local message="${1:-}"
+    local url="${2:-}"
+
+    # Guard: topic must be set
+    if [[ -z "${RALPH_COS_NTFY_TOPIC:-}" ]]; then
+        echo "[push-on-completion] ntfy push skipped — RALPH_COS_NTFY_TOPIC not set" >&2
+        return 0
+    fi
+
+    # Guard: ntfy binary must be on PATH
+    if ! command -v ntfy >/dev/null 2>&1; then
+        echo "[push-on-completion] ntfy not installed — push skipped" >&2
+        return 0
+    fi
+
+    # Build body: "$message ($url)", truncated to 117 chars + "..." if needed
+    local raw_body="${message} (${url})"
+    local body
+    if [[ ${#raw_body} -gt 117 ]]; then
+        body="${raw_body:0:117}..."
+    else
+        body="$raw_body"
+    fi
+
+    if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+        echo "[push-on-completion] topic=${RALPH_COS_NTFY_TOPIC} body=${body}" >&2
+    fi
+
+    # Fire the push
+    local rc=0
+    ntfy publish "${RALPH_COS_NTFY_TOPIC}" "${body}" || rc=$?
+
+    if [[ "${RALPH_COS_DEBUG:-}" == "1" ]]; then
+        echo "[push-on-completion] ntfy exit_code=${rc}" >&2
+    fi
+
+    if [[ "$rc" -eq 0 ]]; then
+        echo "[push-on-completion] ntfy push: ok" >&2
+    else
+        echo "[push-on-completion] ntfy push: failed (exit ${rc})" >&2
+    fi
+
+    # Always exit 0 — best-effort, the underlying operation already succeeded
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint — only runs when exec'd directly (not when sourced)
+# ---------------------------------------------------------------------------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    push_on_completion "${1:-}" "${2:-}"
+fi

--- a/plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh
+++ b/plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# smoke-push-on-completion.sh — graceful-degradation smoke for push-on-completion.sh
+#
+# Feature H (GH-1275): iOS remote-control integration
+# Plan: thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md (Phase 2, Task 2.3)
+#
+# Tests the two graceful-degradation paths WITHOUT needing a real ntfy topic or binary:
+#   1. RALPH_COS_NTFY_TOPIC unset → exits 0 + stderr contains "skipped"
+#   2. RALPH_COS_NTFY_TOPIC=fake-topic + ntfy not on PATH → exits 0 + stderr contains "not installed"
+#
+# Does NOT test a live ntfy push — that requires a real topic and phone.
+#
+# Usage:
+#   bash plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh
+#
+# Exit codes:
+#   0   All checks passed
+#   1   One or more checks failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+HELPER="${SCRIPT_DIR}/push-on-completion.sh"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "[PASS] $1"; (( PASS++ )) || true; }
+_fail() { echo "[FAIL] $1" >&2; (( FAIL++ )) || true; }
+
+echo "=== push-on-completion.sh smoke test ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Syntax check
+# ---------------------------------------------------------------------------
+if bash -n "$HELPER" 2>/dev/null; then
+    _pass "push-on-completion.sh: no syntax errors"
+else
+    _fail "push-on-completion.sh: syntax error"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Graceful degradation: RALPH_COS_NTFY_TOPIC unset → exit 0 + "skipped"
+# ---------------------------------------------------------------------------
+stderr_out=$(RALPH_COS_NTFY_TOPIC= bash "$HELPER" "test message" "https://example.com" 2>&1) && rc=0 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    _pass "Unset topic: exits 0"
+else
+    _fail "Unset topic: expected exit 0, got ${rc}"
+fi
+if echo "$stderr_out" | grep -q "skipped"; then
+    _pass "Unset topic: stderr contains 'skipped'"
+else
+    _fail "Unset topic: stderr missing 'skipped' (got: ${stderr_out})"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Graceful degradation: topic set + ntfy not on PATH → exit 0 + "not installed"
+# ---------------------------------------------------------------------------
+stderr_out=$(RALPH_COS_NTFY_TOPIC=fake-topic PATH=/usr/bin:/bin bash "$HELPER" "test message" "https://example.com" 2>&1) && rc=0 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    _pass "ntfy off PATH: exits 0"
+else
+    _fail "ntfy off PATH: expected exit 0, got ${rc}"
+fi
+if echo "$stderr_out" | grep -q "not installed"; then
+    _pass "ntfy off PATH: stderr contains 'not installed'"
+else
+    _fail "ntfy off PATH: stderr missing 'not installed' (got: ${stderr_out})"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if (( FAIL > 0 )); then
+    exit 1
+fi
+
+echo "Smoke test PASSED."
+exit 0

--- a/plugin/ralph-hero/skills/cos/SKILL.md
+++ b/plugin/ralph-hero/skills/cos/SKILL.md
@@ -30,7 +30,7 @@ allowed-tools:
 
 # Ralph COS — Chief of Staff
 
-The COS skill surfaces project status, WIP, and priorities. It dispatches to one of three operating modes based on the first argument.
+The COS skill surfaces agent organization status across all five teams (Builders, Watchers, Scouts, Memorykeepers, Caretakers). It dispatches to one of three operating modes based on the first argument.
 
 ## Modes
 

--- a/plugin/ralph-hero/skills/cos/system-prompt.md
+++ b/plugin/ralph-hero/skills/cos/system-prompt.md
@@ -37,3 +37,29 @@ Brief, factual, no narration of internal steps. One paragraph maximum. No preamb
 ## Grading rubric
 
 Morning briefs are graded nightly against the 5-dimension rubric at `plugin/ralph-hero/skills/cos/rubric.md` (specificity, actionability, signal-vs-noise, novelty, brevity — each scored 1–5). Consistently low scores (mean < 3.5 over the last 7 briefs) trigger a self-improvement PR with a revised version of this system prompt for human review.
+
+---
+
+## Five-Team Rollup
+
+Surface all five teams in order. Each section: count, top 3 titles by priority, one WIP sentence ending `<Team> WIP: N issues open.`
+
+## Builders
+
+Query by workflow state (no automation label): `list_issues(workflowState:"In Progress", limit:5)` and `list_issues(workflowState:"In Review", limit:5)`. Use `pipeline_dashboard` for full picture.
+
+## Watchers
+
+Query by label `watcher-auto`: `list_issues(label:"watcher-auto", limit:5)`.
+
+## Scouts
+
+Query by label `scout-auto`: `list_issues(label:"scout-auto", limit:5)`.
+
+## Memorykeepers
+
+No automated producer yet. Render: `Memorykeepers: not yet shipping (no producer; reserved in event-classes.md).` Do NOT call list_issues.
+
+## Caretakers
+
+Query by label `process-improvement`: `list_issues(label:"process-improvement", limit:5)`.

--- a/plugin/ralph-hero/skills/director/IOS-REMOTE.md
+++ b/plugin/ralph-hero/skills/director/IOS-REMOTE.md
@@ -1,0 +1,227 @@
+# iOS Remote-Control Guide
+
+Supervise your Claude Code agent organization from your phone. This guide covers the four core iOS workflows: triggering a team, reading status summaries, receiving completion pushes, and opening Drive artifacts.
+
+No special iOS app is needed — the GitHub mobile app, Termius (or any SSH client), the ntfy app, and Google Drive are the entire cockpit.
+
+---
+
+## 1. Trigger a team from iOS
+
+Add a `trigger:<team>` label to any GitHub issue from the GitHub mobile app. Director picks it up on its next cycle, dispatches the team, and removes the label automatically.
+
+**Available trigger labels:**
+
+| Label | Team dispatched |
+|-------|----------------|
+| `trigger:builders` | Builder team (Hero orchestrator) |
+| `trigger:watch` | Watcher team (log monitoring, SRE) |
+| `trigger:scouts` | Scout team (on-PR + nightly test sweeps) |
+| `trigger:caretake` | Caretaker team (hygiene, triage) |
+| `trigger:memorykeepers` | Memorykeepers (no automation yet — Director emits a `needs input:` marker) |
+
+**Steps from the GitHub mobile app:**
+
+1. Open the issue you want to route.
+2. Tap **Labels** in the sidebar.
+3. Search for `trigger:watch` (or whichever team you want).
+4. Tap to apply. Done.
+
+Director will dispatch the team within its next `/schedule` tick (typically within a minute on an active session). You can also fire Director immediately from an SSH session:
+
+```bash
+ralph director
+```
+
+**How to know it worked:**
+
+- The `trigger:*` label disappears from the issue (Director consumes it at dispatch edge).
+- Director emits a `result: Dispatched #NNN to <team>` line in its session output.
+- If iOS-mode is active (sentinel written by Director), an ntfy push arrives when the team finishes (see section 3).
+
+---
+
+## 2. Read a status summary
+
+From a Termius SSH session (or any terminal on your phone), run:
+
+```bash
+ralph cos remote
+```
+
+This produces a phone-friendly 2–3 sentence summary via the local LLM — no Claude Code, no cloud round-trip. Output is cached for 30 minutes.
+
+For a full five-team breakdown:
+
+```bash
+ralph cos desk   # opens the Streamlit dashboard at localhost:8502 (Tailscale required from phone)
+```
+
+Or ask for a specific summary via cos:
+
+```bash
+ralph cos remote "What is the Watchers team working on?"
+```
+
+**What each section means:**
+
+- **Builders** — issues actively being implemented or in PR review (workflow states `In Progress` / `In Review`)
+- **Watchers** — open monitoring issues carrying the `watcher-auto` label (filed by the Cloud Monitoring → board bridge)
+- **Scouts** — open test-finding issues carrying the `scout-auto` label (filed by the nightly sweep)
+- **Memorykeepers** — placeholder; no automated producer yet
+- **Caretakers** — open hygiene / process improvement issues carrying the `process-improvement` label (filed by the dream-loop classifier)
+
+Each section ends with a one-line WIP sentence: `<Team> WIP: N issues open.`
+
+---
+
+## 3. Receive completion pushes
+
+When Director dispatches a team via a `trigger:*` label, it writes an iOS-mode sentinel at `${TMPDIR:-/tmp}/ralph-ios-mode`. Terminal handlers (currently `ralph-merge`) read this sentinel and fire an ntfy push on successful completion.
+
+**One-time setup:**
+
+1. Install ntfy on your Mac:
+   ```bash
+   brew install ntfy
+   ```
+
+2. Pick a private topic name (treat it like a private channel — hard to guess):
+   ```
+   cos-briefs-<yourname>-<random16hex>
+   # example: cos-briefs-cdubiel08-a3f8c2d1e5b7
+   ```
+
+3. Subscribe to the topic on your iPhone via the [ntfy app](https://ntfy.sh) (free, open source).
+
+4. Set the topic env var on your Mac (add to `~/.zshrc`):
+   ```bash
+   export RALPH_COS_NTFY_TOPIC=cos-briefs-<yourname>-<random16hex>
+   ```
+
+5. Reload your shell:
+   ```bash
+   source ~/.zshrc
+   ```
+
+**Events that fire a push:**
+
+- A PR merges successfully while iOS-mode sentinel is active (`ralph-merge` Step 9c)
+- The morning brief completes (unattended mode — always fires when topic is set)
+
+**Push body format:** `"<event summary> (<URL>)"`
+
+Example: `"Merged: feat(cos): five-team rollup (https://github.com/…/pull/1281)"`
+
+**Graceful degradation:** If `ntfy` is not installed or `RALPH_COS_NTFY_TOPIC` is unset, the push is silently skipped — the underlying operation still succeeds.
+
+**Manual override for testing (without a trigger label):**
+
+```bash
+export RALPH_IOS_MODE=1   # forces iOS-mode ON for the current shell session
+# run ralph-merge or ralph-pr as usual; push fires as if Director set the sentinel
+unset RALPH_IOS_MODE      # restore desk-mode default-OFF behavior
+```
+
+---
+
+## 4. Open Drive artifacts
+
+When iOS-mode is active, terminal handlers push artifacts to Google Drive and include a `Drive: <URL>` line in their GitHub issue comments. Tap the link from the GitHub mobile app to open the artifact in the Google Drive app on your iPhone.
+
+**Artifacts pushed automatically when iOS-mode is active:**
+
+| Handler | Artifact |
+|---------|---------|
+| `ralph-pr` | PR body summary (`.md` file) |
+| `ralph-postmortem` | Session post-mortem report (`.md` file) |
+| `scout-nightly` | Nightly test-sweep results (pending GH-1273 merge) |
+
+All artifacts land in the `claude-shared` Google Drive folder (managed by the `gdrive-push` skill). No per-team subfolders.
+
+**One-time setup (gws authentication):**
+
+The `gdrive-push` skill requires the Google Workspace CLI (`gws`) to be authenticated:
+
+```bash
+# Install gws (if not already installed)
+brew install gws-cli   # or see gws documentation for your platform
+
+# Authenticate once
+gws auth login
+```
+
+After authentication, `gdrive-push` works silently. If authentication lapses, the push is skipped with a warning and the artifact still lands locally — no data is lost.
+
+**Force Drive push from a desk session (without iOS-mode sentinel):**
+
+```bash
+ralph pr 1275 --push-drive         # explicit opt-in
+ralph pr 1275 --no-push-drive      # explicit opt-out (overrides sentinel if present)
+```
+
+The `--push-drive` / `--no-push-drive` CLI flag always wins over the sentinel and `RALPH_IOS_MODE`.
+
+---
+
+## Troubleshooting
+
+**No ntfy push arrived after a merge**
+
+1. Check `RALPH_COS_NTFY_TOPIC` is set in the shell where `ralph-merge` runs:
+   ```bash
+   echo "${RALPH_COS_NTFY_TOPIC:-UNSET}"
+   ```
+   If `UNSET`, add the export to `~/.zshrc` and reload.
+
+2. Check `ntfy` is installed on your Mac:
+   ```bash
+   command -v ntfy || echo "ntfy not found — brew install ntfy"
+   ```
+
+3. Check the iOS-mode sentinel was written (only fires if Director dispatched via `trigger:*`):
+   ```bash
+   ls -la "${TMPDIR:-/tmp}/ralph-ios-mode" 2>/dev/null || echo "sentinel not present"
+   ```
+   If absent: the merge was triggered from a desk session (sentinel absent = no push, by design). Use `RALPH_IOS_MODE=1` to force it.
+
+4. Check the ntfy app on your phone is subscribed to the correct topic — must exactly match `RALPH_COS_NTFY_TOPIC`.
+
+**Drive link missing from issue comment**
+
+1. Check `gws` authentication:
+   ```bash
+   gws auth status
+   ```
+   Re-authenticate with `gws auth login` if needed.
+
+2. Check that iOS-mode was active when the handler ran (same sentinel check as above).
+
+3. You can always push an artifact manually:
+   ```bash
+   bash plugin/ralph-hero/scripts/lib/push-artifact.sh \
+       thoughts/shared/reports/YYYY-MM-DD-ralph-team-foo.md \
+       "Postmortem: foo session" \
+       --push-drive
+   ```
+
+**Trigger label not consumed / team not dispatched**
+
+1. Confirm Director is running (via autopilot or manually):
+   ```bash
+   ralph director
+   ```
+
+2. Check the trigger label name exactly — must be `trigger:watch`, `trigger:scouts`, `trigger:caretake`, `trigger:builders`, or `trigger:memorykeepers` (not `watch`, not `trigger-watch`).
+
+3. If the team entrypoint is not yet implemented (e.g., `ralph-hero:watch` pending GH-1270), Director emits a `needs input:` marker and still consumes the label. Check the session output for `needs input: team watchers not yet implemented`.
+
+---
+
+## See also
+
+- [Director SKILL.md](SKILL.md) — event classifier and team dispatcher internals
+- [event-classes.md](event-classes.md) — canonical event taxonomy and iOS-mode sentinel contract
+- [cos README](../../scripts/cos/README.md) — five-team rollup, model roles, write gate
+- [cos Phase 3 plan](../../../../thoughts/shared/plans/2026-05-15-GH-1255-cos-phase3-morning-brief-ntfy.md) — underlying ntfy convention (topic env var, graceful degradation pattern)
+- [Feature H implementation plan](../../../../thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md) — full spec for this feature

--- a/plugin/ralph-hero/skills/director/SKILL.md
+++ b/plugin/ralph-hero/skills/director/SKILL.md
@@ -99,6 +99,16 @@ Set `DISPATCH_REASON=workflow_state:${ISSUE_WORKFLOW_STATE}`.
 
 Director dispatches using `Skill()`. It does NOT call `Agent()` — Director is an orchestrator, not a worker. Team entrypoints receive the issue number as a bare number `NNN` (not `--issue NNN`).
 
+**iOS-mode sentinel write (Feature H contract):**
+
+Before the `Skill()` call, if `DISPATCH_REASON` starts with `trigger:` OR equals `RemoteTrigger`, write the iOS-mode sentinel:
+
+```bash
+touch "${TMPDIR:-/tmp}/ralph-ios-mode"
+```
+
+This signals downstream producers (Feature H) that the current dispatch is iOS-initiated. Workflow_state-driven dispatches (Priority 3) do NOT write the sentinel — only Priority 1 (`trigger:*`) and `RemoteTrigger` paths do. The sentinel may persist until session end; that is intentional — producers running inside the dispatched session see it. No explicit cleanup is required.
+
 **Team → entrypoint mapping:**
 
 | team | entrypoint | status |
@@ -107,7 +117,7 @@ Director dispatches using `Skill()`. It does NOT call `Agent()` — Director is 
 | watchers | `ralph-hero:watch` | pending Feature C (GH-1270) |
 | scouts | `ralph-hero:scouts` | pending Feature F (GH-1273) |
 | memorykeepers | manual `dream-now` | no skill; Director emits `needs input:` |
-| caretakers | `ralph-hero:caretake` | pending Feature G (GH-1274) |
+| caretakers | `ralph-hero:caretake` | live (Feature G, GH-1274) |
 
 **If the target entrypoint exists (builders / live teams):**
 
@@ -180,3 +190,9 @@ result: Queue empty. No events to dispatch.
 - **Trigger-label priority**: `trigger:*` labels give humans and iOS shortcuts a direct, auditable override path without requiring a separate tool surface.
 - **Consumption at dispatch edge**: Removing the label after dispatch (not after team completion) ensures the trigger is not re-processed on the next tick even if the team runs long or fails.
 - **`needs input:` for unimplemented teams**: Director ships before Features C, F, and G. Emitting a marker instead of erroring keeps the system functional during the rollout window.
+
+## See also
+
+- [IOS-REMOTE.md](IOS-REMOTE.md) — user-facing guide: trigger teams from iOS, read `cos` summaries, receive ntfy completion pushes, open Drive artifacts
+- [event-classes.md](event-classes.md) — canonical event taxonomy and iOS-mode sentinel contract
+- [plugin/ralph-hero/skills/cos/SKILL.md](../cos/SKILL.md) — chief-of-staff five-team rollup

--- a/plugin/ralph-hero/skills/director/SKILL.md
+++ b/plugin/ralph-hero/skills/director/SKILL.md
@@ -46,7 +46,7 @@ Director accepts events from three sources in priority order:
 Parse `$ARGUMENTS` for an optional `--issue NNN` flag.
 
 - If `--issue NNN` is present: set `TARGET_ISSUE=NNN`. Skip to Step 2b.
-- If a `RemoteTrigger` tool input is present in the session context: extract `issue_number` and `team` from the tool payload. Set `TARGET_ISSUE` and `FORCED_TEAM` accordingly. Skip to Step 4 (dispatch directly with `FORCED_TEAM`).
+- If a `RemoteTrigger` tool input is present in the session context: extract `issue_number` and `team` from the tool payload. Set `TARGET_ISSUE`, `FORCED_TEAM`, and `DISPATCH_REASON=RemoteTrigger`. Skip to Step 4 (dispatch directly with `FORCED_TEAM`).
 - Otherwise: proceed to Step 2a (read `next_actions`).
 
 ### Step 2a: Read next_actions (no issue override)

--- a/plugin/ralph-hero/skills/director/event-classes.md
+++ b/plugin/ralph-hero/skills/director/event-classes.md
@@ -73,6 +73,16 @@ Director evaluates in this order:
 
 ---
 
+## iOS-mode sentinel (Feature H contract)
+
+Director writes the sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` immediately before `Skill()` dispatch when `DISPATCH_REASON` matches `trigger:*` or `RemoteTrigger`. Downstream producers (`ralph-pr`, `ralph-postmortem`, scout-nightly, `ralph-merge`) test for this file to decide whether `--push-drive` and ntfy completion hooks default ON.
+
+The legacy `RALPH_IOS_MODE=1` env var is also honored as a manual operator override (e.g., for desk-mode forced pushes during testing). If either the sentinel file OR `RALPH_IOS_MODE=1` is set, producers treat iOS-mode as active.
+
+Priority 3 (workflow_state-driven) dispatches do NOT write the sentinel — only Priority 1 (`trigger:*`) and `RemoteTrigger` paths do. The sentinel persists until `$TMPDIR` rotation or session end; no explicit cleanup is required.
+
+---
+
 ## Producers
 
 This table is the canonical inventory of automated label producers as of Feature D (GH-1271). New producers should add a row here when they land.

--- a/plugin/ralph-hero/skills/ralph-merge/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-merge/SKILL.md
@@ -309,6 +309,30 @@ After merging a PR, check if cross-repo dependents are now unblocked:
 
 Then stop — do not run Steps 6-9 (no merge, no Done transition).
 
+## Step 9c: iOS Completion Push (Feature H)
+
+After completing Step 9 (post completion comment), fire an ntfy push when iOS-mode is active.
+
+iOS-mode is active when either:
+- The sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` exists (written by Director on `trigger:*` or `RemoteTrigger` dispatch), OR
+- The env var `RALPH_IOS_MODE` is non-empty (manual operator override for desk-mode testing)
+
+```bash
+# iOS completion push — Feature H (GH-1275)
+# See: thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md Phase 2
+if [[ -f "${TMPDIR:-/tmp}/ralph-ios-mode" ]] || [[ -n "${RALPH_IOS_MODE:-}" ]]; then
+    bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/push-on-completion.sh" \
+        "Merged: ${PR_TITLE}" \
+        "${PR_URL}" || true
+fi
+```
+
+Where `PR_TITLE` is the PR title fetched in Step 3 and `PR_URL` is the PR URL.
+
+Failure of `push-on-completion.sh` does NOT fail the merge skill — the merge already succeeded. The `|| true` ensures this step is best-effort.
+
+`Bash` is already in ralph-merge's `allowed-tools`; no allowlist change is needed.
+
 ## Step 10: Report Result
 
 Output completion status:

--- a/plugin/ralph-hero/skills/ralph-postmortem/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-postmortem/SKILL.md
@@ -173,6 +173,28 @@ Create a new issue with:
 
 Update the blocker entry in the post-mortem to include the created issue number: `[issue created: #NNN]`
 
+## Step 6.5: Drive Push (Feature H)
+
+After writing the post-mortem report to disk (Step 4), optionally push it to Google Drive.
+
+iOS-mode is active when the sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` exists (Director writes it on `trigger:*` / `RemoteTrigger` dispatch) OR when `RALPH_IOS_MODE` is non-empty (manual operator override). The `push-artifact.sh` helper checks both conditions internally.
+
+ralph-postmortem has no CLI args (it is invoked inline by the team lead). The iOS-mode sentinel from Phase 0 (or the legacy `RALPH_IOS_MODE=1` env var) is the only opt-in path — no `--push-drive` / `--no-push-drive` flag is needed here.
+
+```bash
+# Drive push — Feature H (GH-1275)
+# See: thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md Phase 3
+DRIVE_URL=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/push-artifact.sh" \
+    "${REPORT_PATH}" \
+    "Postmortem: ${SESSION_SUMMARY}" 2>/dev/null || true)
+```
+
+Where `REPORT_PATH` is the path written in Step 4 and `SESSION_SUMMARY` is the report title (first H1 line, e.g., "Ralph Team Session Report: {team-name}").
+
+If `DRIVE_URL` is non-empty, include a `Drive: <URL>` line in any `## Postmortem` comment body posted on blocker issues. If `DRIVE_URL` is empty (skip or failure), the comment is posted unchanged — bit-identical to pre-Feature-H behavior.
+
+`Bash` is already in ralph-postmortem's `allowed-tools`; no allowlist change needed.
+
 ## Step 7: Commit and Push
 
 ```bash

--- a/plugin/ralph-hero/skills/ralph-pr/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull request for a completed implementation — pushes branch, creates PR via gh, moves issues to In Review. Use when you want to create a PR for a completed issue.
 user-invocable: false
-argument-hint: <issue-number> [--worktree path]
+argument-hint: <issue-number> [--worktree path] [--push-drive | --no-push-drive]
 context: fork
 model: haiku
 hooks:
@@ -337,9 +337,37 @@ This step runs after Step 6 (Move Issues to In Review) completes on the success 
 
 If the MCP call fails, log to stderr (`echo "outcome-record failed: ..." >&2`) and continue to Step 7.
 
+## Step 6.7: Drive Push (Feature H)
+
+After the outcome event (Step 6.5), optionally push the PR body to Google Drive.
+
+Parse `--push-drive` / `--no-push-drive` from the original arguments (forwarded unparsed to the helper — the helper performs centralized flag parsing).
+
+```bash
+# Drive push — Feature H (GH-1275)
+# See: thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md Phase 3
+PR_BODY_TMP=$(mktemp -t "ralph-pr-${ISSUE_NUMBER}-body-XXXXXX.md")
+# Write the PR body (same content as submitted to gh pr create) to the temp file
+cat > "$PR_BODY_TMP" <<'BODYEOF'
+[PR body content composed in Step 5 — substitute the actual rendered body here]
+BODYEOF
+
+DRIVE_URL=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/push-artifact.sh" \
+    "$PR_BODY_TMP" \
+    "PR for GH-${ISSUE_NUMBER}" \
+    ${PUSH_DRIVE_FLAG:+"$PUSH_DRIVE_FLAG"} 2>/dev/null || true)
+rm -f "$PR_BODY_TMP"
+```
+
+Where `PUSH_DRIVE_FLAG` is `--push-drive`, `--no-push-drive`, or unset (if the user passed no flag — the helper then decides based on the sentinel / `RALPH_IOS_MODE`).
+
+If `DRIVE_URL` is non-empty, append a `Drive: <URL>` line to the `## Pull Request` comment body composed in Step 7 BEFORE posting the comment. If `DRIVE_URL` is empty (skip or failure), the comment is posted unchanged — bit-identical to pre-Feature-H behavior.
+
+`Bash` is already in ralph-pr's `allowed-tools`; no allowlist change needed.
+
 ## Step 7: Post Comment
 
-Post a comment on the issue with the PR URL:
+Post a comment on the issue with the PR URL (include `Drive: <URL>` line if Step 6.7 returned a non-empty Drive URL):
 ```markdown
 ## Pull Request
 

--- a/thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md
+++ b/thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md
@@ -1,6 +1,7 @@
 ---
 date: 2026-05-16
 status: draft
+iteration: 2
 type: plan
 github_issue: 1275
 github_issues: [1275]
@@ -13,6 +14,17 @@ tags: [ios-remote, cos, ntfy, gdrive-push, director, integration]
 
 # Feature H: iOS Remote-Control Integration — Atomic Implementation Plan
 
+## Iteration Notes
+
+**Iteration 2 (2026-05-16)** — Addresses four FAIL-rated findings from `thoughts/shared/reviews/2026-05-16-GH-1275-critique.md`:
+
+- **Issue 1 (HIGH) — `RALPH_IOS_MODE=1` cross-plan-contract gap**: Verified that the merged Director skill (`plugin/ralph-hero/skills/director/SKILL.md`) and its `event-classes.md` do NOT set `RALPH_IOS_MODE`. Picked critique option B: drop the env-var dependency entirely. The `--push-drive` default is now keyed off Director's own dispatch path — Director writes a sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` when consuming a `trigger:*` label or a `RemoteTrigger` tool input, and producers test for that file. This Feature H ships the sentinel-writing code (one-line addition to Director's Step 5 + a small docs edit to `event-classes.md`), eliminating any forward dependency on Feature B in-flight work. The flag-and-env-var fallback (`--push-drive` / `--no-push-drive` CLI flag, and the legacy `RALPH_IOS_MODE` env var still respected as a manual operator opt-in) remain.
+- **Issue 2 (HIGH) — `team:<team>` labels fabricated**: Verified via grep across `plugin/ralph-hero/skills/` and all sibling plans — `team:watch`/`team:scout`/`team:caretake` etc. exist nowhere. Phase 1 now uses the actual label families Director recognizes: `watcher-auto` for Watchers, `scout-auto` for Scouts, `process-improvement` for Caretakers. Builders are detected via workflow-state membership (`In Progress` / `In Review` etc.) — no team-attribution label exists for builders today, but the workflow_state taxonomy in `event-classes.md` is the authoritative mapping. Memorykeepers has no producer yet; cos rollup shows a "not yet shipping" placeholder per critique option B's guidance.
+- **Issue 3 (MEDIUM) — `list_issues` signature**: Verified at `plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts:104` that the parameter is `label: string` (singular). Task 1.1 acceptance updated to issue one call per team via `{ label: "<label>" }` with the correct singular parameter name. For builders, `workflowState` filter is used instead of a label.
+- **Issue 4 (MEDIUM) — Task 3.4 scout-producer path**: Read `thoughts/shared/plans/2026-05-16-GH-1273-scout-scheduling.md`. The concrete producer is `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` (GH-1273 Task 4.1). The nightly script invokes `/ralph-playwright:test-e2e --label scout-auto`. Task 3.4 now points at this exact path. If GH-1273 has not yet merged at impl time, the task includes a forward-compat fallback (apply the `--push-drive` flag to whichever shape lands).
+
+Issues 5 and 6 from the critique are LOW-severity polish that the iterator also addressed pre-emptively (decision-logic reorder in Task 3.1; clarification of caller responsibilities).
+
 ## Prior Work
 
 - builds_on:: [[2026-05-16-GH-1267-unified-agent-system-epic]]
@@ -22,16 +34,17 @@ tags: [ios-remote, cos, ntfy, gdrive-push, director, integration]
 
 ## Overview
 
-Single GH-1275 issue (estimate S) implemented as four phases in one PR. This feature is the iOS-cockpit polish on top of the unified agent system. It depends on Director (GH-1269), Watcher (GH-1270), Scouts (GH-1273), and Caretakers (GH-1274) existing — but those features' deliverables are stubbed-or-real on disk before this plan starts. Feature H's job is to roll up all five teams in `cos`, wire ntfy push on team-session completion, integrate `gdrive-push` on PR/postmortem/scout-report producers, and ship the user-facing IOS-REMOTE.md doc.
+Single GH-1275 issue (estimate S) implemented as five phases in one PR. This feature is the iOS-cockpit polish on top of the unified agent system. It depends on Director (GH-1269, MERGED), Watcher (GH-1270), Scouts (GH-1273), and Caretakers (GH-1274) existing — Feature B is shipped; the others are stubbed-or-real on disk before this plan starts. Feature H's job is to write the iOS-mode sentinel inside Director's dispatch path, roll up all five teams in `cos`, wire ntfy push on team-session completion, integrate `gdrive-push` on PR/postmortem/scout-report producers, and ship the user-facing IOS-REMOTE.md doc.
 
 | Phase | Issue | Title | Estimate |
 |-------|-------|-------|----------|
+| 0 | GH-1275 | Director iOS-mode sentinel write | (phase of S) |
 | 1 | GH-1275 | cos five-team rollup | (phase of S) |
 | 2 | GH-1275 | ntfy completion hooks on team sessions | (phase of S) |
 | 3 | GH-1275 | gdrive-push --push-drive wiring on producers | (phase of S) |
 | 4 | GH-1275 | IOS-REMOTE.md user doc | (phase of S) |
 
-**Why phased as one PR**: All four phases share the same user-facing surface (the iOS workflow). They are individually atomic but lose meaning in isolation — the doc references rollups, ntfy, and Drive links that don't exist until phases 1–3 land. Shipping as one PR keeps the documentation accurate at merge time.
+**Why phased as one PR**: All five phases share the same user-facing surface (the iOS workflow). They are individually atomic but lose meaning in isolation — the doc references rollups, ntfy, and Drive links that don't exist until phases 0–3 land. Shipping as one PR keeps the documentation accurate at merge time.
 
 ## Shared Constraints
 
@@ -50,7 +63,7 @@ Inherited verbatim from `thoughts/shared/plans/2026-05-16-GH-1267-unified-agent-
 
 Feature-H-specific constraints:
 
-- **`--push-drive` defaults are direction-sensitive.** Default OFF for direct CLI invocations from a desk session (no Drive surprises). Default ON when invoked through Director's iOS-trigger path. The signal is the `RALPH_IOS_MODE=1` env var, which Director's dispatcher sets when consuming a `trigger:<team>` label (per Feature B). Producers read this env var to decide the default; the `--push-drive` / `--no-push-drive` CLI flag always overrides the env var.
+- **`--push-drive` defaults are direction-sensitive.** Default OFF for direct CLI invocations from a desk session (no Drive surprises). Default ON when invoked through Director's iOS-trigger path. The signal is a **sentinel file** at `${TMPDIR:-/tmp}/ralph-ios-mode` — Director writes the sentinel (touch-only, ignored content) immediately before its `Skill()` dispatch when the dispatch source is a `trigger:*` label or a `RemoteTrigger` tool input (Director's `DISPATCH_REASON` field already captures this; see `event-classes.md`). The sentinel survives across the dispatched skill's lifetime and is cleaned up at session end. Producers check `[[ -f "${TMPDIR:-/tmp}/ralph-ios-mode" ]]` to decide the default. The `--push-drive` / `--no-push-drive` CLI flag always overrides the sentinel. **Legacy fallback:** the env var `RALPH_IOS_MODE=1` is still respected as a manual operator opt-in (e.g., for desk-mode forced pushes during testing) — if either the sentinel OR `RALPH_IOS_MODE=1` is set, default is ON.
 - **ntfy topic is private to the operator.** Reuse the existing `RALPH_COS_NTFY_TOPIC` env var from cos Phase 3 (`thoughts/shared/plans/2026-05-15-GH-1255-cos-phase3-morning-brief-ntfy.md`). No new topic env var. The completion hook reads this env var at exit time; if unset, push skips with a stderr warning. No new ntfy infrastructure.
 - **Graceful degradation everywhere.** If `gws` (Google Workspace CLI) is unauthenticated, `gdrive-push` already errors out cleanly — producers must treat a non-zero `gdrive-push` exit as a warning, not a fatal error (the underlying artifact still landed). Same for ntfy: missing `ntfy` binary or unset topic → warn-and-continue.
 - **The cos five-team rollup is read-only.** No new MCP write tools added to the cos allowlist (per the cos Phase 1 PREFLIGHT.md rule). The rollup composes existing `list_issues` / `pipeline_dashboard` / `get_issue` calls filtered by team labels.
@@ -58,15 +71,15 @@ Feature-H-specific constraints:
 
 ## Sibling Context (inherited from invocation)
 
-- **Feature B Director (GH-1269) — PLANNED**: Produces `plugin/ralph-hero/skills/director/SKILL.md`, `plugin/ralph-hero/skills/director/event-classes.md`, the `RemoteTrigger` + `trigger:<team>` label dispatch contract. Director's dispatcher sets `RALPH_IOS_MODE=1` when consuming a trigger label — this feature consumes that env var to flip `--push-drive` defaults.
-- **Feature C Watcher (GH-1270) — PLANNED**: Produces `plugin/ralph-hero/skills/watch/SKILL.md`, `plugin/ralph-hero/skills/watch/SOUL.md`, `log-reader` + `sre-fixit` subagents, `/schedule` heartbeat. The cos five-team rollup expects a `team:watch` label or workflow-state filter on Watcher-produced issues — verify the convention in the Watcher plan at implementation time and follow it.
-- **Feature F Scouts (GH-1273) — PLANNED**: Produces `plugin/ralph-hero/skills/scouts/SOUL.md`, `pr-agent /scout` trigger comment, `merge-agent` gate, nightly `/schedule` routine creating `scout-auto` issues. The scout report producer (nightly sweep) is the third producer this feature wires for `gdrive-push`.
-- **Feature G Caretakers (GH-1274) — PLANNED**: Produces `plugin/ralph-hero/skills/caretake/SKILL.md`, `plugin/ralph-hero/skills/caretake/SOUL.md`, hourly hygiene / daily report / weekly trends schedules. The cos five-team rollup includes a Caretakers section that reads from the caretake state surface (probably `team:caretake` label on caretake-touched issues).
+- **Feature B Director (GH-1269) — MERGED**: Ships `plugin/ralph-hero/skills/director/SKILL.md`, `plugin/ralph-hero/skills/director/event-classes.md`, the `RemoteTrigger` + `trigger:<team>` label dispatch contract. **Verified**: Director sets no `RALPH_IOS_MODE` env var. The dispatch path's reliable signal is the `DISPATCH_REASON` string (`trigger:<label>` for label-driven dispatch, `RemoteTrigger` for tool-input dispatch, `workflow_state:*` for fallback). This Feature H ships a tiny one-line addition to Director's Step 5 to write a sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` whenever `DISPATCH_REASON` starts with `trigger:` or equals `RemoteTrigger` — Phase 0 below. Producers consume the sentinel.
+- **Feature C Watcher (GH-1270) — PLANNED**: Produces `plugin/ralph-hero/skills/watch/SKILL.md`, `plugin/ralph-hero/skills/watch/SOUL.md`, `log-reader` + `sre-fixit` subagents, `/schedule` heartbeat. Watcher issues carry the `watcher-auto` label (per `event-classes.md`'s Priority 2 row). The cos five-team rollup queries by `label: "watcher-auto"` for the Watchers section.
+- **Feature F Scouts (GH-1273) — PLANNED**: Produces `plugin/ralph-hero/skills/scouts/SOUL.md`, `pr-agent /scout` trigger comment, `merge-agent` gate, nightly `/schedule` routine creating `scout-auto` issues. The nightly sweep script (`plugin/ralph-hero/scripts/schedule/scout-nightly.sh`) is the scout-report producer; it shells out to `/ralph-playwright:test-e2e --label scout-auto`. Phase 3 of this plan wires `gdrive-push` into that script.
+- **Feature G Caretakers (GH-1274) — PLANNED**: Produces `plugin/ralph-hero/skills/caretake/SKILL.md`, `plugin/ralph-hero/skills/caretake/SOUL.md`, hourly hygiene / daily report / weekly trends schedules. Caretaker-produced issues carry the `process-improvement` label (per `event-classes.md`'s Priority 2 row). The cos five-team rollup queries by `label: "process-improvement"` for the Caretakers section.
 
 **Interface contract for this feature**:
-- `cos` extension: roll up state from all five teams (builders, watchers, scouts, memorykeepers, caretakers), not just builders. Team membership is determined by `team:<team>` label on issues OR by which orchestrator skill ran (recorded in the team-session log).
+- `cos` extension: roll up state from all five teams (builders, watchers, scouts, memorykeepers, caretakers), not just builders. Team attribution uses the **actual** label families Director recognizes (per `event-classes.md`): `watcher-auto`, `scout-auto`, `process-improvement`. Builders have no automation label — the cos prompt queries by workflow_state instead (any of `Research Needed`, `Research in Progress`, `Ready for Plan`, `Plan in Progress`, `Plan in Review`, `In Progress`, `In Review`). Memorykeepers has no producer yet — the section renders a "not yet shipping (Feature B taxonomy reserved)" placeholder.
 - ntfy hooks: fire on team-session completion (terminal handlers' last step) following the `2026-05-15-GH-1255-cos-phase3-morning-brief-ntfy.md` pattern. Single source of completion-push convention.
-- `gdrive-push --push-drive` wired into `ralph-pr` (PR artifact = the plan + diff summary), `ralph-postmortem` (postmortem .md), and the scout report producer (nightly sweep's `scout-auto` issue body or attached report). Default ON when `RALPH_IOS_MODE=1`; default OFF otherwise; CLI flag always wins.
+- `gdrive-push --push-drive` wired into `ralph-pr` (PR artifact = the plan + diff summary), `ralph-postmortem` (postmortem .md), and the scout-nightly producer (`scripts/schedule/scout-nightly.sh`). Default ON when the sentinel `${TMPDIR:-/tmp}/ralph-ios-mode` exists OR `RALPH_IOS_MODE=1` is set; default OFF otherwise; CLI flag always wins.
 - `plugin/ralph-hero/skills/director/IOS-REMOTE.md` covers: (a) trigger via labels, (b) read `cos` summaries, (c) receive ntfy pushes, (d) open Drive artifacts.
 
 ## Current State Analysis
@@ -79,13 +92,13 @@ After Features A–G land (sibling waves), the following are on disk:
 - **ralph-pr skill** (`plugin/ralph-hero/skills/ralph-pr/SKILL.md`) — terminal handler that pushes a branch, creates the PR via `gh`, and transitions the issue to "In Review". Currently has no Drive push step. Phase 3 of this plan adds the `--push-drive` flag and the gdrive-push call in the success exit path.
 - **ralph-postmortem skill** (`plugin/ralph-hero/skills/ralph-postmortem/SKILL.md`) — generates a structured postmortem from `TaskList` data, writes to disk, calls `knowledge_record_outcome`. Currently has no Drive push step. Phase 3 adds it after the postmortem .md is written.
 - **scout report producer** — the nightly sweep registered by Feature F (GH-1273) creates a `scout-auto` issue per finding. The "scout report" artifact is either the issue body itself (small finding) or an attached report file (large finding). Feature F's plan defines which; Phase 3 of this plan wires `gdrive-push` into whichever shape Feature F lands. If the producer is a skill, add the flag to its frontmatter; if it's a script, add a `--push-drive` CLI arg.
-- **Director skill** (`plugin/ralph-hero/skills/director/SKILL.md` from Feature B) — dispatches teams; sets `RALPH_IOS_MODE=1` when consuming a `trigger:<team>` label. Phase 4 of this plan adds `IOS-REMOTE.md` next to it.
-- **`team:<team>` label convention** — Features C, F, G are expected to apply `team:watch`, `team:scout`, `team:caretake` labels to issues their orchestrators touch (per the epic plan's "team-orchestrator contract" in §Integration Strategy). The cos five-team rollup in Phase 1 of this plan filters by these labels.
+- **Director skill** (`plugin/ralph-hero/skills/director/SKILL.md` from Feature B, MERGED) — dispatches teams; **does not set any env var** today. Phase 0 of this plan adds a one-line sentinel-file write (`touch "${TMPDIR:-/tmp}/ralph-ios-mode"`) to Director's Step 5 when `DISPATCH_REASON` starts with `trigger:` or equals `RemoteTrigger`. Phase 4 adds `IOS-REMOTE.md` next to Director's SKILL.md.
+- **Label families actually used by Director** (verified at `plugin/ralph-hero/skills/director/event-classes.md`): Priority 1 trigger labels (`trigger:builders`, `trigger:watch`, `trigger:scouts`, `trigger:caretake`, `trigger:memorykeepers`) — manual overrides, consumed at dispatch edge; Priority 2 automation labels (`watcher-auto`, `scout-auto`, `process-improvement`) — applied by automated producers, NOT consumed by Director; Priority 3 fallback by workflow_state. **No `team:<name>` labels exist anywhere in the codebase or sibling plans.** The cos five-team rollup in Phase 1 keys off the Priority 2 automation labels for Watchers / Scouts / Caretakers, and off workflow_state for Builders. Memorykeepers has no producer; cos shows a placeholder.
 
 ### Key Discoveries
 
 - **The morning-brief ntfy pattern is the right template.** It writes the artifact, extracts a one-line summary, calls `ntfy publish "$TOPIC" "$SUMMARY ($PATH)"`, and gracefully degrades. Phase 2 of this plan copies this shape into terminal handlers (`ralph-merge`, optionally `ralph-pr` and `ralph-postmortem`). Per Feature H acceptance criteria, picking `ralph-merge` is the smoke target — the others are optional follow-ups that ride on the same hook helper.
-- **The `--push-drive` flag is the right contract.** Default OFF for desk invocations, default ON for iOS-mode (detected via `RALPH_IOS_MODE=1` env var set by Director). The flag is parsed in each producer's args; the env var sets the default. CLI flag always wins.
+- **The `--push-drive` flag is the right contract.** Default OFF for desk invocations, default ON for iOS-mode (detected via the sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` written by Director in Phase 0; legacy `RALPH_IOS_MODE=1` env var also honored). The flag is parsed centrally in the `push-artifact.sh` helper (per Task 3.1); callers forward it unparsed. CLI flag always wins (rule 1 of Task 3.1's decision logic).
 - **cos extension is purely additive.** The existing cos `system-prompt.md` already has section conventions; adding four new sections (Watch, Scouts, Memorykeepers, Caretakers) below the existing Builders section is mechanical. The `pipeline_dashboard` and `list_issues` MCP calls already filter by label — no new MCP tool needed.
 - **IOS-REMOTE.md is user-facing.** Its tone differs from internal SKILL.md files: copy-pasteable commands, screenshots-or-equivalent prose, no internal jargon (no "skill", "hook", "MCP"; use "Claude Code automation", "trigger label", "Google Drive folder"). The cos README at `plugin/ralph-hero/scripts/cos/README.md` is a closer voice-match than any SKILL.md file in the repo.
 
@@ -93,18 +106,20 @@ After Features A–G land (sibling waves), the following are on disk:
 
 After this plan merges:
 
-1. **`cos` extended**: Running `ralph cos remote` or `ralph cos desk` shows five clearly-labeled sections: Builders, Watchers, Scouts, Memorykeepers, Caretakers. Each section lists active issues + WIP count for that team. Phone-readable (no horizontal scroll, no >80-char lines).
-2. **ntfy completion hooks**: `ralph-merge` (and any other terminal handler that opts in via the shared hook helper) fires an ntfy push on successful merge when `RALPH_IOS_MODE=1` is set. Push body: `"Merged: <PR title> (<PR URL>)"`. Gracefully degrades on missing ntfy / unset topic.
-3. **`gdrive-push --push-drive` wired**: `ralph-pr`, `ralph-postmortem`, and the scout report producer accept a `--push-drive` flag. Default ON when `RALPH_IOS_MODE=1`, default OFF otherwise; CLI flag always overrides. On push, the Drive URL is appended to the issue comment that the producer was going to post anyway (no new comment header).
+0. **Director sentinel write**: Director writes `${TMPDIR:-/tmp}/ralph-ios-mode` immediately before its `Skill()` dispatch when `DISPATCH_REASON` starts with `trigger:` or equals `RemoteTrigger`. One-line addition to Director's Step 5, documented in `event-classes.md`.
+1. **`cos` extended**: Running `ralph cos remote` or `ralph cos desk` shows five clearly-labeled sections: Builders, Watchers, Scouts, Memorykeepers, Caretakers. Each section queries by its actual taxonomy entry (`watcher-auto` / `scout-auto` / `process-improvement` labels; workflow_state for Builders; placeholder for Memorykeepers). Phone-readable (no horizontal scroll, no >80-char lines).
+2. **ntfy completion hooks**: `ralph-merge` (and any other terminal handler that opts in via the shared hook helper) fires an ntfy push on successful merge when the iOS-mode sentinel exists (or `RALPH_IOS_MODE=1` is set as a manual override). Push body: `"Merged: <PR title> (<PR URL>)"`. Gracefully degrades on missing ntfy / unset topic.
+3. **`gdrive-push --push-drive` wired**: `ralph-pr`, `ralph-postmortem`, and `scripts/schedule/scout-nightly.sh` accept a `--push-drive` flag. Default ON when iOS-mode sentinel exists OR `RALPH_IOS_MODE=1` set, default OFF otherwise; CLI flag always overrides. On push, the Drive URL is appended to the issue comment that the producer was going to post anyway (no new comment header).
 4. **`IOS-REMOTE.md` user doc**: Covers the four iOS workflows with copy-pasteable steps. Lives at `plugin/ralph-hero/skills/director/IOS-REMOTE.md`. Referenced from Director SKILL.md "See also" section and from `plugin/ralph-hero/skills/cos/README.md`.
 
 ### Verification
 
+- [x] `grep -q 'ralph-ios-mode' plugin/ralph-hero/skills/director/SKILL.md` (Director writes the sentinel)
 - [ ] `ralph cos remote` output contains the strings "Builders", "Watchers", "Scouts", "Memorykeepers", "Caretakers" as section headers
-- [ ] On a merge with `RALPH_IOS_MODE=1` set + `RALPH_COS_NTFY_TOPIC` set + `ntfy` installed, an ntfy push fires within 30s of merge completion
-- [ ] `ralph-pr --push-drive <issue>` (or `RALPH_IOS_MODE=1 ralph-pr <issue>`) results in a Drive link being posted in the PR's `## Implementation Complete` comment
+- [ ] On a merge with the sentinel file present + `RALPH_COS_NTFY_TOPIC` set + `ntfy` installed, an ntfy push fires within 30s of merge completion
+- [ ] `ralph-pr --push-drive <issue>` results in a Drive link being posted in the PR's `## Implementation Complete` comment (works with or without the sentinel)
 - [ ] `IOS-REMOTE.md` exists at `plugin/ralph-hero/skills/director/IOS-REMOTE.md` and contains four H2 sections matching the four workflows
-- [ ] End-to-end smoke (manual): add `trigger:watch` label from iOS → Director dispatches Watch → Watch finishes and posts a Drive link → ntfy push lands on phone → tap link opens Drive
+- [ ] End-to-end smoke (manual): add `trigger:watch` label from iOS → Director writes sentinel + dispatches Watch → Watch finishes and pushes its report to Drive via the Phase 3 path → ntfy push lands on phone → tap link opens Drive
 
 ## What We're NOT Doing
 
@@ -115,20 +130,67 @@ After this plan merges:
 - **No automatic retries on push failure.** If ntfy push fails or Drive push fails, the operation still succeeded (the merge happened, the artifact landed). Log a warning and move on.
 - **No fan-out push to multiple devices.** ntfy topic is one topic; one phone subscribes. Multi-device is a Phase-2 concern, not this feature.
 - **No "session done" markers beyond ntfy.** The harness already emits `result:` / `needs input:` markers per the epic plan §Shared Constraints rule 5; this plan does not add to that vocabulary.
-- **No iOS-mode-on-by-default.** `RALPH_IOS_MODE=1` is set by Director when consuming a trigger label (per Feature B). All other invocation paths leave it unset, which means `--push-drive` defaults OFF — no surprise Drive uploads from desk sessions.
+- **No iOS-mode-on-by-default.** The iOS-mode sentinel file is written by Director only when its dispatch is triggered by a `trigger:*` label or `RemoteTrigger` tool input (this PR adds that write). Desk-mode invocations leave the sentinel absent, which means `--push-drive` defaults OFF — no surprise Drive uploads from desk sessions. The legacy `RALPH_IOS_MODE=1` env var remains a manual override for testing.
 - **No editing of producer skill bodies beyond the new flag.** This plan does not refactor `ralph-pr`, `ralph-postmortem`, or the scout producer. It only adds the `--push-drive` flag-handling block and the gdrive-push call.
 - **No tests for the IOS-REMOTE.md doc beyond "the file exists and has the four sections."** Markdown linting is out of scope.
 
 ## Implementation Approach
 
-Phases in order; each is one PR-able unit, but all four ship in a single PR for documentation coherence. Phases 1 and 4 are independent; Phases 2 and 3 share a tiny shell helper (`push-on-completion.sh`) but are otherwise independent.
+Phases in order; each is one PR-able unit, but all five ship in a single PR for documentation coherence. Phases 0, 1, and 4 are independent; Phases 2 and 3 share a `scripts/lib/` directory but their helpers (`push-on-completion.sh`, `push-artifact.sh`) are otherwise independent.
 
-1. **Phase 1: cos five-team rollup** — Extend `system-prompt.md` and the relevant cos handler scripts to surface all five teams. Pure additive content + minor MCP filter logic.
+0. **Phase 0: Director sentinel write** — Add a one-line `touch` to Director's Step 5 to write `${TMPDIR:-/tmp}/ralph-ios-mode` when `DISPATCH_REASON` matches `trigger:*` or `RemoteTrigger`. Update `event-classes.md` to document the sentinel contract. Two file edits, both trivial.
+1. **Phase 1: cos five-team rollup** — Extend `system-prompt.md` and the relevant cos handler scripts to surface all five teams using the **actual** label families Director recognizes (`watcher-auto`, `scout-auto`, `process-improvement`) plus workflow_state for Builders. Pure additive content + label-based MCP filter logic.
 2. **Phase 2: ntfy completion hooks** — Author a small shared shell helper (`plugin/ralph-hero/scripts/lib/push-on-completion.sh`) and wire it into `ralph-merge`'s exit path. Pick `ralph-merge` as the smoke target per the issue body's acceptance criteria.
-3. **Phase 3: gdrive-push --push-drive wiring** — Add `--push-drive` flag parsing and a gdrive-push call to `ralph-pr`, `ralph-postmortem`, and the scout report producer. All three consume a shared helper `plugin/ralph-hero/scripts/lib/push-artifact.sh` for the gdrive-push invocation + Drive-URL extraction.
+3. **Phase 3: gdrive-push --push-drive wiring** — Add `--push-drive` flag parsing and a gdrive-push call to `ralph-pr`, `ralph-postmortem`, and the scout report producer (`plugin/ralph-hero/scripts/schedule/scout-nightly.sh` from GH-1273). All three consume a shared helper `plugin/ralph-hero/scripts/lib/push-artifact.sh` for the gdrive-push invocation + Drive-URL extraction.
 4. **Phase 4: IOS-REMOTE.md user doc** — Author the user-facing doc at `plugin/ralph-hero/skills/director/IOS-REMOTE.md`. Cross-reference from Director SKILL.md "See also" and from cos README.
 
-Phases can land in any internal order; Phase 4 should be last so it can cite the exact behavior shipped in Phases 1–3.
+Phases can land in any internal order; Phase 4 should be last so it can cite the exact behavior shipped in Phases 0–3. Phase 0 should land before Phase 2 / Phase 3 so the sentinel is testable.
+
+---
+
+## Phase 0: Director iOS-mode sentinel write
+
+- **depends_on**: null
+
+### Overview
+
+Director (Feature B, MERGED) does not currently signal iOS-mode to downstream skills. This phase adds a one-line `touch` of `${TMPDIR:-/tmp}/ralph-ios-mode` to Director's Step 5 (just before `Skill()` dispatch) when `DISPATCH_REASON` starts with `trigger:` or equals `RemoteTrigger`. Phase 2 and Phase 3 producers read the sentinel to flip `--push-drive` and ntfy defaults.
+
+### Tasks
+
+#### Task 0.1: Add sentinel write to Director Step 5
+- **files**: `plugin/ralph-hero/skills/director/SKILL.md` (modify)
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: null
+- **acceptance**:
+  - [ ] Director's Step 4 (Dispatch) or Step 5 (Consume trigger label) prose adds: "Before the `Skill()` call (Step 4), if `DISPATCH_REASON` starts with `trigger:` OR equals `RemoteTrigger`, write the iOS-mode sentinel: `touch \"${TMPDIR:-/tmp}/ralph-ios-mode\"`. This signals downstream producers (Feature H) that the current dispatch is iOS-initiated."
+  - [ ] The new instruction is a single bash line in the skill body; Director's allowlist already includes `Bash`, so no allowlist change
+  - [ ] Workflow_state-driven dispatches (Priority 3) do NOT write the sentinel — only Priority 1 (`trigger:*`) and `RemoteTrigger` paths do
+  - [ ] The bullet near the end of Step 5 also documents: "After successful dispatch, the sentinel may persist until session end; that is intentional — producers running inside the dispatched session see it. No explicit cleanup."
+
+#### Task 0.2: Document the sentinel contract in event-classes.md
+- **files**: `plugin/ralph-hero/skills/director/event-classes.md` (modify)
+- **tdd**: false
+- **complexity**: low
+- **depends_on**: [0.1]
+- **acceptance**:
+  - [ ] Append a new section after "Classification algorithm" titled `## iOS-mode sentinel (Feature H contract)`
+  - [ ] Section explains: "Director writes the sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` immediately before `Skill()` dispatch when `DISPATCH_REASON` matches `trigger:*` or `RemoteTrigger`. Downstream producers (ralph-pr, ralph-postmortem, scout-nightly, ralph-merge) test for this file to decide whether `--push-drive` and ntfy completion hooks default ON. The legacy `RALPH_IOS_MODE=1` env var is also honored as a manual operator override."
+  - [ ] Section is ≤15 lines and consistent in voice with the rest of `event-classes.md`
+
+### Phase Success Criteria
+
+#### Automated Verification:
+- [x] `grep -q 'ralph-ios-mode' plugin/ralph-hero/skills/director/SKILL.md`
+- [x] `grep -q 'ralph-ios-mode' plugin/ralph-hero/skills/director/event-classes.md`
+- [x] `grep -q 'iOS-mode sentinel' plugin/ralph-hero/skills/director/event-classes.md`
+
+#### Manual Verification:
+- [ ] Run Director with `--issue NNN` on an issue carrying `trigger:builders`; verify the sentinel file appears at `${TMPDIR:-/tmp}/ralph-ios-mode`
+- [ ] Run Director with `--issue NNN` on an issue with no trigger label (workflow_state path); verify the sentinel file is NOT created
+
+**Creates for next phase**: A reliable iOS-mode signal that Phases 2 and 3 read.
 
 ---
 
@@ -150,8 +212,14 @@ Extend the `cos` skill's system prompt + handler scripts to surface state from a
 - **acceptance**:
   - [ ] Existing builders section preserved verbatim
   - [ ] Four new H2 sections appended in order: `## Watchers`, `## Scouts`, `## Memorykeepers`, `## Caretakers`
-  - [ ] Each new section instructs the agent to call `ralph_hero__list_issues({ labels: ["team:<team>"], limit: 5 })` and surface (a) count of open issues, (b) titles of the top 3 by priority, (c) most recent status update from `recent_activity` filtered to that team
-  - [ ] Each section ends with a one-line WIP-status sentence (e.g., "Watchers WIP: 2 issues in progress, 1 needs input.")
+  - [ ] Each new section instructs the agent to call `ralph_hero__list_issues` with the **actual** Director-recognized taxonomy (`label` is **singular** per `plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts:104` — `label: z.string().optional()`):
+    - Watchers: `ralph_hero__list_issues({ label: "watcher-auto", limit: 5 })` (per `event-classes.md` Priority 2)
+    - Scouts: `ralph_hero__list_issues({ label: "scout-auto", limit: 5 })` (per `event-classes.md` Priority 2)
+    - Caretakers: `ralph_hero__list_issues({ label: "process-improvement", limit: 5 })` (per `event-classes.md` Priority 2)
+    - Memorykeepers: render the literal string "Memorykeepers: not yet shipping (no producer; reserved in event-classes.md)" — do NOT issue a list_issues call
+  - [ ] The existing Builders section (already in `system-prompt.md`) is preserved verbatim — it uses workflow_state filtering (`In Progress`, `In Review`, etc.) rather than a label because Builders has no automation label in the Director taxonomy
+  - [ ] Each non-placeholder section surfaces: (a) count of open issues matching the label, (b) titles of the top 3 by priority, (c) most recent status update from `recent_activity` (no team-label filter — `recent_activity` is a project-wide log)
+  - [ ] Each section ends with a one-line WIP-status sentence (e.g., "Watchers WIP: 2 issues open with label `watcher-auto`.")
   - [ ] Overall prompt size remains under 4 KB (phone-readable output budget; existing prompt is ~2 KB)
   - [ ] No new MCP tool additions — composed from existing read-only allowlist
 
@@ -162,7 +230,7 @@ Extend the `cos` skill's system prompt + handler scripts to surface state from a
 - **depends_on**: [1.1]
 - **acceptance**:
   - [ ] cos README has a new `## Five-team rollup` section explaining that cos output covers all five teams since Feature H landed
-  - [ ] Documents that team membership is determined by `team:<team>` labels (set by each team's orchestrator per the epic plan's team-orchestrator contract)
+  - [ ] Documents that team attribution comes from the Director event-classes taxonomy (`watcher-auto` / `scout-auto` / `process-improvement` labels for Wave 2 teams; workflow_state for Builders; placeholder for Memorykeepers) — references `plugin/ralph-hero/skills/director/event-classes.md` as the canonical source
   - [ ] References `IOS-REMOTE.md` (Phase 4 deliverable, link will resolve after Phase 4 lands in the same PR)
   - [ ] `plugin/ralph-hero/skills/cos/SKILL.md` introduction paragraph updated from "project status" to "agent organization status across all five teams" (one-line edit)
 
@@ -179,17 +247,17 @@ Extend the `cos` skill's system prompt + handler scripts to surface state from a
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `bash -n plugin/ralph-hero/scripts/cos/smoke.sh` — no syntax errors
-- [ ] `grep -q '## Watchers' plugin/ralph-hero/skills/cos/system-prompt.md`
-- [ ] `grep -q '## Scouts' plugin/ralph-hero/skills/cos/system-prompt.md`
-- [ ] `grep -q '## Memorykeepers' plugin/ralph-hero/skills/cos/system-prompt.md`
-- [ ] `grep -q '## Caretakers' plugin/ralph-hero/skills/cos/system-prompt.md`
-- [ ] `wc -c plugin/ralph-hero/skills/cos/system-prompt.md` returns < 4096
+- [x] `bash -n plugin/ralph-hero/scripts/cos/smoke.sh` — no syntax errors
+- [x] `grep -q '## Watchers' plugin/ralph-hero/skills/cos/system-prompt.md`
+- [x] `grep -q '## Scouts' plugin/ralph-hero/skills/cos/system-prompt.md`
+- [x] `grep -q '## Memorykeepers' plugin/ralph-hero/skills/cos/system-prompt.md`
+- [x] `grep -q '## Caretakers' plugin/ralph-hero/skills/cos/system-prompt.md`
+- [x] `wc -c plugin/ralph-hero/skills/cos/system-prompt.md` returns < 4096
 
 #### Manual Verification:
 - [ ] On a machine with `pi` + `mlx-openai-server` running, `ralph cos remote` produces output with all five section headers, no horizontal scroll on a phone-width terminal (80 cols)
 
-**Creates for next phase**: A documented `team:<team>` label convention that Phase 3's scout-report producer relies on for cos visibility of scout-auto issues.
+**Creates for next phase**: A documented mapping from cos sections to the Director event-classes taxonomy. Phase 3's scout-nightly producer continues to file its issues with the `scout-auto` label (per GH-1273), which the Scouts section of cos now reads.
 
 ---
 
@@ -224,10 +292,10 @@ Author a small shared helper (`push-on-completion.sh`) that wraps the cos-Phase-
 - **files**: `plugin/ralph-hero/skills/ralph-merge/SKILL.md` (modify), `plugin/ralph-hero/scripts/lib/push-on-completion.sh` (read)
 - **tdd**: false
 - **complexity**: medium
-- **depends_on**: [2.1]
+- **depends_on**: [2.1, 0.1]
 - **acceptance**:
-  - [ ] After ralph-merge's existing success path (issue transitioned to Done, worktree cleaned up), add a step that invokes `push-on-completion.sh` with message `"Merged: <PR title>"` and url `<PR URL>` when `[[ -n "${RALPH_IOS_MODE:-}" ]]`
-  - [ ] When `RALPH_IOS_MODE` is unset, the merge skill behavior is bit-identical to today (no ntfy call)
+  - [ ] After ralph-merge's existing success path (issue transitioned to Done, worktree cleaned up), add a step that invokes `push-on-completion.sh` with message `"Merged: <PR title>"` and url `<PR URL>` when iOS-mode is active. The iOS-mode predicate is: `[[ -f "${TMPDIR:-/tmp}/ralph-ios-mode" ]] || [[ -n "${RALPH_IOS_MODE:-}" ]]` (sentinel from Phase 0 OR legacy env var override).
+  - [ ] When neither the sentinel nor `RALPH_IOS_MODE` is set, the merge skill behavior is bit-identical to today (no ntfy call)
   - [ ] Failure of `push-on-completion.sh` does NOT fail the merge skill (best-effort; the merge already succeeded)
   - [ ] The new step is documented in ralph-merge's body with a one-line comment pointing at this plan's filename
   - [ ] `Bash` is already in ralph-merge's `allowed-tools`; no allowlist change needed
@@ -247,15 +315,15 @@ Author a small shared helper (`push-on-completion.sh`) that wraps the cos-Phase-
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `bash -n plugin/ralph-hero/scripts/lib/push-on-completion.sh` — no syntax errors
-- [ ] `bash -n plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh` — no syntax errors
-- [ ] `bash plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh` exits 0 (smoke covers the graceful-degradation paths without needing a real ntfy topic)
-- [ ] `[ -x plugin/ralph-hero/scripts/lib/push-on-completion.sh ]` (executable bit set)
-- [ ] `grep -q push-on-completion.sh plugin/ralph-hero/skills/ralph-merge/SKILL.md` (helper is invoked)
+- [x] `bash -n plugin/ralph-hero/scripts/lib/push-on-completion.sh` — no syntax errors
+- [x] `bash -n plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh` — no syntax errors
+- [x] `bash plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh` exits 0 (smoke covers the graceful-degradation paths without needing a real ntfy topic)
+- [x] `[ -x plugin/ralph-hero/scripts/lib/push-on-completion.sh ]` (executable bit set)
+- [x] `grep -q push-on-completion.sh plugin/ralph-hero/skills/ralph-merge/SKILL.md` (helper is invoked)
 
 #### Manual Verification:
-- [ ] On a machine with `ntfy` installed and `RALPH_COS_NTFY_TOPIC` + `RALPH_IOS_MODE=1` set, complete a real ralph-merge run and confirm the push lands on the subscribed phone within 30s
-- [ ] Run ralph-merge without `RALPH_IOS_MODE` set; confirm no ntfy call is made (verify with `tail -f` on the ntfy server logs or absence of stderr `ntfy push: ok` line)
+- [ ] On a machine with `ntfy` installed, `RALPH_COS_NTFY_TOPIC` set, AND the iOS-mode sentinel present (`touch "${TMPDIR:-/tmp}/ralph-ios-mode"` — or rely on Director from Phase 0), complete a real ralph-merge run and confirm the push lands on the subscribed phone within 30s
+- [ ] Run ralph-merge with neither the sentinel nor `RALPH_IOS_MODE` set; confirm no ntfy call is made (verify with `tail -f` on the ntfy server logs or absence of stderr `ntfy push: ok` line)
 
 **Creates for next phase**: A shared `scripts/lib/` directory pattern that Phase 3's `push-artifact.sh` helper follows.
 
@@ -263,13 +331,13 @@ Author a small shared helper (`push-on-completion.sh`) that wraps the cos-Phase-
 
 ## Phase 3: gdrive-push --push-drive wiring on producers
 
-- **depends_on**: [phase-2]
+- **depends_on**: [phase-0, phase-2]
 
 ### Overview
 
-Add `--push-drive` flag handling and a gdrive-push invocation to `ralph-pr`, `ralph-postmortem`, and the scout report producer. All three share a thin helper (`push-artifact.sh`) that wraps the gdrive-push skill invocation and extracts the resulting Drive URL for posting to the issue. Default ON when `RALPH_IOS_MODE=1`; default OFF otherwise; CLI flag always wins.
+Add `--push-drive` flag handling and a gdrive-push invocation to `ralph-pr`, `ralph-postmortem`, and the scout-nightly producer (`plugin/ralph-hero/scripts/schedule/scout-nightly.sh` from GH-1273). All three share a thin helper (`push-artifact.sh`) that wraps the gdrive-push skill invocation and extracts the resulting Drive URL for posting to the issue. Default ON when iOS-mode is active (sentinel from Phase 0 OR legacy `RALPH_IOS_MODE=1` env var); default OFF otherwise; CLI flag always wins.
 
-`depends_on` is set to phase-2 only because both phases author files under `plugin/ralph-hero/scripts/lib/` — sequencing them avoids merge conflicts in the lib directory's README/index if one exists. Functionally, Phase 3 does not consume Phase 2's helper.
+`depends_on` includes phase-0 (sentinel must exist before the producers can read it) and phase-2 (both phases author files under `plugin/ralph-hero/scripts/lib/` — sequencing avoids merge conflicts). Functionally, Phase 3 does not consume Phase 2's helper but does consume Phase 0's sentinel contract.
 
 ### Tasks
 
@@ -281,17 +349,19 @@ Add `--push-drive` flag handling and a gdrive-push invocation to `ralph-pr`, `ra
 - **acceptance**:
   - [ ] File exists, marked executable
   - [ ] Has `#!/usr/bin/env bash` shebang and `set -euo pipefail`
-  - [ ] CLI signature: `push-artifact.sh <path> [description]`
+  - [ ] CLI signature: `push-artifact.sh <path> [description] [--push-drive | --no-push-drive]`
+  - [ ] The helper parses `--push-drive` / `--no-push-drive` from its own `$@` (centralized parsing — callers do not pre-strip flags; addresses critique Issue 6)
   - [ ] Returns the Drive URL on stdout (one line) when successful; returns empty stdout on failure or skip
-  - [ ] Decision logic for whether to push:
-    - If `--push-drive` flag was passed by the caller (caller is responsible for stripping the flag from args before calling this helper): push
-    - Else if `[[ -n "${RALPH_IOS_MODE:-}" ]]`: push (iOS-mode default ON)
-    - Else if `--no-push-drive` flag was passed: skip (caller is responsible for stripping)
-    - Else: skip (desk-mode default OFF)
-  - [ ] On push: invokes the gdrive-push skill by running `claude -p '/gdrive-push <path> "<description>"' 2>&1` and parses stdout for the Drive URL (gdrive-push emits URLs like `https://drive.google.com/file/d/...`)
+  - [ ] Decision logic for whether to push (evaluated in this exact order — explicit overrides win first; addresses critique Issue 5):
+    1. If `--no-push-drive` was passed: SKIP (explicit operator opt-out always wins)
+    2. Else if `--push-drive` was passed: PUSH (explicit operator opt-in always wins)
+    3. Else if `[[ -f "${TMPDIR:-/tmp}/ralph-ios-mode" ]]`: PUSH (Phase 0 sentinel; iOS-mode default ON)
+    4. Else if `[[ -n "${RALPH_IOS_MODE:-}" ]]`: PUSH (legacy env var manual override)
+    5. Else: SKIP (desk-mode default OFF)
+  - [ ] On PUSH: invokes the gdrive-push skill by running `claude -p '/gdrive-push <path> "<description>"' 2>&1` and parses stdout for the Drive URL (gdrive-push emits URLs like `https://drive.google.com/file/d/...`)
   - [ ] If `gws` is not authenticated (gdrive-push exits non-zero), prints `[push-artifact] gdrive-push failed — artifact still landed locally at <path>` to stderr and exits 0 with empty stdout
-  - [ ] If the operator did not opt in (skip path), prints nothing to stderr (no warning needed for the expected default-OFF case) and exits 0 with empty stdout
-  - [ ] When `RALPH_COS_DEBUG=1`, prints the resolved decision (PUSH / SKIP) and reason to stderr
+  - [ ] If the operator did not opt in (SKIP path), prints nothing to stderr (no warning needed for the expected default-OFF case) and exits 0 with empty stdout
+  - [ ] When `RALPH_COS_DEBUG=1`, prints the resolved decision (PUSH / SKIP) and the matched rule number (1–5) to stderr
 
 #### Task 3.2: Wire push-artifact into ralph-pr
 - **files**: `plugin/ralph-hero/skills/ralph-pr/SKILL.md` (modify), `plugin/ralph-hero/scripts/lib/push-artifact.sh` (read)
@@ -299,9 +369,9 @@ Add `--push-drive` flag handling and a gdrive-push invocation to `ralph-pr`, `ra
 - **complexity**: medium
 - **depends_on**: [3.1]
 - **acceptance**:
-  - [ ] `ralph-pr` accepts a new `--push-drive` / `--no-push-drive` flag in its argument-hint and parses it from `ARGUMENTS`
+  - [ ] `ralph-pr` accepts a new `--push-drive` / `--no-push-drive` flag in its argument-hint and forwards it (unparsed) to `push-artifact.sh` — ralph-pr does NOT parse the flag itself; the helper does (per Task 3.1's centralized parsing)
   - [ ] After the PR is created and the `## Implementation Complete` comment body is composed, the skill writes the comment body to a temp .md file under `/tmp/ralph-pr-NNN-body.md`
-  - [ ] Calls `push-artifact.sh /tmp/ralph-pr-NNN-body.md "PR for GH-NNN"` (with the `--push-drive` flag forwarded as appropriate)
+  - [ ] Calls `push-artifact.sh /tmp/ralph-pr-NNN-body.md "PR for GH-NNN" <forwarded-flag-if-present>` — bash word-splitting is fine since the helper handles missing/present flags uniformly
   - [ ] If the helper returns a non-empty Drive URL on stdout, appends a `Drive: <URL>` line to the `## Implementation Complete` comment body BEFORE posting the comment via `create_comment`
   - [ ] If the helper returns empty stdout (skip or failure), the comment is posted unchanged — bit-identical to today's behavior
   - [ ] No new MCP tool added to ralph-pr's allowlist (Bash is already there for shell-outs)
@@ -317,42 +387,44 @@ Add `--push-drive` flag handling and a gdrive-push invocation to `ralph-pr`, `ra
   - [ ] If the helper returns a non-empty Drive URL, include the URL in the `## Postmortem` comment body that ralph-postmortem already posts on blocker issues (per its existing flow), as a `Drive: <URL>` line
   - [ ] If helper returns empty, comment is posted unchanged
   - [ ] No new MCP tool / shell allowlist change (Bash already in `allowed-tools`)
-  - [ ] Argument-hint (if present) updated to surface `--push-drive` / `--no-push-drive`. If ralph-postmortem has no CLI args today (it is invoked inline by team), the env var `RALPH_IOS_MODE=1` is the only opt-in path — document that in the skill body
+  - [ ] Argument-hint (if present) updated to surface `--push-drive` / `--no-push-drive`. If ralph-postmortem has no CLI args today (it is invoked inline by team), the iOS-mode sentinel from Phase 0 (or the legacy `RALPH_IOS_MODE=1` env var) is the only opt-in path — document that in the skill body
 
-#### Task 3.4: Wire push-artifact into the scout report producer
-- **files**: TBD at implementation time — read Feature F plan first to identify the producer file. Likely `plugin/ralph-hero/skills/scouts/SKILL.md` or `plugin/ralph-hero/scripts/scouts/nightly-sweep.sh` (read Feature F plan when present)
+#### Task 3.4: Wire push-artifact into the scout-nightly producer
+- **files**: `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` (modify — created by GH-1273 Task 4.1)
 - **tdd**: false
 - **complexity**: medium
 - **depends_on**: [3.1]
 - **acceptance**:
-  - [ ] Locate the scout report producer by reading the Feature F (GH-1273) plan document at `thoughts/shared/plans/*GH-1273*.md`. If the file is not yet on disk at implementation time, STOP and escalate — Phase 3 cannot proceed without knowing the producer interface.
-  - [ ] Add `--push-drive` / `--no-push-drive` flag parsing to the producer
-  - [ ] After the scout report is written (issue body or attached file — whichever shape Feature F lands), invoke `push-artifact.sh <report-path> "Scout report: <date>"`
-  - [ ] If the helper returns a Drive URL, include it in the scout-auto issue body or comment that the producer posts (matching the producer's existing comment convention)
-  - [ ] Bit-identical behavior to today when neither `--push-drive` nor `RALPH_IOS_MODE=1` is set
+  - [ ] **Concrete producer path verified from `thoughts/shared/plans/2026-05-16-GH-1273-scout-scheduling.md` Task 4.1**: the scout-nightly producer is `plugin/ralph-hero/scripts/schedule/scout-nightly.sh`. It invokes `/ralph-playwright:test-e2e --label scout-auto` against the latest deployed build URL; findings are filed as GitHub issues with the `scout-auto` label.
+  - [ ] **Forward-compat fallback**: If `scout-nightly.sh` is not yet on disk at this PR's impl time (GH-1273 has not merged), this task is gated — the impl-agent should: (1) confirm the GH-1273 plan path is still as documented above, (2) author this task's changes as a follow-up commit instructions block in the PR description, (3) note in the PR body that the scout-nightly wire-up lands in a follow-up PR after GH-1273 merges. Do NOT create the file from scratch in this PR — GH-1273 owns it.
+  - [ ] When `scout-nightly.sh` exists: add `--push-drive` / `--no-push-drive` flag parsing to its argument-handling block (forwarded directly to `push-artifact.sh` — same pattern as ralph-pr per Task 3.2)
+  - [ ] After test-e2e exits and any `scout-auto` issues have been filed, invoke `push-artifact.sh <test-results-dir> "Scout report: $(date +%Y-%m-%d)"` once per nightly run (one helper call per run, not per issue)
+  - [ ] If the helper returns a Drive URL, append a `Drive: <URL>` line to a `## Scout Nightly Summary` comment posted to the most-recently-filed `scout-auto` issue (or to a single tracker issue if GH-1273 introduces one — defer to GH-1273's existing comment convention)
+  - [ ] Bit-identical behavior to today when neither `--push-drive` nor the iOS-mode sentinel/env-var is set
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `bash -n plugin/ralph-hero/scripts/lib/push-artifact.sh` — no syntax errors
-- [ ] `[ -x plugin/ralph-hero/scripts/lib/push-artifact.sh ]` (executable bit)
-- [ ] `grep -q push-artifact.sh plugin/ralph-hero/skills/ralph-pr/SKILL.md`
-- [ ] `grep -q push-artifact.sh plugin/ralph-hero/skills/ralph-postmortem/SKILL.md`
-- [ ] `grep -q '\-\-push-drive' plugin/ralph-hero/skills/ralph-pr/SKILL.md` (flag documented in skill body)
+- [x] `bash -n plugin/ralph-hero/scripts/lib/push-artifact.sh` — no syntax errors
+- [x] `[ -x plugin/ralph-hero/scripts/lib/push-artifact.sh ]` (executable bit)
+- [x] `grep -q push-artifact.sh plugin/ralph-hero/skills/ralph-pr/SKILL.md`
+- [x] `grep -q push-artifact.sh plugin/ralph-hero/skills/ralph-postmortem/SKILL.md`
+- [x] `grep -q '--push-drive' plugin/ralph-hero/skills/ralph-pr/SKILL.md` (flag documented in skill body)
 
 #### Manual Verification:
-- [ ] On a machine with `gws` authenticated, `RALPH_IOS_MODE=1` set, run ralph-pr against a test issue and verify the `## Implementation Complete` comment contains a `Drive:` line with a working Drive URL
-- [ ] Run ralph-pr without `RALPH_IOS_MODE` and without `--push-drive`; verify the comment has no `Drive:` line (regression check)
-- [ ] Run ralph-pr with `--no-push-drive` and `RALPH_IOS_MODE=1` set; verify the CLI flag wins (no Drive line)
+- [ ] On a machine with `gws` authenticated and the iOS-mode sentinel present (`touch "${TMPDIR:-/tmp}/ralph-ios-mode"`), run ralph-pr against a test issue and verify the `## Implementation Complete` comment contains a `Drive:` line with a working Drive URL
+- [ ] Remove the sentinel and unset `RALPH_IOS_MODE`; run ralph-pr without `--push-drive`; verify the comment has no `Drive:` line (regression check)
+- [ ] Run ralph-pr with `--no-push-drive` AND the sentinel present (sentinel says PUSH, flag says SKIP); verify the CLI flag wins (no Drive line) — exercises rule 1 of Task 3.1's decision logic
+- [ ] Run ralph-pr with `--push-drive` and no sentinel; verify Drive URL appears — exercises rule 2
 - [ ] Repeat the smoke for ralph-postmortem on a fake blocker issue (or use a test run with `RALPH_DEBUG=1`)
 
-**Creates for next phase**: A documented `--push-drive` / `RALPH_IOS_MODE` contract that Phase 4's IOS-REMOTE.md describes for the user.
+**Creates for next phase**: A documented `--push-drive` / sentinel / `RALPH_IOS_MODE` precedence contract that Phase 4's IOS-REMOTE.md describes for the user.
 
 ---
 
 ## Phase 4: IOS-REMOTE.md user doc
 
-- **depends_on**: [phase-1, phase-2, phase-3]
+- **depends_on**: [phase-0, phase-1, phase-2, phase-3]
 
 ### Overview
 
@@ -373,7 +445,7 @@ Author the user-facing iOS workflow doc at `plugin/ralph-hero/skills/director/IO
     - `## 1. Trigger a team from iOS` — explains adding `trigger:watch` / `trigger:scout` / `trigger:caretake` labels via the GitHub mobile app; what happens next; how to know it worked
     - `## 2. Read a status summary` — explains `ralph cos remote` from a Termius/SSH session on the phone; what each of the five sections means
     - `## 3. Receive completion pushes` — explains setting up ntfy on the phone (subscribe to topic), configuring `RALPH_COS_NTFY_TOPIC` on the Mac, what kinds of events push (merges, postmortems, scout reports); links to the cos Phase 3 plan for the underlying convention
-    - `## 4. Open Drive artifacts` — explains the `claude-shared` Drive folder, how Drive links appear in issue comments when `RALPH_IOS_MODE=1`, how to open them on iOS
+    - `## 4. Open Drive artifacts` — explains the `claude-shared` Drive folder, how Drive links appear in issue comments when Director's iOS-mode sentinel is active (i.e., when the dispatch came from a `trigger:*` label or `RemoteTrigger`), how to open them on iOS, and how the operator can manually set `RALPH_IOS_MODE=1` for forced pushes during testing
   - [ ] Each section includes at least one copy-pasteable command or step
   - [ ] Includes a final `## Troubleshooting` section with at least three common issues: (a) no ntfy push fired, (b) Drive link missing from comment, (c) trigger label not consumed
   - [ ] Includes a `## See also` section linking to: Director SKILL.md, cos README, cos Phase 3 plan, this plan
@@ -393,14 +465,14 @@ Author the user-facing iOS workflow doc at `plugin/ralph-hero/skills/director/IO
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `[ -f plugin/ralph-hero/skills/director/IOS-REMOTE.md ]`
+- [x] `[ -f plugin/ralph-hero/skills/director/IOS-REMOTE.md ]`
 - [ ] `grep -cE '^## ' plugin/ralph-hero/skills/director/IOS-REMOTE.md` returns at least 5 (four workflow sections + troubleshooting; "See also" makes 6)
-- [ ] `grep -q 'trigger:watch' plugin/ralph-hero/skills/director/IOS-REMOTE.md`
-- [ ] `grep -q 'RALPH_COS_NTFY_TOPIC' plugin/ralph-hero/skills/director/IOS-REMOTE.md`
-- [ ] `grep -q 'claude-shared' plugin/ralph-hero/skills/director/IOS-REMOTE.md`
-- [ ] `grep -q 'IOS-REMOTE' plugin/ralph-hero/skills/director/SKILL.md`
-- [ ] `grep -q 'IOS-REMOTE' plugin/ralph-hero/scripts/cos/README.md`
-- [ ] Word count: `wc -w plugin/ralph-hero/skills/director/IOS-REMOTE.md` returns between 500 and 2500
+- [x] `grep -q 'trigger:watch' plugin/ralph-hero/skills/director/IOS-REMOTE.md`
+- [x] `grep -q 'RALPH_COS_NTFY_TOPIC' plugin/ralph-hero/skills/director/IOS-REMOTE.md`
+- [x] `grep -q 'claude-shared' plugin/ralph-hero/skills/director/IOS-REMOTE.md`
+- [x] `grep -q 'IOS-REMOTE' plugin/ralph-hero/skills/director/SKILL.md`
+- [x] `grep -q 'IOS-REMOTE' plugin/ralph-hero/scripts/cos/README.md`
+- [x] Word count: `wc -w plugin/ralph-hero/skills/director/IOS-REMOTE.md` returns between 500 and 2500
 
 #### Manual Verification:
 - [ ] Read IOS-REMOTE.md on an iPhone-width browser (or 375px viewport). All commands are copy-pasteable. No horizontal scroll on a phone.
@@ -416,17 +488,17 @@ End-to-end smoke from the epic plan's "Integration tests" section (epic §Integr
 
 1. From the iOS GitHub app, add label `trigger:watch` to an arbitrary issue.
 2. Wait for Director's next `/schedule` tick (or trigger manually via `ralph director` on the Mac for the smoke).
-3. Confirm Director removes the `trigger:watch` label and dispatches Watch.
-4. Watch runs its mission, emits a `result:` line, calls `outcome-recorder`, and pushes its report to Drive via the `--push-drive` path landed in Phase 3 (Watch is one of the producers if/when Feature C/F decide to wire it; otherwise the smoke uses a `ralph-pr` or scout-auto producer).
-5. ntfy fires a push to the iOS device (Phase 2 hook).
+3. Confirm Director writes the iOS-mode sentinel (`${TMPDIR:-/tmp}/ralph-ios-mode`) and removes the `trigger:watch` label, then dispatches Watch.
+4. Watch runs its mission, emits a `result:` line, calls `outcome-recorder`, and pushes its report to Drive via the `--push-drive` path landed in Phase 3 (Watch is one of the producers if/when Feature C/F decide to wire it; otherwise the smoke uses a `ralph-pr` or scout-nightly producer).
+5. ntfy fires a push to the iOS device (Phase 2 hook reads the same sentinel).
 6. iOS opens the Drive link from the push body or the issue comment.
 
 Additional cross-phase checks:
 
-- [ ] `ralph cos remote` after Watch finishes shows the Watchers section reflecting the completed run (count of Watch-touched issues moved on the board)
+- [ ] `ralph cos remote` after Watch finishes shows the Watchers section reflecting the completed run (count of issues carrying the `watcher-auto` label that Watch moved on the board)
 - [ ] `IOS-REMOTE.md`'s Troubleshooting section's "no ntfy push fired" entry correctly diagnoses an unset `RALPH_COS_NTFY_TOPIC` (matches Phase 2 behavior)
-- [ ] All three producers (ralph-pr, ralph-postmortem, scout sweep) respect the `--no-push-drive` override when set, even with `RALPH_IOS_MODE=1` (CLI wins)
-- [ ] No regression on desk-mode flows: running ralph-pr / ralph-postmortem with neither flag nor env var produces bit-identical comments to pre-feature behavior
+- [ ] All three producers (ralph-pr, ralph-postmortem, scout-nightly) respect the `--no-push-drive` override when set, even with the iOS-mode sentinel present (CLI wins — rule 1 of Task 3.1's decision logic)
+- [ ] No regression on desk-mode flows: running ralph-pr / ralph-postmortem with neither flag nor sentinel/env-var produces bit-identical comments to pre-feature behavior
 
 ## Performance Considerations
 
@@ -437,27 +509,32 @@ Additional cross-phase checks:
 
 ## Migration Notes
 
-Purely additive feature. No env var renames or removals. New env vars:
+Purely additive feature. No env var renames or removals.
 
-- `RALPH_IOS_MODE` (set by Director when consuming a trigger label per Feature B; consumed by this feature's producers to flip `--push-drive` defaults)
+New state:
+- **iOS-mode sentinel file** at `${TMPDIR:-/tmp}/ralph-ios-mode` — written by Director's Step 5 (Phase 0) when dispatch source is `trigger:*` or `RemoteTrigger`. Cleaned up implicitly on `$TMPDIR` rotation. No persistent state on disk outside `/tmp`.
+
+New (manual override) env vars:
+- `RALPH_IOS_MODE` (manual operator override; honored by all Phase 2/3 producers as a fallback to the sentinel). Not set by any harness code in this PR — purely for desk-mode testing or scripted scenarios.
 
 Reused env vars (no changes):
-
 - `RALPH_COS_NTFY_TOPIC` (already documented in cos Phase 3 README; same role here — completion push body topic)
 - `RALPH_COS_DEBUG` (already documented; this feature respects it in both new helpers)
 
-No new state directories. No new MCP tools. No new daemons. No changes to existing skill allowlists beyond what's described per task.
+No new persistent state directories. No new MCP tools. No new daemons. No changes to existing skill allowlists beyond what's described per task.
 
 ## References
 
 - Issue: [GH-1275](https://github.com/cdubiel08/ralph-hero/issues/1275)
 - Parent epic: [GH-1267](https://github.com/cdubiel08/ralph-hero/issues/1267)
 - Plan-of-plans: `thoughts/shared/plans/2026-05-16-GH-1267-unified-agent-system-epic.md` (Feature H section, lines 140–148)
-- Sibling Feature B (Director): GH-1269 — provides `RALPH_IOS_MODE=1` env var setting on trigger-label dispatch
-- Sibling Feature C (Watcher): GH-1270 — provides `team:watch` label convention consumed by cos rollup
-- Sibling Feature F (Scouts): GH-1273 — provides scout-auto producer and scout SOUL.md
-- Sibling Feature G (Caretakers): GH-1274 — provides `team:caretake` label convention consumed by cos rollup
+- Critique addressed by iteration 2: `thoughts/shared/reviews/2026-05-16-GH-1275-critique.md`
+- Sibling Feature B (Director): GH-1269 (MERGED) — provides `plugin/ralph-hero/skills/director/SKILL.md` + `event-classes.md`; this PR adds the iOS-mode sentinel write in Phase 0
+- Sibling Feature C (Watcher): GH-1270 — produces issues with the `watcher-auto` label (per `event-classes.md` Priority 2); consumed by cos Watchers section
+- Sibling Feature F (Scouts): GH-1273 — produces `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` (concrete producer path for Phase 3 Task 3.4) and files issues with `scout-auto` label
+- Sibling Feature G (Caretakers): GH-1274 — produces issues with the `process-improvement` label (per `event-classes.md` Priority 2); consumed by cos Caretakers section
 - Prior plan: `thoughts/shared/plans/2026-05-15-GH-1255-cos-phase3-morning-brief-ntfy.md` — canonical ntfy invocation pattern reused in Phase 2's `push-on-completion.sh` helper
 - Existing skill: `plugin/ralph-hero/skills/cos/SKILL.md` and `plugin/ralph-hero/skills/cos/system-prompt.md`
 - Existing skill: `plugin/ralph-hero/skills/gdrive-push/SKILL.md` — invoked by Phase 3's `push-artifact.sh` helper
 - Existing skill: `plugin/ralph-hero/skills/ralph-pr/SKILL.md`, `plugin/ralph-hero/skills/ralph-postmortem/SKILL.md`, `plugin/ralph-hero/skills/ralph-merge/SKILL.md` — producers modified in Phases 2 and 3
+- MCP tool signature reference: `plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts:104` — `list_issues` accepts `label: string` (singular), consumed by Phase 1 Task 1.1


### PR DESCRIPTION
## Summary

Implements Feature H of the unified agent system epic (GH-1275): iOS-cockpit polish wiring all five teams into `cos`, sentinel-based iOS-mode detection, ntfy completion pushes on merge, gdrive-push `--push-drive` wiring on PR/postmortem/scout producers, and the user-facing IOS-REMOTE.md doc.

## Phases shipped

- **Phase 0** — Director sentinel write: `touch ${TMPDIR:-/tmp}/ralph-ios-mode` before `Skill()` dispatch on `trigger:*` / `RemoteTrigger` paths. Documented in `event-classes.md` iOS-mode sentinel section.
- **Phase 1** — cos five-team rollup: `system-prompt.md` extended with `## Builders`, `## Watchers`, `## Scouts`, `## Memorykeepers`, `## Caretakers` sections keyed off real Director event-classes labels (`watcher-auto`, `scout-auto`, `process-improvement`). Under 4 KB. Smoke assertion added.
- **Phase 2** — ntfy completion hooks: `scripts/lib/push-on-completion.sh` shared helper (reuses `RALPH_COS_NTFY_TOPIC` + cos Phase 3 graceful-degradation pattern). Wired into `ralph-merge` Step 9c (iOS-mode gated, best-effort). Smoke test passes clean.
- **Phase 3** — gdrive-push `--push-drive` wiring: `scripts/lib/push-artifact.sh` shared helper with 5-rule decision logic (CLI flag > sentinel > `RALPH_IOS_MODE` > default-OFF). Wired into `ralph-pr` (Step 6.7) and `ralph-postmortem` (Step 6.5). Scout-nightly deferred — GH-1273 not yet merged; wire-up noted for follow-up PR after GH-1273 merges.
- **Phase 4** — IOS-REMOTE.md user doc: four H2 workflow sections (trigger, cos summary, ntfy pushes, Drive artifacts) + Troubleshooting + See also. 1213 words, copy-pasteable, no internal jargon.

## Forward-compat note

Task 3.4 (scout-nightly `--push-drive` wire-up) is deferred. `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` is owned by GH-1273 (Feature F, currently in Human Needed). After GH-1273 merges, add `push-artifact.sh` call following the same pattern as ralph-pr Step 6.7.

## Test plan

- [ ] `grep -q 'ralph-ios-mode' plugin/ralph-hero/skills/director/SKILL.md`
- [ ] `grep -q 'iOS-mode sentinel' plugin/ralph-hero/skills/director/event-classes.md`
- [ ] `grep -q '## Watchers' plugin/ralph-hero/skills/cos/system-prompt.md`
- [ ] `wc -c plugin/ralph-hero/skills/cos/system-prompt.md` → < 4096
- [ ] `bash -n plugin/ralph-hero/scripts/lib/push-on-completion.sh`
- [ ] `bash plugin/ralph-hero/scripts/lib/smoke-push-on-completion.sh` → exits 0
- [ ] `bash -n plugin/ralph-hero/scripts/lib/push-artifact.sh`
- [ ] `grep -q push-on-completion.sh plugin/ralph-hero/skills/ralph-merge/SKILL.md`
- [ ] `grep -q push-artifact.sh plugin/ralph-hero/skills/ralph-pr/SKILL.md`
- [ ] `[ -f plugin/ralph-hero/skills/director/IOS-REMOTE.md ]`
- [ ] Manual: add `trigger:builders` label to an issue → Director writes sentinel → `ls ${TMPDIR:-/tmp}/ralph-ios-mode`
- [ ] Manual: run ralph-merge with sentinel present + `RALPH_COS_NTFY_TOPIC` set → ntfy push arrives within 30s

Closes #1275

🤖 Generated with [Claude Code](https://claude.ai/claude-code)