### PR TITLE
chore(plans): groom completed acceptance criteria checkboxes

### DIFF
--- a/thoughts/shared/plans/2026-05-13-GH-1192-setup-skill-delegation-docs-polish.md
+++ b/thoughts/shared/plans/2026-05-13-GH-1192-setup-skill-delegation-docs-polish.md
@@ -177,13 +177,13 @@ Add a "Step 6c — Delegation Onboarding (Optional)" sub-step to the setup skill
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` in `plugin/ralph-hero/mcp-server/` — no errors (no TS changes expected, but build must remain green for the merge)
-- [ ] `grep -nri "upcoming" plugin/ralph-hero/skills/shared/delegation-conventions.md` — zero matches
-- [ ] `grep -c "## Delegation" /Users/dubiel/projects/ralph-hero/README.md` — at least 1
-- [ ] `grep -c "### Delegation" /Users/dubiel/projects/ralph-hero/CLAUDE.md` — at least 1
-- [ ] `grep -c "Step 6c" plugin/ralph-hero/skills/setup/SKILL.md` — at least 1
-- [ ] `grep -c "ralph-delegate.sh --health-check" plugin/ralph-hero/skills/setup/SKILL.md` — at least 1 (the probe invocation)
-- [ ] `grep -c "RALPH_DELEGATE_ENABLED" plugin/ralph-hero/skills/setup/SKILL.md` — at least 1 (the env var the skill writes)
+- [x] `npm run build` in `plugin/ralph-hero/mcp-server/` — no errors (no TS changes expected, but build must remain green for the merge)
+- [x] `grep -nri "upcoming" plugin/ralph-hero/skills/shared/delegation-conventions.md` — zero matches
+- [x] `grep -c "## Delegation" /Users/dubiel/projects/ralph-hero/README.md` — at least 1
+- [x] `grep -c "### Delegation" /Users/dubiel/projects/ralph-hero/CLAUDE.md` — at least 1
+- [x] `grep -c "Step 6c" plugin/ralph-hero/skills/setup/SKILL.md` — at least 1
+- [x] `grep -c "ralph-delegate.sh --health-check" plugin/ralph-hero/skills/setup/SKILL.md` — at least 1 (the probe invocation)
+- [x] `grep -c "RALPH_DELEGATE_ENABLED" plugin/ralph-hero/skills/setup/SKILL.md` — at least 1 (the env var the skill writes)
 
 #### Manual Verification:
 - [ ] Live test 1 (probe succeeds): run `gemma-up` on the dev machine, then `/ralph-hero:setup` (or read through the SKILL.md Step 6c flow mentally) — confirm the AskUserQuestion appears with both options

--- a/thoughts/shared/plans/2026-05-15-GH-1258-cos-phase6-self-improvement.md
+++ b/thoughts/shared/plans/2026-05-15-GH-1258-cos-phase6-self-improvement.md
@@ -274,16 +274,16 @@ Ship the env-flag-gated nightly grading + auto-PR loop in a single PR. The work 
 
 #### Automated Verification:
 
-- [ ] `shellcheck plugin/ralph-hero/scripts/cos/self-improve.sh` — no warnings
-- [ ] `shellcheck plugin/ralph-hero/scripts/cos/self-improve-smoke.sh` — no warnings
-- [ ] `plutil -lint plugin/ralph-hero/scripts/cos/launchd/com.ralph.cos-self-improve.plist.template` — `OK`
-- [ ] `grep -F "rubric.md" plugin/ralph-hero/skills/cos/system-prompt.md` — exit 0
-- [ ] `grep -F "rubric.md" plugin/ralph-hero/scripts/cos/self-improve.sh` — exit 0
-- [ ] `grep -F "two manual verification" plugin/ralph-hero/scripts/cos/README.md` — exit 0 (case-insensitive: `grep -iF`)
-- [ ] `grep -F "RALPH_COS_SELF_IMPROVE" plugin/ralph-hero/scripts/cos/self-improve.sh` — exit 0
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors (regression check — this phase touches no TS but the gate must stay green)
-- [ ] `unset RALPH_COS_SELF_IMPROVE && plugin/ralph-hero/scripts/cos/self-improve.sh; echo $?` — prints `0` (env-gate fast-exit)
-- [ ] `unset RALPH_COS_SELF_IMPROVE && plugin/ralph-hero/scripts/cos/self-improve.sh 2>&1 >/dev/null | grep -F "quarantined"` — exit 0
+- [x] `shellcheck plugin/ralph-hero/scripts/cos/self-improve.sh` — no warnings
+- [x] `shellcheck plugin/ralph-hero/scripts/cos/self-improve-smoke.sh` — no warnings
+- [x] `plutil -lint plugin/ralph-hero/scripts/cos/launchd/com.ralph.cos-self-improve.plist.template` — `OK`
+- [x] `grep -F "rubric.md" plugin/ralph-hero/skills/cos/system-prompt.md` — exit 0
+- [x] `grep -F "rubric.md" plugin/ralph-hero/scripts/cos/self-improve.sh` — exit 0
+- [x] `grep -F "two manual verification" plugin/ralph-hero/scripts/cos/README.md` — exit 0 (case-insensitive: `grep -iF`)
+- [x] `grep -F "RALPH_COS_SELF_IMPROVE" plugin/ralph-hero/scripts/cos/self-improve.sh` — exit 0
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no errors (regression check — this phase touches no TS but the gate must stay green)
+- [x] `unset RALPH_COS_SELF_IMPROVE && plugin/ralph-hero/scripts/cos/self-improve.sh; echo $?` — prints `0` (env-gate fast-exit)
+- [x] `unset RALPH_COS_SELF_IMPROVE && plugin/ralph-hero/scripts/cos/self-improve.sh 2>&1 >/dev/null | grep -F "quarantined"` — exit 0
 
 #### Manual Verification:
 

--- a/thoughts/shared/plans/2026-05-16-GH-1272-self-healing-closure.md
+++ b/thoughts/shared/plans/2026-05-16-GH-1272-self-healing-closure.md
@@ -205,12 +205,12 @@ Add a shared `outcome-recorder` fragment, patch the four terminal handlers to in
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `cd plugin/ralph-knowledge && npm test` — all tests passing including the new `outcome-merge-ingest.test.ts`
-- [ ] `cd plugin/ralph-knowledge && npm run typecheck` — no errors
-- [ ] `cd plugin/ralph-knowledge && npm run build` — clean build
-- [ ] `grep -c "outcome-recorder" plugin/ralph-hero/skills/ralph-merge/SKILL.md plugin/ralph-hero/skills/ralph-pr/SKILL.md plugin/ralph-hero/skills/ralph-val/SKILL.md plugin/ralph-hero/skills/ralph-postmortem/SKILL.md` returns `≥ 1` for each of the four files
-- [ ] `grep -c "knowledge_record_outcome" plugin/ralph-hero/skills/ralph-merge/SKILL.md plugin/ralph-hero/skills/ralph-pr/SKILL.md plugin/ralph-hero/skills/ralph-val/SKILL.md plugin/ralph-hero/skills/ralph-postmortem/SKILL.md` returns `≥ 1` for each of the four files
-- [ ] `wc -l plugin/ralph-hero/skills/shared/fragments/outcome-recorder.md` returns ≤ 50
+- [x] `cd plugin/ralph-knowledge && npm test` — all tests passing including the new `outcome-merge-ingest.test.ts`
+- [x] `cd plugin/ralph-knowledge && npm run typecheck` — no errors
+- [x] `cd plugin/ralph-knowledge && npm run build` — clean build
+- [x] `grep -c "outcome-recorder" plugin/ralph-hero/skills/ralph-merge/SKILL.md plugin/ralph-hero/skills/ralph-pr/SKILL.md plugin/ralph-hero/skills/ralph-val/SKILL.md plugin/ralph-hero/skills/ralph-postmortem/SKILL.md` returns `≥ 1` for each of the four files
+- [x] `grep -c "knowledge_record_outcome" plugin/ralph-hero/skills/ralph-merge/SKILL.md plugin/ralph-hero/skills/ralph-pr/SKILL.md plugin/ralph-hero/skills/ralph-val/SKILL.md plugin/ralph-hero/skills/ralph-postmortem/SKILL.md` returns `≥ 1` for each of the four files
+- [x] `wc -l plugin/ralph-hero/skills/shared/fragments/outcome-recorder.md` returns ≤ 50
 
 #### Manual Verification:
 - [ ] Trigger a real merge via `Skill("ralph-hero:ralph-merge", ...)` against a test issue; confirm a `merge_completed` row lands in `~/.ralph-hero/knowledge.db` via `sqlite3 ~/.ralph-hero/knowledge.db "SELECT * FROM outcome_events ORDER BY timestamp DESC LIMIT 1"`

--- a/thoughts/shared/plans/2026-05-17-group-GH-1285-typed-mcp-kubectl-tools.md
+++ b/thoughts/shared/plans/2026-05-17-group-GH-1285-typed-mcp-kubectl-tools.md
@@ -238,11 +238,11 @@ Register `ralph_hero__sre__scale` and establish the canonical per-class adversar
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` — no TypeScript errors
-- [ ] `npx vitest run src/__tests__/sre-tools.test.ts -t "sre__scale"` — all sre__scale tests pass
+- [x] `npm run build` — no TypeScript errors
+- [x] `npx vitest run src/__tests__/sre-tools.test.ts -t "sre__scale"` — all sre__scale tests pass
 
 #### Manual Verification:
