### PR TITLE
feat(routines): add ralph-pr-merged skill + Routine setup + launchd fallback + docs/routines.md (#1301)

### DIFF
--- a/plugin/ralph-hero/docs/routines.md
+++ b/plugin/ralph-hero/docs/routines.md
@@ -170,18 +170,19 @@ When the `ralph-hero-pr-merged` cloud Routine is unavailable (host offline, Rout
 | Host dependency | None — runs on Anthropic infrastructure | Mac must be on and awake |
 | Offline support | No — requires cloud connectivity | Yes — uses local `gh` CLI |
 | Subscription budget | One Routine invocation per merge | One `claude -p` call per unhandled PR per poll |
-| Setup | One-time UI plugin install | Copy plist, replace `__INSTALL_PATH__`, `launchctl load` |
+| Setup | One-time UI plugin install | Copy plist, replace `__REPO_ROOT__`, `launchctl load` |
 
 **Installation**
 
-1. Copy the plist template and replace the `__INSTALL_PATH__` placeholder:
+1. Copy the plist template and replace the `__REPO_ROOT__` placeholder:
 
 ```bash
 cp plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template \
    ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
 
-# Edit: replace __INSTALL_PATH__ with the absolute path to poll-merged-prs.sh
-# Example: /Users/yourname/projects/ralph-hero/plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
+# Edit: replace __REPO_ROOT__ with the absolute path to the ralph-hero repo root directory
+# Example: /Users/yourname/projects/ralph-hero
+# The plist runs: cd __REPO_ROOT__ && ./plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
 $EDITOR ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
 ```
 

--- a/plugin/ralph-hero/docs/routines.md
+++ b/plugin/ralph-hero/docs/routines.md
@@ -1,0 +1,210 @@
+# ralph-hero Cloud Routines
+
+Cloud Routines are external producers that fire ralph-hero skills via `RemoteTrigger`. Each Routine is created once in the `claude.ai/code` UI and then triggers automatically on a schedule or event. Because cloud Routine sessions do not auto-install plugins from `settings.json`, the ralph-hero plugin must be installed manually once per Routine via the Routine session's plugin panel. See project memory `project_cloud_routines_plugin_install_gap` for the root cause; the live `ralph-hero-pr-drain` Routine is the proof-of-concept that this one-time UI install pattern works reliably.
+
+Ralph-hero currently uses three Routines:
+
+| Routine | Trigger | Skill |
+|---------|---------|-------|
+| `ralph-hero-pr-drain` | `pull_request: opened/reopened/synchronize` | `ralph-pr-drain` |
+| `ralph-hero-pr-merged` | `pull_request: closed (merged to main)` | `ralph-pr-merged` |
+| `ralph-hero-critical-alert` | Fired by monitoring-bridge on `CRITICAL` severity | `director` (RemoteTrigger payload) |
+
+---
+
+## ralph-hero-pr-drain
+
+Drains pull requests that Director cannot dispatch — typically Dependabot bumps, stale unlinked PRs, or non-ralph-hero-flow opens. Classifies each PR, runs code review as the merge gate for auto-merge candidates, and threads a synthetic Ralph issue through the project board so pipeline dashboards and dream-loop metrics remain accurate.
+
+**Trigger event**
+
+```
+pull_request: opened / reopened / synchronize
+base_branch: main
+repo: cdubiel08/ralph-hero
+```
+
+**One-time setup**
+
+```
+RemoteTrigger(
+  name: "ralph-hero-pr-drain",
+  prompt: "/ralph-hero:ralph-pr-drain --pr {{ pr.number }}",
+  trigger: {
+    type: "github",
+    event: "pull_request",
+    filter: {
+      action: ["opened", "reopened", "synchronize"],
+      base_branch: "main"
+    }
+  },
+  model: "sonnet",
+  repos: ["cdubiel08/ralph-hero"]
+)
+```
+
+**Skill invoked**: `plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md`
+
+**Verification commands**
+
+```bash
+# Most recent drain events
+sqlite3 ~/.ralph-hero/knowledge.db \
+  "SELECT * FROM outcome_events WHERE event_type='pr_drain' ORDER BY timestamp DESC LIMIT 5"
+
+# Confirm idempotency label on a drained PR
+gh pr view <N> --json labels | jq -r '.labels[].name' | grep pr-drained
+```
+
+---
+
+## ralph-hero-pr-merged
+
+Fires post-merge propagation for PRs merged outside `ralph-merge` (GitHub UI, `gh pr merge`, Dependabot auto-merge, teammate merge). Resolves PR to linked issue, applies a 60-second idempotency guard to avoid double Done-transitions when `ralph-merge` already ran, fires `PushNotification`, and records a `merge_completed` outcome event.
+
+**Trigger event**
+
+```
+pull_request: closed (merged)
+base_branch: main
+repo: cdubiel08/ralph-hero
+```
+
+**One-time setup**
+
+```
+RemoteTrigger(
+  name: "ralph-hero-pr-merged",
+  prompt: "/ralph-hero:ralph-pr-merged --pr {{ pr.number }}",
+  trigger: {
+    type: "github",
+    event: "pull_request",
+    filter: {
+      action: "closed",
+      is_merged: true,
+      base_branch: "main"
+    }
+  },
+  model: "haiku",
+  repos: ["cdubiel08/ralph-hero"]
+)
+```
+
+Run the setup helper to print the full instructions and verification commands:
+
+```bash
+bash plugin/ralph-hero/scripts/routines/setup-pr-merged-routine.sh
+```
+
+**Skill invoked**: `plugin/ralph-hero/skills/ralph-pr-merged/SKILL.md`
+
+**Idempotency design**
+
+- **`pr-merged-handled` label** (Step 1): checked before any work; re-fires on the same PR exit immediately.
+- **60-second `closedAt` window** (Step 4): if the linked issue is already `workflowState=Done` and `closedAt` is within 60 seconds of now, the skill skips `save_issue` but still fires `PushNotification` and records the outcome. This covers the race where `ralph-merge` ran first.
+- **`issue_number=0` sentinel**: PRs with no linked issue (e.g., Dependabot bumps, docs PRs) set `issue_number=0`, skip `save_issue`, and still fire `PushNotification` and `knowledge_record_outcome`.
+- **Double-write safety**: `knowledge_record_outcome` is append-only; two `merge_completed` rows for the same PR are correctness-safe. The `source: "ralph-pr-merged"` payload field distinguishes Routine-sourced events from `ralph-merge`-sourced events.
+
+**Verification commands**
+
+```bash
+# Most recent merge_completed events
+sqlite3 ~/.ralph-hero/knowledge.db \
+  "SELECT * FROM outcome_events WHERE event_type='merge_completed' ORDER BY timestamp DESC LIMIT 5"
+
+# Confirm idempotency label on a handled PR
+gh pr view <N> --json labels | jq -r '.labels[].name' | grep pr-merged-handled
+
+# Tail Routine log after a test merge
+tail -f ~/.claude-code/routines/ralph-hero-pr-merged.log
+```
+
+---
+
+## ralph-hero-critical-alert
+
+Fires when the Cloud Monitoring bridge (`monitoring-bridge`) detects a CRITICAL-severity alert. The bridge runs as a local `subscribe.py` process that tails Google Cloud Monitoring pubsub; on CRITICAL severity it calls `gh routine fire ralph-hero-critical-alert` with the incident payload. Director receives the RemoteTrigger payload, classifies it as a CRITICAL event, and dispatches the appropriate team.
+
+**Trigger event**
+
+Fired imperatively by `monitoring-bridge/subscribe.py` when `incident.severity == "CRITICAL"` (case-sensitive). Not a GitHub webhook trigger.
+
+**One-time setup**
+
+```
+RemoteTrigger(
+  name: "ralph-hero-critical-alert",
+  prompt: "CRITICAL alert fired: {{ payload }}. Dispatch Director.",
+  trigger: { type: "manual" },
+  model: "sonnet",
+  repos: ["cdubiel08/ralph-hero"]
+)
+```
+
+See [`scripts/monitoring-bridge/README.md` § CRITICAL-alert RemoteTrigger](../scripts/monitoring-bridge/README.md#critical-alert-remotetrigger) for the full payload shape and rate-of-fire risk notes.
+
+**Skill invoked**: Director (`plugin/ralph-hero/skills/director/SKILL.md`) via the RemoteTrigger payload.
+
+**Verification commands**
+
+```bash
+# Tail monitoring-bridge output
+tail -f /tmp/ralph-monitoring-bridge.out
+
+# Most recent CRITICAL routing events
+sqlite3 ~/.ralph-hero/knowledge.db \
+  "SELECT * FROM outcome_events WHERE event_type='critical_alert' ORDER BY timestamp DESC LIMIT 5"
+```
+
+---
+
+## Offline fallback (launchd)
+
+When the `ralph-hero-pr-merged` cloud Routine is unavailable (host offline, Routine paused, or preview-period cap hit), the launchd polling fallback provides equivalent coverage at a 5-minute polling cadence.
+
+**Trade-offs**
+
+| | Cloud Routine | launchd fallback |
+|---|---|---|
+| Latency | ~seconds (webhook push) | up to 5 minutes (poll interval) |
+| Host dependency | None — runs on Anthropic infrastructure | Mac must be on and awake |
+| Offline support | No — requires cloud connectivity | Yes — uses local `gh` CLI |
+| Subscription budget | One Routine invocation per merge | One `claude -p` call per unhandled PR per poll |
+| Setup | One-time UI plugin install | Copy plist, replace `__INSTALL_PATH__`, `launchctl load` |
+
+**Installation**
+
+1. Copy the plist template and replace the `__INSTALL_PATH__` placeholder:
+
+```bash
+cp plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template \
+   ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
+
+# Edit: replace __INSTALL_PATH__ with the absolute path to poll-merged-prs.sh
+# Example: /Users/yourname/projects/ralph-hero/plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
+$EDITOR ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
+```
+
+2. Load the agent:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
+```
+
+3. Verify it registered and monitor output:
+
+```bash
+launchctl list | grep pr-merged-poll
+tail -f /tmp/ralph-pr-merged-poll.out
+```
+
+The poll script (`poll-merged-prs.sh`) uses a 10-minute look-back window on each invocation, so an occasional missed tick does not lose events.
+
+---
+
+## See also
+
+- Parent plan-of-plans: [`thoughts/shared/plans/2026-05-17-claude-code-dispatch-incremental-adoption.md`](../../../thoughts/shared/plans/2026-05-17-claude-code-dispatch-incremental-adoption.md)
+- Research (pr-merged design): [`thoughts/shared/research/2026-05-22-GH-1301-pr-merged-routine-design.md`](../../../thoughts/shared/research/2026-05-22-GH-1301-pr-merged-routine-design.md)
+- Director external producers contract: [`skills/director/IOS-REMOTE.md` § 5](skills/director/IOS-REMOTE.md#5-external-producers-remotetrigger-payload-shape)
+- CRITICAL-alert RemoteTrigger: [`scripts/monitoring-bridge/README.md` § CRITICAL-alert RemoteTrigger](scripts/monitoring-bridge/README.md#critical-alert-remotetrigger)

--- a/plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template
+++ b/plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template
@@ -7,9 +7,9 @@
   cloud Routine is unavailable or during offline periods.
 
   Installation:
-    1. Replace __INSTALL_PATH__ below with the absolute path to the
-       poll-merged-prs.sh script. Example:
-         /Users/yourname/projects/ralph-hero/plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
+    1. Replace __REPO_ROOT__ below with the absolute path to your ralph-hero
+       repository root. Example:
+         /Users/yourname/projects/ralph-hero
 
     2. Copy to LaunchAgents:
          cp com.ralph.pr-merged-poll.plist.template \
@@ -36,7 +36,7 @@
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>__INSTALL_PATH__</string>
+		<string>cd __REPO_ROOT__ &amp;&amp; ./plugin/ralph-hero/scripts/routines/poll-merged-prs.sh</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>300</integer>

--- a/plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template
+++ b/plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.ralph.pr-merged-poll.plist.template
+  Launchd polling fallback for the ralph-hero-pr-merged cloud Routine.
+  Runs poll-merged-prs.sh every 5 minutes to catch PRs merged while the
+  cloud Routine is unavailable or during offline periods.
+
+  Installation:
+    1. Replace __INSTALL_PATH__ below with the absolute path to the
+       poll-merged-prs.sh script. Example:
+         /Users/yourname/projects/ralph-hero/plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
+
+    2. Copy to LaunchAgents:
+         cp com.ralph.pr-merged-poll.plist.template \
+            ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
+
+    3. Load the agent:
+         launchctl load ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
+
+    4. Verify it is registered:
+         launchctl list | grep pr-merged-poll
+
+    5. Monitor output:
+         tail -f /tmp/ralph-pr-merged-poll.out
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
+    rm ~/Library/LaunchAgents/com.ralph.pr-merged-poll.plist
+-->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.ralph.pr-merged-poll</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-lc</string>
+		<string>__INSTALL_PATH__</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardOutPath</key>
+	<string>/tmp/ralph-pr-merged-poll.out</string>
+	<key>StandardErrorPath</key>
+	<string>/tmp/ralph-pr-merged-poll.err</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+	</dict>
+</dict>
+</plist>

--- a/plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
+++ b/plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# poll-merged-prs.sh — launchd polling fallback for the ralph-hero-pr-merged
+# cloud Routine. Finds PRs merged in the last 10 minutes that have NOT yet
+# received the pr-merged-handled label, and invokes ralph-pr-merged for each.
+#
+# Intended to be run by the launchd plist template at:
+#   plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template
+#
+# Can also be run manually:
+#   bash plugin/ralph-hero/scripts/routines/poll-merged-prs.sh
+
+set -euo pipefail
+
+# Compute a 10-minute window — portable across macOS (BSD date) and Linux (GNU date)
+SINCE=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -d "10 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+
+echo "[poll-merged-prs] Scanning for PRs merged since ${SINCE} (without pr-merged-handled label)"
+
+# Fetch PR numbers that are merged, target main, within the window, and not yet labeled
+PR_NUMBERS=$(gh pr list \
+  --state merged \
+  --json number,headRefName,mergedAt,labels \
+  --search "base:main merged:>=${SINCE}" \
+  --jq '.[] | select((.labels | map(.name) | contains(["pr-merged-handled"])) | not) | .number' \
+  2>/dev/null || true)
+
+if [[ -z "$PR_NUMBERS" ]]; then
+  echo "[poll-merged-prs] No unhandled merged PRs found in window."
+  exit 0
+fi
+
+echo "[poll-merged-prs] Unhandled merged PRs: $(echo "$PR_NUMBERS" | tr '\n' ' ')"
+
+while IFS= read -r pr_num; do
+  if [[ -z "$pr_num" ]]; then
+    continue
+  fi
+  echo "[poll-merged-prs] Processing PR #${pr_num}"
+  claude -p "/ralph-hero:ralph-pr-merged --pr ${pr_num}" || true
+done <<< "$PR_NUMBERS"
+
+echo "[poll-merged-prs] Done."

--- a/plugin/ralph-hero/scripts/routines/setup-pr-merged-routine.sh
+++ b/plugin/ralph-hero/scripts/routines/setup-pr-merged-routine.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# setup-pr-merged-routine.sh — prints one-time setup instructions for the
+# ralph-hero-pr-merged cloud Routine. Documentation only; does not call
+# any external commands or create the Routine automatically (Routine creation
+# requires the interactive claude.ai/code UI).
+#
+# Usage:
+#   bash plugin/ralph-hero/scripts/routines/setup-pr-merged-routine.sh
+
+set -euo pipefail
+
+cat <<'EOF'
+# Setup: ralph-hero-pr-merged Cloud Routine
+
+This script documents the one-time steps to create the ralph-hero-pr-merged
+cloud Routine on claude.ai/code. The Routine fires on every PR merged to main
+and invokes the ralph-pr-merged skill to propagate post-merge observability
+surfaces (PushNotification, knowledge_record_outcome) for PRs merged outside
+ralph-merge.
+
+## One-time setup
+
+1. Open https://claude.ai/code → Routines → New Routine.
+
+2. In the Routine session, install the ralph-hero plugin (same as local setup):
+   - The plugin is NOT auto-installed from settings.json in cloud Routine
+     sessions. You must install it once via the Routine's plugin panel.
+   - Reference: project memory "project_cloud_routines_plugin_install_gap"
+   - Live proof-of-concept: the ralph-hero-pr-drain Routine follows the same
+     pattern and is currently in production.
+
+3. Configure the GitHub trigger using the RemoteTrigger invocation below:
+
+RemoteTrigger(
+  name: "ralph-hero-pr-merged",
+  prompt: "/ralph-hero:ralph-pr-merged --pr {{ pr.number }}",
+  trigger: {
+    type: "github",
+    event: "pull_request",
+    filter: {
+      action: "closed",
+      is_merged: true,
+      base_branch: "main"
+    }
+  },
+  model: "haiku",
+  repos: ["cdubiel08/ralph-hero"]
+)
+
+## Verification commands
+
+After creating the Routine, verify it is working with the following:
+
+(a) Merge a test PR via the GitHub UI, then tail the Routine log:
+    tail -f ~/.claude-code/routines/ralph-hero-pr-merged.log
+
+(b) Confirm the outcome event was recorded:
+    sqlite3 ~/.ralph-hero/knowledge.db \
+      "SELECT * FROM outcome_events WHERE event_type='merge_completed' ORDER BY timestamp DESC LIMIT 5"
+
+(c) Confirm the idempotency label was applied to the PR:
+    gh pr view <N> --json labels | jq -r '.labels[].name' | grep pr-merged-handled
+
+## Offline fallback (launchd)
+
+If the cloud Routine is unavailable or you prefer host-local polling, use the
+launchd template instead:
+
+    plugin/ralph-hero/scripts/routines/launchd/com.ralph.pr-merged-poll.plist.template
+
+See plugin/ralph-hero/docs/routines.md § Offline fallback (launchd) for
+trade-offs and installation steps.
+
+EOF
+
+exit 0

--- a/plugin/ralph-hero/skills/ralph-pr-merged/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-pr-merged/SKILL.md
@@ -1,0 +1,208 @@
+---
+description: Post-merge propagation for PRs merged outside ralph-merge (GitHub UI, gh pr merge, Dependabot, teammate). Resolves PR → issue, applies idempotency guard, fires PushNotification, and records a merge_completed outcome event. Invoked by the ralph-hero-pr-merged cloud Routine; also user-invocable locally.
+argument-hint: "--pr <PR-NUMBER>"
+user-invocable: true
+model: haiku
+context: inline
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=pr-merged"
+allowed-tools:
+  - Read
+  - Bash
+  - PushNotification
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+---
+
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+
+# Ralph PR-Merged
+
+Post-merge propagation for PRs merged outside `ralph-merge`. Fires `PushNotification` and records `merge_completed` for every merged PR so observability surfaces remain complete regardless of merge path.
+
+## Step 1: Parse arguments and idempotency check
+
+Parse `$ARGUMENTS` for `--pr <N>`. If `--pr` is missing or `<N>` is not a positive integer, emit:
+
+```
+needs input: --pr <PR-NUMBER> is required.
+```
+
+and STOP.
+
+Check the idempotency label:
+
+```bash
+gh pr view <N> --json labels --jq '.labels[].name' | grep -q "^pr-merged-handled$" && echo "ALREADY_HANDLED"
+```
+
+If `ALREADY_HANDLED` is printed, emit:
+
+```
+result: PR #<N> already handled. Skipping.
+```
+
+and STOP.
+
+## Step 2: Fetch the PR
+
+```bash
+gh pr view <N> --json number,url,title,headRefName,body,state,mergedAt,mergeCommit,closingIssuesReferences
+```
+
+If `gh pr view` exits non-zero (PR does not exist, repo access denied, etc.), emit:
+
+```
+result: PR #<N> not accessible. Skipping.
+```
+
+and STOP.
+
+If `state != MERGED`, emit:
+
+```
+result: PR #<N> is not merged (state: <state>). Skipping.
+```
+
+and STOP.
+
+Store the parsed JSON as `PR_JSON` for the remaining steps.
+
+## Step 3: Resolve linked issue
+
+Try the following in order. First match sets `ISSUE_NUMBER`. If nothing matches, set `ISSUE_NUMBER=0`.
+
+1. `closingIssuesReferences[0].number` — GitHub's built-in closing-reference detection
+2. Regex `feature/GH-(\d+)` against `headRefName`
+3. Regex `(?:closes|fixes|resolves)\s+#(\d+)` (case-insensitive) against `body`
+
+```bash
+# Python 3 — portable macOS + Linux
+ISSUE_NUMBER=$(python3 -c "
+import json, re, sys
+pr = json.load(sys.stdin)
+refs = pr.get('closingIssuesReferences', [])
+if refs:
+    print(refs[0]['number']); sys.exit()
+m = re.search(r'feature/GH-(\d+)', pr.get('headRefName', ''))
+if m:
+    print(m.group(1)); sys.exit()
+m = re.search(r'(?:closes|fixes|resolves)\s+#(\d+)', pr.get('body', ''), re.I)
+if m:
+    print(m.group(1)); sys.exit()
+print(0)
+" <<< "$PR_JSON")
+```
+
+## Step 4: Idempotency guard (Done-within-60s window)
+
+If `ISSUE_NUMBER > 0`, fetch the issue:
+
+```
+ralph_hero__get_issue(number=ISSUE_NUMBER)
+```
+
+If `workflowState == "Done"` AND `closedAt` is within the last 60 seconds (compare to current UTC time), set `SKIP_TRANSITION=true`. The 60-second window covers the case where `ralph-merge` already ran the Done-transition. Otherwise set `SKIP_TRANSITION=false`.
+
+```bash
+# Portable date comparison — macOS + Linux
+SKIP_TRANSITION=$(python3 -c "
+from datetime import datetime, timezone
+import sys
+closed_at = '$CLOSED_AT'
+if not closed_at or closed_at == 'null':
+    print('false'); sys.exit()
+dt = datetime.fromisoformat(closed_at.replace('Z', '+00:00'))
+delta = (datetime.now(timezone.utc) - dt).total_seconds()
+print('true' if delta < 60 else 'false')
+")
+```
+
+If `ISSUE_NUMBER == 0`, set `SKIP_TRANSITION=true` (no issue to transition).
+
+## Step 5: Done transition (gated)
+
+If `ISSUE_NUMBER > 0` AND `SKIP_TRANSITION=false`:
+
+```
+ralph_hero__save_issue(number=ISSUE_NUMBER, workflowState="__COMPLETE__", command="ralph_merge")
+```
+
+If `SKIP_TRANSITION=true` AND `ISSUE_NUMBER > 0`, emit to stderr:
+
+```
+Skip save_issue: ralph-merge already transitioned #<ISSUE_NUMBER> within 60s window
+```
+
+## Step 6: PushNotification (best-effort, unconditional)
+
+Fire the native push notification regardless of `SKIP_TRANSITION` or `ISSUE_NUMBER`:
+
+```
+PushNotification(
+  title="Merged #<ISSUE_NUMBER>",      # When ISSUE_NUMBER > 0
+  body="<PR_JSON.title> (<PR_JSON.url>)"
+)
+```
+
+When `ISSUE_NUMBER == 0`, use `Merged PR #<N>` as the title instead.
+
+Failure does NOT fail the skill. The call is best-effort — `PushNotification` no-ops gracefully when Remote Control is unpaired or routed through Bedrock/Vertex.
+
+## Step 7: Record outcome (unconditional)
+
+```
+mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome({
+  event_type: "merge_completed",
+  issue_number: ISSUE_NUMBER,
+  verdict: "merged",
+  payload: {
+    pr_url: <PR_JSON.url>,
+    commit_sha: <PR_JSON.mergeCommit.oid or null>,
+    repo: <RALPH_GH_REPO>,
+    skip_transition: SKIP_TRANSITION,
+    source: "ralph-pr-merged"
+  }
+})
+```
+
+This step fires on every path including the idempotent-skip path. Double-writes on the `merge_completed` event type are correctness-safe (the table is append-only) and the dream-loop `reflect.py` uses them as signal, not unique-count. If the MCP call fails, log to stderr and continue.
+
+## Step 8: Apply idempotency label (best-effort)
+
+```bash
+gh pr edit <N> --add-label pr-merged-handled || true
+```
+
+Failure does NOT fail the skill.
+
+## Step 9: Emit result marker
+
+```
+result: Processed PR #<N> (issue: #<ISSUE_NUMBER>, skip_transition: <SKIP_TRANSITION>)
+```
+
+## Constraints
+
+- **Idempotency contract**: The `pr-merged-handled` label (Step 1) is the primary guard — re-fires on the same PR exit immediately without side-effects. The 60s `closedAt` window (Step 4) guards the race between this Routine and `ralph-merge` running concurrently.
+- **Unconditional outcome recording**: `knowledge_record_outcome` fires on every path, including the `SKIP_TRANSITION=true` path. The `source: "ralph-pr-merged"` payload field lets callers distinguish Routine-sourced events from `ralph-merge`-sourced events.
+- **`issue_number=0` sentinel**: When a PR has no linked issue (Dependabot bumps, docs-only PRs, etc.), `ISSUE_NUMBER` is set to `0` and `save_issue` is skipped. The outcome event still records `issue_number=0`; the `outcome_events` schema accepts `INTEGER NOT NULL` and `0` is the canonical sentinel.
+- **Best-effort surfaces**: `PushNotification` and the idempotency label are wrapped with `|| true` or equivalent so failures never block the skill.
+- **No `outcome-collector.sh` hook**: This skill calls `knowledge_record_outcome` directly via MCP. The `outcome-collector.sh` hook fires only on `ralph_hero__save_issue` with specific command/workflowState pairs — no hook update required.
+
+## See also
+
+- Research: [`thoughts/shared/research/2026-05-22-GH-1301-pr-merged-routine-design.md`](../../../../thoughts/shared/research/2026-05-22-GH-1301-pr-merged-routine-design.md)
+- `ralph-merge` Step 7.5 and Step 9c — the surfaces this skill mirrors for non-ralph-merge paths
+- Cloud Routine configuration: `plugin/ralph-hero/scripts/routines/setup-pr-merged-routine.sh`
+- Routine catalog: `plugin/ralph-hero/docs/routines.md`
+- Sibling pattern (live proof-of-concept): `plugin/ralph-hero/skills/ralph-pr-drain/SKILL.md`


### PR DESCRIPTION
## Summary

- Adds `plugin/ralph-hero/skills/ralph-pr-merged/SKILL.md` — lightweight haiku-model skill that propagates post-merge observability for PRs merged outside `ralph-merge` (GitHub UI, `gh pr merge`, Dependabot, teammate). Implements the idempotency contract: 60-second `closedAt` window to skip double Done-transition when `ralph-merge` already ran, unconditional `PushNotification` + `knowledge_record_outcome`, `issue_number=0` sentinel for unlinked PRs, and `pr-merged-handled` label as the primary re-fire guard.
- Adds `plugin/ralph-hero/scripts/routines/setup-pr-merged-routine.sh` — documentation helper that prints cloud Routine creation instructions (the `RemoteTrigger(...)` block) and verification commands. Documentation-only; no external commands invoked.
- Adds `plugin/ralph-hero/scripts/routines/poll-merged-prs.sh` + `launchd/com.ralph.pr-merged-poll.plist.template` — offline fallback: polls `gh pr list` every 5 minutes for unhandled merged PRs and drives them through the skill via `claude -p`.
- Adds `plugin/ralph-hero/docs/routines.md` — canonical Routine catalog documenting all three ralph-hero Routines (`pr-drain`, `pr-merged`, `critical-alert`) with setup commands, payload shapes, idempotency notes, and offline fallback trade-offs.

## Plan

`thoughts/shared/plans/2026-05-22-GH-1301-pr-merged-routine.md` — APPROVED verdict in plan review comment on the issue.

## Automated verification (all pass)

- `npm run build` — clean
- `bash -n setup-pr-merged-routine.sh` — syntax OK
- `bash -n poll-merged-prs.sh` — syntax OK
- `bash setup-pr-merged-routine.sh` — exits 0, prints `RemoteTrigger(...)` block
- `xmllint --noout com.ralph.pr-merged-poll.plist.template` — valid XML
- `grep` for `model: haiku` + `user-invocable: true` — both found
- `grep` for tool call references — 18 matches (threshold: 5)

## Test plan

- [ ] Merge a test PR via GitHub UI — Routine fires, `PushNotification` arrives, `outcome_events` row appears with `event_type=merge_completed`, PR gets `pr-merged-handled` label
- [ ] Merge a PR via `ralph-merge` — verify Routine's `outcome_events` row has `payload.skip_transition=true` (60s window honored)
- [ ] Merge a Dependabot PR (no linked issue) — `outcome_events` row has `issue_number=0`, no `save_issue` attempted
- [ ] Install launchd plist, verify polling activity in `/tmp/ralph-pr-merged-poll.out`
- [ ] Verify `docs/routines.md` renders cleanly in GitHub markdown preview

Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)