### PR TITLE
GH-1322: finish Step 4 deterministic verdict gate

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/__tests__/finish-review-verdict.test.sh
+++ b/plugin/ralph-hero/hooks/scripts/__tests__/finish-review-verdict.test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Tests for finish-review-verdict.sh
+# Run: bash plugin/ralph-hero/hooks/scripts/__tests__/finish-review-verdict.test.sh
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/finish-review-verdict.sh"
+TEST_DIR="$(mktemp -d)"
+SHIM_DIR="$TEST_DIR/bin"
+mkdir -p "$SHIM_DIR"
+trap "rm -rf $TEST_DIR" EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $msg"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $msg"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+echo "Testing $SCRIPT"
+
+# ---------------------------------------------------------------------------
+# Test case 1: Missing argument -> ERROR: PR_NUMBER required, exit 1
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 1: missing arg -> ERROR: PR_NUMBER required, exit 1"
+output=$(bash "$SCRIPT" 2>&1) && exit_code=0 || exit_code=$?
+assert_eq "ERROR: PR_NUMBER required" "$output" "missing arg: correct error message"
+assert_eq "1" "$exit_code" "missing arg: exit 1"
+
+# ---------------------------------------------------------------------------
+# Test case 2: reviewDecision=APPROVED -> APPROVED
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 2: reviewDecision=APPROVED -> APPROVED"
+cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# argv: pr view 999 --json reviewDecision --jq '.reviewDecision'
+echo "APPROVED"
+exit 0
+EOF
+chmod +x "$SHIM_DIR/gh"
+output=$(PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 999 2>&1)
+assert_eq "APPROVED" "$output" "APPROVED decision -> APPROVED verdict"
+
+# ---------------------------------------------------------------------------
+# Test case 3: reviewDecision=CHANGES_REQUESTED -> NEEDS_FIX
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 3: reviewDecision=CHANGES_REQUESTED -> NEEDS_FIX"
+cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "CHANGES_REQUESTED"
+exit 0
+EOF
+chmod +x "$SHIM_DIR/gh"
+output=$(PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 999 2>&1)
+assert_eq "NEEDS_FIX" "$output" "CHANGES_REQUESTED decision -> NEEDS_FIX verdict"
+
+# ---------------------------------------------------------------------------
+# Test case 4: null decision + self-authored + last comment "Found 1 issue:" -> NEEDS_FIX
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 4: null decision + self-authored + 'Found 1 issue:' comment -> NEEDS_FIX"
+cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# Dispatch on subcommand and --json field
+if [[ "$*" == *"reviewDecision"* ]]; then
+  echo ""
+elif [[ "$*" == *"author"* ]]; then
+  echo "testuser"
+elif [[ "$*" == "api user"* ]]; then
+  echo "testuser"
+elif [[ "$*" == *"comments"* ]]; then
+  echo "### Code review"$'\n'"Found 1 issue: something bad"
+fi
+exit 0
+EOF
+chmod +x "$SHIM_DIR/gh"
+output=$(PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 999 2>&1)
+assert_eq "NEEDS_FIX" "$output" "self-authored + Found comment -> NEEDS_FIX"
+
+# ---------------------------------------------------------------------------
+# Test case 5: null decision + self-authored + last comment "No issues found." -> APPROVED
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 5: null decision + self-authored + 'No issues found.' comment -> APPROVED"
+cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"reviewDecision"* ]]; then
+  echo ""
+elif [[ "$*" == *"author"* ]]; then
+  echo "testuser"
+elif [[ "$*" == "api user"* ]]; then
+  echo "testuser"
+elif [[ "$*" == *"comments"* ]]; then
+  echo "### Code review"$'\n'"No issues found."
+fi
+exit 0
+EOF
+chmod +x "$SHIM_DIR/gh"
+output=$(PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 999 2>&1)
+assert_eq "APPROVED" "$output" "self-authored + No issues found -> APPROVED"
+
+# ---------------------------------------------------------------------------
+# Test case 6: null decision + multi-author (pr_author != current_user) -> BLOCKED
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 6: null decision + multi-author -> BLOCKED"
+cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"reviewDecision"* ]]; then
+  echo ""
+elif [[ "$*" == *"author"* ]]; then
+  echo "otheruser"
+elif [[ "$*" == "api user"* ]]; then
+  echo "testuser"
+fi
+exit 0
+EOF
+chmod +x "$SHIM_DIR/gh"
+output=$(PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 999 2>&1)
+assert_eq "BLOCKED" "$output" "cross-author + null decision -> BLOCKED"
+
+# ---------------------------------------------------------------------------
+# Test case 7: null decision + self-authored + no code-review comment found -> BLOCKED
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 7: null decision + self-authored + no code-review comment -> BLOCKED"
+cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"reviewDecision"* ]]; then
+  echo ""
+elif [[ "$*" == *"author"* ]]; then
+  echo "testuser"
+elif [[ "$*" == "api user"* ]]; then
+  echo "testuser"
+elif [[ "$*" == *"comments"* ]]; then
+  echo ""
+fi
+exit 0
+EOF
+chmod +x "$SHIM_DIR/gh"
+output=$(PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 999 2>&1)
+assert_eq "BLOCKED" "$output" "self-authored + no code-review comment -> BLOCKED"
+
+# ---------------------------------------------------------------------------
+# Test case 8: gh exits non-zero -> ERROR: ..., exit 1
+# ---------------------------------------------------------------------------
+echo
+echo "Test case 8: gh failure -> ERROR: ..., exit 1"
+cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$SHIM_DIR/gh"
+output=$(PATH="$SHIM_DIR:$PATH" bash "$SCRIPT" 999 2>&1) && exit_code=0 || exit_code=$?
+# Output should start with "ERROR:"
+case "$output" in
+  ERROR:*)
+    PASS=$((PASS + 1))
+    echo "  PASS: gh failure -> ERROR: prefix"
+    ;;
+  *)
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: gh failure -> ERROR: prefix"
+    echo "    expected: ERROR: ..."
+    echo "    actual:   $output"
+    ;;
+esac
+assert_eq "1" "$exit_code" "gh failure -> exit 1"
+
+# ---------------------------------------------------------------------------
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugin/ralph-hero/hooks/scripts/finish-review-verdict.sh
+++ b/plugin/ralph-hero/hooks/scripts/finish-review-verdict.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# finish-review-verdict.sh — single-token verdict gate for finish Step 4.
+# Usage: finish-review-verdict.sh PR_NUMBER
+# Prints one of: APPROVED | NEEDS_FIX | BLOCKED | ERROR: <message>
+# Exit: 0 on success, 1 on gh failure or missing arg
+
+set -uo pipefail
+
+PR_NUMBER="${1:-}"
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "ERROR: PR_NUMBER required"
+  exit 1
+fi
+
+decision=$(gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision' 2>/dev/null) || {
+  echo "ERROR: gh pr view (reviewDecision) failed"
+  exit 1
+}
+
+case "$decision" in
+  APPROVED)
+    echo "APPROVED"
+    exit 0
+    ;;
+  CHANGES_REQUESTED)
+    echo "NEEDS_FIX"
+    exit 0
+    ;;
+esac
+
+pr_author=$(gh pr view "$PR_NUMBER" --json author --jq '.author.login' 2>/dev/null) || {
+  echo "ERROR: gh pr view (author) failed"
+  exit 1
+}
+current_user=$(gh api user --jq '.login' 2>/dev/null) || {
+  echo "ERROR: gh api user failed"
+  exit 1
+}
+
+if [[ "$pr_author" != "$current_user" ]]; then
+  echo "BLOCKED"
+  exit 0
+fi
+
+last_comment=$(gh pr view "$PR_NUMBER" --json comments \
+  --jq '.comments | map(select(.body | startswith("### Code review"))) | last | .body // ""' 2>/dev/null) || {
+  echo "ERROR: gh pr view (comments) failed"
+  exit 1
+}
+
+if [[ -z "$last_comment" ]]; then
+  echo "BLOCKED"
+elif [[ "$last_comment" == *"No issues found"* ]]; then
+  echo "APPROVED"
+elif [[ "$last_comment" == *"Found "* ]]; then
+  echo "NEEDS_FIX"
+else
+  echo "BLOCKED"
+fi