-- [ ] Reading `sre-tools.ts` for the scale handler, confirm argv is constructed as a single array literal with no string interpolation
+- [x] Reading `sre-tools.ts` for the scale handler, confirm argv is constructed as a single array literal with no string interpolation
 
 **Creates for next phase**: The adversarial-test pattern (one named test per bypass class) that phases 3-5 reuse.
 
@@ -266,10 +266,10 @@ Register `ralph_hero__sre__rollout_restart`. Single-shape op — narrowest input
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `server.tool("ralph_hero__sre__rollout_restart", ...)` registered
-  - [ ] Zod schema: `namespace: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `deployment: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `.strict()`
-  - [ ] Argv: `["rollout", "restart", "--namespace", namespace, \`deployment/${deployment}\`]` — the `deployment/` literal prefix is safe because the regex forbids `/` in the suffix
-  - [ ] Handler invokes `runKubectl(argv)` and returns via `toolSuccess`/`toolError`
+  - [x] `server.tool("ralph_hero__sre__rollout_restart", ...)` registered
+  - [x] Zod schema: `namespace: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `deployment: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `.strict()`
+  - [x] Argv: `["rollout", "restart", "--namespace", namespace, \`deployment/${deployment}\`]` — the `deployment/` literal prefix is safe because the regex forbids `/` in the suffix
+  - [x] Handler invokes `runKubectl(argv)` and returns via `toolSuccess`/`toolError`
 
 #### Task 3.2: Adversarial test suite for sre__rollout_restart
 - **files**: `plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts` (modify)
