### PR TITLE
docs: mark cloud-Routine surfaces as deprecated/blocked

### DIFF
--- a/plugin/ralph-hero/skills/director/SKILL.md
+++ b/plugin/ralph-hero/skills/director/SKILL.md
@@ -33,9 +33,11 @@ Director is a pure dispatcher. It reads the project queue, classifies the top ev
 
 ## Remote-trigger contract
 
+> **DEPRECATED — `RemoteTrigger` source (Priority 1) cannot be exercised end-to-end.** Cloud Routines (the only producer surface that fires `RemoteTrigger` tool inputs) do not currently install ralph-hero plugins at session start, so a Routine that POSTs to a `/fire` endpoint starts a cloud session where Director itself is "Unknown skill" and never runs. The wire is preserved here for the day Anthropic ships imperative cloud plugin install; until then, **do not build new producers against `RemoteTrigger`**. The shipped producer in `scripts/monitoring-bridge/subscribe.py` (GH-1300, PR #1310) is similarly inert. Verified empirically 2026-05-22; see PRs #1352/#1353 and the `cloud-routines-plugin-install-gap` memory.
+
 Director accepts events from three sources in priority order:
 
-1. **`RemoteTrigger` tool inputs** — if surfaced by the harness, these arrive as structured tool arguments and take precedence over all other inputs.
+1. **`RemoteTrigger` tool inputs** *(deprecated, see callout above)* — if surfaced by the harness, these arrive as structured tool arguments and take precedence over all other inputs.
 2. **`trigger:<team>` issue labels** — checked via `get_issue` labels array after fetching the candidate issue. Consumed (removed) after dispatch.
 3. **`/schedule` heartbeat or direct CLI invocation** — no explicit input; Director reads `next_actions` and picks the top-ranked event.
 

--- a/thoughts/shared/plans/2026-05-22-pr-drain-routine.md
+++ b/thoughts/shared/plans/2026-05-22-pr-drain-routine.md
@@ -724,6 +724,8 @@ Expected: exactly one issue matches.
 
 ## Phase 5 — Cloud Routine setup
 
+> **BLOCKED — Anthropic cloud Routine plugin install gap.** Verified empirically 2026-05-22 with the `pr-drain-smoke` routine (now deleted): cloud Routine sessions do NOT install ralph-hero plugins from a committed `.claude/settings.json`, and `/plugin install` is not available in cloud session input. The init pane shows zero "Install plugins" step; `/ralph-hero:*` skills fail with "Unknown skill". This makes the routine prompt below ("invoke `/ralph-hero:ralph-pr-drain --pr <N>`") a no-op in every cloud-fired session. PRs #1352 (added a candidate fix) and #1353 (reverted it) capture the investigation; see also the `cloud-routines-plugin-install-gap` memory. Do not pick up this phase until Anthropic ships imperative cloud plugin install. **Phase 4 (local invocation via `/ralph-hero:ralph-pr-drain --pr <N>`) remains fully working** and is the supported path for pr-drain today. The phase content below is preserved for future re-use when the cloud gap closes.
+
 Manual configuration in the claude.ai UI. The routine prompt is short because all classification + action logic lives in the skill.
 
 ### Task 5.1: Create the routine


### PR DESCRIPTION
## Summary

Two doc-only edits surfacing the cloud Routine plugin-install gap discovered while smoke-testing pr-drain Phase 5. Items 2 and 3 of the cleanup list from the session that produced PRs #1352/#1353.

## Changes

### 1. `plugin/ralph-hero/skills/director/SKILL.md`

Adds a **DEPRECATED** callout to the "Remote-trigger contract" section. The `RemoteTrigger` Priority-1 source cannot be exercised end-to-end because cloud Routine sessions do not install ralph-hero plugins from a committed `.claude/settings.json`. Director itself fails with "Unknown skill" in any Routine-fired cloud session, so a Routine that POSTs to `/fire` starts a session where nothing runs.

The wire is preserved for the day Anthropic ships imperative cloud plugin install; until then, new producers should not be built against `RemoteTrigger`. The callout also notes that the **shipped** producer in `scripts/monitoring-bridge/subscribe.py` (GH-1300, PR #1310) is inert for the same reason.

### 2. `thoughts/shared/plans/2026-05-22-pr-drain-routine.md`

Adds a **BLOCKED** callout to Phase 5 with the same evidence. Phase 4 (local invocation) remains fully working and is the supported path for pr-drain today. Phase content is preserved verbatim for future re-use when the cloud gap closes.

## Evidence trail

- PR #1352 — committed `.claude/settings.json` hoping to trigger cloud install
- PR #1353 — reverted #1352 after empirical validation
- `pr-drain-smoke` Routine init pane (now deleted) confirmed zero plugin-install step
- `/plugin install` is not exposed in cloud session input either
- Memory: `cloud-routines-plugin-install-gap.md` (saved during the same session)

## Test plan

- [ ] CI passes
- [ ] No code paths altered — pure doc edits

## Not in this PR (deferred)

- **Live `RemoteTrigger` producer in `subscribe.py`** still fires `gh routine fire` on CRITICAL alerts. Either silently no-ops (no Routine exists) or starts a cloud session that does nothing useful (if a Routine was set up per README). Worth a follow-up issue to short-circuit the producer + add "BLOCKED" warnings to `monitoring-bridge/README.md` and `IOS-REMOTE.md` — but not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)