### PR TITLE
feat(pr-drain): filter unlinkable PRs from next_actions + new ralph-pr-drain skill

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
@@ -1159,3 +1159,40 @@ describe("rankDirections — human-needed-unblock", () => {
     expect(result[0].signals.questionCount).toBe(4);
   });
 });
+
+// ---------------------------------------------------------------------------
+// PR filter — drop unlinkable PRs (no feature/GH-NNNN head-ref)
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — unlinkable PR filter", () => {
+  it("drops PRs whose headRefName does not match feature/GH-NNNN", () => {
+    const items = [
+      makeItem({ number: 1, workflowState: "Plan in Review", priority: "P1" }),
+    ];
+    // ageHours: 168 (>= PR_STALE_HOURS=24) gives PRs a non-zero stale score so
+    // they reach the merged-loop filter; scorePR drops score=0 PRs before then.
+    const openPRs: OpenPR[] = [
+      makePR({ number: 100, headRefName: "feature/GH-1", ageHours: 168 }),       // linked → keep
+      makePR({ number: 101, headRefName: "feature/GH-2", ageHours: 168 }),       // linked → keep
+      makePR({ number: 102, headRefName: "dependabot/pip/idna-3.8", ageHours: 168 }), // unlinked → drop
+    ];
+    const result = rankDirections(items, openPRs, makeConfig({ limit: 10 }));
+
+    const prDirections = result.filter((d) => d.kind === "pr");
+    expect(prDirections).toHaveLength(2);
+    const prNumbers = prDirections.map((d) => d.pr?.number).sort();
+    expect(prNumbers).toEqual([100, 101]);
+  });
+
+  it("returns empty PR slice when every PR is unlinkable", () => {
+    // ageHours: 168 (>= PR_STALE_HOURS=24) gives PRs a non-zero stale score so
+    // they reach the merged-loop filter; scorePR drops score=0 PRs before then.
+    const openPRs: OpenPR[] = [
+      makePR({ number: 200, headRefName: "dependabot/pip/idna-3.8", ageHours: 168 }),
+      makePR({ number: 201, headRefName: "dependabot/npm/typescript-5.6", ageHours: 168 }),
+    ];
+    const result = rankDirections([], openPRs, makeConfig({ limit: 10 }));
+    const prDirections = result.filter((d) => d.kind === "pr");
+    expect(prDirections).toHaveLength(0);
+  });
+});

