### PR TITLE
fix(autopilot): inverse Stop hook catches silent-drop on missing ScheduleWakeup

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/autopilot-director-postcheck.sh
+++ b/plugin/ralph-hero/hooks/scripts/autopilot-director-postcheck.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/autopilot-director-postcheck.sh
+# PostToolUse:Skill — when Director returns inside an autopilot /loop turn,
+# write or clear a sentinel file that the Stop hook reads to detect the
+# silent-drop failure mode (non-terminal Director result + omitted
+# ScheduleWakeup → /loop interprets absent wakeup as "task complete").
+#
+# See GH-1346 and thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md
+# for the failure mode this guards against.
+#
+# Self-discriminates on RALPH_COMMAND=autopilot — passes through silently
+# for any other skill that uses Skill().
+#
+# Exit codes:
+#   0 - Always (observer, never blocks)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Pass through for non-autopilot sessions.
+[[ "${RALPH_COMMAND:-}" == "autopilot" ]] || exit 0
+
+# Only act on the Director skill. Skill name may carry the plugin namespace
+# prefix (ralph-hero:director) or be bare (director); accept either.
+skill_name=$(get_field '.tool_input.skill')
+case "${skill_name##*:}" in
+  director) ;;
+  *) exit 0 ;;
+esac
+
+# Sentinel path is session-scoped. session_id is part of the standard hook
+# payload; fall back to PPID if missing so the hook still functions in tests.
+session_id=$(get_field '.session_id')
+sentinel_dir="${TMPDIR:-/tmp}"
+sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+
+# Skill returns the model's final synthesis from the inner skill run.
+# Shape varies: MCP-style { content: [{ text }] } for some tools, plain string
+# for the built-in Skill tool. Use a single defensive jq expression that
+# handles both without crashing on type mismatch.
+response_text=$(printf '%s' "$RALPH_HOOK_INPUT" | jq -r '
+  .tool_response
+  | if type == "object" then (.content // [{}])[0].text // ""
+    elif type == "string" then .
+    else . | tostring
+    end // ""
+' 2>/dev/null || echo "")
+
+# Extract the last line beginning with `result:` (Director can emit several
+# intermediate lines; the final `result:` is the operative one).
+result_line=$(printf '%s\n' "$response_text" | grep -E '^result:' | tail -n 1 || true)
+
+if [[ -z "$result_line" ]]; then
+  # No `result:` line found — response wasn't from Director (maybe an error
+  # or a non-director Skill call we don't recognize). Leave the sentinel
+  # alone; the next valid Director response will resolve it.
+  exit 0
+fi
+
+if printf '%s' "$result_line" | grep -qE 'Queue empty'; then
+  # Terminal — autopilot is allowed to end without a ScheduleWakeup call.
+  rm -f -- "$sentinel" 2>/dev/null || true
+else
+  # Non-terminal — Director returned forward-progress, skip, or classification
+  # text. Autopilot's contract requires a follow-up ScheduleWakeup. Record the
+  # pending state; the wakeup-clear hook will rm it if ScheduleWakeup fires,
+  # otherwise the Stop hook will surface the omission.
+  printf '%s\n' "$result_line" > "$sentinel" 2>/dev/null || true
+fi
+
+exit 0

--- a/plugin/ralph-hero/hooks/scripts/autopilot-stop-gate.sh
+++ b/plugin/ralph-hero/hooks/scripts/autopilot-stop-gate.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/autopilot-stop-gate.sh
+# Stop — if a sentinel file exists indicating Director emitted a non-terminal
+# result without a subsequent ScheduleWakeup, block stop with a loud message
+# so the silent-drop failure mode becomes a noisy, recoverable one.
+#
+# See GH-1346 and thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md.
+#
+# Self-discriminates on RALPH_COMMAND=autopilot — passes through silently
+# for any other skill. Uses stop_hook_active for re-entry safety following
+# the pattern in team-stop-gate.sh.
+#
+# Exit codes:
+#   0 - No pending wakeup, allow stop
+#   2 - Pending wakeup detected, block stop and surface omission
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Pass through for non-autopilot sessions.
+[[ "${RALPH_COMMAND:-}" == "autopilot" ]] || exit 0
+
+# Re-entry safety: if we already fired once and the model still wants to stop,
+# we've made our case — let it stop. Otherwise we'd loop forever.
+stop_hook_active=$(get_field '.stop_hook_active')
+if [[ "$stop_hook_active" == "true" ]]; then
+  # Clean up the sentinel so it doesn't bleed into a future autopilot run.
+  session_id=$(get_field '.session_id')
+  sentinel_dir="${TMPDIR:-/tmp}"
+  sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+  rm -f -- "$sentinel" 2>/dev/null || true
+  exit 0
+fi
+
+session_id=$(get_field '.session_id')
+sentinel_dir="${TMPDIR:-/tmp}"
+sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+
+[[ -f "$sentinel" ]] || exit 0
+
+pending_result=$(cat -- "$sentinel" 2>/dev/null || echo "(unreadable)")
+
+cat >&2 <<EOF
+═══════════════════════════════════════════════════════════════
+ Autopilot stop blocked: pending ScheduleWakeup not observed
+
+ Director returned a non-terminal result, but no ScheduleWakeup
+ call followed. Without one, /loop interprets the absent wakeup
+ as "task complete" and the autopilot drops silently.
+
+ Last Director result:
+   $pending_result
+
+ Required next action:
+   Call ScheduleWakeup with delaySeconds in [60,270] (warm-cache
+   continuation, work likely to resume soon) or [1200,1800] (idle
+   retry window). Avoid 300s.
+
+   prompt: pass back the same /ralph-hero:autopilot continuation
+   prompt or the <<autonomous-loop-dynamic>> sentinel.
+
+ If you genuinely intend to stop (queue is drained, Director just
+ hasn't said so), invoke Director once more and confirm it emits
+ 'result: Queue empty' before exiting.
+═══════════════════════════════════════════════════════════════
+EOF
+
+exit 2

--- a/plugin/ralph-hero/hooks/scripts/autopilot-wakeup-clear.sh
+++ b/plugin/ralph-hero/hooks/scripts/autopilot-wakeup-clear.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/autopilot-wakeup-clear.sh
+# PreToolUse:ScheduleWakeup — validate the wakeup call and clear the sentinel
+# that autopilot-director-postcheck.sh wrote after a non-terminal Director
+# result. Combines the GH-1140 anti-pattern checks (delaySeconds != 300,
+# autopilot-shaped prompt) with the post-GH-1267 sentinel-clear behavior.
+#
+# See GH-1346 and thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md.
+#
+# Self-discriminates on RALPH_COMMAND=autopilot — passes through silently
+# for any other skill that uses ScheduleWakeup().
+#
+# Exit codes:
+#   0 - Allowed (sentinel cleared)
+#   2 - Blocked (delaySeconds=300 cache-window anti-pattern)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Pass through for non-autopilot sessions.
+[[ "${RALPH_COMMAND:-}" == "autopilot" ]] || exit 0
+
+delay_seconds=$(get_field '.tool_input.delaySeconds')
+
+# Cache-window anti-pattern: 300s falls outside both the warm-cache window
+# (<=270s) and the cost-amortized committed window (>=1200s). Reject loudly.
+if [[ "$delay_seconds" == "300" ]]; then
+  cat >&2 <<'EOF'
+═══════════════════════════════════════════════════════════════
+ Autopilot ScheduleWakeup blocked: delaySeconds=300
+
+ 300s is the 5-minute cache-window anti-pattern — it pays the
+ prompt-cache miss without amortizing the cost across a longer
+ idle period.
+
+ Pick <=270s (warm-cache continuation, work likely to resume) or
+ >=1200s (committed idle wait, cache miss amortized).
+═══════════════════════════════════════════════════════════════
+EOF
+  exit 2
+fi
+
+# The wakeup is going through. Clear the sentinel so the Stop hook lets the
+# session end cleanly. Sentinel path mirrors autopilot-director-postcheck.sh.
+session_id=$(get_field '.session_id')
+sentinel_dir="${TMPDIR:-/tmp}"
+sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+rm -f -- "$sentinel" 2>/dev/null || true
+
+exit 0

--- a/plugin/ralph-hero/skills/autopilot/SKILL.md
+++ b/plugin/ralph-hero/skills/autopilot/SKILL.md
@@ -12,6 +12,19 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-enable-gate.sh"
+    - matcher: "ScheduleWakeup"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-wakeup-clear.sh"
+  PostToolUse:
+    - matcher: "Skill"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-director-postcheck.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-stop-gate.sh"
 allowed-tools:
   - Skill
   - ScheduleWakeup
@@ -41,7 +54,11 @@ Skill("loop", args="Run /ralph-hero:director on the next-most-important event on
 
 Director reads next_actions and picks the top-ranked event automatically — do not pre-filter the queue yourself. Director handles all routing decisions including trigger:<team> label consumption and team dispatch.
 
-Continuation rule: after each Director dispatch, re-check the queue by invoking Director again. If Director emits 'result: Queue empty', end the loop (return without calling ScheduleWakeup). Otherwise, call ScheduleWakeup with a delay you judge appropriate for the prior outcome — short (60-270s) when Director made forward progress and fresh follow-on work is likely, longer (1200-1800s) when the queue has only stuck or in-review items that need time before retry. Avoid 300s (the cache-window anti-pattern).
+Continuation rule (LOAD-BEARING — enforced by hook):
+  • Director emits 'result: Queue empty'  → end the loop, do NOT call ScheduleWakeup.
+  • Director emits ANY OTHER result line  → you MUST call ScheduleWakeup before returning.
+
+There is no third option. Narrating that you scheduled a wakeup without invoking the tool will be caught by the Stop hook (autopilot-stop-gate.sh) and the session will block with a loud error — the loop will not silently drop. Pick a delay: 60-270s when Director made forward progress and fresh follow-on work is likely; 1200-1800s when the queue has only stuck or in-review items that need time before retry. Never 300s (the cache-window anti-pattern is rejected by autopilot-wakeup-clear.sh).
 
 Trust Director's classification and team dispatch decisions. When a team moves an issue to Human Needed, the issue is filtered out of the next pick automatically — Director will skip it on the next tick. Run /ralph-hero:ralph-unblock or /ralph-hero:unblock in a separate loop to drain Human Needed work.")
 ```
@@ -54,6 +71,7 @@ That is all. Do not maintain your own iteration counter, audit log, cooldown tab
 - **Director owns routing**: Director classifies events via the taxonomy table in `event-classes.md` and dispatches the correct team. Autopilot does not need to know which team handles which event — that knowledge lives in Director.
 - **Opt-in gate is deterministic**: a hook that exits 2 with a fixed message is faster, more reliable, and more auditable than asking the model to read an env var and decide whether to stop.
 - **No special handling for the worktree-collision case**: hero/impl-agent already enforces worktree safety via `impl-worktree-gate.sh`. If a team hits a stale worktree, the team escalates the issue to `Human Needed` and Director skips it on the next tick.
+- **Inverse Stop gate catches silent drops** (GH-1346): a sentinel file written by `autopilot-director-postcheck.sh` after every non-`Queue empty` Director result is cleared by `autopilot-wakeup-clear.sh` when ScheduleWakeup fires. If the model returns without invoking ScheduleWakeup, the sentinel survives and `autopilot-stop-gate.sh` blocks session exit with a loud message naming the omitted call. The failure mode is now noisy and recoverable instead of silent.
 
 ## What the user sees
 

--- a/plugin/ralph-hero/skills/autopilot/eval-scenarios.md
+++ b/plugin/ralph-hero/skills/autopilot/eval-scenarios.md
@@ -153,6 +153,36 @@ The model is instructed (via the autopilot dispatch prompt) to avoid `delaySecon
 
 ---
 
+## Scenario 7: Silent-drop guard — non-terminal Director result + omitted ScheduleWakeup (GH-1346)
+
+### Input
+
+A test session where Director emits any non-`Queue empty` `result:` line (e.g., `result: Top direction is PR #N with no linked issue. Skipping.`, `result: Dispatched #N to <team>...`, `result: #N is terminal (...). Skipping.`).
+
+Simulated failure mode: the model narrates rescheduling in prose but does NOT actually invoke `ScheduleWakeup` before the /loop turn returns.
+
+- **Env**: `RALPH_AUTOPILOT_ENABLE=true`
+- **Invocation**: `/ralph-hero:autopilot`
+
+### Expected
+
+1. `autopilot-director-postcheck.sh` (PostToolUse:Skill) fires after Director returns. It reads the `result:` line, sees it is not `Queue empty`, and writes `${TMPDIR}/ralph-autopilot-pending-wakeup-<session_id>` containing the result text.
+2. Model produces prose claiming a wakeup was scheduled but does not invoke `ScheduleWakeup` (the bug we are guarding against).
+3. /loop turn returns. Session attempts to stop.
+4. `autopilot-stop-gate.sh` (Stop) fires, sees the sentinel exists, exits 2 with a loud message naming the omitted call and the last Director result.
+5. The session does NOT silently drop. The model is forced to either invoke `ScheduleWakeup` (which would clear the sentinel via `autopilot-wakeup-clear.sh`) or invoke Director once more and confirm `Queue empty` before exiting.
+
+### Assertions
+
+- [ ] After Director emits a non-terminal result and the model omits `ScheduleWakeup`, Stop hook exits 2 (not 0)
+- [ ] Stderr from the Stop hook contains `"Autopilot stop blocked"` and the last Director `result:` text
+- [ ] The sentinel file exists at `${TMPDIR}/ralph-autopilot-pending-wakeup-<session_id>` between Director return and Stop hook firing
+- [ ] After the model invokes `ScheduleWakeup` (in response to the block, or correctly the first time), the sentinel is removed and the second Stop firing (`stop_hook_active=true`) exits 0
+- [ ] When Director emits `result: Queue empty`, the postcheck hook removes the sentinel (or never wrote one) and Stop exits 0 with no message
+- [ ] For non-autopilot sessions (`RALPH_COMMAND != "autopilot"`), all three hooks exit 0 silently — no cross-skill interference
+
+---
+
 ## What's NOT covered (and why)
 
 - **State-machine internals, audit log shape, cooldown math**: removed in the redesign. Autopilot doesn't maintain its own state. Anything that used to live in `~/.ralph-hero/autopilot.jsonl` either now lives in `/loop`'s session state or is unrecorded. If tooling needs per-tick forensics, that's a separate concern from autopilot.


### PR DESCRIPTION
## Summary

- Adds three coordinated hooks (PostToolUse:Skill, PreToolUse:ScheduleWakeup, Stop) that turn the autopilot silent-drop failure mode into a noisy, recoverable block.
- Strengthens the autopilot SKILL.md continuation rule from prose paragraph to a two-option imperative, and documents the new enforcement in the "Why this design" section.
- Adds Scenario 7 to `eval-scenarios.md` covering the negative case.

Closes #1346.

## Why

The 2026-05-21 research trace (`thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md`) documented a silent-drop bug: when Director emits any non-`Queue empty` result, the model is supposed to call `ScheduleWakeup` to keep the loop alive — but it can narrate the wakeup in prose without actually invoking the tool. `/loop` then interprets the absent wakeup as "task complete" and the session ends with no warning.

GH-1140 (closed) shipped a `PreToolUse:ScheduleWakeup` hook for the pre-GH-1267 architecture; that gate validates calls that happen but can't catch calls that are omitted. The GH-1267 unified-agent redesign rolled GH-1140 back without authoring a replacement.

## How

- **`autopilot-director-postcheck.sh`** (PostToolUse:Skill) — after every `Skill('ralph-hero:director', ...)` call, parse the `result:` line. `Queue empty` → delete the session-scoped sentinel; anything else → write it with the result text. Handles both `tool_response.content[0].text` (MCP-style) and plain-string response shapes via a defensive jq expression.
- **`autopilot-wakeup-clear.sh`** (PreToolUse:ScheduleWakeup) — reject `delaySeconds=300` (cache-window anti-pattern), then clear the sentinel. Inherits the anti-pattern check from the original GH-1140 design.
- **`autopilot-stop-gate.sh`** (Stop) — if the sentinel exists, exit 2 with a loud message naming the omitted call and the last Director result. Uses `stop_hook_active` for re-entry safety following the `team-stop-gate.sh` pattern.

All three hooks self-discriminate on `RALPH_COMMAND=autopilot` so they pass through silently for other skills.

Sentinel path: `${TMPDIR:-/tmp}/ralph-autopilot-pending-wakeup-${session_id}` — session-scoped to avoid cross-session collisions, with a PPID fallback for tests.

## Test plan

- [x] `shellcheck -S warning` clean on all three new scripts
- [x] YAML frontmatter still parses (`python3 -c "import yaml; yaml.safe_load(...)" `)
- [x] `npm test`: 1621 passed | 3 skipped (no MCP-server changes; unchanged baseline)
- [x] Postcheck smoke tests: non-autopilot session passes through; Queue empty clears sentinel; non-terminal Skipping writes sentinel; non-director Skill call leaves sentinel untouched; both MCP-shape and plain-string `tool_response` handled
- [x] Wakeup-clear smoke tests: passes through for non-autopilot; blocks exit 2 on `delaySeconds=300`; clears sentinel and allows on 60/270/1200
- [x] Stop-gate smoke tests: passes through for non-autopilot; allows when no sentinel; blocks exit 2 with stderr "Autopilot stop blocked" when sentinel present; re-entry path (`stop_hook_active=true`) allows + cleans up sentinel

## References

- Closed prior art: #1140 (PreToolUse-only validation, rolled back in #1267)
- Research trace: `thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md`
- Reference Stop hook: `plugin/ralph-hero/hooks/scripts/team-stop-gate.sh`
- Reference PostToolUse pattern: `plugin/ralph-hero/hooks/scripts/split-estimate-gate.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)