### PR TITLE
GH-1306: Add knowledge_expert(domain) MCP tool — domain-keyed memory bundles with built-in telemetry

### DIFF
--- a/plugin/ralph-hero/agents/research-agent.md
+++ b/plugin/ralph-hero/agents/research-agent.md
@@ -2,7 +2,7 @@
 name: research-agent
 description: Research issues - investigates codebase, creates findings document, updates workflow state
 model: sonnet
-tools: Read, Write, Glob, Grep, Bash, Agent, WebSearch, WebFetch, mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency, mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+tools: Read, Write, Glob, Grep, Bash, Agent, WebSearch, WebFetch, mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency, mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_expert
 skills:
   - ralph-hero:ralph-research
 ---

--- a/plugin/ralph-hero/skills/ralph-research/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-research/SKILL.md
@@ -50,6 +50,7 @@ allowed-tools:
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_expert
 ---
 
 ## Configuration (resolved at load time)
@@ -171,6 +172,33 @@ This step runs autonomously — no user questions, just detect-and-act. Run the 
 **Power-user note:** `knowledge_recall` wraps `knowledge_search` with the researcher tier policy. If you need an explicit tier (e.g., `memory_tier="wiki"` only), call `knowledge_search` directly — both tools remain available.
 
 If the searches return nothing relevant, proceed to Step 4 with full sub-agent dispatch — the knowledge graph may be stale or sparse on this topic. Do NOT skip sub-agent dispatch on the basis of an empty knowledge result alone.
+
+### Step 3d: Domain Expert Primer
+
+If `knowledge_expert` is available, call it to load a curated domain bundle before dispatching sub-tasks. This narrows the search space — instead of rediscovering relevant docs from scratch, you start with the wiki entries + recent reflections + prior outcomes the corpus has already accumulated for this topic.
+
+**Domain extraction heuristic** (in priority order):
+1. If the issue has a label matching a known domain tag (e.g., `ralph-knowledge`, `auth`, `memory-tiers`), use the first match.
+2. Otherwise, extract the most prominent noun phrase from the issue title (e.g., "knowledge_expert(domain) MCP tool" → `ralph-knowledge`).
+3. If still unclear, skip this step and proceed directly to Step 4.
+
+**Call** (when domain is determinable):
+```
+mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_expert({
+  domain: "<extracted-domain>",
+  issue_number: <current-issue>,
+  limit: 5,
+  recency_window_days: 30
+})
+```
+
+**What to do with the result**:
+- If `wiki` or `reflections` is non-empty: read those docs first, before launching sub-tasks. They are pre-curated context — they should shape the research questions you ask.
+- If `prior_outcomes` is non-empty: review the verdicts; if past calls for this domain ended in `blocked` or `needs_iteration`, flag the recurring issue.
+- If `warning` is set (no docs match): proceed with regular sub-agent research; note the warning in your final research doc so future curators can fill the gap.
+- **Save the `query_id`**. Pass it to `knowledge_record_outcome` in Step 8 so the research outcome correlates back to this expert call.
+
+This step degrades gracefully — skip silently if the tool is unavailable or if no domain can be extracted from the issue.
 
 ### Step 4: Conduct Research
 
@@ -399,11 +427,12 @@ git push origin main
      component_area="[discovered area, e.g., src/tools/]",
      verdict="complete",
      model="sonnet",