--- a/plugin/ralph-hero/mcp-server/src/lib/directions.ts
+++ b/plugin/ralph-hero/mcp-server/src/lib/directions.ts
@@ -894,7 +894,13 @@ export function rankDirections(
 
   const merged: Entry[] = [];
   for (const c of candidates) merged.push({ kind: "issueRow", payload: c });
-  for (const p of prScored) merged.push({ kind: "prRow", payload: p });
+  // Filter unlinkable PRs (no linked issue) so they don't appear in next_actions.
+  // These are handled by the pr-drain Routine (out of band of Director).
+  // See: thoughts/shared/research/2026-05-22-pr-drain-routine-design.md
+  for (const p of prScored) {
+    if (p.linkedIssueNumber === null) continue;
+    merged.push({ kind: "prRow", payload: p });
+  }
 
   merged.sort((a, b) => {
     const scoreA = a.kind === "issueRow" ? a.payload.score : a.payload.score;

--- a/plugin/ralph-hero/skills/director/SKILL.md
+++ b/plugin/ralph-hero/skills/director/SKILL.md
@@ -56,9 +56,7 @@ Call `next_actions({})` to get the ranked project queue. Do NOT recompute rankin
 - If the queue is empty or all issues are in terminal states (`Done`, `Canceled`): emit `result: Queue empty. No events to dispatch.` and STOP.
 - Select the top-ranked direction (the entry marked `recommended: true`, or the first entry if none is marked). Resolve `TARGET_ISSUE` from the direction based on its `kind` — process only this one direction per invocation:
   - `kind: "issue" | "tree-continue" | "lock-stale" | "human-needed-unblock"` → `TARGET_ISSUE = direction.issue.number`. Proceed to Step 2b.
-  - `kind: "pr"` → `direction.issue` is `null`. Use the linked-issue fallback:
-    - If `direction.signals.linkedIssueNumber` is set: `TARGET_ISSUE = direction.signals.linkedIssueNumber`. Proceed to Step 2b; Step 3 classifies the linked issue's `workflowState` via the taxonomy.
-    - If `linkedIssueNumber` is absent (the PR's `headRefName` did not match `feature/GH-NNNN`): emit `result: Top direction is PR #<N> with no linked issue. Skipping.` and STOP. Do NOT iterate the rest of the list — Director processes one direction per invocation, and `/loop` owns the re-tick cadence.
+  - `kind: "pr"` → `direction.issue` is `null`. `direction.signals.linkedIssueNumber` is guaranteed to be set because `next_actions` filters out PRs with a null `linkedIssueNumber` at the source (see `mcp-server/src/lib/directions.ts`; unlinkable PRs are handled by the pr-drain Routine, not Director). Set `TARGET_ISSUE = direction.signals.linkedIssueNumber` and proceed to Step 2b; Step 3 classifies the linked issue's `workflowState` via the taxonomy.
 
 ### Step 2b: Fetch specific issue (--issue override or label trigger)
 

--- a/plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
@@ -241,7 +241,7 @@ Emit:
 needs input: PR #<N> shape unrecognized by ralph-pr-drain — manual triage required. Author: <author>, headRef: <headRefName>, title: <title>.
 ```
 
-Do NOT post an audit comment, do NOT add the `pr-drained` label, do NOT advance the synth issue. Instead set `FINAL_CLASS = "needs-human"` and skip directly to Step 7 (where the synth advances to Human Needed rather than Done).
+Do NOT post an audit comment and do NOT add the `pr-drained` label in Step 6. Set `FINAL_CLASS = "needs-human"` and skip Step 6, proceeding directly to Step 7 (which advances the synth to `Human Needed`).
 
 ### Step 6: Audit trail on the PR
 

--- a/plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
@@ -92,6 +92,18 @@ Date math is portable across macOS and Linux via a Python 3 one-liner (no `date 
 DAYS_OLD=$(python3 -c "from datetime import datetime, timezone; print(int((datetime.now(timezone.utc) - datetime.fromisoformat('$updatedAt'.replace('Z','+00:00'))).total_seconds() / 86400))")
 ```
 
+**Pre-classification guard — CI still running:**
+
+Before classifying, check `PR_JSON.statusCheckRollup`. If any element has `conclusion` (or `state`) in `[PENDING, IN_PROGRESS, QUEUED]` AND no element is `FAILURE`/`ERROR`/`CANCELLED`, CI is still running. Exit the skill immediately without creating a synth issue, posting a comment, or applying the `pr-drained` label — the next routine fire will reclassify when CI reaches a terminal state. Emit:
+
+```
+result: PR #<N> CI still pending — will reclassify on next fire.
+```
+
+This is the only path that leaves the PR unlabeled on purpose. All terminal classifications below either apply `pr-drained` (success) or skip it intentionally (`needs-human`, `merge-failed`).
+
+**Classification (CI is terminal — all checks have a non-pending conclusion):**
+
 1. **`dependabot-auto-merge` candidate** — all of:
    - `PR_JSON.author.login == "app/dependabot"`
    - Title parses as a patch or minor version bump. The Dependabot convention is `Bump <pkg> from X.Y.Z to A.B.C`. Compute the bump type by comparing `X.Y.Z` and `A.B.C`:
@@ -99,8 +111,8 @@ DAYS_OLD=$(python3 -c "from datetime import datetime, timezone; print(int((datet
      - Else if `Y != B` → minor
      - Else → patch
      - Match only if the bump type is patch or minor.
-   - Every element of `PR_JSON.statusCheckRollup` has `conclusion` (or `state` — the JSON shape varies, check both) in `[SUCCESS, SKIPPED, NEUTRAL]`. If any element is `PENDING` or `IN_PROGRESS` → not yet ready, fall through to `dependabot-needs-review`. If any element is `FAILURE`, `ERROR`, or `CANCELLED` → also fall through to `dependabot-needs-review`.
-2. **`dependabot-needs-review`** — `author == "app/dependabot"` AND any of: bump is major, title doesn't parse as a version bump, or any CI check is non-passing per rule 1.
+   - Every element of `PR_JSON.statusCheckRollup` has `conclusion` (or `state` — the JSON shape varies, check both) in `[SUCCESS, SKIPPED, NEUTRAL]`. If any element is `FAILURE`, `ERROR`, or `CANCELLED` → fall through to `dependabot-needs-review`.
+2. **`dependabot-needs-review`** — `author == "app/dependabot"` AND any of: bump is major, title doesn't parse as a version bump, or any CI check is failed/errored/cancelled per rule 1. (PENDING/IN_PROGRESS is handled by the pre-classification guard above, never here.)
 3. **`stale-close`** — `DAYS_OLD > 30` (using the Python snippet above; threshold 30 days since `updatedAt`).
 4. **`stale-ping`** — `DAYS_OLD > 14` (same snippet; threshold 14 days since `updatedAt`).
 5. **`needs-human`** — default.
@@ -307,6 +319,7 @@ result: Drained PR #<N> (class: <FINAL_CLASS>, synthetic issue: #<SYNTH_NUMBER>)
 ## Constraints
 
 - ralph-pr-drain MUST NOT add the `pr-drained` label until the action attempted in Step 5 has either succeeded or been intentionally held (MUST_FIX / dependabot-needs-review). A failed merge must NOT be labeled drained — the next routine fire must retry.
+- ralph-pr-drain MUST exit early without labeling, commenting, or creating a synth issue when CI is still pending (any check `PENDING`/`IN_PROGRESS`/`QUEUED` AND no terminal failure). The next routine fire reclassifies on CI completion.
 - ralph-pr-drain MUST create the synthetic issue BEFORE attempting any PR mutation, so even a partial-completion failure leaves a queryable board artifact.
 - Code review verdict is the merge gate — never bypass it for auto-merge candidates, even if CI is green.
 - Reuse the synthetic issue (Step 4 list_issues check) — do not create duplicates if the routine fires twice for the same PR before the first run completes.

--- a/plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
@@ -1,0 +1,327 @@
+---
+description: Drain a pull request that Director cannot dispatch (typically Dependabot bumps or stale unlinked PRs). Classifies the PR, runs code-review as the merge gate for auto-merge candidates, acts (merge/comment/close), and threads a synthetic Ralph issue through the board for observability. Invoked by the pr-drain cloud Routine on pull_request events; also user-invocable locally.
+argument-hint: "--pr <PR-NUMBER>"
+user-invocable: true
+model: sonnet
+context: inline
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=pr-drain"
+allowed-tools:
+  - Read
+  - Bash
+  - Skill
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+---
+
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+
+# Ralph PR-Drain
+
+Drain a pull request that Director cannot dispatch. Typically invoked by the cloud `pr-drain` Routine on a `pull_request` event, or manually for one-off cases.
+
+This skill is the operator for the pr-drain pipeline. It classifies a PR, gates auto-merge candidates through `code-review:code-review`, acts on the PR, and threads a synthetic Ralph issue through the project board so the pipeline dashboard, snapshots, dream loop, and cos summaries all see the work.
+
+## Workflow
+
+### Step 1: Parse arguments and idempotency check
+
+Parse `$ARGUMENTS` for `--pr <N>`. If `--pr` is missing or `<N>` is not a positive integer, emit:
+
+```
+needs input: --pr <PR-NUMBER> is required.
+```
+
+and STOP.
+
+Then check whether the PR has already been drained:
+
+```bash
+gh pr view <N> --json labels --jq '.labels[].name' | grep -q "^pr-drained$" && echo "ALREADY_DRAINED"
+```
+
+If `ALREADY_DRAINED` is printed, emit:
+
+```
+result: PR #<N> already drained. Skipping.
+```
+
+and STOP.
+
+### Step 2: Fetch the PR
+
+```bash
+gh pr view <N> --json number,url,title,author,statusCheckRollup,mergeable,headRefName,createdAt,updatedAt,body,state,mergedAt
+```
+
+If `gh pr view` exits non-zero (PR does not exist, repo access denied, etc.), emit:
+
+```
+result: PR #<N> no longer accessible. Skipping.
+```
+
+and STOP.
+
+If `state` is `MERGED` or `CLOSED`, emit:
+
+```
+result: PR #<N> already in terminal state (<state>). Skipping.
+```
+
+and STOP.
+
+Store the parsed JSON as `PR_JSON` for the remaining steps.
+
+### Step 3: Classify
+
+Apply these rules in priority order. First match wins. Store the result as `CLASS`.
+
+Date math is portable across macOS and Linux via a Python 3 one-liner (no `date -d`, which is GNU-only):
+
+```bash
+DAYS_OLD=$(python3 -c "from datetime import datetime, timezone; print(int((datetime.now(timezone.utc) - datetime.fromisoformat('$updatedAt'.replace('Z','+00:00'))).total_seconds() / 86400))")
+```
+
+1. **`dependabot-auto-merge` candidate** — all of:
+   - `PR_JSON.author.login == "app/dependabot"`
+   - Title parses as a patch or minor version bump. The Dependabot convention is `Bump <pkg> from X.Y.Z to A.B.C`. Compute the bump type by comparing `X.Y.Z` and `A.B.C`:
+     - If `X != A` → major
+     - Else if `Y != B` → minor
+     - Else → patch
+     - Match only if the bump type is patch or minor.
+   - Every element of `PR_JSON.statusCheckRollup` has `conclusion` (or `state` — the JSON shape varies, check both) in `[SUCCESS, SKIPPED, NEUTRAL]`. If any element is `PENDING` or `IN_PROGRESS` → not yet ready, fall through to `dependabot-needs-review`. If any element is `FAILURE`, `ERROR`, or `CANCELLED` → also fall through to `dependabot-needs-review`.
+2. **`dependabot-needs-review`** — `author == "app/dependabot"` AND any of: bump is major, title doesn't parse as a version bump, or any CI check is non-passing per rule 1.
+3. **`stale-close`** — `DAYS_OLD > 30` (using the Python snippet above; threshold 30 days since `updatedAt`).
+4. **`stale-ping`** — `DAYS_OLD > 14` (same snippet; threshold 14 days since `updatedAt`).
+5. **`needs-human`** — default.
+
+### Step 4: Create-or-reuse the synthetic Ralph issue
+
+First, check for an existing synthetic issue for this PR:
+
+```
+ralph_hero__list_issues({ label: "kind:pr-drain", state: "OPEN", limit: 50 })
+```
+
+Scan returned issue titles for the substring `PR #<N>`. If a match is found, set `SYNTH_NUMBER` to its issue number. If its `workflowState` is not already `In Progress`, advance it:
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "In Progress" })
+```
+
+Otherwise leave it alone, then skip to Step 5.
+
+If no match is found, create a new issue already in `In Progress` (single call — `create_issue` accepts `workflowState` directly, no separate save_issue needed):
+
+```
+ralph_hero__create_issue({
+  title: "Drain: PR #<N> — <PR_JSON.title>",
+  labels: ["pr-drain", "kind:pr-drain"],
+  workflowState: "In Progress",
+  body: "Auto-created by ralph-pr-drain.\n\nClassification: <CLASS>\nPR: <PR_JSON.url>\nAuthor: <PR_JSON.author.login>\nHead ref: <PR_JSON.headRefName>"
+})
+```
+
+Capture the returned issue number as `SYNTH_NUMBER`.
+
+### Step 5: Act per CLASS
+
+#### `dependabot-auto-merge` candidate
+
+Run code review as the merge gate:
+
+```
+Skill("code-review:code-review", "<N>")
+```
+
+The code-review skill does NOT return a verdict to the caller — it posts a comment on the PR. After the skill completes, fetch the most recent code-review comment to detect the verdict:
+
+```bash
+COMMENT=$(gh pr view <N> --comments --json comments --jq '.comments | map(select(.body | startswith("### Code review"))) | last.body // ""')
+```
+
+Classify the verdict:
+
+- **`COMMENT` is empty** → code-review opted out (its Haiku eligibility agent treats Dependabot/automated PRs as not needing review). We trust that signal and proceed to merge. Treat as **GREEN**.
+- **`COMMENT` contains `No issues found`** → **GREEN**.
+- **`COMMENT` contains `Found` and `issues:`** → **MUST_FIX**.
+- **Otherwise** → **review-error** (unparseable shape).
+
+**If GREEN:**
+
+```bash
+gh pr merge <N> --squash --auto
+MERGE_RC=$?
+```
+
+Set `FINAL_CLASS = "dependabot-auto-merge"`. Set `REVIEW_VERDICT = "GREEN"`. Carry `MERGE_RC` to Step 6.
+
+**If MUST_FIX:**
+
+Use a single-quoted heredoc to suppress shell interpolation (the body is fully static here):
+
+```bash
+gh pr comment <N> --body-file - <<'BODY_EOF'
+## Code Review — MUST_FIX
+
+ralph-pr-drain ran code-review:code-review as the auto-merge gate. Review flagged issues; holding for human review. See the code-review comment posted above for findings.
+BODY_EOF
+```
+
+Set `FINAL_CLASS = "dependabot-review-flagged"`. Set `REVIEW_VERDICT = "MUST_FIX"`. Do NOT merge.
+
+**If review-error:**
+
+```bash
+gh pr comment <N> --body-file - <<'BODY_EOF'
+## Code Review — error
+
+ralph-pr-drain tried to run code-review:code-review as the auto-merge gate but the verdict shape was not parseable. Holding for human review.
+BODY_EOF
+```
+
+Set `FINAL_CLASS = "review-error"`. Set `REVIEW_VERDICT = "n/a"`. Do NOT merge.
+
+#### `dependabot-needs-review`
+
+Run code review anyway to give the human a head start, but do not merge:
+
+```
+Skill("code-review:code-review", "<N>")
+```
+
+Then post a routing comment (the code-review skill has already posted its findings — or opted out — as a separate comment, so we just point at it):
+
+```bash
+gh pr comment <N> --body-file - <<'BODY_EOF'
+## Major version bump — needs human review
+
+ralph-pr-drain classified this as a Dependabot bump that needs human review (major bump, unparseable version, or non-passing CI). The code-review skill ran above; see its comment for findings.
+BODY_EOF
+```
+
+Set `FINAL_CLASS = "dependabot-needs-review"`. Parse the code-review comment with the same logic as the auto-merge branch to capture `REVIEW_VERDICT` (`GREEN`, `MUST_FIX`, or `n/a`). The verdict is informational only — we don't merge either way.
+
+#### `stale-close`
+
+```bash
+gh pr close <N> --comment "Closing as stale: this PR has had no activity in 30+ days. Reopen if still relevant."
+```
+
+Set `FINAL_CLASS = "stale-close"`. Set `REVIEW_VERDICT = "n/a"`.
+
+#### `stale-ping`
+
+Bind the author login first, then use an unquoted heredoc so `${AUTHOR_LOGIN}` interpolates:
+
+```bash
+AUTHOR_LOGIN=$(printf '%s' "$PR_JSON" | jq -r '.author.login')
+gh pr comment <N> --body-file - <<BODY_EOF
+This PR has been open >14 days with no activity. @${AUTHOR_LOGIN} — is this still active? If not, ralph-pr-drain will close it in another ~16 days.
+BODY_EOF
+```
+
+Set `FINAL_CLASS = "stale-ping"`. Set `REVIEW_VERDICT = "n/a"`.
+
+#### `needs-human`
+
+Emit:
+
+```
+needs input: PR #<N> shape unrecognized by ralph-pr-drain — manual triage required. Author: <author>, headRef: <headRefName>, title: <title>.
+```
+
+Do NOT post an audit comment, do NOT add the `pr-drained` label, do NOT advance the synth issue. Instead set `FINAL_CLASS = "needs-human"` and skip directly to Step 7 (where the synth advances to Human Needed rather than Done).
+
+### Step 6: Audit trail on the PR
+
+Only run this step for non-`needs-human` classes.
+
+Determine action success deterministically by capturing the exit code of the Step 5 action immediately after it runs (e.g. `gh pr merge <N> --squash --auto; MERGE_RC=$?`). If `MERGE_RC` is non-zero (and the failure is not "already merged" — distinguish via stderr inspection), the action failed. Build the failure body with printf so `SYNTH_NUMBER`, `CLASS`, and the captured stderr interpolate safely:
+
+```bash
+printf '## PR Drain — merge failed\n\nralph-pr-drain attempted to act on this PR but the operation failed. Holding for human review.\n\nSynthetic issue: #%s\nClassification: %s\nError: %s\n' \
+  "$SYNTH_NUMBER" "$CLASS" "$STDERR" | gh pr comment <N> --body-file -
+```
+
+Set `FINAL_CLASS = "merge-failed"` and proceed to Step 7 (advance synth to Human Needed). Do NOT add the `pr-drained` label.
+
+Otherwise, post the success audit comment:
+
+```bash
+printf '## PR Drain\n\nralph-pr-drain processed this PR.\n\n- Classification: %s\n- Synthetic issue: #%s\n- Review verdict: %s\n' \
+  "$FINAL_CLASS" "$SYNTH_NUMBER" "$REVIEW_VERDICT" | gh pr comment <N> --body-file -
+```
+
+Then add the idempotency label:
+
+```bash
+gh pr edit <N> --add-label pr-drained
+```
+
+### Step 7: Advance synth issue and record outcome
+
+For terminal-success classes (`dependabot-auto-merge`, `dependabot-needs-review`, `dependabot-review-flagged`, `review-error`, `stale-close`, `stale-ping`):
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "Done" })
+```
+
+For terminal-handoff classes (`needs-human`, `merge-failed`):
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "Human Needed" })
+```
+
+Then record the outcome using the real schema (`event_type`, `issue_number`, `verdict`, `payload` — verified in `plugin/ralph-knowledge/src/index.ts`):
+
+```
+mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome({
+  event_type: "pr_drain",
+  issue_number: SYNTH_NUMBER,
+  verdict: FINAL_CLASS,
+  payload: {
+    pr: <N>,
+    review_verdict: REVIEW_VERDICT,
+    author: <PR_JSON.author.login>
+  }
+})
+```
+
+### Step 8: Emit result marker
+
+```
+result: Drained PR #<N> (class: <FINAL_CLASS>, synthetic issue: #<SYNTH_NUMBER>)
+```
+
+## Constraints
+
+- ralph-pr-drain MUST NOT add the `pr-drained` label until the action attempted in Step 5 has either succeeded or been intentionally held (MUST_FIX / dependabot-needs-review). A failed merge must NOT be labeled drained — the next routine fire must retry.
+- ralph-pr-drain MUST create the synthetic issue BEFORE attempting any PR mutation, so even a partial-completion failure leaves a queryable board artifact.
+- Code review verdict is the merge gate — never bypass it for auto-merge candidates, even if CI is green.
+- Reuse the synthetic issue (Step 4 list_issues check) — do not create duplicates if the routine fires twice for the same PR before the first run completes.
+- Verdict detection is deterministic: parse the most recent `### Code review` comment posted on the PR by the code-review skill. An empty comment (opt-out) is treated as GREEN.
+
+## Why this design
+
+- **Synthetic issue threads PR work through the existing state machine** so the pipeline dashboard, snapshots, velocity metrics, dream loop, and cos summaries all see the work. No shadow channel.
+- **Code review as the merge gate** mirrors `finish` — catches supply-chain attacks and behavior-changing patch bumps that CI-green doesn't.
+- **Three-layer idempotency** (PR label, synth-issue reuse, `gh pr merge --auto`) prevents duplicate work even under race conditions or routine re-fires.
+- **Out-of-band of Director** keeps Director a pure single-event dispatcher; pr-drain is its own loop.
+
+## See also
+
+- Design spec: [`thoughts/shared/research/2026-05-22-pr-drain-routine-design.md`](../../../../thoughts/shared/research/2026-05-22-pr-drain-routine-design.md)
+- The cloud Routine that fires this skill: configured in `claude.ai/code/routines` (not in this repo)
+- Reference for the code-review-as-merge-gate pattern: `plugin/ralph-hero/skills/finish/SKILL.md`
+- Why Director never sees these PRs: `plugin/ralph-hero/mcp-server/src/lib/directions.ts` (filter at line ~895)