--- a/plugin/ralph-hero/skills/finish/SKILL.md
+++ b/plugin/ralph-hero/skills/finish/SKILL.md
@@ -112,110 +112,87 @@ Check the agent output for the verdict:
 >
 > The `code-review:code-review` plugin spawns 5 parallel Sonnet reviewers + N parallel Haiku scorers via the `Agent` tool. Those parallel agents land at depth 1 only when `code-review:code-review` itself is invoked from depth 0. By keeping the code review gate inline in finish (which runs at depth 0), we preserve the parallel-agent fan-out. If code review were dispatched from inside an agent context, the runtime's no-depth-2-Agent rule would silently break the parallel reviewers.
 
-Check whether the PR has received a code review:
+Read the initial verdict from the deterministic helper:
 
 ```bash
-gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
+verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_NUMBER)
 ```
 
-**If `reviewDecision` is `APPROVED`**: a code review has been performed and approved. Proceed to Step 5.
+`case` on `$verdict`:
 
-**If `reviewDecision` is `CHANGES_REQUESTED`**: a human reviewer (not the automated code-review skill) requested changes. Output:
+- **`APPROVED`**: formal review approval or self-authored clean pass — continue to Step 5.
+- **`NEEDS_FIX`**: formal `CHANGES_REQUESTED` or self-authored code-review found issues — proceed to Step 4a.
+- **`BLOCKED`**: multi-author repo with no formal review decision and no self-authored fallback. Branch on `RALPH_REVIEW_MODE`:
+  - **`auto`** (`RALPH_REVIEW_MODE=auto`): run code review inline — do NOT prompt the user:
+    ```
+    Skill("code-review:code-review", "PR_NUMBER")
+    ```
+    The `code-review:code-review` skill runs inline at depth 0; its parallel reviewer agents land at depth 1 (legal). After the review skill completes, re-read the verdict:
+    ```bash
+    verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_NUMBER)
+    ```
+    `case` on the new `$verdict` using the same four arms above.
+  - **`interactive`** (`RALPH_REVIEW_MODE=interactive`, default): present a choice:
 