-     agent_type="analyst"
+     agent_type="analyst",
+     query_id="[query_id from Step 3d, if available]"
    )
    ```
 
-   Skip silently if the tool is unavailable — do not fail the workflow. This builds the outcome ledger that future research can query (Step 3c).
+   Include `query_id` only when Step 3d ran and returned a `query_id` — this correlates the research outcome back to its domain expert call, enabling per-domain hit-rate observability via `knowledge_query_outcomes({ event_type: "expert_call" })`. Skip silently if the tool is unavailable — do not fail the workflow. This builds the outcome ledger that future research can query (Step 3c).
 
 ### Step 9: Team Result Reporting
 
@@ -437,6 +466,8 @@ The Step 3c prior-art discovery, evidence weighting, Pipeline History section, a
 2. **Tools available but `knowledge_recall` (or `knowledge_search`) returns zero results**: try broader search terms first (remove specific qualifiers, drop component prefixes), then fall back to grep-based search of the `thoughts/` directory. Do NOT skip sub-agent dispatch — an empty knowledge result may indicate a stale or sparsely-indexed graph rather than a true absence of prior art. Continue with full Step 4 sub-agent dispatch and let `thoughts-locator` cross-check the filesystem.
 
 The Step 8 outcome recording (`knowledge_record_outcome`) is also subject to graceful degradation — silently skip the call if the tool is unavailable. The workflow advancement to "Ready for Plan" must still complete even when the outcome ledger cannot be written.
+
+The Step 3d domain expert primer (`knowledge_expert`) degrades gracefully — skip silently if the tool is unavailable or if no domain can be determined from the issue. The research workflow is not gated on it.
 
 ## Available Filter Profiles
 

--- a/plugin/ralph-knowledge/README.md
+++ b/plugin/ralph-knowledge/README.md
@@ -142,6 +142,85 @@ gather, and ALSO calls `knowledge_search(type="research", ...)` for an explicit
 artifact lookup where it needs a precise type filter. Keeping both tools in a
 skill's allowlist is the recommended pattern.
 
+## `knowledge_expert` — domain-keyed memory bundles
+
+`knowledge_expert(domain, issue_number, ...)` returns a curated context bundle
+for a named domain — wiki entries, recent reflections, and prior outcomes — so
+sub-agents become per-domain experts via memory rather than per-domain prompts.
+It is the **domain-keyed** companion to `knowledge_recall`'s **role-keyed**
+retrieval: role decides which tiers to surface; domain decides which slice of
+the corpus.
+
+### Signature
+
+```
+knowledge_expert(
+  domain: string,             // Tag to match (e.g. "auth", "memory-tiers", "ralph-knowledge")
+  issue_number: number,       // GitHub issue on whose behalf this call is made — required for telemetry
+  limit?: number,             // Max entries per bucket. Default 5.
+  recency_window_days?: number, // Reflection age cutoff in days. Default 30.
+  path_prefix?: string,       // Optional secondary filter: only docs whose path starts with this prefix.
+  session_id?: string,        // Team/hero session ID — passed through to the outcome event.
+)
+```
+
+Domain matching uses the `tags` table (frontmatter `tags:` arrays are the
+primary signal). `path_prefix` is a secondary narrowing filter — not a
+replacement for tags. Pass `"thoughts/shared/"` to restrict to the shared
+corpus, for example.
+
+### Return shape
+
+```json
+{
+  "query_id": "uuid-v4",
+  "domain": "auth",
+  "wiki": [ ...DocumentRow ],
+  "reflections": [ ...DocumentRow ],
+  "prior_outcomes": [ ...OutcomeEventRow ],
+  "warning": null
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `query_id` | UUID generated per call. Save this and pass it to `knowledge_record_outcome` as `query_id` to correlate downstream outcomes back to this expert call. |
+| `domain` | Echo of the requested domain. |
+| `wiki` | Up to `limit` documents with `memory_tier = 'wiki'` tagged with `domain`, ordered by date descending. |
+| `reflections` | Up to `limit` documents with `memory_tier = 'reflection'` tagged with `domain` and dated within `recency_window_days`. |
+| `prior_outcomes` | Up to `limit` `outcome_events` rows whose `payload` JSON contains `domain` — pipeline history for this domain. |
+| `warning` | Non-null string when both `wiki` and `reflections` are empty, suggesting the caller tag existing docs or broaden the domain term. `null` on a successful hit. |
+
+### Telemetry
+
+Every `knowledge_expert` call writes an `outcome_events` row with
+`event_type = 'expert_call'`. The `payload` JSON carries `query_id`, `domain`,
+`returned_doc_ids`, `limit`, `recency_window_days`, `path_prefix`, and
+`warning`. This makes per-domain hit rate queryable from day one:
+
+```
+knowledge_query_outcomes({ event_type: "expert_call", aggregate: true })
+```
+
+Pass `query_id` to `knowledge_record_outcome` to tie subsequent phase/research
+outcomes back to the originating expert call:
+
+```
+knowledge_record_outcome({
+  event_type: "research_completed",
+  issue_number: 1306,
+  query_id: "<query_id from knowledge_expert>",
+  verdict: "complete"
+})
+```
+
+### Degradation
+
+`knowledge_expert` degrades the same way as the other knowledge tools — return
+an empty bundle with a `warning` when no matching documents exist; never throw
+on a valid call. If the domain cannot be determined at call time, callers should
+skip the call rather than pass an empty string.
+
 ## Environment variables
 
 | Variable | Purpose |

--- a/plugin/ralph-knowledge/src/__tests__/index.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/index.test.ts
@@ -1183,4 +1183,55 @@ describe("knowledge_expert", () => {
     // qid2: only its expert_call = 1
     expect(byQid2).toHaveLength(1);
   });
+
+  it("prior_outcomes domain filter is applied in SQL before LIMIT (not JS-side after)", async () => {
+    // Regression test: a burst of M other-domain expert_call rows (more recent) must not
+    // starve the target domain when prior_outcomes uses a SQL domain predicate + LIMIT.
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+
+    // Seed N=3 target-domain expert_call rows
+    for (let i = 0; i < 3; i++) {
+      db.insertOutcomeEvent({
+        eventType: "expert_call",
+        issueNumber: 1306,
+        sessionId: `session-target-${i}`,
+        agentType: "knowledge_expert",
+        payload: { domain: "auth", query_id: `qid-auth-${i}` },
+      });
+    }
+
+    // Seed M=5 other-domain expert_call rows (these are more recent because inserted after)
+    for (let i = 0; i < 5; i++) {
+      db.insertOutcomeEvent({
+        eventType: "expert_call",
+        issueNumber: 1306,
+        sessionId: `session-other-${i}`,
+        agentType: "knowledge_expert",
+        payload: { domain: "caching", query_id: `qid-caching-${i}` },
+      });
+    }
+
+    // Call knowledge_expert for "auth" with limit=3.
+    // Without the SQL domain predicate, the 5 "caching" rows (being more recent) would
+    // consume the entire LIMIT before the JS filter runs, returning 0 "auth" rows.
+    // With the fix, the SQL WHERE filters first and we get back up to 3 "auth" rows.
+    const result = await callTool(server, "knowledge_expert", {
+      domain: "auth",
+      issue_number: 1306,
+      limit: 3,
+    });
+    expect(result.isError).not.toBe(true);
+
+    const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    const priorOutcomes = payload.prior_outcomes as unknown[];
+
+    // Must return the 3 seeded "auth" rows, not 0 (the pre-fix behavior)
+    expect(priorOutcomes).toHaveLength(3);
+    // Confirm all returned rows are for the "auth" domain
+    for (const row of priorOutcomes) {
+      const rowPayload = JSON.parse((row as { payload: string }).payload) as Record<string, unknown>;
+      expect(rowPayload.domain).toBe("auth");
+    }
+  });
 });

