### PR TITLE
feat(plugin-install): commit .claude/settings.json for cloud Routine sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "extraKnownMarketplaces": {
+    "ralph-hero": {
+      "source": {
+        "source": "github",
+        "repo": "cdubiel08/ralph-hero"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "ralph-hero@ralph-hero": true,
+    "ralph-knowledge@ralph-hero": true
+  }
+}


### PR DESCRIPTION
## Summary

- Commit `.claude/settings.json` declaring the ralph-hero marketplace + enabling `ralph-hero@ralph-hero` and `ralph-knowledge@ralph-hero`.
- Unblocks Phase 5 of [thoughts/shared/plans/2026-05-22-pr-drain-routine.md](thoughts/shared/plans/2026-05-22-pr-drain-routine.md) — cloud Routine sessions otherwise have no skills/MCP servers and `/ralph-hero:*` invocations fail with "Unknown skill".

## Why now

Smoke routine `pr-drain-smoke` (API-triggered, prompt `/ralph-hero:status`, Default cloud environment) confirmed the failure mode:

```
Ran skill /ralph-hero:status
Unknown skill: ralph-hero:status
needs input: ralph-hero plugin not loaded in cloud env
```

Per [Claude Code on the web docs](https://code.claude.com/docs/en/claude-code-on-the-web#what-s-available-in-cloud-sessions), only plugins declared in a **committed** `.claude/settings.json` install at cloud session start. Local user-scope enablement (in `~/.claude/settings.json`) does not transfer.

## Content

Modeled on the proven-working `extraKnownMarketplaces` + `enabledPlugins` blocks in the user-level `~/.claude/settings.json`. Deliberately minimal:

- `env` block excluded — secrets stay out of git; cloud env vars go in the routine UI
- Personal settings (theme, voiceEnabled, permissions overrides) excluded — user-scope, not project-scope

## Side effects

- **Local installs unaffected** — plugins are already enabled at user scope; this is a no-op for existing developers
- **Fresh clones** auto-enable both plugins on first session (marketplace is public on GitHub)
- **No auto-release** — `release.yml` only triggers on MCP server source changes

## Test plan

- [ ] CI passes (`ci.yml` build + test matrix)
- [ ] After merge: re-fire `pr-drain-smoke` routine
- [ ] Expected new transcript: `/ralph-hero:status` runs and emits a dashboard (or fails on env vars, surfacing Gap B/C — separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)