-```
-FINISH BLOCKED
-Issue: #NNN
-PR: #PR_NUMBER
-Reason: Human reviewer requested changes — address feedback before merging.
-```
+    !cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
 
-And stop.
+    ```
+    AskUserQuestion(
+      questions=[{
+        "question": "This PR has no code review yet. Would you like to run one before merging?",
+        "header": "Code Review",
+        "options": [
+          {"label": "Run code review", "description": "Invoke /code-review:code-review on PR #PR_NUMBER before merging"},
+          {"label": "Merge without review", "description": "Skip code review and proceed to merge"}
+        ],
+        "multiSelect": false
+      }]
+    )
+    ```
 
-**If no review decision exists** (`reviewDecision` is null or empty), branch on `RALPH_REVIEW_MODE`:
+    - If user selects **"Run code review"**: invoke `Skill("code-review:code-review", "PR_NUMBER")`. After it completes, re-read the verdict:
+      ```bash
+      verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_NUMBER)
+      ```
+      `case` on the new `$verdict` using the same four arms above.
+    - If user selects **"Merge without review"**: continue to Step 5.
+    - If user selects **"Other"**: stop.
 
-### Auto mode (`RALPH_REVIEW_MODE=auto`)
+  If the `code-review:code-review` skill is NOT installed:
 