@@ -277,19 +277,19 @@ Register `ralph_hero__sre__rollout_restart`. Single-shape op — narrowest input
 - **complexity**: low
 - **depends_on**: [3.1]
 - **acceptance**:
-  - [ ] `describe("ralph_hero__sre__rollout_restart")` block added
-  - [ ] Test `happy path produces expected argv` — asserts argv was `["rollout", "restart", "--namespace", "default", "deployment/nginx"]`
-  - [ ] Test `rejects shell-metacharacter injection` — same metacharacters as phase 2
-  - [ ] Test `rejects multiline-suffix injection`
-  - [ ] Test `rejects multiline-prefix injection`
-  - [ ] Test `rejects empty-command injection`
-  - [ ] All tests pass
+  - [x] `describe("ralph_hero__sre__rollout_restart")` block added
+  - [x] Test `happy path produces expected argv` — asserts argv was `["rollout", "restart", "--namespace", "default", "deployment/nginx"]`
+  - [x] Test `rejects shell-metacharacter injection` — same metacharacters as phase 2
+  - [x] Test `rejects multiline-suffix injection`
+  - [x] Test `rejects multiline-prefix injection`
+  - [x] Test `rejects empty-command injection`
+  - [x] All tests pass
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` — no TypeScript errors
-- [ ] `npx vitest run src/__tests__/sre-tools.test.ts -t "rollout_restart"` — all tests pass
+- [x] `npm run build` — no TypeScript errors
+- [x] `npx vitest run src/__tests__/sre-tools.test.ts -t "rollout_restart"` — all tests pass
 
 **Creates for next phase**: No phase-specific output (parallel sibling of phases 4-5).
 
@@ -311,10 +311,10 @@ Register `ralph_hero__sre__delete_pod`. Single-pod-name only; the schema is stru
 - **complexity**: low
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `server.tool("ralph_hero__sre__delete_pod", ...)` registered
-  - [ ] Zod schema: `namespace: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `pod: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `.strict()`
-  - [ ] Argv: `["delete", "pod", "--namespace", namespace, pod]`
-  - [ ] Handler invokes `runKubectl(argv)` and returns via `toolSuccess`/`toolError`
+  - [x] `server.tool("ralph_hero__sre__delete_pod", ...)` registered
+  - [x] Zod schema: `namespace: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `pod: z.string().min(1).regex(/^[a-z0-9-]+$/)`, `.strict()`
+  - [x] Argv: `["delete", "pod", "--namespace", namespace, pod]`
+  - [x] Handler invokes `runKubectl(argv)` and returns via `toolSuccess`/`toolError`
 
 #### Task 4.2: Adversarial test suite for sre__delete_pod
 - **files**: `plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts` (modify)
