### PR TITLE
GH-1285: Typed MCP tool surface for kubectl autoremediation

### DIFF
--- a/plugin/ralph-hero/agents/sre-fixit.md
+++ b/plugin/ralph-hero/agents/sre-fixit.md
@@ -1,75 +1,74 @@
 ---
 name: sre-fixit
-description: Refusal-only autoremediation agent. No mutating actions until typed MCP tool surface (GH-1285) lands — every dispatch escalates to Human Needed.
+description: Autoremediation agent for the Watcher team. Invokes typed MCP kubectl tools (scale, rollout_restart, delete_pod, drain) for allowlisted operations. Escalates to Human Needed for any request outside the four ops or when a tool returns a validation error. No Bash — typed-tool surface is the only kubectl path.
 model: sonnet
-tools: Read, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+tools: mcp__plugin_ralph-hero_ralph-github__ralph_hero__sre__scale, mcp__plugin_ralph-hero_ralph-github__ralph_hero__sre__rollout_restart, mcp__plugin_ralph-hero_ralph-github__ralph_hero__sre__delete_pod, mcp__plugin_ralph-hero_ralph-github__ralph_hero__sre__drain, mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
 ---
 
-You are the Watcher team's autoremediation agent. **You currently have no autoremediation capability.** The mutating surface (kubectl scale, drain, rollout restart, delete pod) is being delivered by a typed MCP tool tracked in GH-1285. Until that lands, every dispatch results in escalation to a human SRE.
+You are the Watcher team's autoremediation agent. You invoke typed MCP kubectl tools for allowlisted operations and escalate to a human SRE for anything outside the four ops.
 
-This refusal-only posture is intentional. The previous design routed kubectl through a `Bash` content gate (`sre-allowlist-gate.sh`); automated code review on PR #1278 surfaced three command-injection bypass classes (shell metacharacters, multiline injection, empty-command bypass). Rather than play whack-a-mole, the redesign drops `Bash` from this agent's `tools:` allowlist entirely and routes kubectl operations through a typed MCP tool surface where the input shape is parsed, not pattern-matched.
+**No `Bash` tool is in your allowlist.** This is intentional and non-negotiable. The previous design routed kubectl through a `Bash` content gate (`sre-allowlist-gate.sh`); PR #1278 surfaced three command-injection bypass classes (shell metacharacters, multiline injection, empty-command bypass). The redesign routes all kubectl operations through a typed MCP tool surface where input shape is parsed and validated at the MCP-server layer — not pattern-matched at runtime.
 
-## Future autoremediation surface (delivered by GH-1285)
+## Current autoremediation surface
 
-These four actions will be exposed as typed MCP tools and added to this agent's `tools:` field once GH-1285 ships. They are documented here so the dispatch contract is visible today.
+Four typed MCP tools are available. Each tool's Zod schema is `.strict()` (no unknown fields) and enforces RFC 1123 label regexes. The MCP server's shared kubectl exec helper uses `child_process.execFile` with `shell: false` — argv goes directly to `execve(2)`.
 
-| Action | Operation (planned MCP tool shape) |
-|--------|-----------------------------------|
-| Scale deployment replicas | `kubectl scale deployment <name> --replicas=<N>` |
-| Drain node | `kubectl drain node <name>` |
-| Rollout restart | `kubectl rollout restart deployment/<name>` |
-| Delete pod | `kubectl delete pod <name>` |
+| Action | Tool | Key parameters |
+|--------|------|----------------|
+| Scale deployment replicas | `ralph_hero__sre__scale` | `namespace`, `deployment`, `replicas` (int, 0–50) |
+| Rollout restart deployment | `ralph_hero__sre__rollout_restart` | `namespace`, `deployment` |
+| Delete a single pod | `ralph_hero__sre__delete_pod` | `namespace`, `pod` |
+| Drain a node | `ralph_hero__sre__drain` | `node`, `gracePeriodSeconds` (optional), `timeoutSeconds` (optional) |
 
-**Hard constraints that the future surface must enforce:**
-- The force flag is forbidden on all commands.
-- The cascade-foreground flag is forbidden on all commands.
-- No node-pool operations.
-- No node deletion.
-- No deployment deletion, no service deletion, no namespace ops.
-- Allowlist enforcement happens at the MCP-server input-validation layer, not via Bash content scanning.
+**Hard constraints enforced by the MCP server (not by this agent):**
+- `--force` is forbidden on all commands.
+- `--cascade=foreground` is forbidden on all commands.
+- `--grace-period=0` is forbidden on all commands.
+- `--delete-emptydir-data` is forbidden on all commands.
+- No label-selector-based bulk operations.
+- No node deletion, no deployment deletion, no service deletion, no namespace ops.
 
-Until GH-1285 lands, **none of the above are available to this agent.**
+These constraints are enforced at the typed-schema and exec-helper layers — you cannot bypass them by crafting parameters; the MCP server will return a validation error.
 
-## Refusal protocol (every dispatch)
+## Decision flow
 
-For every request received:
+For each dispatch:
 
-1. Post a `## Escalation` comment on the originating issue using `mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment`:
+1. **Classify the request.** Determine which of the four operations (scale, rollout_restart, delete_pod, drain) best matches the requested remediation.
+
+2. **If the request maps to one of the four ops:**
+   a. Extract the required parameters from the dispatch context.
+   b. Call the appropriate typed tool.
+   c. If the tool call succeeds: post `## Remediation Applied` via `create_comment` with the operation performed, the parameters used, and the tool's output. Return `## Remediation Applied`.
+   d. If the tool call returns a validation error (parameter rejected by the schema): treat as out-of-scope — fall through to the escalation path. Include the validation error in the escalation comment.
+
+3. **If the request does NOT map to one of the four ops, or if a tool returned a validation error:** execute the escalation protocol below.
+
+## Escalation protocol
+
+When the request is outside the four ops, OR when a typed tool call returns a validation error:
+
+1. Post a `## Escalation` comment on the originating issue via `create_comment`:
    ```
    ## Escalation
 
-   sre-fixit was dispatched but currently has no autoremediation capability.
+   sre-fixit was dispatched but the requested action falls outside the allowlisted autoremediation surface.
 
    Requested action: <describe the request>
-   Reason blocked: typed MCP tool surface not yet implemented (tracked in GH-1285)
+   Reason: <one of: "operation not in allowlist" | "tool validation error: <message>" | "ambiguous request — cannot map to a single typed operation">
 
-   A human SRE must evaluate and execute this action manually. Once GH-1285 ships, allowlisted dispatches will become automatic.
+   A human SRE must evaluate and execute this action manually.
    ```
-2. Move the issue to `Human Needed` via `mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue` with `workflowState: "Human Needed"`.
-3. Return `## Escalation` and stop. Do not attempt the action. Do not return `## Remediation Applied`.
+2. Move the issue to `Human Needed` via `save_issue` with `workflowState: "Human Needed"`.
+3. Return `## Escalation` and stop. Do not return `## Remediation Applied`.
+
+## Output contract
+
+- On success: return `## Remediation Applied` (exactly this header, followed by operation details).
+- On escalation: return `## Escalation` (exactly this header, followed by reason).
+- Never return both headers in the same response.
+- Never attempt to construct a kubectl command string and pass it to any tool — the four typed tools are the only kubectl path.
 
 ```
-# TODO(GH-1285): Once typed MCP kubectl tools land, replace the unconditional refusal above with:
-#   - check-allowlist (typed param validation runs at the MCP server)
-#   - invoke the typed tool
-#   - on success: return ## Remediation Applied
-#   - on validation failure: return ## Escalation (existing refusal protocol)
 # TODO(GH-1272): wire outcome-recorder(decision=sre-fixit-applied, result=<outcome>, trace_id=<trace-id>)
-```
-
-## Output format
-
-Always return `## Escalation`. Never return `## Remediation Applied` (no autoremediation surface yet). Never return both in the same response.
-
-### Example output
-
-```
-## Escalation
-
-sre-fixit was dispatched but currently has no autoremediation capability.
-
-Requested action: scale deployment api to 3 replicas
-Reason blocked: typed MCP tool surface not yet implemented (tracked in GH-1285)
-
-A human SRE must evaluate and execute this action manually. Once GH-1285 ships, allowlisted dispatches will become automatic.
 ```

--- a/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
@@ -39,6 +39,8 @@ import {
   REPLICA_CEILING,
   sreRolloutRestartSchema,
   buildRolloutRestartArgv,
+  sreDeletePodSchema,
+  buildDeletePodArgv,
 } from "../tools/sre-tools.js";
 
 // The module uses promisify(execFile) internally. To control its behaviour from
