### PR TITLE
GH-1312: Director handles kind:"pr" directions from next_actions

### DIFF
--- a/plugin/ralph-hero/skills/director/SKILL.md
+++ b/plugin/ralph-hero/skills/director/SKILL.md
@@ -54,12 +54,11 @@ Parse `$ARGUMENTS` for an optional `--issue NNN` flag.
 Call `next_actions({})` to get the ranked project queue. Do NOT recompute ranking — reuse the tool's output as-is.
 
 - If the queue is empty or all issues are in terminal states (`Done`, `Canceled`): emit `result: Queue empty. No events to dispatch.` and STOP.
-- Select the top-ranked direction (the entry marked `recommended: true`, or the first entry if none is marked). Resolve `TARGET_ISSUE` from the direction based on its `kind`:
-  - `kind: "issue" | "tree-continue" | "lock-stale" | "human-needed-unblock"` → `TARGET_ISSUE = direction.issue.number`.
+- Select the top-ranked direction (the entry marked `recommended: true`, or the first entry if none is marked). Resolve `TARGET_ISSUE` from the direction based on its `kind` — process only this one direction per invocation:
+  - `kind: "issue" | "tree-continue" | "lock-stale" | "human-needed-unblock"` → `TARGET_ISSUE = direction.issue.number`. Proceed to Step 2b.
   - `kind: "pr"` → `direction.issue` is `null`. Use the linked-issue fallback:
-    - If `direction.signals.linkedIssueNumber` is set: `TARGET_ISSUE = direction.signals.linkedIssueNumber`. Proceed to Step 2b — the linked issue's `workflowState` (typically `In Review`) drives routing in Step 3.
-    - If `linkedIssueNumber` is absent (the PR's `headRefName` did not match `feature/GH-NNNN`): skip this direction and try the next one in the list. Repeat until an issue-bearing direction is found.
-    - If every remaining direction is `kind: "pr"` with no `linkedIssueNumber`: emit `result: Queue contains only unlinked PRs. No issue to dispatch.` and STOP.
+    - If `direction.signals.linkedIssueNumber` is set: `TARGET_ISSUE = direction.signals.linkedIssueNumber`. Proceed to Step 2b; Step 3 classifies the linked issue's `workflowState` via the taxonomy.
+    - If `linkedIssueNumber` is absent (the PR's `headRefName` did not match `feature/GH-NNNN`): emit `result: Top direction is PR #<N> with no linked issue. Skipping.` and STOP. Do NOT iterate the rest of the list — Director processes one direction per invocation, and `/loop` owns the re-tick cadence.
 
 ### Step 2b: Fetch specific issue (--issue override or label trigger)
 

--- a/plugin/ralph-hero/skills/director/SKILL.md
+++ b/plugin/ralph-hero/skills/director/SKILL.md
@@ -54,7 +54,12 @@ Parse `$ARGUMENTS` for an optional `--issue NNN` flag.
 Call `next_actions({})` to get the ranked project queue. Do NOT recompute ranking — reuse the tool's output as-is.
 
 - If the queue is empty or all issues are in terminal states (`Done`, `Canceled`): emit `result: Queue empty. No events to dispatch.` and STOP.
-- Select the top-ranked issue (the entry marked `recommended: true`, or the first entry if none is marked). Set `TARGET_ISSUE` to that issue's number.
+- Select the top-ranked direction (the entry marked `recommended: true`, or the first entry if none is marked). Resolve `TARGET_ISSUE` from the direction based on its `kind`:
+  - `kind: "issue" | "tree-continue" | "lock-stale" | "human-needed-unblock"` → `TARGET_ISSUE = direction.issue.number`.
+  - `kind: "pr"` → `direction.issue` is `null`. Use the linked-issue fallback:
+    - If `direction.signals.linkedIssueNumber` is set: `TARGET_ISSUE = direction.signals.linkedIssueNumber`. Proceed to Step 2b — the linked issue's `workflowState` (typically `In Review`) drives routing in Step 3.
+    - If `linkedIssueNumber` is absent (the PR's `headRefName` did not match `feature/GH-NNNN`): skip this direction and try the next one in the list. Repeat until an issue-bearing direction is found.
+    - If every remaining direction is `kind: "pr"` with no `linkedIssueNumber`: emit `result: Queue contains only unlinked PRs. No issue to dispatch.` and STOP.
 
 ### Step 2b: Fetch specific issue (--issue override or label trigger)
 


### PR DESCRIPTION
## Summary

- Document the `kind: "pr"` branch in Director's Step 2a so autopilot can dispatch when the top-ranked `next_actions` direction is an open PR.
- Use `signals.linkedIssueNumber` (parsed from `feature/GH-NNNN`) as the `TARGET_ISSUE` for PR rows; skip to the next direction when the PR has no linked issue; emit a clean `result:` marker if the entire queue is unlinked PRs.

Closes #1312.

## Why

`directions.ts` returns `kind: "pr"` rows with `issue: null` and the issue number tucked under `signals.linkedIssueNumber`. The Director skill only referenced `direction.issue.number`, so when a stale PR ranked top-of-queue the model improvised a "all I see is PRs" complaint instead of dispatching. Live repro: PR #1310 (issue #1300) ranked top-of-queue during today's autopilot session before manual finish merged it.

## Test plan

- [ ] Review Director skill spec wording for the new `kind: "pr"` branch (`plugin/ralph-hero/skills/director/SKILL.md`).
- [ ] Verify the routing rule is unchanged: linked-issue's `workflowState` still drives Priority 3 routing (typically `In Review` → builders → `ralph-hero:hero` → INTEGRATE → `Skill(finish)`).
- [ ] Sanity-check that no other Director docs reference `direction.issue.number` directly (only this Step 2a does).