@@ -322,20 +322,20 @@ Register `ralph_hero__sre__delete_pod`. Single-pod-name only; the schema is stru
 - **complexity**: low
 - **depends_on**: [4.1]
 - **acceptance**:
-  - [ ] `describe("ralph_hero__sre__delete_pod")` block added
-  - [ ] Test `happy path produces expected argv` — asserts argv was `["delete", "pod", "--namespace", "default", "nginx-abc123"]`
-  - [ ] Test `rejects shell-metacharacter injection`
-  - [ ] Test `rejects multiline-suffix injection`
-  - [ ] Test `rejects multiline-prefix injection`
-  - [ ] Test `rejects empty-command injection`
-  - [ ] Test `rejects label-selector field` — passing `{ namespace: "default", pod: "nginx-abc", selector: "app=foo" }` is rejected by the `.strict()` schema (no unknown keys)
-  - [ ] All tests pass
+  - [x] `describe("ralph_hero__sre__delete_pod")` block added
+  - [x] Test `happy path produces expected argv` — asserts argv was `["delete", "pod", "--namespace", "default", "nginx-abc123"]`
+  - [x] Test `rejects shell-metacharacter injection`
+  - [x] Test `rejects multiline-suffix injection`
+  - [x] Test `rejects multiline-prefix injection`
+  - [x] Test `rejects empty-command injection`
+  - [x] Test `rejects label-selector field` — passing `{ namespace: "default", pod: "nginx-abc", selector: "app=foo" }` is rejected by the `.strict()` schema (no unknown keys)
+  - [x] All tests pass
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` — no TypeScript errors
-- [ ] `npx vitest run src/__tests__/sre-tools.test.ts -t "delete_pod"` — all tests pass
+- [x] `npm run build` — no TypeScript errors
+- [x] `npx vitest run src/__tests__/sre-tools.test.ts -t "delete_pod"` — all tests pass
 
 **Creates for next phase**: No phase-specific output (parallel sibling).
 
@@ -359,10 +359,10 @@ Register `ralph_hero__sre__drain`. Largest legitimate flag surface of the four o
 - **complexity**: medium
 - **depends_on**: null
 - **acceptance**:
-  - [ ] `server.tool("ralph_hero__sre__drain", ...)` registered
-  - [ ] Zod schema: `node: z.string().min(1).regex(/^[a-z0-9.-]+$/)`, `gracePeriodSeconds: z.number().int().min(1).max(3600).optional()`, `timeoutSeconds: z.number().int().min(1).max(3600).optional()`, `.strict()`
-  - [ ] Argv builder always prefixes with `["drain", node, "--ignore-daemonsets"]`; appends `["--grace-period", String(gracePeriodSeconds)]` only when defined; appends `["--timeout", \`${timeoutSeconds}s\`]` only when defined
-  - [ ] Handler invokes `runKubectl(argv)` and returns via `toolSuccess`/`toolError`
+  - [x] `server.tool("ralph_hero__sre__drain", ...)` registered
+  - [x] Zod schema: `node: z.string().min(1).regex(/^[a-z0-9.-]+$/)`, `gracePeriodSeconds: z.number().int().min(1).max(3600).optional()`, `timeoutSeconds: z.number().int().min(1).max(3600).optional()`, `.strict()`
+  - [x] Argv builder always prefixes with `["drain", node, "--ignore-daemonsets"]`; appends `["--grace-period", String(gracePeriodSeconds)]` only when defined; appends `["--timeout", \`${timeoutSeconds}s\`]` only when defined
+  - [x] Handler invokes `runKubectl(argv)` and returns via `toolSuccess`/`toolError`
 
 #### Task 5.2: Adversarial + invariant test suite for sre__drain
 - **files**: `plugin/ralph-hero/mcp-server/src/__tests__/sre-tools.test.ts` (modify)
@@ -370,23 +370,23 @@ Register `ralph_hero__sre__drain`. Largest legitimate flag surface of the four o
 - **complexity**: medium
 - **depends_on**: [5.1]
 - **acceptance**:
-  - [ ] `describe("ralph_hero__sre__drain")` block added
-  - [ ] Test `happy path produces expected argv with --ignore-daemonsets` — `{ node: "node-1" }` produces `["drain", "node-1", "--ignore-daemonsets"]`
-  - [ ] Test `--ignore-daemonsets is always present` — runs the handler with several input shapes; asserts every argv contains `--ignore-daemonsets`
-  - [ ] Test `argv never contains forbidden flags` — runs handler across the valid input space (a few representative cases including gracePeriodSeconds=1 — the minimum); asserts none of `--force`, `--cascade=foreground`, `--grace-period=0`, `--delete-emptydir-data` (all four Shared Constraint #3 flags) appear in argv. This identical assertion serves as the same regression gate that phases 2-4 carry, so a future regression points at this phase's invariant rather than a missing assertion.
-  - [ ] Test `rejects gracePeriodSeconds=0` — Zod `.min(1)` rejects 0
-  - [ ] Test `rejects shell-metacharacter injection` (in `node`)
-  - [ ] Test `rejects multiline-suffix injection`
-  - [ ] Test `rejects multiline-prefix injection`
-  - [ ] Test `rejects empty-command injection`
-  - [ ] All tests pass
+  - [x] `describe("ralph_hero__sre__drain")` block added
+  - [x] Test `happy path produces expected argv with --ignore-daemonsets` — `{ node: "node-1" }` produces `["drain", "node-1", "--ignore-daemonsets"]`
+  - [x] Test `--ignore-daemonsets is always present` — runs the handler with several input shapes; asserts every argv contains `--ignore-daemonsets`
+  - [x] Test `argv never contains forbidden flags` — runs handler across the valid input space (a few representative cases including gracePeriodSeconds=1 — the minimum); asserts none of `--force`, `--cascade=foreground`, `--grace-period=0`, `--delete-emptydir-data` (all four Shared Constraint #3 flags) appear in argv. This identical assertion serves as the same regression gate that phases 2-4 carry, so a future regression points at this phase's invariant rather than a missing assertion.
+  - [x] Test `rejects gracePeriodSeconds=0` — Zod `.min(1)` rejects 0
+  - [x] Test `rejects shell-metacharacter injection` (in `node`)
+  - [x] Test `rejects multiline-suffix injection`
+  - [x] Test `rejects multiline-prefix injection`
+  - [x] Test `rejects empty-command injection`
+  - [x] All tests pass
 
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `npm run build` — no TypeScript errors
-- [ ] `npx vitest run src/__tests__/sre-tools.test.ts -t "sre__drain"` — all tests pass
-- [ ] `npm test` (full suite) — all suites green
+- [x] `npm run build` — no TypeScript errors
+- [x] `npx vitest run src/__tests__/sre-tools.test.ts -t "sre__drain"` — all tests pass
+- [x] `npm test` (full suite) — all suites green
 
 **Creates for next phase**: All four sre__* tools now registered; phase 6 can reference them by exact name.
 
@@ -439,9 +439,9 @@ Modify the existing `plugin/ralph-hero/agents/sre-fixit.md` refusal-only stub (s
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `grep -nE '"Bash"|\bBash\b' plugin/ralph-hero/agents/sre-fixit.md` — zero matches
-- [ ] `grep -c "ralph_hero__sre__" plugin/ralph-hero/agents/sre-fixit.md` — exactly 4
-- [ ] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — still clean (no incidental breakage)
+- [x] `grep -nE '"Bash"|\bBash\b' plugin/ralph-hero/agents/sre-fixit.md` — zero matches
+- [x] `grep -c "ralph_hero__sre__" plugin/ralph-hero/agents/sre-fixit.md` — exactly 4
+- [x] `npm run build` (in `plugin/ralph-hero/mcp-server/`) — still clean (no incidental breakage)
 
 #### Manual Verification:
 - [ ] Read the agent body; confirm the four-op documentation and escalation path read coherently


### PR DESCRIPTION
## Summary

- Flips acceptance criteria checkboxes from `[ ]` to `[x]` across four plans whose underlying work has shipped to main: GH-1192, GH-1258, GH-1272, GH-1285.
- GH-1274's plan is intentionally excluded — the working tree has unresolved merge-conflict markers in that file that need manual review.

## Test plan

- [ ] Eyeball the four plan diffs in the PR view to confirm only checkbox flips (no content changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)