--- a/plugin/ralph-knowledge/src/__tests__/index.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/index.test.ts
@@ -894,3 +894,167 @@ describe("knowledge_search rerank parameter (GH-926)", () => {
     }
   });
 });
+
+describe("knowledge_expert", () => {
+  it("is registered alongside knowledge_recall and knowledge_search", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const registered = (server as unknown as Record<string, unknown>)
+      ._registeredTools as Record<string, unknown>;
+    expect(registered).toHaveProperty("knowledge_expert");
+  });
+
+  it("returns empty bundle + warning when no docs match the domain", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const result = await callTool(server, "knowledge_expert", {
+      domain: "nonexistent-domain",
+      issue_number: 1306,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(payload.wiki).toEqual([]);
+    expect(payload.reflections).toEqual([]);
+    expect(payload.warning).toMatch(/No documents found/);
+    expect(typeof payload.query_id).toBe("string");
+    expect((payload.query_id as string)).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("returns wiki + reflection buckets filtered by domain tag", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    // Seed: one wiki doc and one reflection, both tagged 'auth'
+    db.upsertDocument({
+      id: "wiki-auth",
+      path: "thoughts/wiki/auth.md",
+      title: "Auth",
+      date: "2026-04-01",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Authentication best practices.",
+      memoryTier: "wiki",
+    });
+    db.upsertDocument({
+      id: "refl-auth",
+      path: "thoughts/dream-memories/2026/05/refl.md",
+      title: "Auth reflection",
+      date: "2026-05-10",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Reflection on auth patterns observed this week.",
+      memoryTier: "reflection",
+    });
+    db.setTags("wiki-auth", ["auth"]);
+    db.setTags("refl-auth", ["auth", "dream"]);
+
+    const result = await callTool(server, "knowledge_expert", {
+      domain: "auth",
+      issue_number: 1306,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect((payload.wiki as unknown[]).length).toBe(1);
+    expect((payload.reflections as unknown[]).length).toBe(1);
+    expect(payload.warning).toBeNull();
+  });
+
+  it("does not return docs from other tiers in the wiki bucket", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    // Seed a doc-tier and a raw-tier document both tagged 'search'
+    db.upsertDocument({
+      id: "doc-search",
+      path: "thoughts/research/search.md",
+      title: "Search doc",
+      date: "2026-04-01",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Research notes on search.",
+      memoryTier: "doc",
+    });
+    db.upsertDocument({
+      id: "raw-search",
+      path: "thoughts/dream-memories/raw.md",
+      title: "Search raw",
+      date: "2026-04-02",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Raw memory about search.",
+      memoryTier: "raw",
+    });
+    db.setTags("doc-search", ["search"]);
+    db.setTags("raw-search", ["search"]);
+
+    const result = await callTool(server, "knowledge_expert", {
+      domain: "search",
+      issue_number: 1306,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    // Neither doc nor raw tier should appear in wiki or reflections
+    expect((payload.wiki as unknown[]).length).toBe(0);
+    expect((payload.reflections as unknown[]).length).toBe(0);
+    expect(payload.warning).toMatch(/No documents found/);
+  });
+
+  it("respects recency_window_days for reflections", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    // Seed an old reflection (100 days ago) — should be excluded with a 7-day window
+    const oldDate = new Date(Date.now() - 100 * 86_400_000).toISOString().slice(0, 10);
+    db.upsertDocument({
+      id: "refl-old",
+      path: "thoughts/dream-memories/old.md",
+      title: "Old reflection",
+      date: oldDate,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Old reflection about caching.",
+      memoryTier: "reflection",
+    });
+    // Seed a recent reflection
+    const recentDate = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+    db.upsertDocument({
+      id: "refl-recent",
+      path: "thoughts/dream-memories/recent.md",
+      title: "Recent reflection",
+      date: recentDate,
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Recent reflection about caching.",
+      memoryTier: "reflection",
+    });
+    db.setTags("refl-old", ["caching"]);
+    db.setTags("refl-recent", ["caching"]);
+
+    const result = await callTool(server, "knowledge_expert", {
+      domain: "caching",
+      issue_number: 1306,
+      recency_window_days: 7,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    const reflections = payload.reflections as Array<{ id: string }>;
+    const ids = reflections.map((r) => r.id);
+    expect(ids).toContain("refl-recent");
+    expect(ids).not.toContain("refl-old");
+  });
+
+  it("prior_outcomes field is an array (empty when no matching outcomes)", async () => {
+    const mod = await import("../index.js");
+    const { server } = mod.createServer(":memory:");
+    const result = await callTool(server, "knowledge_expert", {
+      domain: "deployment",
+      issue_number: 1306,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(Array.isArray(payload.prior_outcomes)).toBe(true);
+  });
+});

--- a/plugin/ralph-knowledge/src/__tests__/index.test.ts
+++ b/plugin/ralph-knowledge/src/__tests__/index.test.ts
@@ -1057,4 +1057,130 @@ describe("knowledge_expert", () => {
     const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
     expect(Array.isArray(payload.prior_outcomes)).toBe(true);
   });
+
+  // Phase 2 telemetry tests
+
+  it("writes an expert_call outcome event with payload.query_id on every call", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    const result = await callTool(server, "knowledge_expert", {
+      domain: "auth",
+      issue_number: 1306,
+    });
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+
+    // One expert_call event should exist for issue 1306
+    const events = db.queryOutcomeEvents({ issueNumber: 1306, eventType: "expert_call" });
+    expect(events).toHaveLength(1);
+
+    // Payload must carry query_id and domain
+    const evtPayload = JSON.parse(events[0].payload) as Record<string, unknown>;
+    expect(evtPayload.query_id).toBe(payload.query_id);
+    expect(evtPayload.domain).toBe("auth");
+  });
+
+  it("expert_call event payload includes returned_doc_ids with wiki and reflections arrays", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+    // Seed a wiki doc tagged 'logging'
+    db.upsertDocument({
+      id: "wiki-logging",
+      path: "thoughts/wiki/logging.md",
+      title: "Logging",
+      date: "2026-04-01",
+      type: null,
+      status: null,
+      githubIssue: null,
+      content: "Logging best practices.",
+      memoryTier: "wiki",
+    });
+    db.setTags("wiki-logging", ["logging"]);
+
+    await callTool(server, "knowledge_expert", { domain: "logging", issue_number: 1306 });
+
+    const events = db.queryOutcomeEvents({ issueNumber: 1306, eventType: "expert_call" });
+    expect(events).toHaveLength(1);
+    const evtPayload = JSON.parse(events[0].payload) as Record<string, unknown>;
+    const returnedDocIds = evtPayload.returned_doc_ids as { wiki: string[]; reflections: string[] };
+    expect(returnedDocIds.wiki).toContain("wiki-logging");
+    expect(Array.isArray(returnedDocIds.reflections)).toBe(true);
+  });
+
+  it("knowledge_record_outcome accepts query_id and stores it in payload", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+
+    // First call knowledge_expert to get a query_id
+    const expertResult = await callTool(server, "knowledge_expert", {
+      domain: "auth",
+      issue_number: 1306,
+    });
+    expect(expertResult.isError).not.toBe(true);
+    const queryId = (JSON.parse(expertResult.content[0].text) as Record<string, unknown>).query_id as string;
+
+    // Record an outcome correlated to the expert call
+    const recordResult = await callTool(server, "knowledge_record_outcome", {
+      event_type: "phase_completed",
+      issue_number: 1306,
+      query_id: queryId,
+      verdict: "pass",
+    });
+    expect(recordResult.isError).not.toBe(true);
+
+    // Query by query_id: both the expert_call row and the phase_completed row must return
+    const correlated = db.queryOutcomeEventsByQueryId(queryId);
+    expect(correlated).toHaveLength(2);
+
+    // Verify both event types are present
+    const eventTypes = correlated.map((e) => e.eventType);
+    expect(eventTypes).toContain("expert_call");
+    expect(eventTypes).toContain("phase_completed");
+  });
+
+  it("knowledge_record_outcome without query_id still works (backwards compatible)", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+
+    // Call without query_id — must not error
+    const result = await callTool(server, "knowledge_record_outcome", {
+      event_type: "research_started",
+      issue_number: 9999,
+      verdict: "pass",
+    });
+    expect(result.isError).not.toBe(true);
+
+    // Event is stored; querying by a random query_id returns nothing
+    const events = db.queryOutcomeEvents({ issueNumber: 9999 });
+    expect(events).toHaveLength(1);
+    const evtPayload = JSON.parse(events[0].payload) as Record<string, unknown>;
+    // query_id should be absent from payload
+    expect(evtPayload.query_id).toBeUndefined();
+  });
+
+  it("queryOutcomeEventsByQueryId returns only events matching the query_id", async () => {
+    const mod = await import("../index.js");
+    const { server, db } = mod.createServer(":memory:");
+
+    // Call knowledge_expert twice — two different query_ids
+    const r1 = await callTool(server, "knowledge_expert", { domain: "auth", issue_number: 1306 });
+    const r2 = await callTool(server, "knowledge_expert", { domain: "caching", issue_number: 1306 });
+    const qid1 = (JSON.parse(r1.content[0].text) as Record<string, unknown>).query_id as string;
+    const qid2 = (JSON.parse(r2.content[0].text) as Record<string, unknown>).query_id as string;
+
+    // Add a correlated outcome for qid1 only
+    await callTool(server, "knowledge_record_outcome", {
+      event_type: "phase_completed",
+      issue_number: 1306,
+      query_id: qid1,
+    });
+
+    const byQid1 = db.queryOutcomeEventsByQueryId(qid1);
+    const byQid2 = db.queryOutcomeEventsByQueryId(qid2);
+
+    // qid1: expert_call + phase_completed = 2
+    expect(byQid1).toHaveLength(2);
+    // qid2: only its expert_call = 1
+    expect(byQid2).toHaveLength(1);
+  });
 });

--- a/plugin/ralph-knowledge/src/db.ts
+++ b/plugin/ralph-knowledge/src/db.ts
@@ -430,6 +430,26 @@ export class KnowledgeDB {
     return this.db.prepare(sql).all(...values, limit) as OutcomeEventRow[];
   }
 
+  /**
+   * Return outcome events whose payload JSON contains a matching `query_id`.
+   * Uses SQLite's JSON1 `json_extract()` function (available by default in
+   * better-sqlite3). Rows with malformed payload JSON silently return NULL
+   * from json_extract and are excluded — the desired behavior.
+   */
+  queryOutcomeEventsByQueryId(queryId: string, limit = 50): OutcomeEventRow[] {
+    const sql = `
+      SELECT id, event_type AS eventType, issue_number AS issueNumber, session_id AS sessionId,
+             timestamp, duration_ms AS durationMs, verdict, component_area AS componentArea,
+             estimate, drift_count AS driftCount, model, agent_type AS agentType,
+             iteration_count AS iterationCount, payload
+      FROM outcome_events
+      WHERE json_extract(payload, '$.query_id') = ?
+      ORDER BY timestamp DESC
+      LIMIT ?
+    `;
+    return this.db.prepare(sql).all(queryId, limit) as OutcomeEventRow[];
+  }
+
   aggregateOutcomeEvents(params: OutcomeQueryParams = {}): OutcomeAggregate {
     // Override limit to aggregate over all matching events, not just the caller's limit
     const rows = this.queryOutcomeEvents({ ...params, limit: undefined });

--- a/plugin/ralph-knowledge/src/db.ts
+++ b/plugin/ralph-knowledge/src/db.ts
@@ -69,6 +69,7 @@ export interface OutcomeQueryParams {
   verdict?: string;
   sessionId?: string;
   since?: string;
+  domain?: string;
   limit?: number;
 }
 
@@ -412,6 +413,10 @@ export class KnowledgeDB {
     if (params.since !== undefined) {
       conditions.push("timestamp >= ?");
       values.push(params.since);
+    }
+    if (params.domain !== undefined) {
+      conditions.push("json_extract(payload, '$.domain') = ?");
+      values.push(params.domain);
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";

--- a/plugin/ralph-knowledge/src/db.ts
+++ b/plugin/ralph-knowledge/src/db.ts
@@ -304,6 +304,43 @@ export class KnowledgeDB {
     return (this.db.prepare("SELECT tag FROM tags WHERE doc_id = ? ORDER BY tag").all(docId) as Array<{ tag: string }>).map(r => r.tag);
   }
 
+  /**
+   * Return documents matching a domain tag and memory tier.
+   * Joins documents ↔ tags so the domain (frontmatter tag) is the primary
+   * signal. Optional pathPrefix and sinceDate narrow further.
+   */
+  queryByDomain(params: {
+    domain: string;
+    memoryTier: "wiki" | "reflection" | "doc" | "raw";
+    limit: number;
+    pathPrefix?: string;
+    sinceDate?: string;
+  }): DocumentRow[] {
+    const conditions: string[] = ["t.tag = ?", "d.memory_tier = ?"];
+    const values: unknown[] = [params.domain, params.memoryTier];
+
+    if (params.pathPrefix !== undefined) {
+      conditions.push("d.path LIKE ?");
+      values.push(`${params.pathPrefix}%`);
+    }
+    if (params.sinceDate !== undefined) {
+      conditions.push("d.date >= ?");
+      values.push(params.sinceDate);
+    }
+
+    const sql = `
+      SELECT DISTINCT d.id, d.path, d.title, d.date, d.type, d.status,
+             d.github_issue AS githubIssue, d.content, d.is_stub AS isStub
+      FROM documents d
+      JOIN tags t ON t.doc_id = d.id
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY d.date DESC NULLS LAST
+      LIMIT ?
+    `;
+
+    return this.db.prepare(sql).all(...values, params.limit) as DocumentRow[];
+  }
+
   addRelationship(sourceId: string, targetId: string, type: string, context?: string): void {
     this.db.prepare("INSERT OR IGNORE INTO relationships (source_id, target_id, type, context) VALUES (?, ?, ?, ?)").run(sourceId, targetId, type, context ?? null);
   }

--- a/plugin/ralph-knowledge/src/index.ts
+++ b/plugin/ralph-knowledge/src/index.ts
@@ -656,10 +656,15 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
       model: z.string().optional().describe("LLM model used (opus, sonnet, haiku)"),
       agent_type: z.string().optional().describe("Agent type (analyst, builder, integrator)"),
       iteration_count: z.number().optional().describe("Number of retry/review cycles"),
+      query_id: z.string().optional().describe("Query ID returned by a prior knowledge_expert call. Stored in payload.query_id for outcome correlation."),
       payload: z.record(z.unknown()).optional().describe("Arbitrary JSON payload"),
     },
     async (args) => {
       try {
+        const mergedPayload: Record<string, unknown> = {
+          ...(args.payload ?? {}),
+          ...(args.query_id !== undefined ? { query_id: args.query_id } : {}),
+        };
         const result = db.insertOutcomeEvent({
           eventType: args.event_type,
           issueNumber: args.issue_number,
@@ -672,7 +677,7 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
           model: args.model,
           agentType: args.agent_type,
           iterationCount: args.iteration_count,
-          payload: args.payload as Record<string, unknown>,
+          payload: mergedPayload,
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (e) {
@@ -731,7 +736,6 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
       session_id: z.string().optional().describe("Team/hero session identifier — passes through to the outcome event in Phase 2."),
     },
     async (args) => {
-      // Phase 1: pure retrieval (no outcome write — Phase 2 adds that)
       try {
         const queryId = randomUUID();
         const limit = args.limit ?? 5;
@@ -768,6 +772,27 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
           wiki.length === 0 && reflections.length === 0
             ? `No documents found tagged with domain "${args.domain}". Consider tagging existing docs or using a broader domain term.`
             : null;
+
+        // Phase 2: write an outcome_events row per call so per-domain hit rate
+        // is observable from day one via knowledge_query_outcomes({ event_type: 'expert_call' }).
+        db.insertOutcomeEvent({
+          eventType: "expert_call",
+          issueNumber: args.issue_number,
+          sessionId: args.session_id,
+          agentType: "knowledge_expert",
+          payload: {
+            query_id: queryId,
+            domain: args.domain,
+            returned_doc_ids: {
+              wiki: wiki.map((d) => d.id),
+              reflections: reflections.map((d) => d.id),
+            },
+            limit,
+            recency_window_days: recencyWindowDays,
+            path_prefix: args.path_prefix ?? null,
+            warning,
+          },
+        });
 
         const result = {
           query_id: queryId,

--- a/plugin/ralph-knowledge/src/index.ts
+++ b/plugin/ralph-knowledge/src/index.ts
@@ -758,14 +758,8 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
         });
 
         const priorOutcomes = db.queryOutcomeEvents({
+          domain: args.domain,
           limit,
-        }).filter((evt) => {
-          try {
-            const p = JSON.parse(evt.payload ?? "{}") as Record<string, unknown>;
-            return p.domain === args.domain;
-          } catch {
-            return false;
-          }
         });
 
         const warning =

--- a/plugin/ralph-knowledge/src/index.ts
+++ b/plugin/ralph-knowledge/src/index.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { KnowledgeDB } from "./db.js";
 import { FtsSearch } from "./search.js";
 import { VectorSearch } from "./vector-search.js";
@@ -713,6 +713,72 @@ export function createServer(dbPath: string, opts: CreateServerOptions = {}) {
         }
         const rows = db.queryOutcomeEvents(params);
         return { content: [{ type: "text" as const, text: JSON.stringify(rows, null, 2) }] };
+      } catch (e) {
+        return { content: [{ type: "text" as const, text: `Error: ${(e as Error).message}` }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "knowledge_expert",
+    "Return a domain-keyed memory bundle: curated wiki entries + recent reflections + prior outcomes for a named domain. Use to specialize a sub-agent's context for a topic before it starts work.",
+    {
+      domain: z.string().describe("Domain tag (e.g., 'auth', 'memory-tiers', 'ralph-knowledge'). Matches against frontmatter tags; open string."),
+      issue_number: z.number().describe("GitHub issue number this call is being made on behalf of (required for outcome correlation)."),
+      limit: z.number().optional().default(5).describe("Max entries per bucket (wiki, reflections, outcomes). Default 5."),
+      recency_window_days: z.number().optional().default(30).describe("Reflection age cutoff in days. Default 30."),
+      path_prefix: z.string().optional().describe("Optional secondary filter: only return docs whose path starts with this prefix (e.g., 'thoughts/shared/'). Tags are the primary signal."),
+      session_id: z.string().optional().describe("Team/hero session identifier — passes through to the outcome event in Phase 2."),
+    },
+    async (args) => {
+      // Phase 1: pure retrieval (no outcome write — Phase 2 adds that)
+      try {
+        const queryId = randomUUID();
+        const limit = args.limit ?? 5;
+        const recencyWindowDays = args.recency_window_days ?? 30;
+
+        const wiki = db.queryByDomain({
+          domain: args.domain,
+          memoryTier: "wiki",
+          limit,
+          pathPrefix: args.path_prefix,
+        });
+
+        const sinceIso = new Date(Date.now() - recencyWindowDays * 86_400_000).toISOString();
+        const reflections = db.queryByDomain({
+          domain: args.domain,
+          memoryTier: "reflection",
+          limit,
+          pathPrefix: args.path_prefix,
+          sinceDate: sinceIso,
+        });
+
+        const priorOutcomes = db.queryOutcomeEvents({
+          limit,
+        }).filter((evt) => {
+          try {
+            const p = JSON.parse(evt.payload ?? "{}") as Record<string, unknown>;
+            return p.domain === args.domain;
+          } catch {
+            return false;
+          }
+        });
+
+        const warning =
+          wiki.length === 0 && reflections.length === 0
+            ? `No documents found tagged with domain "${args.domain}". Consider tagging existing docs or using a broader domain term.`
+            : null;
+
+        const result = {
+          query_id: queryId,
+          domain: args.domain,
+          wiki,
+          reflections,
+          prior_outcomes: priorOutcomes,
+          warning,
+        };
+
+        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (e) {
         return { content: [{ type: "text" as const, text: `Error: ${(e as Error).message}` }], isError: true };
       }


### PR DESCRIPTION
## Summary

Three sequential phases implementing the `knowledge_expert(domain)` MCP tool: Phase 1 adds the retriever composing hybrid search + tag-table joins to return curated wiki/reflection/outcome bundles; Phase 2 wires outcome telemetry (`expert_call` events with `query_id` correlation); Phase 3 wires `research-agent` as the first consumer via domain extraction heuristics.

## Plan

Implementation plan with detailed Success Criteria and technical justification:
- Path: `thoughts/shared/plans/2026-05-18-GH-1306-knowledge-expert-domain-mcp-tool.md` (on branch `worktree-GH-1306-knowledge-expert-plan`)

Plan review and approval:
- Path: `thoughts/shared/reviews/2026-05-18-GH-1306-critique.md` (currently unpushed; captured during planning phase)
- Verdict: APPROVED — zero schema migration, telemetry-first ordering, all claims technically verified

## Test plan

- [x] Phase 1: `npm run build && npm test` passes with 5 new tests (registration check, empty-domain bundle, two-bucket return, tier isolation, recency window)
- [x] Phase 2: `npm test` passes with 5 additional telemetry tests (expert_call row write, returned_doc_ids shape, correlation roundtrip, backwards-compat, isolation)
- [x] Phase 3: No new tests needed; agent/skill markdown parses cleanly; skill-level pre-approval (`allowed-tools`) and agent-level runtime enforcement (`tools:`) both updated
- [x] Cross-phase integration: `knowledge_expert` called, two outcomes recorded with `query_id`, query by `query_id` returns both rows — verified in Phase 2 test suite
- [x] Manual: Domain extraction heuristic (issue labels → title noun phrase → skip if unclear) documented in `ralph-research/SKILL.md` Step 3d for future consumers to copy

**Phases shipped**: 3 of 3

Closes #1306