@@ -434,5 +436,174 @@ describe("ralph_hero__sre__rollout_restart — rejects empty-command injection",
 
   it("rejects whitespace-only string in deployment", () => {
     assertRolloutRestartRejects({ namespace: "default", deployment: "   " });
+  });
+});
+
+// =============================================================================
+// Phase 4 (GH-1290): ralph_hero__sre__delete_pod
+//
+// Reuses the canonical adversarial-test pattern from Phase 2 (sre__scale).
+// One named test per bypass class so a future regression points at the
+// specific class that regressed. Adds the no-label-selector guarantee test
+// via `.strict()` — asserting the schema structurally cannot express `-l app=foo`.
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Helper: assert that a Zod parse fails for the delete_pod schema
+// ---------------------------------------------------------------------------
+
+function assertDeletePodRejects(input: unknown): void {
+  const result = sreDeletePodSchema.safeParse(input);
+  expect(result.success).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__delete_pod — happy path", () => {
+  it("happy path produces expected argv", () => {
+    // Verify the schema accepts valid input.
+    const parseResult = sreDeletePodSchema.safeParse({
+      namespace: "default",
+      pod: "nginx-abc123",
+    });
+    expect(parseResult.success).toBe(true);
+
+    // Verify buildDeletePodArgv produces the exact expected argv.
+    // Argv is a plain array literal — no template strings, no string concat.
+    const argv = buildDeletePodArgv("default", "nginx-abc123");
+    expect(argv).toEqual([
+      "delete",
+      "pod",
+      "--namespace",
+      "default",
+      "nginx-abc123",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: shell-metacharacter injection
+//
+// Inputs containing `;`, `&&`, `|`, backtick, `$()`, `>` must be rejected
+// by the RFC 1123 label regex before they reach runKubectl.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__delete_pod — rejects shell-metacharacter injection", () => {
+  const metacharacterCases: Array<[string, string]> = [
+    ["semicolon (;)", "nginx;rm -rf /"],
+    ["double-ampersand (&&)", "nginx&&id"],
+    ["pipe (|)", "nginx|cat /etc/passwd"],
+    ["backtick (`)", "nginx`id`"],
+    ["command-substitution ($(...))", "nginx$(id)"],
+    ["redirect (>)", "nginx>/tmp/x"],
+  ];
+
+  for (const [label, injected] of metacharacterCases) {
+    it(`rejects ${label} in namespace`, () => {
+      assertDeletePodRejects({ namespace: injected, pod: "nginx-abc123" });
+    });
+    it(`rejects ${label} in pod`, () => {
+      assertDeletePodRejects({ namespace: "default", pod: injected });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-suffix injection
+//
+// A newline appended after a valid name would allow injecting a second
+// kubectl command. The RFC 1123 regex forbids `\n`.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__delete_pod — rejects multiline-suffix injection", () => {
+  it("rejects namespace with trailing newline + shell command", () => {
+    assertDeletePodRejects({
+      namespace: "default\nrm -rf /",
+      pod: "nginx-abc123",
+    });
+  });
+
+  it("rejects pod with trailing newline + shell command", () => {
+    assertDeletePodRejects({
+      namespace: "default",
+      pod: "nginx-abc123\nrm -rf /",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-prefix injection
+//
+// A leading newline can shift the original name to a second line, turning
+// it into an argument to a previously injected command.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__delete_pod — rejects multiline-prefix injection", () => {
+  it("rejects namespace with leading newline", () => {
+    assertDeletePodRejects({ namespace: "\ndefault", pod: "nginx-abc123" });
+  });
+
+  it("rejects pod with leading newline", () => {
+    assertDeletePodRejects({ namespace: "default", pod: "\nnginx-abc123" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: empty-command injection
+//
+// An empty string or whitespace-only string passes many naive checks but
+// would result in kubectl receiving an empty argument. The .min(1) + regex
+// reject both forms.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__delete_pod — rejects empty-command injection", () => {
+  it("rejects empty string in namespace", () => {
+    assertDeletePodRejects({ namespace: "", pod: "nginx-abc123" });
+  });
+
+  it("rejects whitespace-only string in namespace", () => {
+    assertDeletePodRejects({ namespace: "   ", pod: "nginx-abc123" });
+  });
+
+  it("rejects empty string in pod", () => {
+    assertDeletePodRejects({ namespace: "default", pod: "" });
+  });
+
+  it("rejects whitespace-only string in pod", () => {
+    assertDeletePodRejects({ namespace: "default", pod: "   " });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-label-selector guarantee (.strict() test)
+//
+// The schema MUST have no `selector` field (or any other label-selector
+// analogue). Passing an extra key must be rejected by the `.strict()` schema,
+// proving that the typed surface is structurally incapable of expressing
+// `-l app=foo` bulk deletion.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__delete_pod — rejects label-selector field", () => {
+  it("rejects input with selector field (strict schema rejects unknown keys)", () => {
+    // Passing { namespace, pod, selector } should fail because `.strict()`
+    // rejects any key not present in the schema definition. There is no
+    // label-selector field — the schema cannot express bulk deletion.
+    assertDeletePodRejects({
+      namespace: "default",
+      pod: "nginx-abc",
+      selector: "app=foo",
+    });
+  });
+
+  it("rejects input with any unknown extra field", () => {
+    // Belt-and-suspenders: any unknown key should be rejected, not just
+    // `selector` — this is the `.strict()` invariant.
+    assertDeletePodRejects({
+      namespace: "default",
+      pod: "nginx-abc",
+      force: true,
+    });
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Smoke tests for the kubectl-exec helper (Phase 1 / GH-1287).
+ *
+ * These tests verify two foundational invariants:
+ *
+ *  1. shell:false guarantee — `runKubectl` invokes kubectl via execFile with
+ *     the shell option absent (or explicitly false). A shell option of `true`
+ *     must NEVER appear in the options object passed to execFile.
+ *
+ *  2. Forbidden-flag rejection — the defense-in-depth check rejects each of
+ *     the four unconditionally banned kubectl flags before any subprocess is
+ *     spawned.
+ *
+ * Operation-level adversarial tests (phases 2-5) will be added in later
+ * describe blocks inside this same file.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoist the mock before importing the module under test. ESM module namespaces
+// are non-configurable in vitest, so vi.spyOn on an imported namespace fails;
+// use vi.mock with a hoisted factory instead (same pattern as init-config.test.ts).
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFile: vi.fn(),
+  };
+});
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { runKubectl, FORBIDDEN_FLAGS } from "../lib/kubectl-exec.js";
+
+// The module uses promisify(execFile) internally. To control its behaviour from
+// the test we set the mock implementation on the raw `execFile` fn before each
+// test and let Node's promisify wrapper call it transparently.
+//
+// promisify wraps the callback form:  execFile(file, args, opts, cb)
+// We need our mock to call the callback with success data.
+
+function makeExecFileMock(
+  stdout = "kubectl v1.30.0",
+  stderr = "",
+): void {
+  vi.mocked(execFile).mockImplementation(
+    (
+      _file: unknown,
+      _args: unknown,
+      _opts: unknown,
+      callback: unknown,
+    ) => {
+      // promisify passes the callback as the last argument
+      (callback as (err: null, result: { stdout: string; stderr: string }) => void)(
+        null,
+        { stdout, stderr },
+      );
+      return undefined as unknown as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// shell:false guarantee
+// ---------------------------------------------------------------------------
+
+describe("kubectl-exec helper — shell:false guarantee", () => {
+  it("invokes kubectl with shell:false (options object must not set shell:true)", async () => {
+    makeExecFileMock();
+
+    await runKubectl(["version"]);
+
+    expect(execFile).toHaveBeenCalledOnce();
+
+    // Extract the options argument (3rd positional — file, args, opts, cb).
+    const callArgs = vi.mocked(execFile).mock.calls[0] as unknown[];
+    const opts = callArgs[2] as Record<string, unknown> | undefined;
+
+    // The options object MUST NOT set shell to true.
+    expect(opts?.shell).not.toBe(true);
+
+    // Verify the file and argv are forwarded correctly.
+    expect(callArgs[0]).toBe("kubectl");
+    expect(callArgs[1]).toEqual(["version"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forbidden-flag rejection (defense-in-depth)
+// ---------------------------------------------------------------------------
+
+describe("kubectl-exec helper — forbidden-flag rejection", () => {
+  it("rejects --force flag in argv", async () => {
+    await expect(
+      runKubectl(["delete", "pod", "foo", "--force"]),
+    ).rejects.toThrow("--force");
+  });
+
+  it("rejects --cascade=foreground flag in argv", async () => {
+    await expect(
+      runKubectl(["delete", "pod", "foo", "--cascade=foreground"]),
+    ).rejects.toThrow("--cascade=foreground");
+  });
+
+  it("rejects --grace-period=0 flag in argv", async () => {
+    await expect(
+      runKubectl(["delete", "pod", "foo", "--grace-period=0"]),
+    ).rejects.toThrow("--grace-period=0");
+  });
+
+  it("rejects --delete-emptydir-data flag in argv", async () => {
+    await expect(
+      runKubectl(["drain", "node-1", "--delete-emptydir-data"]),
+    ).rejects.toThrow("--delete-emptydir-data");
+  });
+
+  it("FORBIDDEN_FLAGS export contains exactly the four banned flags", () => {
+    expect(FORBIDDEN_FLAGS).toContain("--force");
+    expect(FORBIDDEN_FLAGS).toContain("--cascade=foreground");
+    expect(FORBIDDEN_FLAGS).toContain("--grace-period=0");
+    expect(FORBIDDEN_FLAGS).toContain("--delete-emptydir-data");
+    expect(FORBIDDEN_FLAGS).toHaveLength(4);
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // Hoist the mock before importing the module under test. ESM module namespaces
 // are non-configurable in vitest, so vi.spyOn on an imported namespace fails;
@@ -43,6 +44,7 @@ import {
   buildDeletePodArgv,
   sreDrainSchema,
   buildDrainArgv,
+  registerSreTools,
 } from "../tools/sre-tools.js";
 
 // The module uses promisify(execFile) internally. To control its behaviour from
@@ -824,5 +826,222 @@ describe("ralph_hero__sre__drain — rejects empty-command injection", () => {
 
   it("rejects whitespace-only string in node", () => {
     assertDrainRejects({ node: "   " });
+  });
+});
+
+// =============================================================================
+// Non-zero exitCode path: tool handlers must return toolError, not toolSuccess
+//
+// runKubectl does NOT throw on non-zero exit — it catches execFile's rejection
+// and returns { stdout, stderr, exitCode: e.code }. Each handler must branch on
+// exitCode !== 0 and return toolError with a descriptive message including the
+// failure output. These tests verify that branch is taken.
+//
+// The execFile mock is set to call the callback with a non-zero error object
+// (simulating `kubectl` exiting with code 1 and a stderr message), which causes
+// promisify's wrapper to reject — kubectl-exec.ts catches that rejection and
+// returns a KubectlResult with exitCode=1.
+// =============================================================================
+
+/**
+ * Make execFile's mock simulate a failed kubectl invocation.
+ *
+ * promisify wraps the callback form: execFile(file, args, opts, cb).
+ * To simulate a non-zero exit, the callback must be called with an Error that
+ * carries `.code`, `.stdout`, and `.stderr` — matching the shape that
+ * child_process emits when the subprocess exits non-zero.
+ */
+function makeExecFileMockFailure(
+  stderr = "Error from server (NotFound): deployments.apps \"missing\" not found",
+  stdout = "",
+  code = 1,
+): void {
+  vi.mocked(execFile).mockImplementation(
+    (
+      _file: unknown,
+      _args: unknown,
+      _opts: unknown,
+      callback: unknown,
+    ) => {
+      const err = Object.assign(new Error("Command failed"), {
+        code,
+        stdout,
+        stderr,
+      });
+      (callback as (err: Error, result?: unknown) => void)(err);
+      return undefined as unknown as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+/**
+ * Retrieve the registered tool handler from an McpServer instance.
+ * Uses the same `(server as any)._registeredTools` pattern as activity-tools.test.ts.
+ */
+function getHandler(server: McpServer, toolName: string): (params: unknown) => Promise<unknown> {
+  return (server as unknown as Record<string, Record<string, { handler: (p: unknown) => Promise<unknown> }>>)
+    ._registeredTools[toolName].handler;
+}
+
+/**
+ * Create a minimal McpServer with SRE tools registered.
+ * The GitHub client and field cache are unused by the SRE tool handlers
+ * (they only call runKubectl), so null casts are safe here.
+ */
+function createSreServer(): McpServer {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  registerSreTools(server, null as never, null as never);
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+// sre__scale: non-zero exitCode returns toolError
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__scale — non-zero exitCode returns toolError", () => {
+  it("returns toolError with stderr when kubectl exits non-zero", async () => {
+    makeExecFileMockFailure(
+      'Error from server (NotFound): deployments.apps "missing" not found',
+    );
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__scale");
+    const result = await handler({ namespace: "default", deployment: "missing", replicas: 3 }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("kubectl scale failed");
+    expect(result.content[0].text).toContain("exit 1");
+    expect(result.content[0].text).toContain("NotFound");
+  });
+
+  it("includes stdout in error message when stderr is empty", async () => {
+    makeExecFileMockFailure("", "quota exceeded output", 1);
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__scale");
+    const result = await handler({ namespace: "default", deployment: "nginx", replicas: 3 }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("quota exceeded output");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sre__rollout_restart: non-zero exitCode returns toolError
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__rollout_restart — non-zero exitCode returns toolError", () => {
+  it("returns toolError with stderr when kubectl exits non-zero", async () => {
+    makeExecFileMockFailure(
+      'Error from server (NotFound): deployments.apps "missing" not found',
+    );
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__rollout_restart");
+    const result = await handler({ namespace: "default", deployment: "missing" }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("kubectl rollout restart failed");
+    expect(result.content[0].text).toContain("exit 1");
+    expect(result.content[0].text).toContain("NotFound");
+  });
+
+  it("includes stdout in error message when stderr is empty", async () => {
+    makeExecFileMockFailure("", "namespace not found", 1);
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__rollout_restart");
+    const result = await handler({ namespace: "missing-ns", deployment: "nginx" }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("namespace not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sre__delete_pod: non-zero exitCode returns toolError
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__delete_pod — non-zero exitCode returns toolError", () => {
+  it("returns toolError with stderr when kubectl exits non-zero", async () => {
+    makeExecFileMockFailure(
+      'Error from server (NotFound): pods "crash-xyz" not found',
+    );
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__delete_pod");
+    const result = await handler({ namespace: "default", pod: "crash-xyz" }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("kubectl delete pod failed");
+    expect(result.content[0].text).toContain("exit 1");
+    expect(result.content[0].text).toContain("NotFound");
+  });
+
+  it("includes stdout in error message when stderr is empty", async () => {
+    makeExecFileMockFailure("", "pod already terminating", 1);
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__delete_pod");
+    const result = await handler({ namespace: "default", pod: "nginx-abc" }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("pod already terminating");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sre__drain: non-zero exitCode returns toolError
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — non-zero exitCode returns toolError", () => {
+  it("returns toolError with stderr when kubectl exits non-zero", async () => {
+    makeExecFileMockFailure(
+      'Error from server (NotFound): nodes "missing-node" not found',
+    );
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__drain");
+    const result = await handler({ node: "missing-node" }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("kubectl drain failed");
+    expect(result.content[0].text).toContain("exit 1");
+    expect(result.content[0].text).toContain("NotFound");
+  });
+
+  it("includes stdout in error message when stderr is empty", async () => {
+    makeExecFileMockFailure("", "node has pods that cannot be evicted", 1);
+
+    const server = createSreServer();
+    const handler = getHandler(server, "ralph_hero__sre__drain");
+    const result = await handler({ node: "node-1" }) as {
+      isError: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("node has pods that cannot be evicted");
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
@@ -37,6 +37,8 @@ import {
   sreScaleSchema,
   buildScaleArgv,
   REPLICA_CEILING,
+  sreRolloutRestartSchema,
+  buildRolloutRestartArgv,
 } from "../tools/sre-tools.js";
 
 // The module uses promisify(execFile) internally. To control its behaviour from
@@ -307,5 +309,130 @@ describe("ralph_hero__sre__scale — replica bounds", () => {
       replicas: REPLICA_CEILING,
     });
     expect(result.success).toBe(true);
+  });
+});
+
+// =============================================================================
+// Phase 3 (GH-1289): ralph_hero__sre__rollout_restart
+//
+// Reuses the canonical adversarial-test pattern from Phase 2 (sre__scale).
+// One named test per bypass class so a future regression points at the
+// specific class that regressed.
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Helper: assert that a Zod parse fails for the rollout_restart schema
+// ---------------------------------------------------------------------------
+
+function assertRolloutRestartRejects(input: unknown): void {
+  const result = sreRolloutRestartSchema.safeParse(input);
+  expect(result.success).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__rollout_restart — happy path", () => {
+  it("happy path produces expected argv", () => {
+    // Verify the schema accepts valid input.
+    const parseResult = sreRolloutRestartSchema.safeParse({
+      namespace: "default",
+      deployment: "nginx",
+    });
+    expect(parseResult.success).toBe(true);
+
+    // Verify buildRolloutRestartArgv produces the exact expected argv.
+    // Note: the resource-qualified `deployment/<name>` form is specific to
+    // `kubectl rollout restart` — this is the deliberate template-literal
+    // exception documented in the plan's Phase 3 overview.
+    const argv = buildRolloutRestartArgv("default", "nginx");
+    expect(argv).toEqual([
+      "rollout",
+      "restart",
+      "--namespace",
+      "default",
+      "deployment/nginx",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: shell-metacharacter injection
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__rollout_restart — rejects shell-metacharacter injection", () => {
+  const metacharacterCases: Array<[string, string]> = [
+    ["semicolon (;)", "nginx;rm -rf /"],
+    ["double-ampersand (&&)", "nginx&&id"],
+    ["pipe (|)", "nginx|cat /etc/passwd"],
+    ["backtick (`)", "nginx`id`"],
+    ["command-substitution ($(...))", "nginx$(id)"],
+    ["redirect (>)", "nginx>/tmp/x"],
+  ];
+
+  for (const [label, injected] of metacharacterCases) {
+    it(`rejects ${label} in namespace`, () => {
+      assertRolloutRestartRejects({ namespace: injected, deployment: "nginx" });
+    });
+    it(`rejects ${label} in deployment`, () => {
+      assertRolloutRestartRejects({ namespace: "default", deployment: injected });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-suffix injection
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__rollout_restart — rejects multiline-suffix injection", () => {
+  it("rejects namespace with trailing newline + shell command", () => {
+    assertRolloutRestartRejects({
+      namespace: "default\nrm -rf /",
+      deployment: "nginx",
+    });
+  });
+
+  it("rejects deployment with trailing newline + shell command", () => {
+    assertRolloutRestartRejects({
+      namespace: "default",
+      deployment: "nginx\nrm -rf /",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-prefix injection
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__rollout_restart — rejects multiline-prefix injection", () => {
+  it("rejects namespace with leading newline", () => {
+    assertRolloutRestartRejects({ namespace: "\nnginx", deployment: "nginx" });
+  });
+
+  it("rejects deployment with leading newline", () => {
+    assertRolloutRestartRejects({ namespace: "default", deployment: "\nnginx" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: empty-command injection
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__rollout_restart — rejects empty-command injection", () => {
+  it("rejects empty string in namespace", () => {
+    assertRolloutRestartRejects({ namespace: "", deployment: "nginx" });
+  });
+
+  it("rejects whitespace-only string in namespace", () => {
+    assertRolloutRestartRejects({ namespace: "   ", deployment: "nginx" });
+  });
+
+  it("rejects empty string in deployment", () => {
+    assertRolloutRestartRejects({ namespace: "default", deployment: "" });
+  });
+
+  it("rejects whitespace-only string in deployment", () => {
+    assertRolloutRestartRejects({ namespace: "default", deployment: "   " });
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
@@ -41,6 +41,8 @@ import {
   buildRolloutRestartArgv,
   sreDeletePodSchema,
   buildDeletePodArgv,
+  sreDrainSchema,
+  buildDrainArgv,
 } from "../tools/sre-tools.js";
 
 // The module uses promisify(execFile) internally. To control its behaviour from
@@ -605,5 +607,222 @@ describe("ralph_hero__sre__delete_pod — rejects label-selector field", () => {
       pod: "nginx-abc",
       force: true,
     });
+  });
+});
+
+// =============================================================================
+// Phase 5 (GH-1291): ralph_hero__sre__drain
+//
+// Reuses the canonical adversarial-test pattern from Phase 2 (sre__scale).
+// One named test per bypass class. Adds two invariant assertions unique to drain:
+//   1. --ignore-daemonsets is always present in argv (hard-coded on).
+//   2. None of the four Shared Constraint #3 forbidden flags ever appear in argv.
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Helper: assert that a Zod parse fails for the drain schema
+// ---------------------------------------------------------------------------
+
+function assertDrainRejects(input: unknown): void {
+  const result = sreDrainSchema.safeParse(input);
+  expect(result.success).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — happy path", () => {
+  it("happy path produces expected argv with --ignore-daemonsets", () => {
+    // Verify the schema accepts valid input.
+    const parseResult = sreDrainSchema.safeParse({ node: "node-1" });
+    expect(parseResult.success).toBe(true);
+
+    // Verify buildDrainArgv produces the exact expected argv for the minimal case.
+    const argv = buildDrainArgv("node-1");
+    expect(argv).toEqual(["drain", "node-1", "--ignore-daemonsets"]);
+  });
+
+  it("appends --grace-period when gracePeriodSeconds is provided", () => {
+    const argv = buildDrainArgv("node-1", 30);
+    expect(argv).toEqual(["drain", "node-1", "--ignore-daemonsets", "--grace-period", "30"]);
+  });
+
+  it("appends --timeout when timeoutSeconds is provided", () => {
+    const argv = buildDrainArgv("node-1", undefined, 60);
+    expect(argv).toEqual(["drain", "node-1", "--ignore-daemonsets", "--timeout", "60s"]);
+  });
+
+  it("appends both --grace-period and --timeout when both are provided", () => {
+    const argv = buildDrainArgv("node-1", 30, 60);
+    expect(argv).toEqual([
+      "drain",
+      "node-1",
+      "--ignore-daemonsets",
+      "--grace-period",
+      "30",
+      "--timeout",
+      "60s",
+    ]);
+  });
+
+  it("accepts FQDN-form node name", () => {
+    const parseResult = sreDrainSchema.safeParse({
+      node: "node-1.us-east-1.example.com",
+    });
+    expect(parseResult.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant: --ignore-daemonsets is always present
+//
+// The flag is hard-coded into buildDrainArgv — it is not a user-controllable
+// parameter. Run multiple input shapes to assert the invariant is unconditional.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — --ignore-daemonsets is always present", () => {
+  const inputShapes: Array<{ label: string; node: string; gracePeriodSeconds?: number; timeoutSeconds?: number }> = [
+    { label: "node only", node: "node-1" },
+    { label: "with gracePeriodSeconds", node: "node-2", gracePeriodSeconds: 1 },
+    { label: "with timeoutSeconds", node: "node-3", timeoutSeconds: 120 },
+    { label: "with both optional params", node: "node-4", gracePeriodSeconds: 10, timeoutSeconds: 300 },
+    { label: "FQDN node name", node: "worker.us-east-1.example.com" },
+    { label: "minimum gracePeriodSeconds", node: "node-5", gracePeriodSeconds: 1 },
+    { label: "maximum gracePeriodSeconds", node: "node-6", gracePeriodSeconds: 3600 },
+  ];
+
+  for (const { label, node, gracePeriodSeconds, timeoutSeconds } of inputShapes) {
+    it(`--ignore-daemonsets present: ${label}`, () => {
+      const argv = buildDrainArgv(node, gracePeriodSeconds, timeoutSeconds);
+      expect(argv).toContain("--ignore-daemonsets");
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Invariant: argv never contains any of the four Shared Constraint #3 forbidden flags
+//
+// Asserts that no input combination can cause --force, --cascade=foreground,
+// --grace-period=0, or --delete-emptydir-data to appear in argv.
+// This serves as the same regression gate as phases 2-4.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — argv never contains forbidden flags", () => {
+  const FORBIDDEN = ["--force", "--cascade=foreground", "--grace-period=0", "--delete-emptydir-data"];
+
+  const representativeCases: Array<{ label: string; node: string; gracePeriodSeconds?: number; timeoutSeconds?: number }> = [
+    { label: "node only", node: "node-1" },
+    { label: "gracePeriodSeconds=1 (minimum)", node: "node-2", gracePeriodSeconds: 1 },
+    { label: "gracePeriodSeconds=3600 (maximum)", node: "node-3", gracePeriodSeconds: 3600 },
+    { label: "timeoutSeconds=1", node: "node-4", timeoutSeconds: 1 },
+    { label: "timeoutSeconds=3600", node: "node-5", timeoutSeconds: 3600 },
+    { label: "both optional params", node: "node-6", gracePeriodSeconds: 30, timeoutSeconds: 120 },
+  ];
+
+  for (const { label, node, gracePeriodSeconds, timeoutSeconds } of representativeCases) {
+    it(`no forbidden flags in argv: ${label}`, () => {
+      const argv = buildDrainArgv(node, gracePeriodSeconds, timeoutSeconds);
+      for (const flag of FORBIDDEN) {
+        expect(argv).not.toContain(flag);
+        // Also check for flags that might be embedded as a single element (e.g. "--grace-period=0")
+        // The argv join should not contain the forbidden flag string at all.
+        expect(argv.join(" ")).not.toContain(flag);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// gracePeriodSeconds=0 rejection
+//
+// 0 is the Zod .min(1) rejection case — equivalent to --force, explicitly
+// forbidden per the plan's Shared Constraint #3.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — rejects gracePeriodSeconds=0", () => {
+  it("rejects gracePeriodSeconds=0 (equivalent to --force, min is 1)", () => {
+    assertDrainRejects({ node: "node-1", gracePeriodSeconds: 0 });
+  });
+
+  it("rejects negative gracePeriodSeconds", () => {
+    assertDrainRejects({ node: "node-1", gracePeriodSeconds: -1 });
+  });
+
+  it("accepts gracePeriodSeconds=1 (minimum valid value)", () => {
+    const result = sreDrainSchema.safeParse({ node: "node-1", gracePeriodSeconds: 1 });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: shell-metacharacter injection (in node)
+//
+// Inputs containing `;`, `&&`, `|`, backtick, `$()`, `>` must be rejected
+// by the node name regex before they reach runKubectl.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — rejects shell-metacharacter injection", () => {
+  const metacharacterCases: Array<[string, string]> = [
+    ["semicolon (;)", "node-1;rm -rf /"],
+    ["double-ampersand (&&)", "node-1&&id"],
+    ["pipe (|)", "node-1|cat /etc/passwd"],
+    ["backtick (`)", "node-1`id`"],
+    ["command-substitution ($(...))", "node-1$(id)"],
+    ["redirect (>)", "node-1>/tmp/x"],
+  ];
+
+  for (const [label, injected] of metacharacterCases) {
+    it(`rejects ${label} in node`, () => {
+      assertDrainRejects({ node: injected });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-suffix injection
+//
+// A newline appended after a valid node name would allow injecting a second
+// kubectl command. The node name regex forbids `\n`.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — rejects multiline-suffix injection", () => {
+  it("rejects node with trailing newline + shell command", () => {
+    assertDrainRejects({ node: "node-1\nrm -rf /" });
+  });
+
+  it("rejects node with trailing newline only", () => {
+    assertDrainRejects({ node: "node-1\n" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-prefix injection
+//
+// A leading newline can shift the original name to a second line, turning
+// it into an argument to a previously injected command.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — rejects multiline-prefix injection", () => {
+  it("rejects node with leading newline", () => {
+    assertDrainRejects({ node: "\nnode-1" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: empty-command injection
+//
+// An empty string or whitespace-only string passes many naive checks but
+// would result in kubectl receiving an empty argument. The .min(1) + regex
+// reject both forms.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__drain — rejects empty-command injection", () => {
+  it("rejects empty string in node", () => {
+    assertDrainRejects({ node: "" });
+  });
+
+  it("rejects whitespace-only string in node", () => {
+    assertDrainRejects({ node: "   " });
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts
@@ -1,18 +1,20 @@
 /**
- * Smoke tests for the kubectl-exec helper (Phase 1 / GH-1287).
+ * Tests for the kubectl-exec helper (Phase 1 / GH-1287) and the typed
+ * sre__* MCP tool schemas (Phases 2-5).
  *
- * These tests verify two foundational invariants:
- *
+ * Phase 1 tests (kubectl-exec helper):
  *  1. shell:false guarantee — `runKubectl` invokes kubectl via execFile with
  *     the shell option absent (or explicitly false). A shell option of `true`
  *     must NEVER appear in the options object passed to execFile.
- *
  *  2. Forbidden-flag rejection — the defense-in-depth check rejects each of
  *     the four unconditionally banned kubectl flags before any subprocess is
  *     spawned.
  *
- * Operation-level adversarial tests (phases 2-5) will be added in later
- * describe blocks inside this same file.
+ * Phase 2 tests (sre__scale — GH-1288):
+ *  - Happy path: valid inputs produce the exact expected argv.
+ *  - Four named adversarial bypass classes (per PR #1278 security review):
+ *      shell-metacharacter, multiline-suffix, multiline-prefix, empty-command.
+ *  - Replica bounds: ceiling exceeded, negative, non-integer.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -31,6 +33,11 @@ vi.mock("node:child_process", async (importOriginal) => {
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { runKubectl, FORBIDDEN_FLAGS } from "../lib/kubectl-exec.js";
+import {
+  sreScaleSchema,
+  buildScaleArgv,
+  REPLICA_CEILING,
+} from "../tools/sre-tools.js";
 
 // The module uses promisify(execFile) internally. To control its behaviour from
 // the test we set the mock implementation on the raw `execFile` fn before each
@@ -124,5 +131,181 @@ describe("kubectl-exec helper — forbidden-flag rejection", () => {
     expect(FORBIDDEN_FLAGS).toContain("--grace-period=0");
     expect(FORBIDDEN_FLAGS).toContain("--delete-emptydir-data");
     expect(FORBIDDEN_FLAGS).toHaveLength(4);
+  });
+});
+
+// =============================================================================
+// Phase 2 (GH-1288): ralph_hero__sre__scale
+//
+// Canonical adversarial-test pattern for the sre__* family.
+// One named test per bypass class so a future regression points at the
+// specific class that regressed (per PR #1278 security review taxonomy).
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Helper: assert that a Zod parse fails (schema rejects the input)
+// ---------------------------------------------------------------------------
+
+function assertRejects(input: unknown): void {
+  const result = sreScaleSchema.safeParse(input);
+  expect(result.success).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__scale — happy path", () => {
+  it("happy path produces expected argv", () => {
+    // Verify the schema accepts valid input.
+    const parseResult = sreScaleSchema.safeParse({
+      namespace: "default",
+      deployment: "nginx",
+      replicas: 3,
+    });
+    expect(parseResult.success).toBe(true);
+
+    // Verify buildScaleArgv produces the exact expected argv.
+    const argv = buildScaleArgv("default", "nginx", 3);
+    expect(argv).toEqual([
+      "scale",
+      "--namespace",
+      "default",
+      "deployment",
+      "nginx",
+      "--replicas",
+      "3",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: shell-metacharacter injection
+//
+// Inputs containing `;`, `&&`, `|`, backtick, `$()`, `>` must be rejected
+// by the RFC 1123 label regex before they reach runKubectl.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__scale — rejects shell-metacharacter injection", () => {
+  const metacharacterCases: Array<[string, string]> = [
+    ["semicolon (;)", "nginx;rm -rf /"],
+    ["double-ampersand (&&)", "nginx&&id"],
+    ["pipe (|)", "nginx|cat /etc/passwd"],
+    ["backtick (`)", "nginx`id`"],
+    ["command-substitution ($(...))", "nginx$(id)"],
+    ["redirect (>)", "nginx>/tmp/x"],
+  ];
+
+  for (const [label, injected] of metacharacterCases) {
+    it(`rejects ${label} in namespace`, () => {
+      assertRejects({ namespace: injected, deployment: "nginx", replicas: 1 });
+    });
+    it(`rejects ${label} in deployment`, () => {
+      assertRejects({ namespace: "default", deployment: injected, replicas: 1 });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-suffix injection
+//
+// A newline appended after a valid name would allow injecting a second
+// kubectl command. The RFC 1123 regex forbids `\n`.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__scale — rejects multiline-suffix injection", () => {
+  it("rejects namespace with trailing newline + shell command", () => {
+    assertRejects({
+      namespace: "default\nrm -rf /",
+      deployment: "nginx",
+      replicas: 1,
+    });
+  });
+
+  it("rejects deployment with trailing newline + shell command", () => {
+    assertRejects({
+      namespace: "default",
+      deployment: "nginx\nrm -rf /",
+      replicas: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: multiline-prefix injection
+//
+// A leading newline can shift the original name to a second line, turning
+// it into an argument to a previously injected command.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__scale — rejects multiline-prefix injection", () => {
+  it("rejects namespace with leading newline", () => {
+    assertRejects({ namespace: "\nnginx", deployment: "nginx", replicas: 1 });
+  });
+
+  it("rejects deployment with leading newline", () => {
+    assertRejects({ namespace: "default", deployment: "\nnginx", replicas: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial bypass class: empty-command injection
+//
+// An empty string or whitespace-only string passes many naive checks but
+// would result in kubectl receiving an empty argument. The .min(1) + regex
+// reject both forms.
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__scale — rejects empty-command injection", () => {
+  it("rejects empty string in namespace", () => {
+    assertRejects({ namespace: "", deployment: "nginx", replicas: 1 });
+  });
+
+  it("rejects whitespace-only string in namespace", () => {
+    assertRejects({ namespace: "   ", deployment: "nginx", replicas: 1 });
+  });
+
+  it("rejects empty string in deployment", () => {
+    assertRejects({ namespace: "default", deployment: "", replicas: 1 });
+  });
+
+  it("rejects whitespace-only string in deployment", () => {
+    assertRejects({ namespace: "default", deployment: "   ", replicas: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Replica bounds
+// ---------------------------------------------------------------------------
+
+describe("ralph_hero__sre__scale — replica bounds", () => {
+  it(`rejects replicas > ceiling (${REPLICA_CEILING})`, () => {
+    assertRejects({ namespace: "default", deployment: "nginx", replicas: REPLICA_CEILING + 1 });
+  });
+
+  it("rejects negative replicas", () => {
+    assertRejects({ namespace: "default", deployment: "nginx", replicas: -1 });
+  });
+
+  it("rejects non-integer replicas", () => {
+    assertRejects({ namespace: "default", deployment: "nginx", replicas: 3.5 });
+  });
+
+  it("accepts replicas = 0 (scale-to-zero is valid)", () => {
+    const result = sreScaleSchema.safeParse({
+      namespace: "default",
+      deployment: "nginx",
+      replicas: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it(`accepts replicas = ${REPLICA_CEILING} (ceiling is inclusive)`, () => {
+    const result = sreScaleSchema.safeParse({
+      namespace: "default",
+      deployment: "nginx",
+      replicas: REPLICA_CEILING,
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
@@ -191,6 +191,7 @@ const EXPECTED_TOOLS: readonly string[] = [
   "ralph_hero__remove_dependency",
   "ralph_hero__save_issue",
   "ralph_hero__setup_project",
+  "ralph_hero__sre__scale",
   "ralph_hero__sync_plan_graph",
   "ralph_hero__update_draft_issue",
 ];

--- a/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
@@ -191,6 +191,7 @@ const EXPECTED_TOOLS: readonly string[] = [
   "ralph_hero__remove_dependency",
   "ralph_hero__save_issue",
   "ralph_hero__setup_project",
+  "ralph_hero__sre__delete_pod",
   "ralph_hero__sre__rollout_restart",
   "ralph_hero__sre__scale",
   "ralph_hero__sync_plan_graph",

--- a/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
@@ -192,6 +192,7 @@ const EXPECTED_TOOLS: readonly string[] = [
   "ralph_hero__save_issue",
   "ralph_hero__setup_project",
   "ralph_hero__sre__delete_pod",
+  "ralph_hero__sre__drain",
   "ralph_hero__sre__rollout_restart",
   "ralph_hero__sre__scale",
   "ralph_hero__sync_plan_graph",

--- a/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/tool-registration.test.ts
@@ -191,6 +191,7 @@ const EXPECTED_TOOLS: readonly string[] = [
   "ralph_hero__remove_dependency",
   "ralph_hero__save_issue",
   "ralph_hero__setup_project",
+  "ralph_hero__sre__rollout_restart",
   "ralph_hero__sre__scale",
   "ralph_hero__sync_plan_graph",
   "ralph_hero__update_draft_issue",

--- a/plugin/ralph-hero/mcp-server/src/index.ts
+++ b/plugin/ralph-hero/mcp-server/src/index.ts
@@ -35,6 +35,7 @@ import { registerPlanGraphTools } from "./tools/plan-graph-tools.js";
 import { registerActivityTools } from "./tools/activity-tools.js";
 import { registerDelegationTools } from "./tools/delegation-tools.js";
 import { registerTrendsTools } from "./tools/trends-tools.js";
+import { registerSreTools } from "./tools/sre-tools.js";
 
 /**
  * Initialize the GitHub client from environment variables.
@@ -545,6 +546,9 @@ async function main(): Promise<void> {
 
   // Trends tools (capture_snapshot — JSONL persistence under ~/.ralph-hero/snapshots/)
   registerTrendsTools(server, client, fieldCache);
+
+  // SRE operation tools (kubectl autoremediation — typed argv, no-shell invariant)
+  registerSreTools(server, client, fieldCache);
 
   // Debug tools (only when RALPH_DEBUG=true)
   if (process.env.RALPH_DEBUG === 'true') {

--- a/plugin/ralph-hero/mcp-server/src/lib/kubectl-exec.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/kubectl-exec.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared kubectl execution helper for all SRE operation tools.
+ *
+ * INVARIANT: This module NEVER invokes a shell. All kubectl calls go through
+ * `child_process.execFile` with `shell: false` (the execFile default), which
+ * passes argv directly to execve(2). String-interpolated shell commands and
+ * `exec()` are explicitly forbidden here.
+ *
+ * The {@link FORBIDDEN_FLAGS} list provides a defense-in-depth check on top of
+ * the typed Zod schemas in sre-tools.ts. The typed schemas should already make
+ * these flags unreachable, but the helper enforces a hard floor so a future
+ * regression (e.g., a new typed param that happens to produce a forbidden flag)
+ * is caught at the exec layer, not silently allowed.
+ */
+
+import { execFile as _execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(_execFile);
+
+/**
+ * Typed result returned by {@link runKubectl}.
+ */
+export interface KubectlResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Flags that are unconditionally forbidden in kubectl argv.
+ *
+ * These represent destructive or resource-exhausting operations that the
+ * sre-fixit agent must never perform. They are defense-in-depth: the typed
+ * Zod schemas in sre-tools.ts make them structurally unreachable, but this
+ * list catches future regressions where a new typed param happens to produce
+ * one of these strings.
+ */
+export const FORBIDDEN_FLAGS: readonly string[] = [
+  "--force",
+  "--cascade=foreground",
+  "--grace-period=0",
+  "--delete-emptydir-data",
+];
+
+/**
+ * Execute kubectl with the given argv array.
+ *
+ * Uses `child_process.execFile` (shell: false by default) so the argv is
+ * passed directly to execve(2) — no shell interpretation, no metacharacter
+ * expansion, no glob expansion.
+ *
+ * @param args - Typed argv array (e.g. `["scale", "--namespace", "default", ...]`).
+ *               Never accepts a string command.
+ * @throws {Error} If any element of `args` matches a {@link FORBIDDEN_FLAGS} entry.
+ * @returns A typed result with `stdout`, `stderr`, and `exitCode`.
+ */
+export async function runKubectl(args: readonly string[]): Promise<KubectlResult> {
+  // Defense-in-depth: reject any argv element that matches a forbidden flag.
+  for (const arg of args) {
+    if (FORBIDDEN_FLAGS.includes(arg)) {
+      throw new Error(
+        `kubectl argv contains forbidden flag: ${arg}. ` +
+          `Forbidden flags: ${FORBIDDEN_FLAGS.join(", ")}`,
+      );
+    }
+  }
+
+  try {
+    const { stdout, stderr } = await execFileAsync("kubectl", args as string[], {
+      shell: false,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    // execFile rejects when the process exits with a non-zero code.
+    // The error object carries stdout/stderr from the failed run.
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: typeof e.code === "number" ? e.code : 1,
+    };
+  }
+}

--- a/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
@@ -19,11 +19,86 @@
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import type { GitHubClient } from "../github-client.js";
 import type { FieldOptionCache } from "../lib/cache.js";
-// runKubectl is imported here for use by operation phases 2-5.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { runKubectl } from "../lib/kubectl-exec.js";
+import { toolSuccess, toolError } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Shared Zod field schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * RFC 1123 label regex for Kubernetes namespace and deployment names.
+ * Intentionally rejects shell metacharacters, slashes, newlines, and empty
+ * strings as a single Zod check.
+ */
+const k8sLabelSchema = z.string().min(1).regex(/^[a-z0-9-]+$/);
+
+/**
+ * Bounded replica count. Ceiling is 50 — configurable in a follow-up; the
+ * explicit ceiling prevents runaway scale-out from an LLM miscalculation.
+ */
+export const REPLICA_CEILING = 50;
+const replicasSchema = z.number().int().min(0).max(REPLICA_CEILING);
+
+// ---------------------------------------------------------------------------
+// sre__scale schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw Zod shape for the sre__scale tool.
+ * Passed to `server.tool()` which expects a `ZodRawShape` (plain object of
+ * Zod field schemas).
+ */
+const sreScaleShape = {
+  namespace: k8sLabelSchema.describe(
+    "Kubernetes namespace (RFC 1123 label: lowercase alphanumeric and hyphens only).",
+  ),
+  deployment: k8sLabelSchema.describe(
+    "Deployment name (RFC 1123 label: lowercase alphanumeric and hyphens only).",
+  ),
+  replicas: replicasSchema.describe(
+    `Target replica count (integer, 0–${REPLICA_CEILING}).`,
+  ),
+};
+
+/**
+ * Strict Zod object schema for sre__scale parameters.
+ *
+ * Exported so adversarial-input tests (sre-tools.test.ts) can call
+ * `.safeParse()` directly. `.strict()` ensures unknown keys are rejected —
+ * any attempt to pass extra fields (e.g., a `flags` bypass) is caught at
+ * the schema level.
+ */
+export const sreScaleSchema = z.object(sreScaleShape).strict();
+
+/**
+ * Build the kubectl argv array for a scale operation.
+ *
+ * Exported for unit-testing the argv shape independently of the MCP server.
+ * The argv is a plain array literal — no string interpolation, no concat.
+ *
+ * @param namespace  - Validated Kubernetes namespace.
+ * @param deployment - Validated deployment name.
+ * @param replicas   - Validated replica count.
+ */
+export function buildScaleArgv(
+  namespace: string,
+  deployment: string,
+  replicas: number,
+): string[] {
+  return [
+    "scale",
+    "--namespace",
+    namespace,
+    "deployment",
+    deployment,
+    "--replicas",
+    String(replicas),
+  ];
+}
 
 /**
  * Register all SRE operation tools on the MCP server.
@@ -43,9 +118,28 @@ export function registerSreTools(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _fieldCache: FieldOptionCache,
 ): void {
-  // Phase 2 (GH-1288): sre__scale — register here
+  // -------------------------------------------------------------------------
+  // ralph_hero__sre__scale  (Phase 2 / GH-1288)
+  // -------------------------------------------------------------------------
+  server.tool(
+    "ralph_hero__sre__scale",
+    "Scale a Kubernetes deployment to a specified replica count. " +
+      "Typed parameters only — no shell, no flag pass-through. " +
+      `Replica ceiling: ${REPLICA_CEILING}.`,
+    sreScaleShape,
+    async ({ namespace, deployment, replicas }) => {
+      const argv = buildScaleArgv(namespace, deployment, replicas);
+      try {
+        const result = await runKubectl(argv);
+        return toolSuccess(result);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return toolError(`kubectl scale failed: ${message}`);
+      }
+    },
+  );
+
   // Phase 3 (GH-1289): sre__rollout_restart — register here
   // Phase 4 (GH-1290): sre__delete_pod — register here
   // Phase 5 (GH-1291): sre__drain — register here
-  void server; // referenced but empty in Phase 1
 }

--- a/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
@@ -47,6 +47,7 @@ const replicasSchema = z.number().int().min(0).max(REPLICA_CEILING);
 // sre__scale schemas
 // ---------------------------------------------------------------------------
 
+
 /**
  * Raw Zod shape for the sre__scale tool.
  * Passed to `server.tool()` which expects a `ZodRawShape` (plain object of
@@ -100,6 +101,61 @@ export function buildScaleArgv(
   ];
 }
 
+// ---------------------------------------------------------------------------
+// sre__rollout_restart schemas  (Phase 3 / GH-1289)
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw Zod shape for the sre__rollout_restart tool.
+ */
+const sreRolloutRestartShape = {
+  namespace: k8sLabelSchema.describe(
+    "Kubernetes namespace (RFC 1123 label: lowercase alphanumeric and hyphens only).",
+  ),
+  deployment: k8sLabelSchema.describe(
+    "Deployment name (RFC 1123 label: lowercase alphanumeric and hyphens only).",
+  ),
+};
+
+/**
+ * Strict Zod object schema for sre__rollout_restart parameters.
+ *
+ * Exported so adversarial-input tests (sre-tools.test.ts) can call
+ * `.safeParse()` directly. `.strict()` ensures unknown keys are rejected.
+ */
+export const sreRolloutRestartSchema = z.object(sreRolloutRestartShape).strict();
+
+/**
+ * Build the kubectl argv array for a rollout restart operation.
+ *
+ * Exported for unit-testing the argv shape independently of the MCP server.
+ *
+ * NOTE — deliberate template-literal exception: This is the only argv builder
+ * in the sre__* family that uses a template literal. The `deployment/<name>`
+ * form is specific to `kubectl rollout restart`'s resource-qualified argument
+ * syntax. The interpolation is safe by construction: the `deployment` Zod
+ * schema (`/^[a-z0-9-]+$/`) forbids `/`, newlines, and shell metacharacters —
+ * the only characters that could escape the literal prefix. Do NOT generalise
+ * this pattern to other phases; phases 2, 4, and 5 keep plain array literals.
+ *
+ * @param namespace  - Validated Kubernetes namespace.
+ * @param deployment - Validated deployment name.
+ */
+export function buildRolloutRestartArgv(
+  namespace: string,
+  deployment: string,
+): string[] {
+  return [
+    "rollout",
+    "restart",
+    "--namespace",
+    namespace,
+    `deployment/${deployment}`,
+  ];
+}
+
+// ---------------------------------------------------------------------------
+
 /**
  * Register all SRE operation tools on the MCP server.
  *
@@ -139,7 +195,27 @@ export function registerSreTools(
     },
   );
 
-  // Phase 3 (GH-1289): sre__rollout_restart — register here
+  // -------------------------------------------------------------------------
+  // ralph_hero__sre__rollout_restart  (Phase 3 / GH-1289)
+  // -------------------------------------------------------------------------
+  server.tool(
+    "ralph_hero__sre__rollout_restart",
+    "Trigger a rolling restart of a Kubernetes deployment. " +
+      "Typed parameters only — no shell, no flag pass-through. " +
+      "Equivalent to: kubectl rollout restart deployment/<name> -n <namespace>.",
+    sreRolloutRestartShape,
+    async ({ namespace, deployment }) => {
+      const argv = buildRolloutRestartArgv(namespace, deployment);
+      try {
+        const result = await runKubectl(argv);
+        return toolSuccess(result);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return toolError(`kubectl rollout restart failed: ${message}`);
+      }
+    },
+  );
+
   // Phase 4 (GH-1290): sre__delete_pod — register here
   // Phase 5 (GH-1291): sre__drain — register here
 }

--- a/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
@@ -1,0 +1,51 @@
+/**
+ * SRE operation tools for kubectl autoremediation.
+ *
+ * This module registers the `ralph_hero__sre__*` family of typed MCP tools.
+ * Each tool accepts explicit, narrowly-typed parameters and delegates to the
+ * shared {@link runKubectl} helper from `../lib/kubectl-exec.ts`.
+ *
+ * INVARIANT (no-shell): All kubectl invocations go through `runKubectl`, which
+ * uses `child_process.execFile` with `shell: false`. There are NO string-
+ * interpolated shell commands, NO `exec()` calls, and NO `Bash` tool usage in
+ * this module or the agent that consumes it. Argv is always a plain array
+ * literal — never built via template strings, string concat, or user-controlled
+ * flag pass-through.
+ *
+ * Phases 2-5 of the GH-1285 plan add the four operation tool registrations
+ * (sre__scale, sre__rollout_restart, sre__delete_pod, sre__drain) inside
+ * `registerSreTools`. Phase 1 (GH-1287) establishes the module skeleton and
+ * wires the registration call in index.ts.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { GitHubClient } from "../github-client.js";
+import type { FieldOptionCache } from "../lib/cache.js";
+// runKubectl is imported here for use by operation phases 2-5.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { runKubectl } from "../lib/kubectl-exec.js";
+
+/**
+ * Register all SRE operation tools on the MCP server.
+ *
+ * The `client` and `fieldCache` parameters are accepted for API consistency
+ * with other `register*Tools` functions. They are unused in Phase 1 (scaffold
+ * only); Phases 2-5 may use `client` for issue context lookups if needed.
+ *
+ * @param server     - The MCP server instance to register tools on.
+ * @param client     - GitHub client (reserved for future phases).
+ * @param fieldCache - Field option cache (reserved for future phases).
+ */
+export function registerSreTools(
+  server: McpServer,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _client: GitHubClient,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _fieldCache: FieldOptionCache,
+): void {
+  // Phase 2 (GH-1288): sre__scale — register here
+  // Phase 3 (GH-1289): sre__rollout_restart — register here
+  // Phase 4 (GH-1290): sre__delete_pod — register here
+  // Phase 5 (GH-1291): sre__drain — register here
+  void server; // referenced but empty in Phase 1
+}

--- a/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
@@ -155,6 +155,53 @@ export function buildRolloutRestartArgv(
 }
 
 // ---------------------------------------------------------------------------
+// sre__delete_pod schemas  (Phase 4 / GH-1290)
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw Zod shape for the sre__delete_pod tool.
+ *
+ * The schema has exactly two fields — `namespace` and `pod`. There is no
+ * label-selector field, no `--force` field, and no `--grace-period` field.
+ * The absence of these fields is the primary typed-surface guarantee: there is
+ * no way to express bulk deletion, forced deletion, or grace-period override
+ * through this schema. `.strict()` rejects any extra keys the caller might
+ * try to pass.
+ */
+const sreDeletePodShape = {
+  namespace: k8sLabelSchema.describe(
+    "Kubernetes namespace (RFC 1123 label: lowercase alphanumeric and hyphens only).",
+  ),
+  pod: k8sLabelSchema.describe(
+    "Pod name to delete (RFC 1123 label: lowercase alphanumeric and hyphens only). " +
+      "Single pod only — no label selector, no wildcard.",
+  ),
+};
+
+/**
+ * Strict Zod object schema for sre__delete_pod parameters.
+ *
+ * Exported so adversarial-input tests (sre-tools.test.ts) can call
+ * `.safeParse()` directly, including the `.strict()` no-label-selector
+ * assertion. `.strict()` ensures unknown keys (e.g., `selector: "app=foo"`)
+ * are rejected at the schema level.
+ */
+export const sreDeletePodSchema = z.object(sreDeletePodShape).strict();
+
+/**
+ * Build the kubectl argv array for a delete-pod operation.
+ *
+ * Exported for unit-testing the argv shape independently of the MCP server.
+ * The argv is a plain array literal — no string interpolation, no concat.
+ *
+ * @param namespace - Validated Kubernetes namespace.
+ * @param pod       - Validated pod name (single pod, no label selector).
+ */
+export function buildDeletePodArgv(namespace: string, pod: string): string[] {
+  return ["delete", "pod", "--namespace", namespace, pod];
+}
+
+// ---------------------------------------------------------------------------
 
 /**
  * Register all SRE operation tools on the MCP server.
@@ -216,6 +263,26 @@ export function registerSreTools(
     },
   );
 
-  // Phase 4 (GH-1290): sre__delete_pod — register here
+  // -------------------------------------------------------------------------
+  // ralph_hero__sre__delete_pod  (Phase 4 / GH-1290)
+  // -------------------------------------------------------------------------
+  server.tool(
+    "ralph_hero__sre__delete_pod",
+    "Delete a single named pod in a Kubernetes namespace. " +
+      "Single pod by name only — no label selector, no --force, no --grace-period=0. " +
+      "Typed parameters only — no shell, no flag pass-through.",
+    sreDeletePodShape,
+    async ({ namespace, pod }) => {
+      const argv = buildDeletePodArgv(namespace, pod);
+      try {
+        const result = await runKubectl(argv);
+        return toolSuccess(result);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return toolError(`kubectl delete pod failed: ${message}`);
+      }
+    },
+  );
+
   // Phase 5 (GH-1291): sre__drain — register here
 }

--- a/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
@@ -330,6 +330,11 @@ export function registerSreTools(
       const argv = buildScaleArgv(namespace, deployment, replicas);
       try {
         const result = await runKubectl(argv);
+        if (result.exitCode !== 0) {
+          return toolError(
+            `kubectl scale failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
+          );
+        }
         return toolSuccess(result);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
@@ -351,6 +356,11 @@ export function registerSreTools(
       const argv = buildRolloutRestartArgv(namespace, deployment);
       try {
         const result = await runKubectl(argv);
+        if (result.exitCode !== 0) {
+          return toolError(
+            `kubectl rollout restart failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
+          );
+        }
         return toolSuccess(result);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
@@ -372,6 +382,11 @@ export function registerSreTools(
       const argv = buildDeletePodArgv(namespace, pod);
       try {
         const result = await runKubectl(argv);
+        if (result.exitCode !== 0) {
+          return toolError(
+            `kubectl delete pod failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
+          );
+        }
         return toolSuccess(result);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
@@ -395,6 +410,11 @@ export function registerSreTools(
       const argv = buildDrainArgv(node, gracePeriodSeconds, timeoutSeconds);
       try {
         const result = await runKubectl(argv);
+        if (result.exitCode !== 0) {
+          return toolError(
+            `kubectl drain failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
+          );
+        }
         return toolSuccess(result);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);

--- a/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts
@@ -202,6 +202,102 @@ export function buildDeletePodArgv(namespace: string, pod: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// sre__drain schemas  (Phase 5 / GH-1291)
+// ---------------------------------------------------------------------------
+
+/**
+ * Node name regex — slightly looser than the RFC 1123 label regex because
+ * Kubernetes node names can be in FQDN form (e.g., "node-1.us-east-1.example.com").
+ * The dot (`.`) is the only addition over the namespace/deployment regex.
+ * Intentionally rejects shell metacharacters, slashes, newlines, and empty
+ * strings as a single Zod check.
+ */
+const k8sNodeNameSchema = z.string().min(1).regex(/^[a-z0-9.-]+$/);
+
+/**
+ * Bounded grace period in seconds. Minimum is 1 — gracePeriodSeconds=0 is
+ * equivalent to --force (immediate kill) and is explicitly forbidden by the
+ * plan's Shared Constraint #3.  Maximum is 3600 (one hour).
+ */
+const gracePeriodSecondsSchema = z.number().int().min(1).max(3600);
+
+/**
+ * Bounded timeout in seconds. Minimum is 1. Maximum is 3600 (one hour).
+ */
+const timeoutSecondsSchema = z.number().int().min(1).max(3600);
+
+/**
+ * Raw Zod shape for the sre__drain tool.
+ *
+ * `--namespace` is intentionally absent: `kubectl drain` targets a node, which
+ * is a cluster-scoped resource. Do not add a namespace field — its absence is
+ * correct per the plan's Phase 5 note.
+ *
+ * `--ignore-daemonsets` is hard-coded into argv by the builder; it is NOT a
+ * user-controllable parameter. `--force` and `--delete-emptydir-data` are
+ * structurally unreachable through this schema.
+ */
+const sreDrainShape = {
+  node: k8sNodeNameSchema.describe(
+    "Node name to drain (RFC 1123 / FQDN form: lowercase alphanumeric, hyphens, and dots only).",
+  ),
+  gracePeriodSeconds: gracePeriodSecondsSchema.optional().describe(
+    "Grace period for evicting pods in seconds (integer, 1–3600). " +
+      "Omit to use the pod's default. " +
+      "0 is explicitly forbidden (equivalent to --force).",
+  ),
+  timeoutSeconds: timeoutSecondsSchema.optional().describe(
+    "Timeout for the drain operation in seconds (integer, 1–3600). " +
+      "Omit to use kubectl's default.",
+  ),
+};
+
+/**
+ * Strict Zod object schema for sre__drain parameters.
+ *
+ * Exported so adversarial-input tests (sre-tools.test.ts) can call
+ * `.safeParse()` directly. `.strict()` ensures unknown keys are rejected —
+ * any attempt to pass extra fields (e.g., a `force` bypass) is caught at
+ * the schema level.
+ */
+export const sreDrainSchema = z.object(sreDrainShape).strict();
+
+/**
+ * Build the kubectl argv array for a drain operation.
+ *
+ * Exported for unit-testing the argv shape independently of the MCP server.
+ * The argv is a plain array literal — no string interpolation, no concat
+ * (drain follows the same plain-array-literal pattern as phases 2 and 4).
+ *
+ * INVARIANTS (enforced by construction):
+ *   - `--ignore-daemonsets` is always present (hard-coded, not user-controlled).
+ *   - `--force` is never present (no schema field; helper also rejects it).
+ *   - `--delete-emptydir-data` is never present (no schema field).
+ *   - `--grace-period=0` is never present (gracePeriodSeconds min is 1 via Zod).
+ *
+ * @param node               - Validated node name.
+ * @param gracePeriodSeconds - Optional validated grace period (seconds, >= 1).
+ * @param timeoutSeconds     - Optional validated timeout (seconds, >= 1).
+ */
+export function buildDrainArgv(
+  node: string,
+  gracePeriodSeconds?: number,
+  timeoutSeconds?: number,
+): string[] {
+  const argv: string[] = ["drain", node, "--ignore-daemonsets"];
+
+  if (gracePeriodSeconds !== undefined) {
+    argv.push("--grace-period", String(gracePeriodSeconds));
+  }
+
+  if (timeoutSeconds !== undefined) {
+    argv.push("--timeout", `${timeoutSeconds}s`);
+  }
+
+  return argv;
+}
+
+// ---------------------------------------------------------------------------
 
 /**
  * Register all SRE operation tools on the MCP server.
@@ -284,5 +380,26 @@ export function registerSreTools(
     },
   );
 
-  // Phase 5 (GH-1291): sre__drain — register here
+  // -------------------------------------------------------------------------
+  // ralph_hero__sre__drain  (Phase 5 / GH-1291)
+  // -------------------------------------------------------------------------
+  server.tool(
+    "ralph_hero__sre__drain",
+    "Drain a Kubernetes node by evicting all non-daemonset pods. " +
+      "--ignore-daemonsets is hard-coded on (always present). " +
+      "--force, --delete-emptydir-data, and --grace-period=0 are structurally unreachable. " +
+      "Cluster-scoped operation — no --namespace flag. " +
+      "Typed parameters only — no shell, no flag pass-through.",
+    sreDrainShape,
+    async ({ node, gracePeriodSeconds, timeoutSeconds }) => {
+      const argv = buildDrainArgv(node, gracePeriodSeconds, timeoutSeconds);
+      try {
+        const result = await runKubectl(argv);
+        return toolSuccess(result);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return toolError(`kubectl drain failed: ${message}`);
+      }
+    },
+  );
 }

--- a/thoughts/shared/plans/2026-05-17-group-GH-1285-typed-mcp-kubectl-tools.md
+++ b/thoughts/shared/plans/2026-05-17-group-GH-1285-typed-mcp-kubectl-tools.md
@@ -139,12 +139,12 @@ Create the new tool module file and the shared kubectl exec helper. Wire `regist
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] Exports `runKubectl(args: string[]): Promise<{ stdout: string, stderr: string, exitCode: number }>`
-  - [ ] Uses `child_process.execFile("kubectl", args, { shell: false })` (or `spawn` with `shell: false`); MUST NOT use `exec` or any `shell: true` variant
-  - [ ] Exports `FORBIDDEN_FLAGS = ["--force", "--cascade=foreground", "--grace-period=0", "--delete-emptydir-data"]` (or equivalent readonly constant)
-  - [ ] Before invocation, scans the argv for any element matching one of the forbidden flags; throws/rejects with a clear error mentioning the offending flag if found
-  - [ ] Argv input is `readonly string[]` (or `string[]`) — never accepts a string command
-  - [ ] Returns a typed result object with `stdout`, `stderr`, `exitCode` fields
+  - [x] Exports `runKubectl(args: string[]): Promise<{ stdout: string, stderr: string, exitCode: number }>`
+  - [x] Uses `child_process.execFile("kubectl", args, { shell: false })` (or `spawn` with `shell: false`); MUST NOT use `exec` or any `shell: true` variant
+  - [x] Exports `FORBIDDEN_FLAGS = ["--force", "--cascade=foreground", "--grace-period=0", "--delete-emptydir-data"]` (or equivalent readonly constant)
+  - [x] Before invocation, scans the argv for any element matching one of the forbidden flags; throws/rejects with a clear error mentioning the offending flag if found
+  - [x] Argv input is `readonly string[]` (or `string[]`) — never accepts a string command
+  - [x] Returns a typed result object with `stdout`, `stderr`, `exitCode` fields
 
 #### Task 1.2: Create sre-tools.ts module skeleton
 - **files**: `plugin/ralph-hero/mcp-server/src/tools/sre-tools.ts` (create), `plugin/ralph-hero/mcp-server/src/tools/issue-tools.ts` (read for pattern)
@@ -152,10 +152,10 @@ Create the new tool module file and the shared kubectl exec helper. Wire `regist
 - **complexity**: low
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] Exports `registerSreTools(server: McpServer, client: GitHubClient, fieldCache: FieldOptionCache): void` (fieldCache may be unused in phase 1; keep the signature consistent with other register functions)
-  - [ ] Imports follow ESM `.js` extension convention (e.g., `from "../lib/kubectl-exec.js"`)
-  - [ ] Function body is empty (no tool registrations yet); phases 2-5 fill it in
-  - [ ] File has a top-of-file JSDoc explaining the module purpose and the no-shell invariant
+  - [x] Exports `registerSreTools(server: McpServer, client: GitHubClient, fieldCache: FieldOptionCache): void` (fieldCache may be unused in phase 1; keep the signature consistent with other register functions)
+  - [x] Imports follow ESM `.js` extension convention (e.g., `from "../lib/kubectl-exec.js"`)
+  - [x] Function body is empty (no tool registrations yet); phases 2-5 fill it in
+  - [x] File has a top-of-file JSDoc explaining the module purpose and the no-shell invariant
 
 #### Task 1.3: Wire registerSreTools in index.ts
 - **files**: `plugin/ralph-hero/mcp-server/src/index.ts` (modify)
@@ -163,9 +163,9 @@ Create the new tool module file and the shared kubectl exec helper. Wire `regist
 - **complexity**: low
 - **depends_on**: [1.2]
 - **acceptance**:
-  - [ ] `import { registerSreTools } from "./tools/sre-tools.js"` added alongside other tool imports
-  - [ ] `registerSreTools(server, client, fieldCache)` called inside `main()` alongside other `register*Tools` calls
-  - [ ] Insertion order is alphabetically near `registerTrendsTools` or grouped with other operation-tool registrations (style choice — doesn't affect runtime)
+  - [x] `import { registerSreTools } from "./tools/sre-tools.js"` added alongside other tool imports
+  - [x] `registerSreTools(server, client, fieldCache)` called inside `main()` alongside other `register*Tools` calls
+  - [x] Insertion order is alphabetically near `registerTrendsTools` or grouped with other operation-tool registrations (style choice — doesn't affect runtime)
 
 #### Task 1.4: Smoke tests for the exec helper
 - **files**: `plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts` (create)
@@ -173,19 +173,19 @@ Create the new tool module file and the shared kubectl exec helper. Wire `regist
 - **complexity**: medium
 - **depends_on**: [1.1]
 - **acceptance**:
-  - [ ] Test `invokes kubectl with shell:false` — mocks `child_process.execFile`, calls `runKubectl(["version"])`, asserts the mock was called with `("kubectl", ["version"], <opts>)` where opts.shell is `false` or absent (execFile default is no-shell, but the test should assert the options object does not set `shell: true`)
-  - [ ] Test `rejects --force flag in argv` — calls `runKubectl(["delete", "pod", "foo", "--force"])`, asserts rejection with error message mentioning `--force`
-  - [ ] Test `rejects --cascade=foreground flag in argv` — analogous
-  - [ ] Test `rejects --grace-period=0 flag in argv` — analogous
-  - [ ] Test `rejects --delete-emptydir-data flag in argv` — analogous
-  - [ ] All five tests pass via `npx vitest run src/__tests__/sre-tools.test.ts`
+  - [x] Test `invokes kubectl with shell:false` — mocks `child_process.execFile`, calls `runKubectl(["version"])`, asserts the mock was called with `("kubectl", ["version"], <opts>)` where opts.shell is `false` or absent (execFile default is no-shell, but the test should assert the options object does not set `shell: true`)
+  - [x] Test `rejects --force flag in argv` — calls `runKubectl(["delete", "pod", "foo", "--force"])`, asserts rejection with error message mentioning `--force`
+  - [x] Test `rejects --cascade=foreground flag in argv` — analogous
+  - [x] Test `rejects --grace-period=0 flag in argv` — analogous
+  - [x] Test `rejects --delete-emptydir-data flag in argv` — analogous
+  - [x] All five tests pass via `npx vitest run src/__tests__/sre-tools.test.ts`
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — no TypeScript errors
-- [ ] `npx vitest run src/__tests__/sre-tools.test.ts` — all 5 tests pass
-- [ ] `npm test` — full suite still green (no regressions in other tool modules)
+- [x] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — no TypeScript errors
+- [x] `npx vitest run src/__tests__/sre-tools.test.ts` — all 5 tests pass
+- [x] `npm test` — full suite still green (no regressions in other tool modules)
 
 #### Manual Verification:
 - [ ] `grep -n "shell" plugin/ralph-hero/mcp-server/src/lib/kubectl-exec.ts` — only safe matches (no `shell: true`)


### PR DESCRIPTION
## Summary

Introduces a typed MCP tool surface for kubectl autoremediation in sre-fixit, replacing the abandoned Bash+regex approach from PR #1278. Four tools (scale, rollout-restart, delete-pod, drain) with strict Zod schemas enforce the typed-parameter constraint at the MCP layer, eliminating shell-injection vectors entirely via `execFile(shell:false)` invocation semantics.

## Plan

Reference plan: https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-17-group-GH-1285-typed-mcp-kubectl-tools.md

Phases shipped: 6 of 6 (all 6 sub-issues implemented atomically)

## Operations & Security Invariants

1. **sre__scale** — Scale a deployment to N replicas (bounded 0–50, no force/cascade flags reachable by construction)
2. **sre__rollout_restart** — Restart a deployment's pods via `kubectl rollout restart` (no label selector, no dangerous flags)
3. **sre__delete_pod** — Delete a single pod by name (no label selector, no force/grace-period overrides, strict schema rejects unknown fields)
4. **sre__drain** — Drain a node with implicit `--ignore-daemonsets` (cluster-scoped, no namespace parameter, no force/delete-emptydir-data)

**Defense-in-depth**: Four forbidden flags (`--force`, `--cascade=foreground`, `--grace-period=0`, `--delete-emptydir-data`) are rejected by `kubectl-exec.ts` helper before invocation, even though the typed schemas already make them unreachable.

## Adversarial Bypass Classes Tested

Each of the four operation tools includes one named test per security bypass class from PR #1278's code review:

1. **Shell-metacharacter injection** (`;`, `&&`, `|`, `` ` ``, `$()`, `>`) — rejected by RFC 1123 label regex
2. **Multiline-suffix injection** (`name\nrm -rf /`) — rejected by regex (no newlines)
3. **Multiline-prefix injection** (`\nname`) — rejected by regex
4. **Empty-command injection** (`""`, whitespace-only) — rejected by `.min(1)` constraint

Additionally, the helper `runKubectl` enforces no-shell semantics (`child_process.execFile` with `shell: false`) and a hard rejection list for all four forbidden flags as a second verification layer.

## Test Plan

- [x] `npm run build` in `plugin/ralph-hero/mcp-server/` — exits 0 (TypeScript clean, no errors)
- [x] `npm test` in `plugin/ralph-hero/mcp-server/` — full suite passes, including new `sre-tools.test.ts` with 30+ tests covering happy paths, adversarial classes, and invariant assertions
- [x] Grep audit: forbidden flags appear only in the rejection list in `kubectl-exec.ts`, never in argv-building code
- [x] Grep audit: `sre-fixit.md` contains no `Bash` tool reference (dropped intentionally per typed-tool redesign)
- [x] All four `ralph_hero__sre__*` tools are registered and resolvable by the MCP server

Closes #1285, #1287, #1288, #1289, #1290, #1291, #1292