-Run code review automatically — do NOT prompt the user:
-
-```
-Skill("code-review:code-review", "PR_NUMBER")
-```
-
-The `code-review:code-review` skill runs inline at depth 0; its parallel reviewer agents land at depth 1 (legal). After the review skill completes, re-check `reviewDecision`:
-
-```bash
-gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
-```
-
-- If `APPROVED`: continue to Step 5.
-- If `CHANGES_REQUESTED`: proceed to Step 4a (Code Review Fix Cycle).
-- If still null/empty: the code-review skill posts a comment but never creates a formal review (so `reviewDecision` never changes from null). Branch on self-authorship:
-
-  ```bash
-  PR_AUTHOR=$(gh pr view PR_NUMBER --json author --jq '.author.login')
-  CURRENT_USER=$(gh api user --jq '.login')
-  LAST_COMMENT=$(gh pr view PR_NUMBER --json comments --jq '.comments | map(select(.body | startswith("### Code review"))) | last | .body')
+  ```
+  This PR has no code review. Consider installing the code-review plugin:
+    claude plugins install @anthropic/code-review
   ```
 
-  - If `PR_AUTHOR == CURRENT_USER` AND `LAST_COMMENT` contains the literal string `No issues found`: code review passed clean on a self-authored single-contributor repo (GitHub blocks self-approval, so a formal `APPROVED` is unattainable). Treat as APPROVED-equivalent and continue to Step 5.
-  - If `PR_AUTHOR == CURRENT_USER` AND `LAST_COMMENT` contains `Found ` (i.e., the "Found N issues" variant): code review flagged issues. Proceed to Step 4a (Code Review Fix Cycle).
-  - Otherwise (multi-author repo with null `reviewDecision`, or no code-review comment found): output `FINISH BLOCKED` with `Reason: Code review did not produce a reviewDecision and no self-authored fallback applies` and stop.
+  Then present:
 
-### Interactive mode (`RALPH_REVIEW_MODE=interactive`, default)
+  ```
+  AskUserQuestion(
+    questions=[{
+      "question": "Proceed without code review?",
+      "header": "No Code Review Plugin",
+      "options": [
+        {"label": "Merge without review", "description": "Skip code review and proceed to merge"},
+        {"label": "Stop", "description": "Stop here — install the code-review plugin first"}
+      ],
+      "multiSelect": false
+    }]
+  )
+  ```
 
-Present a choice:
+  - If user selects **"Merge without review"**: continue to Step 5.
+  - If user selects **"Stop"** or **"Other"**: stop.
 
-!cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
-
-```
-AskUserQuestion(
-  questions=[{
-    "question": "This PR has no code review yet. Would you like to run one before merging?",
-    "header": "Code Review",
-    "options": [
-      {"label": "Run code review", "description": "Invoke /code-review:code-review on PR #PR_NUMBER before merging"},
-      {"label": "Merge without review", "description": "Skip code review and proceed to merge"}
-    ],
-    "multiSelect": false
-  }]
-)
-```
-
-- If user selects **"Run code review"**: invoke `Skill("code-review:code-review", "PR_NUMBER")`. After it completes, re-check `reviewDecision`. If `APPROVED`, continue to Step 5. If `CHANGES_REQUESTED`, proceed to Step 4a.
-- If user selects **"Merge without review"**: continue to Step 5.
-- If user selects **"Other"**: stop.
-
-### Skill not available
-
-If the `code-review:code-review` skill is NOT installed:
-
-```
-This PR has no code review. Consider installing the code-review plugin:
-  claude plugins install @anthropic/code-review
-```
-
-Then present:
-
-```
-AskUserQuestion(
-  questions=[{
-    "question": "Proceed without code review?",
-    "header": "No Code Review Plugin",
-    "options": [
-      {"label": "Merge without review", "description": "Skip code review and proceed to merge"},
-      {"label": "Stop", "description": "Stop here — install the code-review plugin first"}
-    ],
-    "multiSelect": false
-  }]
-)
-```
-
-- If user selects **"Merge without review"**: continue to Step 5.
-- If user selects **"Stop"** or **"Other"**: stop.
+- **`ERROR: *`**: transient `gh` failure. Retry once:
+  ```bash
+  verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_NUMBER)
+  ```
+  If still `ERROR: *`: output `FINISH BLOCKED` with the error message and stop.
 
 ## Step 4a: Code Review Fix Cycle
 
-Triggered when the auto code review (or interactive "Run code review") returned `CHANGES_REQUESTED`.
+Triggered when Step 4 verdict is `NEEDS_FIX`.
 
 Dispatch impl-agent in Address Mode to fix the flagged issues. The issue is already "In Review" with an open PR that has review comments — impl-agent will auto-detect Address Mode.
 
@@ -229,10 +206,14 @@ After impl-agent completes, re-run code review once:
 Skill("code-review:code-review", "PR_NUMBER")
 ```
 
-Then re-check `reviewDecision` (same self-authored fallback as Step 4):
+Then re-read the verdict via the helper:
+
+```bash
+verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_NUMBER)
+```
 
 - If `APPROVED`: continue to Step 5.
-- If `CHANGES_REQUESTED` again: stop. Max 1 fix cycle. Output:
+- If `NEEDS_FIX` again: stop. Max 1 fix cycle. Output:
 
 ```
 FINISH BLOCKED
@@ -241,16 +222,7 @@ PR: #PR_NUMBER
 Reason: Code review feedback unresolved after 1 fix cycle.
 ```
 
-- If still null/empty: branch on self-authorship + last code-review comment content:
-
-  ```bash
-  PR_AUTHOR=$(gh pr view PR_NUMBER --json author --jq '.author.login')
-  CURRENT_USER=$(gh api user --jq '.login')
-  LAST_COMMENT=$(gh pr view PR_NUMBER --json comments --jq '.comments | map(select(.body | startswith("### Code review"))) | last | .body')
-  ```
-
-  - If `PR_AUTHOR == CURRENT_USER` AND `LAST_COMMENT` contains `No issues found`: the fix cycle resolved the feedback. Continue to Step 5.
-  - Otherwise: stop with `FINISH BLOCKED` and `Reason: Code review feedback unresolved after 1 fix cycle`.
+- If `BLOCKED` or `ERROR: *`: stop with `FINISH BLOCKED` and `Reason: Code review feedback unresolved after 1 fix cycle`.
 
 ## Step 5: Merge (dispatch ralph-merge)
 