--- a/thoughts/shared/plans/2026-05-22-pr-drain-routine.md
+++ b/thoughts/shared/plans/2026-05-22-pr-drain-routine.md
@@ -1,0 +1,856 @@
+---
+date: 2026-05-22
+status: draft
+type: plan
+tags: [pr-drain, routine, director, next_actions, dependabot, observability]
+spec_reference: thoughts/shared/research/2026-05-22-pr-drain-routine-design.md
+---
+
+# PR-Drain Routine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Filter unlinkable PRs out of `next_actions` and handle them in a dedicated cloud Claude Code Routine that classifies, code-reviews, acts (merge/comment/close), and threads work through a synthetic Ralph issue for observability — fixing Director's wasteful re-skip on Dependabot PRs identified in the 2026-05-21 autopilot-loop-handoff research.
+
+**Architecture:** `next_actions` (in `directions.ts`) drops `kind: "pr" && linkedIssueNumber === null` rows so Director never dispatches them. A new Claude Code Routine `pr-drain`, fired by the native GitHub trigger on `pull_request` events, invokes a new local skill `/ralph-hero:ralph-pr-drain --pr <N>`. The skill is the operator: classifies the PR, runs `code-review:code-review` as the merge gate for auto-merge candidates, acts, creates a synthetic Ralph issue threaded through the project board, and records a `pr_drain` outcome event. Director and pr-drain are independent loops sharing only GitHub state (issues, labels, comments).
+
+**Tech Stack:** TypeScript + vitest (MCP server filter and tests), Markdown (skill body), `gh` CLI (PR mechanics), `ralph_hero__*` MCP tools (issue lifecycle), `knowledge_record_outcome` MCP (dream-loop feedback), `code-review:code-review` plugin skill (merge gate), Anthropic Routines (cloud Claude Code) with native GitHub trigger.
+
+**Spec reference:** [`thoughts/shared/research/2026-05-22-pr-drain-routine-design.md`](../research/2026-05-22-pr-drain-routine-design.md)
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `plugin/ralph-hero/mcp-server/src/lib/directions.ts` | Modify (~5 lines added) | Filter PR rows with null `linkedIssueNumber` out of the merged list so Director never sees unlinkable PRs. |
+| `plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts` | Modify (one new describe block) | Test: 3 PRs (2 linked, 1 Dependabot) → only 2 emitted. |
+| `plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md` | Create (~180 lines) | New skill: classify → synth-issue → code-review gate → act → audit trail → outcome. |
+| `plugin/ralph-hero/skills/director/SKILL.md` | Modify (~5 lines removed) | Delete dead `linkedIssueNumber` absent branch in Step 2a. |
+| `claude.ai/code/routines` (cloud UI, not in repo) | Create | New Routine "pr-drain" with native GitHub `pull_request` trigger. |
+
+---
+
+## Phase 1 — MCP filter (TDD)
+
+### Task 1.1: Write the failing test
+
+**Files:**
+- Modify: `plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts` (append a new describe block at the end)
+
+- [ ] **Step 1: Append the new test block to the end of the file**
+
+Open `plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts` and append:
+
+```typescript
+// ---------------------------------------------------------------------------
+// PR filter — drop unlinkable PRs (no feature/GH-NNNN head-ref)
+// ---------------------------------------------------------------------------
+
+describe("rankDirections — unlinkable PR filter", () => {
+  it("drops PRs whose headRefName does not match feature/GH-NNNN", () => {
+    const items = [
+      makeItem({ number: 1, workflowState: "Plan in Review", priority: "P1" }),
+    ];
+    const openPRs: OpenPR[] = [
+      makePR({ number: 100, headRefName: "feature/GH-1" }),       // linked → keep
+      makePR({ number: 101, headRefName: "feature/GH-2" }),       // linked → keep
+      makePR({ number: 102, headRefName: "dependabot/pip/idna-3.8" }), // unlinked → drop
+    ];
+    const result = rankDirections(items, openPRs, makeConfig({ limit: 10 }));
+
+    const prDirections = result.filter((d) => d.kind === "pr");
+    expect(prDirections).toHaveLength(2);
+    const prNumbers = prDirections.map((d) => d.pr?.number).sort();
+    expect(prNumbers).toEqual([100, 101]);
+  });
+
+  it("returns empty PR slice when every PR is unlinkable", () => {
+    const openPRs: OpenPR[] = [
+      makePR({ number: 200, headRefName: "dependabot/pip/idna-3.8" }),
+      makePR({ number: 201, headRefName: "dependabot/npm/typescript-5.6" }),
+    ];
+    const result = rankDirections([], openPRs, makeConfig({ limit: 10 }));
+    const prDirections = result.filter((d) => d.kind === "pr");
+    expect(prDirections).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `plugin/ralph-hero/mcp-server/`:
+
+```bash
+npx vitest run src/__tests__/directions.test.ts -t "unlinkable PR filter"
+```
+
+Expected: 2 tests FAIL. The first fails with something like `expected [...] to have length 2 but got 3` (Dependabot PR is still emitted). The second fails with `expected [...] to have length 0 but got 2`.
+
+### Task 1.2: Implement the filter
+
+**Files:**
+- Modify: `plugin/ralph-hero/mcp-server/src/lib/directions.ts:895-897` (replace 3 lines with a filter-aware version)
+
+- [ ] **Step 1: Edit `directions.ts` to drop unlinkable PRs when building the merged list**
+
+Find this block at line 895:
+
+```typescript
+  const merged: Entry[] = [];
+  for (const c of candidates) merged.push({ kind: "issueRow", payload: c });
+  for (const p of prScored) merged.push({ kind: "prRow", payload: p });
+```
+
+Replace with:
+
+```typescript
+  const merged: Entry[] = [];
+  for (const c of candidates) merged.push({ kind: "issueRow", payload: c });
+  // Filter unlinkable PRs (no linked issue) so they don't appear in next_actions.
+  // These are handled by the pr-drain Routine (out of band of Director).
+  // See: thoughts/shared/research/2026-05-22-pr-drain-routine-design.md
+  for (const p of prScored) {
+    if (p.linkedIssueNumber === null) continue;
+    merged.push({ kind: "prRow", payload: p });
+  }
+```
+
+- [ ] **Step 2: Run the new tests to verify they pass**
+
+```bash
+npx vitest run src/__tests__/directions.test.ts -t "unlinkable PR filter"
+```
+
+Expected: both new tests PASS.
+
+- [ ] **Step 3: Run the full directions test file to verify no regressions**
+
+```bash
+npx vitest run src/__tests__/directions.test.ts
+```
+
+Expected: all tests PASS (including the 35+ pre-existing rankDirections tests).
+
+- [ ] **Step 4: Run the full MCP server test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS. Pay special attention to `directions-tools.test.ts`, `cross-tool-consistency.test.ts`, and any test that builds a `next_actions` fixture with PRs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/ralph-hero/mcp-server/src/lib/directions.ts plugin/ralph-hero/mcp-server/src/__tests__/directions.test.ts
+git commit -m "$(cat <<'EOF'
+feat(directions): drop unlinkable PRs from next_actions
+
+Filter kind:"pr" rows whose linkedIssueNumber is null out of the
+merged candidate list. These PRs (typically Dependabot bumps with
+dependabot/* head-refs) cannot be dispatched by Director under the
+current architecture — Director STOPs on them and /loop re-ticks
+into the same skip, spinning on a wasteful no-op.
+
+Unlinkable PRs are now handled out-of-band by the pr-drain Routine
+(see thoughts/shared/research/2026-05-22-pr-drain-routine-design.md).
+
+Refs: 2026-05-21-autopilot-loop-handoff research
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2 — ralph-pr-drain skill
+
+The skill body is markdown that the model follows; there is no unit-test surface for it. Validation is via Phase 4 smoke testing. The full SKILL.md content is shown inline below so the engineer doesn't need to assemble it from the spec.
+
+### Task 2.1: Create the skill directory and SKILL.md
+
+**Files:**
+- Create: `plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md`
+
+- [ ] **Step 1: Create the directory**
+
+```bash
+mkdir -p plugin/ralph-hero/skills/ralph-pr-drain
+```
+
+- [ ] **Step 2: Write the full SKILL.md content**
+
+Write to `plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md`:
+
+````markdown
+---
+description: Drain a pull request that Director cannot dispatch (typically Dependabot bumps or stale unlinked PRs). Classifies the PR, runs code-review as the merge gate for auto-merge candidates, acts (merge/comment/close), and threads a synthetic Ralph issue through the board for observability. Invoked by the pr-drain cloud Routine on pull_request events; also user-invocable locally.
+argument-hint: "--pr <PR-NUMBER>"
+user-invocable: true
+model: sonnet
+context: inline
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=pr-drain"
+allowed-tools:
+  - Read
+  - Bash
+  - Skill
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+---
+
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+
+# Ralph PR-Drain
+
+Drain a pull request that Director cannot dispatch. Typically invoked by the cloud `pr-drain` Routine on a `pull_request` event, or manually for one-off cases.
+
+This skill is the operator for the pr-drain pipeline. It classifies a PR, gates auto-merge candidates through `code-review:code-review`, acts on the PR, and threads a synthetic Ralph issue through the project board so the pipeline dashboard, snapshots, dream loop, and cos summaries all see the work.
+
+## Workflow
+
+### Step 1: Parse arguments and idempotency check
+
+Parse `$ARGUMENTS` for `--pr <N>`. If `--pr` is missing or `<N>` is not a positive integer, emit:
+
+```
+needs input: --pr <PR-NUMBER> is required.
+```
+
+and STOP.
+
+Then check whether the PR has already been drained:
+
+```bash
+gh pr view <N> --json labels --jq '.labels[].name' | grep -q "^pr-drained$" && echo "ALREADY_DRAINED"
+```
+
+If `ALREADY_DRAINED` is printed, emit:
+
+```
+result: PR #<N> already drained. Skipping.
+```
+
+and STOP.
+
+### Step 2: Fetch the PR
+
+```bash
+gh pr view <N> --json number,url,title,author,statusCheckRollup,mergeable,headRefName,createdAt,updatedAt,body,state,mergedAt
+```
+
+If `gh pr view` exits non-zero (PR does not exist, repo access denied, etc.), emit:
+
+```
+result: PR #<N> no longer accessible. Skipping.
+```
+
+and STOP.
+
+If `state` is `MERGED` or `CLOSED`, emit:
+
+```
+result: PR #<N> already in terminal state (<state>). Skipping.
+```
+
+and STOP.
+
+Store the parsed JSON as `PR_JSON` for the remaining steps.
+
+### Step 3: Classify
+
+Apply these rules in priority order. First match wins. Store the result as `CLASS`.
+
+1. **`dependabot-auto-merge` candidate** — all of:
+   - `PR_JSON.author.login == "app/dependabot"` (or `.author.is_bot == true` with login starting `dependabot`)
+   - Title parses as a patch or minor version bump. The Dependabot convention is `Bump <pkg> from X.Y.Z to A.B.C`. Compute the bump type by comparing `X.Y.Z` and `A.B.C`:
+     - If `X != A` → major
+     - Else if `Y != B` → minor
+     - Else → patch
+     - Match only if the bump type is patch or minor.
+   - All CI checks green: every element of `PR_JSON.statusCheckRollup` has `conclusion == "SUCCESS"` or `state == "SUCCESS"` (the JSON shape varies — check both).
+2. **`dependabot-needs-review`** — `author == "app/dependabot"` AND bump is major (or title doesn't parse as a version bump).
+3. **`stale-close`** — `now - updatedAt > 30 days` (compute in bash: `[ "$(( ($(date +%s) - $(date -d "$updatedAt" +%s)) / 86400 ))" -gt 30 ]`).
+4. **`stale-ping`** — `now - updatedAt > 14 days` (same shape, threshold 14).
+5. **`needs-human`** — default.
+
+### Step 4: Create-or-reuse the synthetic Ralph issue
+
+First, check for an existing synthetic issue for this PR:
+
+```
+ralph_hero__list_issues({ labels: ["kind:pr-drain"], state: "OPEN", limit: 50 })
+```
+
+Scan returned issue titles for the substring `PR #<N>`. If a match is found, set `SYNTH_NUMBER` to its issue number and skip to "advance to In Progress" below.
+
+Otherwise create a new issue:
+
+```
+ralph_hero__create_issue({
+  title: "Drain: PR #<N> — <PR_JSON.title>",
+  labels: ["pr-drain", "kind:pr-drain"],
+  body: "Auto-created by ralph-pr-drain.\n\nClassification: <CLASS>\nPR: <PR_JSON.url>\nAuthor: <PR_JSON.author.login>\nHead ref: <PR_JSON.headRefName>"
+})
+```
+
+Capture the returned issue number as `SYNTH_NUMBER`.
+
+Advance to In Progress:
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "In Progress" })
+```
+
+### Step 5: Act per CLASS
+
+#### `dependabot-auto-merge` candidate
+
+Run code review as the merge gate:
+
+```
+Skill("code-review:code-review", "<N>")
+```
+
+Parse the review output. The review skill emits a verdict line:
+- `GREEN` (or `LGTM` / `APPROVED`) → safe to merge
+- `MUST_FIX` (or `BLOCK` / `RED`) → hold for human
+
+**If GREEN:**
+
+```bash
+gh pr merge <N> --squash --auto
+```
+
+Set `FINAL_CLASS = "dependabot-auto-merge"`. Set `REVIEW_VERDICT = "GREEN"`.
+
+**If MUST_FIX:**
+
+```bash
+gh pr comment <N> --body "## Code Review — MUST_FIX
+
+ralph-pr-drain ran code-review:code-review as the auto-merge gate. Review flagged issues; holding for human review.
+
+<paste review findings here>
+"
+```
+
+Set `FINAL_CLASS = "dependabot-review-flagged"`. Set `REVIEW_VERDICT = "MUST_FIX"`. Do NOT merge.
+
+**If the review skill errors or times out (no verdict line parseable):**
+
+```bash
+gh pr comment <N> --body "## Code Review — error
+
+ralph-pr-drain tried to run code-review:code-review as the auto-merge gate but the review did not complete. Holding for human review.
+"
+```
+
+Set `FINAL_CLASS = "review-error"`. Set `REVIEW_VERDICT = "n/a"`. Do NOT merge.
+
+#### `dependabot-needs-review`
+
+Run code review anyway to give the human a head start, but do not merge:
+
+```
+Skill("code-review:code-review", "<N>")
+```
+
+Then:
+
+```bash
+gh pr comment <N> --body "## Major version bump — needs human review
+
+ralph-pr-drain classified this as a major Dependabot bump. Posting pre-digested code review for the reviewer.
+
+## Code Review
+
+<paste review findings here>
+"
+```
+
+Set `FINAL_CLASS = "dependabot-needs-review"`. Set `REVIEW_VERDICT = GREEN | MUST_FIX | "n/a"` based on what the review emitted (even though we don't merge either way).
+
+#### `stale-close`
+
+```bash
+gh pr close <N> --comment "Closing as stale: this PR has had no activity in 30+ days. Reopen if still relevant."
+```
+
+Set `FINAL_CLASS = "stale-close"`. Set `REVIEW_VERDICT = "n/a"`.
+
+#### `stale-ping`
+
+```bash
+gh pr comment <N> --body "This PR has been open >14 days with no activity. @<PR_JSON.author.login> — is this still active? If not, ralph-pr-drain will close it in another ~16 days."
+```
+
+Set `FINAL_CLASS = "stale-ping"`. Set `REVIEW_VERDICT = "n/a"`.
+
+#### `needs-human`
+
+Emit:
+
+```
+needs input: PR #<N> shape unrecognized by ralph-pr-drain — manual triage required. Author: <author>, headRef: <headRefName>, title: <title>.
+```
+
+Do NOT post an audit comment, do NOT add the `pr-drained` label, do NOT advance the synth issue. Instead set `FINAL_CLASS = "needs-human"` and skip directly to Step 7 (where the synth advances to Human Needed rather than Done).
+
+### Step 6: Audit trail on the PR
+
+Only run this step for non-`needs-human` classes.
+
+If the action attempted in Step 5 failed (e.g. `gh pr merge` exited non-zero for a reason other than "already merged"):
+
+```bash
+gh pr comment <N> --body "## PR Drain — merge failed
+
+ralph-pr-drain attempted to act on this PR but the operation failed. Holding for human review.
+
+Synthetic issue: #<SYNTH_NUMBER>
+Classification: <CLASS>
+Error: <captured stderr>
+"
+```
+
+Set `FINAL_CLASS = "merge-failed"` and proceed to Step 7 (advance synth to Human Needed). Do NOT add the `pr-drained` label.
+
+Otherwise, post the success audit comment:
+
+```bash
+gh pr comment <N> --body "## PR Drain
+
+ralph-pr-drain processed this PR.
+
+- Classification: <FINAL_CLASS>
+- Synthetic issue: #<SYNTH_NUMBER>
+- Review verdict: <REVIEW_VERDICT>
+"
+```
+
+Then add the idempotency label:
+
+```bash
+gh pr edit <N> --add-label pr-drained
+```
+
+### Step 7: Advance synth issue and record outcome
+
+For terminal-success classes (`dependabot-auto-merge`, `dependabot-needs-review`, `dependabot-review-flagged`, `review-error`, `stale-close`, `stale-ping`):
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "Done" })
+```
+
+For terminal-handoff classes (`needs-human`, `merge-failed`):
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "Human Needed" })
+```
+
+Then record the outcome:
+
+```
+mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome({
+  event: "pr_drain",
+  outcome: FINAL_CLASS,
+  metadata: {
+    pr: <N>,
+    synth_issue: SYNTH_NUMBER,
+    review_verdict: REVIEW_VERDICT,
+    author: <PR_JSON.author.login>
+  }
+})
+```
+
+### Step 8: Emit result marker
+
+```
+result: Drained PR #<N> (class: <FINAL_CLASS>, synthetic issue: #<SYNTH_NUMBER>)
+```
+
+## Constraints
+
+- ralph-pr-drain MUST NOT add the `pr-drained` label until the action attempted in Step 5 has either succeeded or been intentionally held (MUST_FIX / dependabot-needs-review). A failed merge must NOT be labeled drained — the next routine fire must retry.
+- ralph-pr-drain MUST create the synthetic issue BEFORE attempting any PR mutation, so even a partial-completion failure leaves a queryable board artifact.
+- Code review verdict is the merge gate — never bypass it for auto-merge candidates, even if CI is green.
+- Reuse the synthetic issue (Step 4 list_issues check) — do not create duplicates if the routine fires twice for the same PR before the first run completes.
+
+## Why this design
+
+- **Synthetic issue threads PR work through the existing state machine** so the pipeline dashboard, snapshots, velocity metrics, dream loop, and cos summaries all see the work. No shadow channel.
+- **Code review as the merge gate** mirrors `finish` — catches supply-chain attacks and behavior-changing patch bumps that CI-green doesn't.
+- **Three-layer idempotency** (PR label, synth-issue reuse, `gh pr merge --auto`) prevents duplicate work even under race conditions or routine re-fires.
+- **Out-of-band of Director** keeps Director a pure single-event dispatcher; pr-drain is its own loop.
+
+## See also
+
+- Design spec: [`thoughts/shared/research/2026-05-22-pr-drain-routine-design.md`](../../../../thoughts/shared/research/2026-05-22-pr-drain-routine-design.md)
+- The cloud Routine that fires this skill: configured in `claude.ai/code/routines` (not in this repo)
+- Reference for the code-review-as-merge-gate pattern: `plugin/ralph-hero/skills/finish/SKILL.md`
+- Why Director never sees these PRs: `plugin/ralph-hero/mcp-server/src/lib/directions.ts` (filter at line ~895)
+````
+
+- [ ] **Step 3: Verify the file is syntactically valid markdown with parseable YAML frontmatter**
+
+```bash
+head -20 plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
+```
+
+Expected: the YAML frontmatter prints cleanly between `---` markers, ending with `---` followed by the `## Configuration` block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md
+git commit -m "$(cat <<'EOF'
+feat(skills): add ralph-pr-drain for unlinkable PRs
+
+Drains PRs that Director cannot dispatch (typically Dependabot
+bumps). Classifies the PR, runs code-review:code-review as the
+merge gate for auto-merge candidates, acts (merge/comment/close),
+and threads a synthetic Ralph issue through the project board for
+observability.
+
+Synthetic issue path: Backlog -> In Progress -> Done (or Human
+Needed for needs-human / merge-failed). Outcome event recorded
+via knowledge_record_outcome for dream-loop feedback.
+
+Three-layer idempotency:
+  1. pr-drained label pre-flight check
+  2. Synth-issue reuse-by-title in Step 4
+  3. gh pr merge --auto natural idempotency
+
+Invoked by the cloud pr-drain Routine on pull_request events;
+also user-invocable for one-off cases.
+
+Refs: thoughts/shared/research/2026-05-22-pr-drain-routine-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Director SKILL.md dead-code cleanup
+
+The filter from Phase 1 makes the `linkedIssueNumber === null` branch in Director's Step 2a unreachable. Removing it prevents future-reader confusion.
+
+### Task 3.1: Delete the dead branch
+
+**Files:**
+- Modify: `plugin/ralph-hero/skills/director/SKILL.md:58-61` (collapse the bullet for `kind: "pr"` so only the linked-issue case remains)
+
+- [ ] **Step 1: Replace the `kind: "pr"` branch with the linked-only version**
+
+Find this block in `plugin/ralph-hero/skills/director/SKILL.md` (around line 58–61):
+
+```markdown
+  - `kind: "pr"` → `direction.issue` is `null`. Use the linked-issue fallback:
+    - If `direction.signals.linkedIssueNumber` is set: `TARGET_ISSUE = direction.signals.linkedIssueNumber`. Proceed to Step 2b; Step 3 classifies the linked issue's `workflowState` via the taxonomy.
+    - If `linkedIssueNumber` is absent (the PR's `headRefName` did not match `feature/GH-NNNN`): emit `result: Top direction is PR #<N> with no linked issue. Skipping.` and STOP. Do NOT iterate the rest of the list — Director processes one direction per invocation, and `/loop` owns the re-tick cadence.
+```
+
+Replace with:
+
+```markdown
+  - `kind: "pr"` → `direction.issue` is `null`. `direction.signals.linkedIssueNumber` is guaranteed to be set because `next_actions` filters out PRs with a null `linkedIssueNumber` at the source (see `mcp-server/src/lib/directions.ts`; unlinkable PRs are handled by the pr-drain Routine, not Director). Set `TARGET_ISSUE = direction.signals.linkedIssueNumber` and proceed to Step 2b; Step 3 classifies the linked issue's `workflowState` via the taxonomy.
+```
+
+- [ ] **Step 2: Verify the skill markdown still parses cleanly**
+
+```bash
+head -80 plugin/ralph-hero/skills/director/SKILL.md
+```
+
+Expected: Step 2a still has clean numbered sub-bullets, no orphaned indentation, no broken markdown lists.
+
+- [ ] **Step 3: Run the full MCP server test suite (Director changes don't break compile or any test fixture)**
+
+```bash
+cd plugin/ralph-hero/mcp-server && npm test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/ralph-hero/skills/director/SKILL.md
+git commit -m "$(cat <<'EOF'
+docs(director): remove dead unlinkable-PR branch from Step 2a
+
+The next_actions filter added in feat(directions) drops kind:"pr"
+rows with null linkedIssueNumber at the source. Director's
+"if linkedIssueNumber is absent → STOP" branch is now unreachable;
+removing it prevents future-reader confusion.
+
+PRs that Director cannot dispatch are now handled by the pr-drain
+Routine (skills/ralph-pr-drain).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Local smoke test of the skill
+
+Validate the skill end-to-end against a real PR before wiring up the cloud Routine. This catches misconfigured `allowed-tools`, broken `gh` command syntax, classification edge cases, and `knowledge_record_outcome` integration issues in an environment where you can see and fix them quickly.
+
+### Task 4.1: Pick or open a smoke-test PR
+
+- [ ] **Step 1: Find an existing Dependabot PR on `cdubiel08/ralph-hero` to smoke against, or open a sacrificial one**
+
+```bash
+gh pr list --repo cdubiel08/ralph-hero --author "app/dependabot" --state open --json number,title,headRefName --limit 5
+```
+
+If at least one Dependabot PR exists, pick the smallest patch-bump (e.g. `Bump idna from 3.7 to 3.8`) and record its PR number as `SMOKE_PR`.
+
+If no Dependabot PRs are open, open a draft PR manually with a Dependabot-shaped title for testing (or wait for the next Dependabot run). Record the PR number as `SMOKE_PR`.
+
+### Task 4.2: Invoke the skill locally
+
+- [ ] **Step 1: Build + reload the MCP server so the filter change takes effect locally**
+
+```bash
+cd plugin/ralph-hero/mcp-server && npm run build
+```
+
+Then restart Claude Code so the MCP server picks up the new `dist/`.
+
+- [ ] **Step 2: Invoke the skill against the smoke PR**
+
+In a fresh Claude Code session:
+
+```
+/ralph-hero:ralph-pr-drain --pr <SMOKE_PR>
+```
+
+Expected output: a sequence of tool calls matching Steps 1–8 of the skill body, ending with a single `result:` line.
+
+### Task 4.3: Verify each step's side effect
+
+- [ ] **Step 1: Verify the synthetic issue was created with the right shape**
+
+```bash
+gh issue list --repo cdubiel08/ralph-hero --label "kind:pr-drain" --json number,title,labels,state --limit 5
+```
+
+Expected: one new issue titled `Drain: PR #<SMOKE_PR> — <pr.title>` with labels `pr-drain` and `kind:pr-drain`, in state `CLOSED` (workflowState `Done`) or `OPEN` with workflowState `Human Needed`.
+
+- [ ] **Step 2: Verify the audit comment was posted on the PR**
+
+```bash
+gh pr view <SMOKE_PR> --comments --repo cdubiel08/ralph-hero | grep -A 5 "## PR Drain"
+```
+
+Expected: a comment containing `## PR Drain`, `Classification: <CLASS>`, `Synthetic issue: #<SYNTH>`, `Review verdict: <VERDICT>`.
+
+- [ ] **Step 3: Verify the `pr-drained` label was added**
+
+```bash
+gh pr view <SMOKE_PR> --json labels --jq '.labels[].name' --repo cdubiel08/ralph-hero
+```
+
+Expected: includes `pr-drained`. (Will not be present if classification was `needs-human` or `merge-failed`.)
+
+- [ ] **Step 4: Verify the outcome event was recorded**
+
+```bash
+sqlite3 ~/.ralph-hero/knowledge.db "SELECT event, outcome, metadata FROM outcome_events ORDER BY ts DESC LIMIT 1;"
+```
+
+Expected: one row with `event = 'pr_drain'`, `outcome` matching the classification, and `metadata` JSON containing `pr`, `synth_issue`, `review_verdict`.
+
+- [ ] **Step 5: For auto-merge candidates: verify the PR was queued for merge**
+
+```bash
+gh pr view <SMOKE_PR> --json autoMergeRequest,mergeStateStatus --repo cdubiel08/ralph-hero
+```
+
+Expected (if classification was `dependabot-auto-merge` and review was GREEN): `autoMergeRequest` is non-null with `mergeMethod: "SQUASH"`. If CI was green, the PR may already be merged by the time you check.
+
+### Task 4.4: Verify idempotency
+
+- [ ] **Step 1: Re-invoke the skill on the same PR**
+
+In a fresh Claude Code session:
+
+```
+/ralph-hero:ralph-pr-drain --pr <SMOKE_PR>
+```
+
+Expected: skill emits `result: PR #<SMOKE_PR> already drained. Skipping.` and exits without creating a second synth issue, posting a second audit comment, or recording a second outcome event.
+
+- [ ] **Step 2: Verify no duplicate synth issue was created**
+
+```bash
+gh issue list --repo cdubiel08/ralph-hero --label "kind:pr-drain" --search "PR #<SMOKE_PR>" --json number --limit 10
+```
+
+Expected: exactly one issue matches.
+
+---
+
+## Phase 5 — Cloud Routine setup
+
+Manual configuration in the claude.ai UI. The routine prompt is short because all classification + action logic lives in the skill.
+
+### Task 5.1: Create the routine
+
+- [ ] **Step 1: Open the routines UI**
+
+Navigate to https://claude.ai/code/routines and click **New Routine**.
+
+- [ ] **Step 2: Configure the routine prompt**
+
+Name: `pr-drain`
+
+Prompt body:
+
+```
+You receive a GitHub pull_request event as a text payload (e.g. "PR 1316 opened
+in cdubiel08/ralph-hero"). Parse the PR number from the text. Then invoke:
+
+  /ralph-hero:ralph-pr-drain --pr <N>
+
+The skill classifies the PR, runs code review for auto-merge candidates, acts
+(merge / comment / close), creates a synthetic Ralph issue for board visibility,
+and records the outcome. Emit the skill's `result:` line and exit.
+
+If you cannot parse a PR number from the payload, emit:
+  needs input: could not parse PR number from payload: <payload>
+and exit.
+```
+
+- [ ] **Step 3: Select repository and environment**
+
+Repo: `cdubiel08/ralph-hero`. Cloud environment: ensure the ralph-hero plugin is installed (the cloud environment needs the same plugin manifest as your local install).
+
+- [ ] **Step 4: Configure the GitHub trigger**
+
+Trigger type: **GitHub**
+
+Event: `pull_request`
+
+Actions: `opened`, `synchronize`, `ready_for_review`
+
+Save the routine.
+
+### Task 5.2: End-to-end smoke test
+
+- [ ] **Step 1: Open a sacrificial PR to trigger the routine**
+
+Either wait for the next Dependabot PR, or open a draft PR with a Dependabot-shaped title:
+
+```bash
+git checkout -b dependabot/pip/smoke-test-1.0-to-1.0.1
+echo "# smoke test" >> SMOKE.md
+git add SMOKE.md
+git commit -m "Bump smoke from 1.0 to 1.0.1"
+git push -u origin dependabot/pip/smoke-test-1.0-to-1.0.1
+gh pr create --title "Bump smoke from 1.0 to 1.0.1" --body "Smoke test" --draft
+```
+
+Record the PR number as `SMOKE_PR_2`.
+
+- [ ] **Step 2: Verify the routine fired**
+
+Within ~30 seconds, the routine should fire. Check the routine's run history in the claude.ai UI for a new run. Inspect the run's output for the skill's `result:` line.
+
+- [ ] **Step 3: Verify side effects (same checks as Task 4.3)**
+
+```bash
+gh issue list --repo cdubiel08/ralph-hero --label "kind:pr-drain" --search "PR #<SMOKE_PR_2>" --json number,title --limit 5
+gh pr view <SMOKE_PR_2> --comments --repo cdubiel08/ralph-hero | grep -A 5 "## PR Drain"
+gh pr view <SMOKE_PR_2> --json labels --jq '.labels[].name' --repo cdubiel08/ralph-hero
+```
+
+Expected: synth issue exists, audit comment posted, `pr-drained` label present.
+
+- [ ] **Step 4: Clean up the sacrificial PR (if applicable)**
+
+```bash
+gh pr close <SMOKE_PR_2> --comment "Smoke test complete; closing."
+git push origin --delete dependabot/pip/smoke-test-1.0-to-1.0.1
+```
+
+Close the synthetic issue manually if it was left in `Human Needed` (the smoke PR is non-Dependabot in author so it likely classified as `needs-human`).
+
+### Task 5.3: Document the routine in the repo
+
+- [ ] **Step 1: Add a brief reference to the routine in the spec's Open Questions section being resolved**
+
+Edit `thoughts/shared/research/2026-05-22-pr-drain-routine-design.md` and update the spec's Open Questions section to record:
+
+- Routine ID (visible in the claude.ai UI URL)
+- Date created
+- Smoke-test PR number used for verification
+
+This is post-hoc operational metadata, not a logic change. Append at the end of the Open Questions section:
+
+```markdown
+## Operational metadata (filled in after setup)
+
+- Routine ID: <fill in after Task 5.1>
+- Created: <date>
+- Smoke test PR: #<SMOKE_PR_2>
+- Smoke test result: <pass / fail with notes>
+```
+
+- [ ] **Step 2: Commit the operational metadata**
+
+```bash
+git add thoughts/shared/research/2026-05-22-pr-drain-routine-design.md
+git commit -m "$(cat <<'EOF'
+docs(spec): record pr-drain routine operational metadata
+
+Adds routine ID, creation date, and smoke-test outcome to the
+pr-drain design spec so the runtime configuration is discoverable
+from the repo.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Done criteria
+
+All of these must hold before this plan is considered complete:
+
+- [ ] Phase 1 tests pass; `npm test` from `mcp-server/` shows zero regressions.
+- [ ] Phase 2 skill loads (visible in `/help` or when invoking the Skill tool by name).
+- [ ] Phase 3 Director skill change committed; full test suite still green.
+- [ ] Phase 4 smoke test ran end-to-end against a real PR; all 4 side effects (synth issue, audit comment, label, outcome event) verified.
+- [ ] Phase 4 idempotency verified (second invocation is a no-op).
+- [ ] Phase 5 routine created in claude.ai UI; smoke PR fired the routine; same side-effect checks pass for the cloud-fired run.
+- [ ] Spec updated with routine ID and smoke-test metadata.
+
+## Out of scope (per the spec)
+
+- `drainedPRs` counter on `pipeline_dashboard`
+- `record_activity_remote` MCP tool to close the cloud→local activity-log gap
+- Fix for GH-1346 (autopilot silent-drop stop-gate)
+- Audit of the `RemoteTrigger` tool URL discrepancy and `subscribe.py` URL path
+- Heartbeat/cron sweep as a safety net for missed routine fires
+- Grouped Dependabot updates (the bump-classification heuristic assumes single-package bumps; grouped updates land as `needs-human` until a follow-up)

--- a/thoughts/shared/plans/2026-05-22-pr-drain-routine.md
+++ b/thoughts/shared/plans/2026-05-22-pr-drain-routine.md
@@ -616,6 +616,18 @@ Validate the skill end-to-end against a real PR before wiring up the cloud Routi
 
 ### Task 4.1: Pick or open a smoke-test PR
 
+- [ ] **Step 0: Create the three GitHub labels** (one-time per repo)
+
+  The skill depends on `pr-drained`, `pr-drain`, and `kind:pr-drain` labels existing on the repo. `gh pr edit --add-label` fails if the label doesn't exist, and `create_issue` silently drops unresolvable labels. Run once:
+
+  ```bash
+  gh label create pr-drained --repo cdubiel08/ralph-hero --color "0075ca" --description "PR processed by ralph-pr-drain" 2>/dev/null || true
+  gh label create pr-drain --repo cdubiel08/ralph-hero --color "e4e669" --description "ralph-pr-drain action" 2>/dev/null || true
+  gh label create kind:pr-drain --repo cdubiel08/ralph-hero --color "fbca04" --description "Synthetic Drain issue created by ralph-pr-drain" 2>/dev/null || true
+  ```
+
+  The `|| true` makes the command idempotent (re-running is a no-op).
+
 - [ ] **Step 1: Find an existing Dependabot PR on `cdubiel08/ralph-hero` to smoke against, or open a sacrificial one**
 
 ```bash

