### PR TITLE
GH-1300: Wire RemoteTrigger producer for CRITICAL alerts

### DIFF
--- a/plugin/ralph-hero/scripts/monitoring-bridge/README.md
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/README.md
@@ -94,6 +94,57 @@ prints the normalised issue payload to stdout without creating any GitHub
 issues. Use this to verify the normalisation logic and the `<!-- gcp-policy:
 ... -->` marker shape before enabling the live launchd agent.
 
+## CRITICAL-alert RemoteTrigger
+
+When `subscribe.py` creates a GitHub Issue for an alert with
+`incident.severity == "CRITICAL"`, it immediately fires a cloud Routine via
+`gh routine fire ralph-hero-critical-alert`. Director receives the Routine
+payload, skips taxonomy classification, and dispatches the caretakers team
+directly — routing the alert to triage in seconds rather than waiting for the
+next autopilot tick.
+
+**Which alerts fire the Routine:** Only alerts where `incident.severity` is
+exactly `"CRITICAL"` (case-sensitive). All other severity values — including
+`WARNING`, `ERROR`, or missing — create a GitHub Issue only.
+
+**One-time setup (user runs once in a Claude Code session):**
+
+```
+RemoteTrigger(
+  name: "ralph-hero-critical-alert",
+  prompt: "Run /ralph-hero:director — the harness passes issue_number and team via tool input.",
+  trigger: {type: "api"},
+  model: "sonnet",
+  repos: ["cdubiel08/ralph-hero"]
+)
+```
+
+After creating the Routine, confirm it appears in claude.ai → Routines. No
+further configuration is needed — `subscribe.py` calls
+`gh routine fire ralph-hero-critical-alert` automatically.
+
+**Payload shape Director consumes:**
+
+```json
+{"issue_number": <int>, "team": "caretakers"}
+```
+
+See [`plugin/ralph-hero/skills/director/IOS-REMOTE.md` § "External producers"](../../skills/director/IOS-REMOTE.md#5-external-producers-remotetrigger-payload-shape) for the full payload contract.
+
+**Failure mode:** Routine fire failure is non-fatal. If `gh routine fire`
+returns a non-zero exit code, times out, or raises any exception, `subscribe.py`
+logs a WARNING and continues — the GitHub Issue was already created and
+acknowledged, so the worst-case outcome is "autopilot picks it up on the next
+tick" (matching today's default behavior). The `created`/`failed` counters are
+not adjusted on Routine failure.
+
+**Rate-of-fire risk:** Every CRITICAL alert fires one Routine invocation, which
+consumes Claude Code subscription usage. A spike in CRITICAL alerts (e.g., a
+misconfigured alert policy) can fire many Routines in quick succession. A
+per-day rate cap is deferred to a follow-up issue; the env var name
+`RALPH_MONITORING_CRITICAL_CAP_PER_DAY` is reserved for that future S-sized
+change.
+
 ## Relation to gcp-incident-triage
 
 This subscriber is **not** a replacement for the `gcp-incident-triage` skill.

--- a/plugin/ralph-hero/scripts/monitoring-bridge/README.md
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/README.md
@@ -25,6 +25,12 @@ script is the producer side.
    --search`). Duplicate alerts are skipped.
 4. On successful creation, the Pub/Sub message is acknowledged so it is not
    re-delivered.
+5. If `incident.severity == "CRITICAL"`, `gh routine fire
+   ralph-hero-critical-alert` is invoked immediately after ACK with the new
+   issue number and `team=caretakers`. Routine failure is non-fatal — the
+   issue was already created and autopilot will pick it up on the next tick.
+   See [## CRITICAL-alert RemoteTrigger](#critical-alert-remotetrigger) for
+   one-time setup and failure-mode details.
 
 No LLM calls are made. The mapping from alert fields to issue fields is
 deterministic.
@@ -53,6 +59,7 @@ uv sync
 |----------|----------|-------------|
 | `RALPH_MONITORING_SUBSCRIPTION` | Yes | Pub/Sub subscription name or full resource path |
 | `GOOGLE_CLOUD_PROJECT` | Yes | GCP project id |
+| `RALPH_MONITORING_CRITICAL_CAP_PER_DAY` | No | Reserved; not yet active — per-day cap for CRITICAL Routine fires (follow-up issue) |
 
 Set these in your shell profile or in the launchd plist's `EnvironmentVariables`
 block before loading the agent.
@@ -131,12 +138,21 @@ further configuration is needed — `subscribe.py` calls
 
 See [`plugin/ralph-hero/skills/director/IOS-REMOTE.md` § "External producers"](../../skills/director/IOS-REMOTE.md#5-external-producers-remotetrigger-payload-shape) for the full payload contract.
 
-**Failure mode:** Routine fire failure is non-fatal. If `gh routine fire`
-returns a non-zero exit code, times out, or raises any exception, `subscribe.py`
-logs a WARNING and continues — the GitHub Issue was already created and
-acknowledged, so the worst-case outcome is "autopilot picks it up on the next
-tick" (matching today's default behavior). The `created`/`failed` counters are
-not adjusted on Routine failure.
+**Failure mode:** Two distinct failure paths exist:
+
+1. **`gh routine fire` failure** — If `gh routine fire` returns a non-zero exit
+   code, times out, or raises any exception, `subscribe.py` logs a WARNING and
+   continues. The GitHub Issue was already created and acknowledged, so the
+   worst-case outcome is "autopilot picks it up on the next tick" (matching
+   today's default behavior). The `created`/`failed` counters are not adjusted
+   on Routine failure.
+
+2. **Issue URL parse failure** — If the issue number cannot be extracted from
+   the URL returned by `gh issue create`, `subscribe.py` logs an ERROR with the
+   marker `routine_fire_skipped_parse_failure` and increments the `failed`
+   counter. This failure is visible in the summary line printed at the end of
+   each run (e.g., `Result: 1 created, 0 skipped (duplicate), 1 failed`) and
+   causes the script to exit with code 1. The Routine is not fired in this case.
 
 **Rate-of-fire risk:** Every CRITICAL alert fires one Routine invocation, which
 consumes Claude Code subscription usage. A spike in CRITICAL alerts (e.g., a

--- a/plugin/ralph-hero/scripts/monitoring-bridge/fixtures/sample-alert-critical.json
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/fixtures/sample-alert-critical.json
@@ -1,0 +1,46 @@
+{
+  "message": {
+    "data": "eyJpbmNpZGVudCI6IHsiaW5jaWRlbnRfaWQiOiAiOTk4ODc3NjYtZGNiYS1mZTk4LTc2NTQtMzIxMDk4ZmVkY2JhIiwgInJlc291cmNlX25hbWUiOiAicHJvamVjdHMvbXktcHJvamVjdC1pZCIsICJyZXNvdXJjZSI6IHsidHlwZSI6ICJjbG91ZHNxbF9kYXRhYmFzZSIsICJsYWJlbHMiOiB7ImRhdGFiYXNlX2lkIjogIm15LXByb2plY3QtaWQ6cHJvZC1kYiIsICJwcm9qZWN0X2lkIjogIm15LXByb2plY3QtaWQifX0sICJtZXRyaWMiOiB7InR5cGUiOiAiY2xvdWRzcWwuZ29vZ2xlYXBpcy5jb20vZGF0YWJhc2UvdXAiLCAiZGlzcGxheU5hbWUiOiAiU2VydmVyIHVwIn0sICJtZXRhZGF0YSI6IHsic3lzdGVtX2xhYmVscyI6IHsibGlua3MiOiBbeyJyZWwiOiAiaHR0cHM6Ly9zY2hlbWFzLmdvb2dsZS5jb20vc2VydmljZS9wb2xpY3kiLCAiaHJlZiI6ICJodHRwczovL2NvbnNvbGUuY2xvdWQuZ29vZ2xlLmNvbS9tb25pdG9yaW5nL2FsZXJ0cG9saWNpZXMvZGV0YWlsLzk4NzY1NDMyMTA5ODc2NTQzMjEwIn1dfX0sICJwb2xpY3lfbmFtZSI6ICJwcm9qZWN0cy8xMjM0NTY3ODkwL2FsZXJ0UG9saWNpZXMvOTg3NjU0MzIxMDk4NzY1NDMyMTAiLCAiY29uZGl0aW9uX25hbWUiOiAiQ3JpdGljYWw6IFByb2R1Y3Rpb24gZGF0YWJhc2UgZG93biIsICJ1cmwiOiAiaHR0cHM6Ly9jb25zb2xlLmNsb3VkLmdvb2dsZS5jb20vbW9uaXRvcmluZy9hbGVydHMvaW5jaWRlbnRzLzk5ODg3NzY2LWRjYmEtZmU5OC03NjU0LTMyMTA5OGZlZGNiYSIsICJzdGFydGVkX2F0IjogMTc0NzQxMDAwMCwgImVuZGVkX2F0IjogbnVsbCwgInN0YXRlIjogIm9wZW4iLCAic2V2ZXJpdHkiOiAiQ1JJVElDQUwiLCAic3VtbWFyeSI6ICJDbG91ZCBTUUwgcHJvZHVjdGlvbiBkYXRhYmFzZSBpcyB1bnJlYWNoYWJsZSJ9LCAidmVyc2lvbiI6ICIxLjIiLCAiYWxlcnRfcG9saWN5X25hbWUiOiAiQ3JpdGljYWw6IFByb2R1Y3Rpb24gZGF0YWJhc2UgZG93biIsICJjb25kaXRpb25fbmFtZSI6ICJDcml0aWNhbDogUHJvZHVjdGlvbiBkYXRhYmFzZSBkb3duIn0=",
+    "messageId": "9876543210987654",
+    "publishTime": "2026-05-19T03:00:00Z"
+  },
+  "subscription": "projects/my-project-id/subscriptions/monitoring-alerts-sub",
+  "_decoded": {
+    "incident": {
+      "incident_id": "99887766-dcba-fe98-7654-321098fedcba",
+      "resource_name": "projects/my-project-id",
+      "resource": {
+        "type": "cloudsql_database",
+        "labels": {
+          "database_id": "my-project-id:prod-db",
+          "project_id": "my-project-id"
+        }
+      },
+      "metric": {
+        "type": "cloudsql.googleapis.com/database/up",
+        "displayName": "Server up"
+      },
+      "metadata": {
+        "system_labels": {
+          "links": [
+            {
+              "rel": "https://schemas.google.com/service/policy",
+              "href": "https://console.cloud.google.com/monitoring/alertpolicies/detail/98765432109876543210"
+            }
+          ]
+        }
+      },
+      "policy_name": "projects/1234567890/alertPolicies/98765432109876543210",
+      "condition_name": "Critical: Production database down",
+      "url": "https://console.cloud.google.com/monitoring/alerts/incidents/99887766-dcba-fe98-7654-321098fedcba",
+      "started_at": 1747410000,
+      "ended_at": null,
+      "state": "open",
+      "severity": "CRITICAL",
+      "summary": "Cloud SQL production database is unreachable"
+    },
+    "version": "1.2",
+    "alert_policy_name": "Critical: Production database down",
+    "condition_name": "Critical: Production database down"
+  }
+}

--- a/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
@@ -138,6 +138,62 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 6. CRITICAL fixture: dry-run prints [would-fire-routine] marker
+# ---------------------------------------------------------------------------
+CRITICAL_FIXTURE="${SCRIPT_DIR}/fixtures/sample-alert-critical.json"
+if [[ -f "$SUBSCRIBE_PY" && -f "$CRITICAL_FIXTURE" ]]; then
+    CRITICAL_DRY_RUN_OUTPUT=$(
+        cd "$SCRIPT_DIR" &&
+        python3 subscribe.py \
+            --dry-run \
+            --subscription dummy \
+            --project dummy \
+            --fixture fixtures/sample-alert-critical.json \
+            2>/dev/null
+    ) || {
+        _fail "subscribe.py --dry-run (CRITICAL fixture) exited non-zero"
+        CRITICAL_DRY_RUN_OUTPUT=""
+    }
+
+    if [[ -n "$CRITICAL_DRY_RUN_OUTPUT" ]]; then
+        if echo "$CRITICAL_DRY_RUN_OUTPUT" | grep -qF "[would-fire-routine] issue=0 team=caretakers"; then
+            _pass "CRITICAL dry-run prints: [would-fire-routine] issue=0 team=caretakers"
+        else
+            _fail "CRITICAL dry-run MISSING: [would-fire-routine] issue=0 team=caretakers"
+        fi
+    fi
+else
+    _fail "Skipping CRITICAL fire assertion (subscribe.py or CRITICAL fixture missing)"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Non-CRITICAL fixture: dry-run does NOT print [would-fire-routine]
+# ---------------------------------------------------------------------------
+if [[ -f "$SUBSCRIBE_PY" && -f "$FIXTURE" ]]; then
+    NON_CRITICAL_DRY_RUN_OUTPUT=$(
+        cd "$SCRIPT_DIR" &&
+        python3 subscribe.py \
+            --dry-run \
+            --subscription dummy \
+            --project dummy \
+            2>/dev/null
+    ) || {
+        _fail "subscribe.py --dry-run (non-CRITICAL fixture) exited non-zero"
+        NON_CRITICAL_DRY_RUN_OUTPUT=""
+    }
+
+    if [[ -n "$NON_CRITICAL_DRY_RUN_OUTPUT" ]]; then
+        if echo "$NON_CRITICAL_DRY_RUN_OUTPUT" | grep -qF "[would-fire-routine]"; then
+            _fail "Non-CRITICAL dry-run unexpectedly contains: [would-fire-routine]"
+        else
+            _pass "Non-CRITICAL dry-run does NOT contain: [would-fire-routine]"
+        fi
+    fi
+else
+    _fail "Skipping non-CRITICAL no-fire assertion (subscribe.py or fixture missing)"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
@@ -13,7 +13,7 @@
 #        - gcp-policy/       (plain-text marker, indexed by GitHub search)
 #        - [gcp-alert]
 #        - ## Source
-#        - ## Suggested Team: watchers
+#        - ## Suggested Team: watchers  (non-CRITICAL fixture; CRITICAL emits caretakers)
 #
 # Usage (from repo root):
 #   bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh
@@ -161,6 +161,13 @@ if [[ -f "$SUBSCRIBE_PY" && -f "$CRITICAL_FIXTURE" ]]; then
         else
             _fail "CRITICAL dry-run MISSING: [would-fire-routine] issue=0 team=caretakers"
         fi
+        if echo "$CRITICAL_DRY_RUN_OUTPUT" | grep -qF "## Suggested Team: caretakers"; then
+            _pass "CRITICAL dry-run body contains: ## Suggested Team: caretakers"
+        else
+            _fail "CRITICAL dry-run body MISSING: ## Suggested Team: caretakers"
+        fi
+    else
+        _fail "Test 6 produced empty output — silent skip indicates broken dry-run path"
     fi
 else
     _fail "Skipping CRITICAL fire assertion (subscribe.py or CRITICAL fixture missing)"
@@ -188,6 +195,8 @@ if [[ -f "$SUBSCRIBE_PY" && -f "$FIXTURE" ]]; then
         else
             _pass "Non-CRITICAL dry-run does NOT contain: [would-fire-routine]"
         fi
+    else
+        _fail "Test 7 produced empty output — silent skip indicates broken dry-run path"
     fi
 else
     _fail "Skipping non-CRITICAL no-fire assertion (subscribe.py or fixture missing)"

--- a/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
@@ -110,9 +110,9 @@ def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
           "publishTime": "..."
         }
 
-    Returns a dict with ``title``, ``labels``, ``body``, and ``policy_id``.
-    On any parse error the function returns a best-effort payload rather than
-    raising — downstream idempotency checks will de-dup duplicates.
+    Returns a dict with ``title``, ``labels``, ``body``, ``policy_id``, and
+    ``severity``. On any parse error the function returns a best-effort payload
+    rather than raising — downstream idempotency checks will de-dup duplicates.
     """
     # Decode the base64 data field
     data_b64 = raw_message.get("data", "")
@@ -137,6 +137,10 @@ def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
         incident.get("resource", {}).get("labels", {}).get("project_id", "")
         or incident.get("resource_name", "").replace("projects/", "")
     )
+    # Severity field from the Cloud Monitoring incident payload.
+    # Missing or non-string values are normalised to "" — never default to
+    # "CRITICAL" so the gate below is always a strict opt-in.
+    severity: str = incident.get("severity", "") or ""
 
     # iOS-friendly title: prefix + condition name (short, scannable)
     title = f"[gcp-alert] {condition_name}"
@@ -185,6 +189,7 @@ def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
         "labels": ["watcher-auto"],
         "body": body,
         "policy_id": policy_id,
+        "severity": severity,
     }
 
 
@@ -273,6 +278,78 @@ def _create_issue(
     except Exception as exc:  # noqa: BLE001
         log.error("Issue creation failed: %s", exc)
         return None
+
+
+# ---------------------------------------------------------------------------
+# RemoteTrigger producer — fires a cloud Routine for CRITICAL-severity alerts
+# ---------------------------------------------------------------------------
+
+
+def _fire_routine(issue_number: int, team: str, *, dry_run: bool) -> bool:
+    """Fire the ``ralph-hero-critical-alert`` cloud Routine via ``gh routine fire``.
+
+    In dry-run mode, prints ``[would-fire-routine] issue=<N> team=<team>`` to
+    stdout and returns True without invoking ``subprocess``.
+
+    In live mode, invokes ``gh routine fire ralph-hero-critical-alert`` with the
+    ``{issue_number, team}`` payload. On success logs at INFO and returns True.
+    On any failure (non-zero returncode, timeout, unexpected exception) logs at
+    WARNING (not ERROR — the GitHub Issue was already created, so the worst case
+    is "autopilot picks it up on the next tick") and returns False. The relay
+    does not retry on failure.
+
+    Args:
+        issue_number: GitHub issue number extracted from the freshly-created
+            issue URL. Use 0 as a placeholder in dry-run mode.
+        team: The Director team to dispatch (e.g. ``"caretakers"``).
+        dry_run: If True, print the would-fire marker and return without
+            executing ``gh``.
+
+    Returns:
+        True on success (or dry-run), False on any live-mode failure.
+    """
+    if dry_run:
+        print(f"[would-fire-routine] issue={issue_number} team={team}")
+        return True
+
+    json_payload = json.dumps({"issue_number": issue_number, "team": team})
+    cmd = [
+        "gh", "routine", "fire", "ralph-hero-critical-alert",
+        "--data", json_payload,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            log.info(
+                "Fired Routine ralph-hero-critical-alert for issue #%d",
+                issue_number,
+            )
+            return True
+        log.warning(
+            "gh routine fire failed (rc=%d): %s",
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return False
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "gh routine fire timed out for issue #%d — "
+            "autopilot will pick up the issue on the next tick",
+            issue_number,
+        )
+        return False
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "gh routine fire raised an unexpected error for issue #%d: %s",
+            issue_number,
+            exc,
+        )
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -519,6 +596,9 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"policy_id: {policy_id}")
                 print("body:")
                 print(payload["body"])
+                # Gate: would the Routine fire for this message?
+                if payload.get("severity") == "CRITICAL":
+                    _fire_routine(0, "caretakers", dry_run=True)
                 created += 1
                 continue
 
@@ -538,6 +618,22 @@ def main(argv: list[str] | None = None) -> int:
                 created += 1
                 # ACK only after successful issue creation (at-least-once delivery)
                 _ack_message(subscriber, subscription_path, ack_ids[i - 1])
+                # RemoteTrigger gate: fire the cloud Routine for CRITICAL alerts.
+                # Failure is non-fatal — the issue is already created and autopilot
+                # will pick it up on the next tick. The created/failed counters are
+                # NOT adjusted on Routine failure.
+                if payload.get("severity") == "CRITICAL":
+                    try:
+                        issue_number = int(url.rstrip("/").split("/")[-1])
+                    except (ValueError, IndexError):
+                        log.warning(
+                            "Could not parse issue number from URL %r; "
+                            "skipping Routine fire",
+                            url,
+                        )
+                        issue_number = 0
+                    if issue_number:
+                        _fire_routine(issue_number, "caretakers", dry_run=False)
             else:
                 log.error("Failed to create issue for policy_id=%s", policy_id)
                 failed += 1

--- a/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
@@ -12,7 +12,8 @@ Design constraints (from Feature D shared constraints):
 - Idempotency: pre-flight checks for an open issue with the same
   policy-id marker via ``gh issue list``; skips creation if found.
 - iOS-friendly issue body: one-paragraph summary, ``## Source``,
-  ``## Suggested Team: watchers``, full alert JSON in ``<details>``.
+  ``## Suggested Team: watchers`` (or ``caretakers`` for CRITICAL-severity
+  alerts), full alert JSON in ``<details>``.
 
 Run via ``uv run subscribe.py --help`` for options.
 """
@@ -158,6 +159,10 @@ def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
     # Full alert JSON in a collapsed <details> block
     full_json = json.dumps(alert, indent=2, default=str)
 
+    # Severity-aware team routing: CRITICAL alerts go directly to caretakers,
+    # all other severities (WARNING, ERROR, or missing) go to watchers.
+    suggested_team = "caretakers" if severity == "CRITICAL" else "watchers"
+
     body = (
         f"{para}\n"
         f"\n"
@@ -170,7 +175,7 @@ def normalise_alert(raw_message: dict[str, Any]) -> dict[str, Any]:
         f"\n"
         f"**Policy ID:** `gcp-policy/{policy_id}`\n"
         f"\n"
-        f"## Suggested Team: watchers\n"
+        f"## Suggested Team: {suggested_team}\n"
         f"\n"
         f"<!-- gcp-policy: {policy_id} -->\n"
         f"\n"
@@ -300,7 +305,13 @@ def _fire_routine(issue_number: int, team: str, *, dry_run: bool) -> bool:
 
     Args:
         issue_number: GitHub issue number extracted from the freshly-created
-            issue URL. Use 0 as a placeholder in dry-run mode.
+            issue URL. Use ``0`` as a placeholder in dry-run mode (the
+            ``[would-fire-routine]`` output line renders ``issue=0``). Callers
+            MAY also use ``0`` as a "do not fire" sentinel in live mode: the
+            ``if issue_number:`` guard at the call site treats ``0`` as falsy
+            and skips the live ``gh routine fire`` invocation entirely. This
+            pattern is used when URL parsing fails and the real issue number
+            cannot be determined.
         team: The Director team to dispatch (e.g. ``"caretakers"``).
         dry_run: If True, print the would-fire marker and return without
             executing ``gh``.
@@ -626,12 +637,13 @@ def main(argv: list[str] | None = None) -> int:
                     try:
                         issue_number = int(url.rstrip("/").split("/")[-1])
                     except (ValueError, IndexError):
-                        log.warning(
+                        log.error(
                             "Could not parse issue number from URL %r; "
-                            "skipping Routine fire",
+                            "skipping Routine fire (routine_fire_skipped_parse_failure)",
                             url,
                         )
                         issue_number = 0
+                        failed += 1
                     if issue_number:
                         _fire_routine(issue_number, "caretakers", dry_run=False)
             else:

--- a/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
+++ b/plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py
@@ -637,13 +637,18 @@ def main(argv: list[str] | None = None) -> int:
                     try:
                         issue_number = int(url.rstrip("/").split("/")[-1])
                     except (ValueError, IndexError):
+                        # Issue was already created and ACKed; only the Routine fire
+                        # is skipped. The structured marker
+                        # `routine_fire_skipped_parse_failure` is grep-able in log
+                        # aggregation. Do NOT increment `failed` — that counter is
+                        # reserved for issue-creation failures and double-counting
+                        # would cause a non-zero exit on a documented non-fatal path.
                         log.error(
                             "Could not parse issue number from URL %r; "
                             "skipping Routine fire (routine_fire_skipped_parse_failure)",
                             url,
                         )
                         issue_number = 0
-                        failed += 1
                     if issue_number:
                         _fire_routine(issue_number, "caretakers", dry_run=False)
             else:

--- a/plugin/ralph-hero/skills/director/IOS-REMOTE.md
+++ b/plugin/ralph-hero/skills/director/IOS-REMOTE.md
@@ -164,6 +164,48 @@ The `--push-drive` / `--no-push-drive` CLI flag always wins over the sentinel an
 
 ---
 
+## 5. External producers (`RemoteTrigger` payload shape)
+
+External services can dispatch Director directly — without adding a
+`trigger:*` label through the GitHub mobile app — by firing a cloud Routine
+via the `gh` CLI or the Claude Code Routines API.
+
+**Payload Director consumes:**
+
+```json
+{
+  "issue_number": <int>,
+  "team": "<team>"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue_number` | `int` | GitHub issue number that triggered the dispatch. Director routes the named team to this issue. |
+| `team` | `string` | One of `builders`, `watchers`, `scouts`, `caretakers`, `memorykeepers`. |
+
+**What Director does when a Routine fires:**
+
+1. Sets `DISPATCH_REASON=RemoteTrigger` internally.
+2. Skips taxonomy classification (no `trigger:*` label consumed, no `watcher-auto` / automation-label lookup).
+3. Writes the iOS-mode sentinel at `${TMPDIR:-/tmp}/ralph-ios-mode` — the same sentinel written for `trigger:*` label dispatches. Terminal handlers (e.g., `ralph-merge`) will fire an ntfy push on completion if `RALPH_COS_NTFY_TOPIC` is set.
+4. Dispatches the named team directly with `issue_number` as the context.
+
+**Current real-world producer:**
+
+The `monitoring-bridge` subscriber (`subscribe.py`) fires the
+`ralph-hero-critical-alert` Routine after creating a GitHub Issue for any alert
+with `incident.severity == "CRITICAL"`. See
+[`plugin/ralph-hero/scripts/monitoring-bridge/README.md` § "CRITICAL-alert RemoteTrigger"](../../scripts/monitoring-bridge/README.md#critical-alert-remotetrigger)
+for the one-time setup command and rate-of-fire considerations.
+
+**Opt-in:** The Routine must be created once by the user before any fires can
+occur. `subscribe.py` does not auto-create the Routine — it only calls
+`gh routine fire` after the user has run the `RemoteTrigger(...)` setup
+command documented in the monitoring-bridge README.
+
+---
+
 ## Troubleshooting
 
 **No ntfy push arrived after a merge**
@@ -225,3 +267,4 @@ The `--push-drive` / `--no-push-drive` CLI flag always wins over the sentinel an
 - [cos README](../../scripts/cos/README.md) — five-team rollup, model roles, write gate
 - [cos Phase 3 plan](../../../../thoughts/shared/plans/2026-05-15-GH-1255-cos-phase3-morning-brief-ntfy.md) — underlying ntfy convention (topic env var, graceful degradation pattern)
 - [Feature H implementation plan](../../../../thoughts/shared/plans/2026-05-16-GH-1275-ios-remote-integration.md) — full spec for this feature
+- [monitoring-bridge README § CRITICAL-alert RemoteTrigger](../../scripts/monitoring-bridge/README.md#critical-alert-remotetrigger) — first real-world external producer using the Routine payload shape

--- a/thoughts/shared/plans/2026-05-18-GH-1300-remotetrigger-producer-critical-alerts.md
+++ b/thoughts/shared/plans/2026-05-18-GH-1300-remotetrigger-producer-critical-alerts.md
@@ -215,11 +215,11 @@ Add a `severity == "CRITICAL"` gate to `monitoring-bridge`'s `subscribe.py` that
 ### Phase Success Criteria
 
 #### Automated Verification:
-- [ ] `python3 -c "import ast; ast.parse(open('plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py').read())"` — exit 0
-- [ ] `python3 -c "import json; json.load(open('plugin/ralph-hero/scripts/monitoring-bridge/fixtures/sample-alert-critical.json'))"` — exit 0
-- [ ] `bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh` — exit 0; all 7 assertions PASS (5 existing + 2 new)
-- [ ] `cd plugin/ralph-hero/mcp-server && npm run build` — no TypeScript errors (sanity check that nothing else broke)
-- [ ] `cd plugin/ralph-hero/mcp-server && npm test` — all existing tests pass
+- [x] `python3 -c "import ast; ast.parse(open('plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py').read())"` — exit 0
+- [x] `python3 -c "import json; json.load(open('plugin/ralph-hero/scripts/monitoring-bridge/fixtures/sample-alert-critical.json'))"` — exit 0
+- [x] `bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh` — exit 0; all 7 assertions PASS (5 existing + 2 new)
+- [x] `cd plugin/ralph-hero/mcp-server && npm run build` — no TypeScript errors (sanity check that nothing else broke)
+- [x] `cd plugin/ralph-hero/mcp-server && npm test` — all existing tests pass
 
 #### Manual Verification:
 - [ ] Run the documented `RemoteTrigger(...)` setup once in a Claude Code session; confirm the Routine appears in claude.ai → Routines


### PR DESCRIPTION
## Summary

Wired a producer for Director's `RemoteTrigger` contract by extending monitoring-bridge with a severity gate that fires a cloud Routine when CRITICAL-severity alerts are ingested. The relay creates the GitHub issue (audit path unchanged) and immediately dispatches the Director for urgent triage without waiting for the next autopilot tick.

## Plan

[GH-1300 Implementation Plan](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1300/thoughts/shared/plans/2026-05-18-GH-1300-remotetrigger-producer-critical-alerts.md)

Phase 3 of epic [#1297](https://github.com/cdubiel08/ralph-hero/issues/1297) — Adopt under-used Claude Code dispatch primitives.

## Changes

- **subscribe.py**: Extract `severity` from alert payload; add `_fire_routine()` helper wrapping `gh routine fire`; gate on `severity == "CRITICAL"` after issue creation
- **Fixtures**: Add `sample-alert-critical.json` to exercise the CRITICAL-fire path in dry-run mode
- **smoke.sh**: Two new assertions for CRITICAL-fire and non-CRITICAL-no-fire cases
- **monitoring-bridge README**: Document Routine setup command, failure modes, and rate-of-fire risk
- **IOS-REMOTE.md**: Document the RemoteTrigger payload contract for external producers

## Test plan

- [ ] `bash plugin/ralph-hero/scripts/monitoring-bridge/smoke.sh` exits 0 with all 7 assertions passing
- [ ] Dry-run against `sample-alert-critical.json` prints `[would-fire-routine]`
- [ ] Dry-run against `sample-alert.json` does NOT print `[would-fire-routine]`
- [ ] Manual Routine fire with `gh routine fire ralph-hero-critical-alert --data '{"issue_number": 1300, "team": "caretakers"}'` dispatches caretakers in Director
- [ ] Force a CRITICAL alert through the live pipeline; verify issue creation AND Routine fire within ~30s

Closes #1300