--- a/plugin/ralph-hero/skills/finish/SKILL.md
+++ b/plugin/ralph-hero/skills/finish/SKILL.md
@@ -131,7 +131,11 @@ verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_N
     ```bash
     verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_NUMBER)
     ```
-    `case` on the new `$verdict` using the same four arms above.
+    `case` on the new `$verdict`:
+    - **`APPROVED`**: continue to Step 5.
+    - **`NEEDS_FIX`**: proceed to Step 4a (Code Review Fix Cycle).
+    - **`BLOCKED`**: emit `FINISH BLOCKED` with reason "Code review did not produce a verdict and no self-authored fallback applies" and stop.
+    - **`ERROR: *`**: emit `FINISH BLOCKED` with the error message and stop.
   - **`interactive`** (`RALPH_REVIEW_MODE=interactive`, default): present a choice:
 
     !cat ${CLAUDE_PLUGIN_ROOT}/skills/shared/fragments/ask-user-question.md
@@ -154,7 +158,11 @@ verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_N
       ```bash
       verdict=$(bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/finish-review-verdict.sh PR_NUMBER)
       ```
-      `case` on the new `$verdict` using the same four arms above.
+      `case` on the new `$verdict`:
+      - **`APPROVED`**: continue to Step 5.
+      - **`NEEDS_FIX`**: proceed to Step 4a (Code Review Fix Cycle).
+      - **`BLOCKED`**: emit `FINISH BLOCKED` with reason "Code review did not produce a verdict and no self-authored fallback applies" and stop.
+      - **`ERROR: *`**: emit `FINISH BLOCKED` with the error message and stop.
     - If user selects **"Merge without review"**: continue to Step 5.
     - If user selects **"Other"**: stop.
 


### PR DESCRIPTION
## Summary

Replace finish's prose-and-bullet-list code-review gate with a single deterministic Bash helper. Eliminates the buried-conditional drift that caused Step 4a to be skipped on PR #1315. Three sequential phases delivered: (1) finish-review-verdict.sh verdict emitter, (2) finish/SKILL.md Step 4 rewrite to case on verdicts, (3) comprehensive unit tests with mocked gh.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1323/thoughts/shared/plans/2026-05-19-GH-1322-finish-review-verdict-gate.md

Phases shipped: 3 of 3

## Changes

- **Phase 1 (GH-1323)**: New `plugin/ralph-hero/hooks/scripts/finish-review-verdict.sh` — deterministic single-token verdict gate. Emits one of `APPROVED | NEEDS_FIX | BLOCKED | ERROR: <message>`.
- **Phase 2 (GH-1324)**: Rewired `plugin/ralph-hero/skills/finish/SKILL.md` Step 4 + 4a + interactive mode to call the helper and case on its output. Removed buried-bullet logic.
- **Phase 3 (GH-1325)**: Added `plugin/ralph-hero/hooks/scripts/__tests__/finish-review-verdict.test.sh` with 8 test cases (10 assert_eq), mocked gh via PATH shim.

## Test plan

- [x] Automated verification per plan Success Criteria:
  - Helper emits APPROVED on formal approval
  - Helper emits NEEDS_FIX on CHANGES_REQUESTED
  - Helper emits BLOCKED on multi-author with null decision
  - Helper emits APPROVED on self-authored + No issues found
  - Helper emits NEEDS_FIX on self-authored + Found issues
  - Unit tests cover all 8 cases, exit 0 with all assertions passing
  - `grep -c 'finish-review-verdict.sh' finish/SKILL.md` = 3
  - CI picks up test file automatically via existing find *.test.sh pattern

- [x] Regression check: bash finish-review-verdict.sh 1315 → NEEDS_FIX (original failing case)
- [x] Syntax check: bash -n finish-review-verdict.sh → clean
- [x] Cross-phase integration: finish Step 4 nests ≤ 2 levels, verdict-then-case is only conditional surface

Closes #1322
Closes #1323
Closes #1324
Closes #1325