--- a/thoughts/shared/research/2026-05-22-pr-drain-routine-design.md
+++ b/thoughts/shared/research/2026-05-22-pr-drain-routine-design.md
@@ -1,0 +1,278 @@
+---
+date: 2026-05-22
+topic: "PR-drain routine: handling unlinkable PRs without feeding them to Director"
+tags: [design, spec, pr-drain, routine, director, next_actions, dependabot, observability]
+status: complete
+type: research
+git_commit: fd0a38d820f9398df8030d1c3826a9cc7018d012
+git_branch: main
+---
+
+# PR-drain routine: handling unlinkable PRs without feeding them to Director
+
+## Prior Work
+
+- builds_on:: [[2026-05-21-autopilot-loop-handoff]] (research — silent-drop bug; identifies the wasteful-skip director problem this spec fixes)
+- builds_on:: [[2026-05-17-GH-1267-unified-agent-system-usage-guide]] (research — Director/teams/operators architecture this design extends)
+- builds_on:: commit `57a735a2 fix(director): STOP on unlinked PR instead of iterating directions` (the change that surfaced the wasteful-skip behavior)
+- contrasts_with:: GH-1346 (in-flight autopilot silent-drop stop-gate — orthogonal fix for a different failure mode)
+
+## Problem
+
+`next_actions` ranks open PRs alongside open issues. When a PR's head-ref does not match `feature/GH-NNNN` (typical for Dependabot bumps), Director's Step 2a emits `result: Top direction is PR #<N> with no linked issue. Skipping.` and STOPs (per commit `57a735a2`, which rejected the alternative "iterate within one invocation" because Director is documented as a pure single-event dispatcher).
+
+`/loop` re-ticks back into the same top-of-queue entry, Director emits the same skip, the loop spins on the same wasteful no-op. Observed in a background session on 2026-05-21 where the top three queue entries were Dependabot bumps and Director skipped each one in sequence on every tick.
+
+Two requirements that constrain the fix:
+
+1. **Director must not see PRs it cannot dispatch** — filtering happens upstream.
+2. **PRs still need to get handled.** Dependabot bumps accumulate; stale non-Dependabot PRs need pinging or closing. The handler must exist somewhere.
+
+## Architectural constraints (from user)
+
+- Per-PR, near-real-time. No 24h heartbeat latency.
+- Aligned with the existing **message-based async-loop, shared-state-with-message-based-triggers** pattern (the same shape that powers caretake heartbeats, scout-nightly, Director's `RemoteTrigger` input, and the monitoring-bridge daemon).
+- Integrated with the existing state machine and observability surfaces — no shadow channel where PR-handling work happens invisibly to the pipeline dashboard, snapshots, dream loop, or cos summaries.
+
+## Summary
+
+A new Claude Code **Routine** named `pr-drain`, hosted on Anthropic's cloud Claude Code infrastructure (Max plan, research-preview surface). Triggered by the **native GitHub trigger** in Routines (Claude GitHub App listens for `pull_request` events on `cdubiel08/ralph-hero`). The routine prompt is a one-liner that parses the PR number out of the text payload and invokes a new local skill `/ralph-hero:ralph-pr-drain --pr <N>`.
+
+The skill is the operator: classify the PR, run `code-review:code-review` as the merge gate for auto-merge candidates, act (merge / comment / close), create a synthetic Ralph issue threaded through the project board for observability, and record the outcome.
+
+Director never sees these PRs because `next_actions` filters out `kind: "pr" && linkedIssueNumber === null` rows at the source. The director STOP branch on unlinked PRs becomes dead code (kept for safety; deleted as cleanup).
+
+## Architecture
+
+```
+PR opened / synchronized / ready_for_review
+        │
+        ▼
+Claude GitHub App (native trigger registered in claude.ai/code UI)
+        │
+        ▼
+Routine "pr-drain" wakes a cloud Claude Code session
+  text payload: e.g. "PR 1316 opened in cdubiel08/ralph-hero"
+        │
+        ▼
+/ralph-hero:ralph-pr-drain --pr 1316
+        │
+        ├─ Classify (Dependabot patch/minor/major, stale-close, stale-ping, needs-human)
+        ├─ Create synthetic Ralph issue (state: Backlog → In Progress)
+        ├─ For auto-merge candidates: Skill("code-review:code-review", "1316") as gate
+        │     ├─ GREEN  → gh pr merge --squash --auto
+        │     └─ MUST_FIX → comment + hold for human (new class: dependabot-review-flagged)
+        ├─ Post audit comment on PR, add `pr-drained` label
+        ├─ Advance synthetic issue to Done (or Human Needed for needs-human / merge-failed)
+        └─ knowledge_record_outcome({ event: "pr_drain", outcome: CLASS, … })
+
+In parallel:
+next_actions (MCP, ranking surface): drops kind: "pr" rows with null linkedIssueNumber.
+Director never sees them. Director's STOP-on-unlinked-PR branch becomes dead code.
+```
+
+**Architectural alignment with the async-loop / message-trigger model:**
+
+| Element | Maps to |
+|---|---|
+| `pull_request` event | the message |
+| Routine text payload | the message content |
+| `pr-drained` label | shared state, queryable by all consumers |
+| Synthetic issue + labels | shared state visible to dashboard, snapshots, cos |
+| Cloud Routine session | the loop (one-shot, per-event) |
+| `ralph-pr-drain` skill | the operator |
+| `next_actions` filter | source-level gate so Director sees no PR work |
+
+Director (issue dispatch) and the pr-drain routine (PR dispatch) are independent loops keyed on different input shapes. They share no orchestration state; they share GitHub state.
+
+## Components
+
+Four files change. One new skill is created.
+
+### 1. `mcp-server/src/lib/directions.ts` (filter)
+
+In the `merged.sort` build phase (currently lines ~895–913), after building `merged` and before computing `tiedCount`, filter out PR rows whose `linkedIssueNumber` is null:
+
+```typescript
+// Filter unlinkable PRs (no linked issue) so they don't appear in next_actions.
+// These are handled by the pr-drain Routine (out of band of Director).
+const drainable = merged.filter((entry) => {
+  if (entry.kind !== "prRow") return true;
+  return entry.payload.linkedIssueNumber !== null;
+});
+```
+
+Use `drainable` everywhere `merged` was used downstream.
+
+No new signal/field surfaces. No new top-level counter (deferred per user decision). The Director STOP branch in `director/SKILL.md` Step 2a becomes dead code; kept in place for safety, deleted as a follow-up cleanup commit.
+
+### 2. `mcp-server/src/__tests__/directions-tools.test.ts` (test)
+
+New test case: 3 candidate PRs in `openPRs` (2 with `feature/GH-NNNN` head-refs, 1 with `dependabot/...`). Assert the resulting `directions` array contains exactly 2 entries, both linked PRs.
+
+### 3. `skills/ralph-pr-drain/SKILL.md` (new skill)
+
+| Concern | Value |
+|---|---|
+| `description` | "Drain a pull request that Director cannot dispatch (typically Dependabot bumps or stale unlinked PRs). Classifies the PR, runs code-review as the merge gate for auto-merge candidates, acts, and threads a synthetic Ralph issue through the board for observability. Invoked by the pr-drain cloud Routine, also user-invocable locally." |
+| `argument-hint` | `--pr <PR-NUMBER>` |
+| `user-invocable` | `true` |
+| `model` | `sonnet` (classification + review parsing benefits from Sonnet; Haiku would be marginal) |
+| `allowed-tools` | `Read`, `Bash`, `Skill`, `mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue`, `mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue`, `mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues`, `mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment`, `mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome` |
+| `hooks.SessionStart` | `set-skill-env.sh RALPH_COMMAND=pr-drain` |
+
+**Skill body (8 steps, ~120 lines):**
+
+1. **Parse `--pr <N>` arg; idempotency check.** `gh pr view <N> --json labels --jq '.labels[].name'`. If `pr-drained` is present → emit `result: PR #N already drained` and STOP.
+2. **Fetch PR.** `gh pr view <N> --json number,url,title,author,statusCheckRollup,mergeable,headRefName,createdAt,updatedAt,body`.
+3. **Classify** (priority order, first match wins):
+   - `author.login == "app/dependabot"` AND title parses as patch/minor bump AND all checks green → `dependabot-auto-merge` candidate
+   - `author.login == "app/dependabot"` AND title parses as major bump → `dependabot-needs-review`
+   - `now - updatedAt > 30d` → `stale-close`
+   - `now - updatedAt > 14d` → `stale-ping`
+   - default → `needs-human`
+4. **Synthetic issue (with reuse check).** First `list_issues({ labels: ["kind:pr-drain"], state: "OPEN" })` and search titles for `Drain: PR #<N>`. If found, reuse its number. Otherwise `create_issue({ title: "Drain: PR #<N> — <pr.title>", labels: ["pr-drain", "kind:pr-drain"], body: "Auto-created by ralph-pr-drain. Classification: <CLASS>. PR: <pr.url>" })`. Then `save_issue({ number: <synth>, workflowState: "In Progress" })`.
+5. **Act per CLASS:**
+   - `dependabot-auto-merge`: `Skill("code-review:code-review", "<N>")` → parse verdict
+     - GREEN: `gh pr merge <N> --squash --auto`; final outcome = `dependabot-auto-merge`
+     - MUST_FIX: post comment with review findings; final outcome = `dependabot-review-flagged`
+   - `dependabot-needs-review`: `Skill("code-review:code-review", "<N>")`, post review as comment, no merge
+   - `stale-close`: `gh pr close <N> --comment "Closing as stale (>30d since last activity). Reopen if still relevant."`
+   - `stale-ping`: `gh pr comment <N> --body "This PR has been open >14d with no activity. @<author> — is this still active?"`
+   - `needs-human`: emit `needs input: PR shape unrecognized; manual triage required.` STOP (do not advance synth to Done).
+6. **Audit trail on PR.** `gh pr comment <N> --body "## PR Drain\n\nClassified as <CLASS>. Action: <action>. Synthetic issue: #<synth>. Review verdict: <verdict-or-n/a>."`. Then `gh pr edit <N> --add-label pr-drained`.
+7. **Advance synth + record outcome.**
+   - For non-`needs-human` classes: `save_issue({ number: <synth>, workflowState: "Done" })`.
+   - For `needs-human` and the runtime `merge-failed` outcome from the Error Handling table: `save_issue({ number: <synth>, workflowState: "Human Needed" })`.
+   - `knowledge_record_outcome({ event: "pr_drain", outcome: CLASS, pr: N, synth_issue: <synth>, review_verdict: GREEN | MUST_FIX | "n/a" })`.
+8. **Emit result marker.** `result: Drained PR #<N> (class: <CLASS>, synthetic issue: #<synth>)`.
+
+### 4. `skills/director/SKILL.md` (dead-code cleanup, optional)
+
+Delete or comment out the `linkedIssueNumber` absent branch in Step 2a (currently lines ~59–61). Not required for correctness — the filter makes it unreachable — but worth removing to avoid future-reader confusion. Can be a separate commit.
+
+### 5. The Routine (lives in claude.ai UI, not in this repo)
+
+Created via `claude.ai/code/routines` → New Routine. Prompt body:
+
+```
+You receive a GitHub pull_request event as a text payload (e.g. "PR 1316 opened
+in cdubiel08/ralph-hero"). Parse the PR number. Then invoke:
+
+  /ralph-hero:ralph-pr-drain --pr <N>
+
+The skill classifies the PR, runs code review for auto-merge candidates, acts
+(merge / comment / close), creates a synthetic Ralph issue for board visibility,
+and records the outcome. Emit the skill's `result:` line and exit.
+```
+
+Trigger: native GitHub → events `pull_request: opened, synchronize, ready_for_review` → repo `cdubiel08/ralph-hero`.
+
+## Data flow
+
+End-to-end happy path for a Dependabot patch bump (`#1316 idna 3.7→3.8`):
+
+```
+T+0s     Dependabot opens PR #1316
+         ├─ headRefName = dependabot/pip/idna-3.8 (no feature/GH-NNNN match)
+         └─ next_actions filter excludes it from Director queue
+
+T+2s     Claude GitHub App fires pr-drain Routine
+         └─ text: "PR 1316 opened in cdubiel08/ralph-hero"
+
+T+5s     Cloud Claude session starts; invokes /ralph-hero:ralph-pr-drain --pr 1316
+
+T+10s    Step 1: gh pr view 1316 → no pr-drained label
+T+15s    Step 2: fetch PR; author = app/dependabot
+T+20s    Step 3: classify → dependabot-auto-merge candidate
+
+T+25s    Step 4: list_issues (no existing drain issue for #1316) →
+         create_issue → #1347 (Backlog → In Progress)
+
+T+30s    Step 5: Skill("code-review:code-review", "1316")
+T+90s    Review verdict: GREEN
+T+92s    gh pr merge 1316 --squash --auto
+
+T+100s   Step 6: gh pr comment audit trail + gh pr edit --add-label pr-drained
+T+102s   Step 7: save_issue #1347 → Done
+T+103s   knowledge_record_outcome({ event: "pr_drain", outcome:
+         "dependabot-auto-merge", pr: 1316, synth_issue: 1347,
+         review_verdict: "GREEN" })
+
+T+105s   result: Drained PR #1316 (class: dependabot-auto-merge,
+         synthetic issue: #1347)
+T+105s   Cloud session ends
+```
+
+**Synthetic issue state transitions** (one full lifecycle inside one skill invocation):
+`Backlog (on create_issue) → In Progress (Step 4) → Done (Step 7)`.
+
+For `needs-human` and `merge-failed`: terminal state is `Human Needed` instead of `Done`.
+
+**Where existing observability picks it up:**
+
+- `pipeline_dashboard`: counts the synthetic issue in its terminal-state bucket
+- `capture_snapshot`: next daily snapshot rolls the synth issue into velocity + lead-time-p50 (lead time will be ~minutes, which is informative — distinguishes drain work from real work)
+- `dream-loop / reflect.py`: clusters outcome events. If `dependabot-review-flagged` outcomes spike, files a process-improvement issue
+- `cos remote`: synthetic issues are filterable via the `kind:pr-drain` label so the "real work" view stays clean
+
+## Error handling
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| `gh pr view` fails (PR deleted / 404) | Non-zero exit | Emit `result: PR #N no longer accessible. Skipping.` No synth issue created. |
+| `code-review:code-review` times out or errors | No verdict line | Treat as MUST_FIX (fail closed for auto-merge); post comment that review didn't complete; outcome `"review-error"`. |
+| `gh pr merge` fails (merge conflict, CI red between view and merge) | Non-zero exit | Post comment with the error, advance synth to `Human Needed`, outcome `"merge-failed"`. |
+| `create_issue` fails (rate limit, GitHub outage) | MCP error | Abort before any PR action. No `pr-drained` label written. Next routine fire retries the whole flow. |
+| Cloud session times out mid-flow | Routine wrapper sees no `result:` line in output | PR has no `pr-drained` label → next event re-runs. Orphan synth issue in `In Progress` is caught by caretake's hygiene mode. |
+| Two routine fires race | Both pass Step 1 check | The Step 4 reuse-by-title check collapses to one synth issue. `gh pr merge --auto` is naturally idempotent. Worst case: two audit comments on the PR (cosmetic). |
+
+## Idempotency (defense in depth)
+
+1. **Pre-flight label check (Step 1):** skill exits silently if PR already has `pr-drained`. Catches double-fire of the routine for the same `pull_request: opened` event.
+2. **Synthetic-issue reuse-by-title (Step 4):** prevents duplicate synth issues if the label check is bypassed (e.g., manual invocation with the label not yet present).
+3. **`gh pr merge --auto`:** idempotent by design — if already merged, exits 0 with a no-op message the skill treats as success.
+
+## Testing strategy
+
+| Layer | What | How |
+|---|---|---|
+| `directions.ts` filter | Unit test in `directions-tools.test.ts` | Fixture: 3 PRs (2 linked, 1 Dependabot). Assert merged list has 2. |
+| Classification rules | Unit test (new `pr-drain.test.ts` or fixture under `mcp-server/src/__tests__/`) | Mock `gh pr view` outputs for each class. Assert correct CLASS string. |
+| Synthetic-issue contract | Integration smoke | Manual: invoke skill against a sandbox PR; assert title format, labels, state machine path. |
+| End-to-end | Manual: open a draft Dependabot-shaped PR | Verify routine fires, drain runs, synth lifecycle, audit comment, label, outcome event. |
+| Idempotency | Manual: invoke skill twice on same PR | Second invocation emits "already drained" and exits. |
+
+No new eval scenarios in `autopilot/eval-scenarios.md` — pr-drain is out-of-band of autopilot.
+
+## What this does NOT do (scope boundaries)
+
+- **Does not** add a `drainedPRs` counter to `pipeline_dashboard`. Drained synth issues fold into existing Done counts. Filterable by `kind:pr-drain` label if a consumer wants to break them out.
+- **Does not** add a `record_activity_remote` MCP tool. The cloud→local activity-log gap stays open. Synthetic-issue + outcome-event traces cover the observability need for v1.
+- **Does not** fix GH-1346 (autopilot silent-drop stop-gate). Orthogonal fix on its own branch.
+- **Does not** change the `RemoteTrigger` tool description or the monitoring-bridge `subscribe.py` URL path. Those may use an older path (`/v1/code/triggers/...` vs official `/v1/claude_code/routines/...`); worth auditing in a follow-up but not blocking on this work.
+- **Does not** introduce a heartbeat or cron sweep as a safety net. Per-event triggering only. If a fire is missed, the PR sits unhandled until the next `pull_request: synchronize` event or until a human notices.
+
+## Setup steps (one-time, after the code merges)
+
+1. Build + publish `ralph-hero-mcp-server` with the `directions.ts` filter (auto-release on merge to main).
+2. Install ralph-hero plugin in the cloud routine session (via `claude.ai/code` UI when creating the routine — same plugin source as local).
+3. `claude.ai/code/routines` → **New Routine** → paste the routine prompt above → trigger: GitHub → events: `pull_request: opened, synchronize, ready_for_review` → repo: `cdubiel08/ralph-hero` → **Create**.
+4. Verify with a smoke PR (open a draft, watch the routine fire, inspect the synth issue + audit comment).
+
+## Open questions
+
+- The `RemoteTrigger` tool description in the local plugin cache says `/v1/code/triggers/...` but the official Anthropic docs say `/v1/claude_code/routines/...`. The monitoring-bridge `subscribe.py` may be hitting an undocumented or internal path. Worth a separate audit but doesn't block this spec because the native GitHub trigger does not use the `RemoteTrigger` tool.
+- `code-review:code-review`'s verdict-parsing contract — does it always emit a parseable GREEN / MUST_FIX line, or does it sometimes emit only prose? Verify before relying on it as a gate. If unreliable, fall back to grep for `MUST_FIX` / `must fix` / `block` in the review output.
+- Dependabot bump-classification heuristic (parsing the title for major vs minor vs patch). The PR title format is conventional but not guaranteed — Dependabot occasionally formats grouped updates differently. Spec assumes single-package bumps; grouped updates would need a follow-up.
+
+## References
+
+- Research: [[2026-05-21-autopilot-loop-handoff]] (silent-drop bug; identifies the wasteful-skip director problem)
+- Director skill: `plugin/ralph-hero/skills/director/SKILL.md` (Step 2a STOP branch becomes dead code)
+- next_actions ranking: `plugin/ralph-hero/mcp-server/src/lib/directions.ts:870–1000`
+- `ralph-merge` (reference for merge mechanics, not directly reusable due to issue coupling): `plugin/ralph-hero/skills/ralph-merge/SKILL.md`
+- `finish` (reference for code-review-as-merge-gate pattern): `plugin/ralph-hero/skills/finish/SKILL.md`
+- Monitoring bridge (in-repo RemoteTrigger producer, for the `URL-shape` audit follow-up): `plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py:289-632`
+- Official Routines docs: https://code.claude.com/docs/en/routines
+- Official fire endpoint: https://platform.claude.com/docs/en/api/claude-code/routines-fire


### PR DESCRIPTION
## Summary

Fixes the Director "wasteful re-skip" identified in the [2026-05-21 autopilot-loop-handoff research](thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md). When `next_actions` ranked an unlinkable PR (typically Dependabot, head-ref doesn't match `feature/GH-NNNN`) at the top, Director correctly STOPped and `/loop` re-ticked into the same skip indefinitely.

**The fix is two-sided:**

1. **`next_actions` filter** — drops `kind: "pr" && linkedIssueNumber === null` rows at source so Director never sees unlinkable PRs.
2. **New `/ralph-hero:ralph-pr-drain` skill** — handles those PRs out-of-band: classifies (5 classes including Dependabot patch/minor/major, stale-close, stale-ping), runs `code-review:code-review` as the merge gate for auto-merge candidates, acts via `gh pr ...`, and threads a synthetic Ralph issue through the project board (Backlog→In Progress→Done) so the existing pipeline dashboard, snapshots, dream loop, and cos summaries all see the work.

Designed to be fired by a cloud Claude Code **Routine** on GitHub `pull_request` events. Routine setup is manual via the claude.ai UI (Phase 5 of the plan).

**Three-layer idempotency:** pre-flight `pr-drained` label check → synth-issue reuse-by-title → `gh pr merge --auto` natural idempotency.

## Spec & plan

- Spec: [thoughts/shared/research/2026-05-22-pr-drain-routine-design.md](thoughts/shared/research/2026-05-22-pr-drain-routine-design.md)
- Plan: [thoughts/shared/plans/2026-05-22-pr-drain-routine.md](thoughts/shared/plans/2026-05-22-pr-drain-routine.md)

## Commits

| SHA | What |
|---|---|
| `df1e4983` | `feat(directions)`: TDD filter in `directions.ts` + 2 vitest cases |
| `9cad0b5d` | `feat(skills)`: new `ralph-pr-drain/SKILL.md` (327 lines) |
| `8d8b1b97` | `docs(director)`: collapse now-dead `linkedIssueNumber === null` branch in Step 2a |
| `418ac88d` | `fix(ralph-pr-drain)`: clarify `needs-human` Step 7 advance instruction (post-review) |
| `7499d3b3` | `docs(plan)`: add Phase 4 label-creation pre-flight (post-review) |

Code review and quality review pass via the subagent-driven-development skill. `npm test` from `mcp-server/`: **1623/1623 passing, 0 regressions.**

## Test plan

- [x] Phase 1: 2 new vitest cases for the filter; full directions suite + full npm test still green
- [x] Phase 2: new skill file 327 lines; MCP tool argument shapes verified against real schemas (`event_type`/`issue_number`/`verdict`/`payload` for `knowledge_record_outcome`, `label` singular for `list_issues`); macOS-portable date math via Python; deterministic verdict parsing via `gh pr view --comments` after `code-review:code-review` runs
- [x] Phase 3: Director Step 2a dead branch removed; SKILL.md still parses
- [ ] Phase 4 (post-merge): smoke against a real Dependabot PR (#1316 idna 3.11→3.15 is the canonical candidate)
- [ ] Phase 5 (post-merge): create the cloud Routine in claude.ai/code/routines with native GitHub `pull_request` trigger

## Pre-flight before Phase 4 smoke

The three GitHub labels are **already created** on this repo: `pr-drained`, `pr-drain`, `kind:pr-drain`.

## Out of scope (deferred follow-ups)

- `drainedPRs` counter on `pipeline_dashboard` (drained synth issues fold into Done counts; filterable by `kind:pr-drain`)
- `record_activity_remote` MCP tool to close the cloud→local activity-log gap
- Audit of the `RemoteTrigger` tool URL discrepancy (`/v1/code/triggers/...` vs official `/v1/claude_code/routines/...`)
- Heartbeat/cron sweep as a safety net for missed routine fires
- Grouped Dependabot updates (current bump-classifier assumes single-package; grouped land as `needs-human`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)