### PR TITLE
feat(ralph): /ralph:form — fold draft/form (Plan 2)

### DIFF
--- a/ralph/README.md
+++ b/ralph/README.md
@@ -4,7 +4,7 @@ Slim successor to `ralph-hero`. The naive hero, less ceremony.
 
 ## Status
 
-**Plan 1 of 11 (catch-up shipped).** This plugin currently exposes one user-facing skill (`/ralph:catch-up`). Verbs are migrated in one at a time per the plan-of-plans.
+**Plan 2 of 11 (form shipped).** This plugin currently exposes two user-facing skills (`/ralph:catch-up`, `/ralph:form`). Verbs are migrated in one at a time per the plan-of-plans.
 
 ## Design
 
@@ -23,7 +23,7 @@ Headline shape:
 |---|---|---|
 | 0 | scaffold | shipped |
 | 1 | `/ralph:catch-up` | shipped |
-| 2 | `/ralph:form` | pending |
+| 2 | `/ralph:form` | shipped |
 | 3 | `/ralph:research` | pending |
 | 4 | `/ralph:plan` | pending |
 | 5 | `/ralph:impl` | pending |

--- a/ralph/skills/form/SKILL.md
+++ b/ralph/skills/form/SKILL.md
@@ -1,0 +1,67 @@
+---
+description: Crystallize draft ideas, research findings, or inline descriptions into
+  structured GitHub issues, implementation plans, research topics, or refined drafts.
+  Use whenever the user says "form this", "turn this into an issue", "make a ticket
+  from this", "shape this idea", "what should this become", or hands over an idea
+  file or research doc. --mode draft is the lightweight quick-capture variant for
+  "just write this down before I forget".
+argument-hint: "[--mode draft] [<idea-path|research-doc-path|inline description>]"
+context: inline
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - AskUserQuestion
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+---
+
+# /ralph:form — Intake
+
+The unified intake verb. Default flow crystallizes ideas, research findings, or
+inline descriptions into structured GitHub artifacts via an interactive picker.
+`--mode draft` is the lightweight quick-capture alternative — saves to
+`thoughts/shared/ideas/` without touching GitHub.
+
+## Mode dispatch
+
+| Mode | Behavior | Equivalent to |
+|---|---|---|
+| (default) | Intake → research → dedup → picker (5 output formats) | `/ralph-hero:form` |
+| `--mode draft` | Quick capture: ask 2-3 questions → write to `thoughts/shared/ideas/` | `/ralph-hero:draft` |
+| `--help` / `-h` | Print this table and exit | — |
+
+## Step 1: Intake routing
+
+Consult `intake-shapes.md` for the input-detection rules. Set `INPUT_TYPE` to one of:
+
+- `"idea"` — argument is a path matching `thoughts/shared/ideas/*.md`, OR an inline description, OR no argument provided (list recent drafts and wait for input).
+- `"research"` — argument is a path matching `thoughts/shared/research/*.md`, OR a path whose frontmatter has `type: research`.
+
+If `INPUT_TYPE == "research"` and the doc's frontmatter has `github_issue`, capture `LINKED_ISSUE` — the research is already linked, and downstream steps must be aware to avoid duplicate issue creation.
+
+If no argument and not `--mode draft`: list files from `thoughts/shared/ideas/` sorted by date (most recent first, max 10), then wait for the user to pick one or supply an inline description.
+
+## Default flow
+
+_(Filled by Phase 2 and Phase 3.)_
+
+## --mode draft
+
+_(Filled by Phase 4.)_
+
+## References
+
+- `intake-shapes.md` — input detection, per-input-type research routing, draft template
+- `duplicate-detection.md` — codebase / thoughts / issue-keyword dedup strategies
+- `issue-template.md` — issue body shape, research-aware variant, ticket-tree structure

--- a/ralph/skills/form/SKILL.md
+++ b/ralph/skills/form/SKILL.md
@@ -108,9 +108,46 @@ Use `AskUserQuestion` with these 5 options. The first option is the default-sele
 
 Wait for the user's structured response, then branch to the matching Step 6 sub-step.
 
-### Step 6: Output paths
+### Step 6a: Create GitHub issue
 
-_(Filled by Phase 3.)_
+Draft the issue body per `issue-template.md` (use the research-aware variant when `INPUT_TYPE == "research"`). Show it for approval along with suggested labels, estimate, and priority. On approval:
+
+1. Call `create_issue` with the drafted title and body; set `estimate` and `workflowState: "Backlog"`.
+2. Update the source-file frontmatter per `issue-template.md` (`status: formed, github_issue: NNN` for ideas; `github_issue: NNN, github_url: https://...` for research docs).
+3. If `INPUT_TYPE == "research"`, post the `## Research Document` artifact comment on the new issue (see `issue-template.md`).
+4. Report the issue URL + suggested next steps (research / plan / iterate).
+
+### Step 6b: Create ticket tree
+
+Break the idea into a parent + 2-6 children. Show the tree for approval. On approval:
+
+1. Create the parent issue (`estimate: L`, `workflowState: "Backlog"`).
+2. For each child, `create_issue` (`estimate: XS`, `workflowState: "Backlog"`) followed by `add_sub_issue` linking it under the parent.
+3. For sequential children, add `add_dependency` edges in submission order.
+4. Update the source-file frontmatter with the parent issue link per `issue-template.md`.
+
+See `issue-template.md` for the tree shape and estimate defaults.
+
+### Step 6c: Hand off to another skill
+
+For "Implementation plan" or "Research topic":
+
+1. Update the source file's frontmatter (`status: forming` for ideas; preserve `type: research` for research docs — no status change).
+2. Suggest the next command with the gathered context inlined:
+   - Plan: `/ralph:plan <context summary>` (or `/ralph-hero:plan` until Plan 4 ships)
+   - Research: `/ralph:research <topic>` (or `/ralph-hero:research` until Plan 3 ships)
+
+Offer to invoke it directly if the user wants.
+
+### Step 6d: Refined draft
+
+For "Keep as refined idea":
+
+1. Update the source file with the enriched content: codebase context, related issues / plans / research, refined scope, updated tags.
+2. Frontmatter: `status: refined` for ideas; preserve `type: research` for research docs (no status field).
+3. Report the path and what was added.
+
+No GitHub mutations.
 
 ## --mode draft
 

--- a/ralph/skills/form/SKILL.md
+++ b/ralph/skills/form/SKILL.md
@@ -54,7 +54,63 @@ If no argument and not `--mode draft`: list files from `thoughts/shared/ideas/` 
 
 ## Default flow
 
-_(Filled by Phase 2 and Phase 3.)_
+### Step 2: Understand the idea
+
+Read the idea (from the file resolved in Step 1, or treat the inline argument as the idea body). Identify:
+
+- What problem does this solve?
+- Who benefits?
+- What's the scope?
+
+Present your understanding to the user and wait for confirmation:
+
+```
+Here's what I understand:
+
+**Core idea**: [one sentence]
+**Problem it solves**: [brief]
+**Scope**: [small / medium / large]
+
+Does this capture it correctly?
+```
+
+If the user corrects you, restate and re-confirm before proceeding.
+
+### Step 3: Research & contextualize
+
+Branch by `INPUT_TYPE` per `intake-shapes.md`:
+
+- `INPUT_TYPE == "research"`: skip codebase-locator / codebase-analyzer (the doc IS the investigation); still run thoughts-locator + thoughts-analyzer + `list_issues` keyword search.
+- `INPUT_TYPE == "idea"`: run the full suite per `duplicate-detection.md`.
+
+Spawn sub-tasks in parallel. Wait for ALL to complete before synthesizing. Do NOT pass `team_name` to any `Agent()` call.
+
+### Step 4: Present larger context
+
+Surface to the user:
+
+- **Related existing work** — issues / plans / research that overlap or connect.
+- **Potential duplicates** — issues that cover similar ground (call out if `LINKED_ISSUE` is already set from intake).
+- **Natural home** — where this fits in the project structure; which epic or initiative it aligns with.
+- **Complexity assessment** — XS / S / M / L / XL with key dependencies and risk areas.
+
+### Step 5: Output picker
+
+Use `AskUserQuestion` with these 5 options. The first option is the default-selected one for ideas without `LINKED_ISSUE`; for ideas with `LINKED_ISSUE`, default to "Implementation plan" instead.
+
+| Label | Behavior |
+|---|---|
+| **GitHub issue** | Create a well-scoped issue ready for the backlog → Step 6a |
+| **Implementation plan** | Hand off to `/ralph:plan` (or `/ralph-hero:plan` until Plan 4 ships) → Step 6c |
+| **Research topic** | Hand off to `/ralph:research` (or `/ralph-hero:research` until Plan 3 ships) → Step 6c |
+| **Ticket tree** | Break into parent + children sub-issues → Step 6b |
+| **Keep as refined idea** | Update the source file with context; no GitHub mutation → Step 6d |
+
+Wait for the user's structured response, then branch to the matching Step 6 sub-step.
+
+### Step 6: Output paths
+
+_(Filled by Phase 3.)_
 
 ## --mode draft
 

--- a/ralph/skills/form/SKILL.md
+++ b/ralph/skills/form/SKILL.md
@@ -151,7 +151,33 @@ No GitHub mutations.
 
 ## --mode draft
 
-_(Filled by Phase 4.)_
+Lightweight quick-capture. No GitHub mutation, no AskUserQuestion picker, no full research suite. The goal is to get the idea into a file before it's lost.
+
+### Step 1 (draft): capture intent
+
+If a topic was provided as the argument, begin capturing. Otherwise prompt: *"What's on your mind? Describe a feature idea, a problem you've noticed, a technical concept, or a workflow improvement worth remembering."* Wait for the user.
+
+### Step 2 (draft): quick clarification
+
+Restate in one sentence, then ask 2-3 focused clarifying questions (most-important first). If the user replies "just capture it" or similar, proceed with what you have — don't block.
+
+### Step 3 (draft): optional light grounding
+
+Only if the idea references specific code areas:
+
+- One `Agent(subagent_type="ralph-hero:codebase-locator", prompt="Find files related to [idea topic]")` to confirm the relevant area exists. Don't go deep.
+
+Only if `knowledge_search` is available, run an optional dedup check (`type: "idea"`, `limit: 3`). If a close match is found, mention it: *"There's an existing idea that may overlap: `[path]` — [title]. Continue with a new idea or build on that one?"*
+
+Skip both steps entirely for purely conceptual ideas — speed over polish.
+
+### Step 4 (draft): write the file
+
+Save to `thoughts/shared/ideas/YYYY-MM-DD-description.md` using the draft template from `intake-shapes.md`.
+
+### Step 5 (draft): report + suggest next steps
+
+Report the file path. Suggest next-step verbs: `/ralph:form <path>` (crystallize into an issue / plan / research / tree), `/ralph:research` or `/ralph-hero:research` (deep dive), `/ralph:plan` or `/ralph-hero:plan` (jump straight to planning). No frontmatter mutation, no GitHub integration — drafts are pre-ticket.
 
 ## References
 

--- a/ralph/skills/form/SKILL.md
+++ b/ralph/skills/form/SKILL.md
@@ -3,8 +3,9 @@ description: Crystallize draft ideas, research findings, or inline descriptions 
   structured GitHub issues, implementation plans, research topics, or refined drafts.
   Use whenever the user says "form this", "turn this into an issue", "make a ticket
   from this", "shape this idea", "what should this become", or hands over an idea
-  file or research doc. --mode draft is the lightweight quick-capture variant for
-  "just write this down before I forget".
+  file or research doc. Use --mode draft (or trigger on "jot this down", "save this
+  thought", "before I forget", "capture an idea") for the lightweight quick-capture
+  variant — saves to thoughts/shared/ideas/ without touching GitHub.
 argument-hint: "[--mode draft] [<idea-path|research-doc-path|inline description>]"
 context: inline
 allowed-tools:
@@ -19,6 +20,7 @@ allowed-tools:
   - WebSearch
   - WebFetch
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
   - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
@@ -43,14 +45,9 @@ inline descriptions into structured GitHub artifacts via an interactive picker.
 
 ## Step 1: Intake routing
 
-Consult `intake-shapes.md` for the input-detection rules. Set `INPUT_TYPE` to one of:
+Read `intake-shapes.md` to set `INPUT_TYPE` (`"idea"` | `"research"`) and (if applicable) capture `LINKED_ISSUE`. If no argument and not `--mode draft`, follow the no-args fallback in `intake-shapes.md` to list recent ideas.
 
-- `"idea"` — argument is a path matching `thoughts/shared/ideas/*.md`, OR an inline description, OR no argument provided (list recent drafts and wait for input).
-- `"research"` — argument is a path matching `thoughts/shared/research/*.md`, OR a path whose frontmatter has `type: research`.
-
-If `INPUT_TYPE == "research"` and the doc's frontmatter has `github_issue`, capture `LINKED_ISSUE` — the research is already linked, and downstream steps must be aware to avoid duplicate issue creation.
-
-If no argument and not `--mode draft`: list files from `thoughts/shared/ideas/` sorted by date (most recent first, max 10), then wait for the user to pick one or supply an inline description.
+If `LINKED_ISSUE` is set, fetch the linked issue's title and current workflow state via `get_issue` — Step 4 surfaces them so the user understands why the picker default below is biased toward "Implementation plan".
 
 ## Default flow
 
@@ -83,20 +80,24 @@ Branch by `INPUT_TYPE` per `intake-shapes.md`:
 - `INPUT_TYPE == "research"`: skip codebase-locator / codebase-analyzer (the doc IS the investigation); still run thoughts-locator + thoughts-analyzer + `list_issues` keyword search.
 - `INPUT_TYPE == "idea"`: run the full suite per `duplicate-detection.md`.
 
-Spawn sub-tasks in parallel. Wait for ALL to complete before synthesizing. Do NOT pass `team_name` to any `Agent()` call.
+Spawn sub-tasks in parallel per `duplicate-detection.md` (which carries the ADR-001 team-isolation rule). Wait for ALL to complete before synthesizing.
 
 ### Step 4: Present larger context
 
 Surface to the user:
 
-- **Related existing work** — issues / plans / research that overlap or connect.
-- **Potential duplicates** — issues that cover similar ground (call out if `LINKED_ISSUE` is already set from intake).
+- **Linked issue** (only when `LINKED_ISSUE` is set) — show its number, title, and current workflow state from the `get_issue` call in Step 1. This is the issue already attached to this research; it explains why the Step 5 picker default below is biased toward "Implementation plan".
+- **Related existing work** — other issues / plans / research that overlap or connect.
+- **Potential duplicates** — issues that cover similar ground.
 - **Natural home** — where this fits in the project structure; which epic or initiative it aligns with.
 - **Complexity assessment** — XS / S / M / L / XL with key dependencies and risk areas.
 
 ### Step 5: Output picker
 
-Use `AskUserQuestion` with these 5 options. The first option is the default-selected one for ideas without `LINKED_ISSUE`; for ideas with `LINKED_ISSUE`, default to "Implementation plan" instead.
+Use `AskUserQuestion` with these 5 options. Default-selected option:
+
+- If `LINKED_ISSUE` is set → **Implementation plan** (the linked issue already exists — creating a separate one would duplicate).
+- Otherwise → **GitHub issue** (the first option; the most common path for ideas without prior linkage).
 
 | Label | Behavior |
 |---|---|
@@ -107,6 +108,8 @@ Use `AskUserQuestion` with these 5 options. The first option is the default-sele
 | **Keep as refined idea** | Update the source file with context; no GitHub mutation → Step 6d |
 
 Wait for the user's structured response, then branch to the matching Step 6 sub-step.
+
+**Source-file presence:** Steps 6a-d's frontmatter updates assume a source file exists. If the input was an inline description (no path argument), offer to write a `thoughts/shared/ideas/YYYY-MM-DD-description.md` first per the draft template in `intake-shapes.md`, then proceed using that file as the source. For Step 6d (refined draft), this file IS the output.
 
 ### Step 6a: Create GitHub issue
 

--- a/ralph/skills/form/duplicate-detection.md
+++ b/ralph/skills/form/duplicate-detection.md
@@ -1,0 +1,3 @@
+# Duplicate detection
+
+_Filled by Phase 2._

--- a/ralph/skills/form/duplicate-detection.md
+++ b/ralph/skills/form/duplicate-detection.md
@@ -1,3 +1,52 @@
 # Duplicate detection
 
-_Filled by Phase 2._
+This reference is consulted by `/ralph:form` Step 3 of the default flow. It carries the dedup strategy: codebase locator, codebase analyzer, thoughts locator, thoughts analyzer, issue keyword search, and optional knowledge-search.
+
+## Strategy: parallel sub-task dispatch
+
+Spawn the sub-tasks below in parallel, then wait for ALL to complete before synthesizing. The skill's allowed-tools includes the relevant `Agent` types and MCP tools.
+
+### Codebase context (skip for `INPUT_TYPE == "research"`)
+
+The research-doc input path already covers this in the doc itself; running these for research inputs duplicates work and bloats context.
+
+- `Agent(subagent_type="ralph-hero:codebase-locator", prompt="Find where [idea topic] would live in the codebase")` — pinpoints the relevant area without reading full files.
+- `Agent(subagent_type="ralph-hero:codebase-analyzer", prompt="What already exists related to [idea topic]? What patterns to build on?")` — identifies existing patterns and code to extend.
+
+### Existing work (always)
+
+- `Agent(subagent_type="ralph-hero:thoughts-locator", prompt="Find related ideas, research, and plans about [topic]")` — surfaces overlapping documents in `thoughts/shared/{ideas,research,plans}/`.
+- `Agent(subagent_type="ralph-hero:thoughts-analyzer", prompt="Extract key decisions and prior art from documents about [topic]")` — dispatch on the top thoughts-locator findings.
+
+### Existing issues (always)
+
+Call `list_issues` with the idea topic as the `query` parameter:
+
+- Duplicate or overlapping issues
+- Related work already planned or in progress
+- Parent epics this might fit under
+
+### Knowledge-search dedup (optional)
+
+If the `knowledge_search` MCP tool is available, search for matching ideas:
+
+```
+knowledge_search(query="[idea topic]", type="idea", limit=3)
+```
+
+If close matches are returned, surface them to the user with a build-on-or-new prompt: *"There's an existing idea that may overlap: `[path]` — [title]. Want to continue with a new idea or build on that one?"*
+
+If `knowledge_search` is not available (no ralph-knowledge plugin installed), skip silently.
+
+## Team isolation
+
+**Do NOT pass `team_name` to any `Agent()` call.** This is the ADR-001 team-isolation convention — sub-agents start fresh and inherit only the prompt + tool list, not the parent's team context.
+
+## Synthesis
+
+After all sub-tasks complete, synthesize for Step 4 of the default flow:
+
+- **Related existing work** — pull from thoughts-analyzer + list_issues output.
+- **Potential duplicates** — surface high-confidence overlaps; mention the source (issue / plan / research).
+- **Natural home** — name the epic or initiative this aligns with (from list_issues parent-epic search).
+- **Complexity assessment** — XS / S / M / L / XL based on scope discovered in the codebase-analyzer findings.

--- a/ralph/skills/form/intake-shapes.md
+++ b/ralph/skills/form/intake-shapes.md
@@ -1,3 +1,56 @@
 # Intake shapes
 
-_Filled by Phase 2; draft template appended by Phase 4._
+This reference is consulted by `/ralph:form` (Step 1 of the default flow and `--mode draft` Step 1). It carries input-detection rules, per-input-type research routing, and (after Phase 4) the lightweight draft template.
+
+## Detection rules
+
+The single positional argument (after `--mode draft` if present) determines `INPUT_TYPE`:
+
+| Argument | INPUT_TYPE | Detection |
+|---|---|---|
+| Path matching `thoughts/shared/research/*.md` | `"research"` | Path glob |
+| Path matching `thoughts/shared/ideas/*.md` | `"idea"` | Path glob |
+| Any other path with `type: research` in frontmatter | `"research"` | Frontmatter `type` field (authoritative) |
+| Any other path with `type: idea` in frontmatter (or no `type:`) | `"idea"` | Frontmatter, then default |
+| Inline description (non-path string) | `"idea"` | Treat as inline idea |
+| No argument provided | (interactive) | List recent ideas; wait for input |
+
+**Frontmatter `type:` is authoritative when present** — it overrides path-based detection. This matters for ideas promoted from research or research imported from elsewhere whose path doesn't match the canonical glob.
+
+## Linked-research handling
+
+If `INPUT_TYPE == "research"` and the doc's frontmatter has `github_issue: NNN`, set `LINKED_ISSUE = NNN`. The research is already linked to an issue.
+
+Downstream behavior in Step 5 (output picker): when `LINKED_ISSUE` is set, default the picker to **"Implementation plan"** or **"Keep as refined idea"** rather than **"GitHub issue"** — creating a new issue would duplicate the existing link. Surface the existing issue link to the user so they can choose explicitly if they want to create a separate issue anyway.
+
+## Per-input-type research routing
+
+Step 3 of the default flow branches research strategy:
+
+### For `INPUT_TYPE == "research"`
+
+The research doc already contains codebase analysis, code references, and architectural context. Skip the codebase-locator and codebase-analyzer sub-tasks — they would re-investigate what the doc already covers. Still run:
+
+- `Agent(subagent_type="ralph-hero:thoughts-locator", prompt="Find related ideas, research, and plans about [topic from research doc]")` — for project-management context the research doc may lack.
+- `Agent(subagent_type="ralph-hero:thoughts-analyzer", prompt="Extract key decisions and prior art from documents about [topic]")` — dispatch on top thoughts-locator findings.
+- `list_issues` keyword search — to find duplicates / overlapping work / parent epics.
+
+This avoids re-investigating while still grounding the idea in the project context.
+
+### For `INPUT_TYPE == "idea"`
+
+Run the full research suite per `duplicate-detection.md`: codebase-locator + codebase-analyzer + thoughts-locator + thoughts-analyzer + `list_issues` keyword search (and optional `knowledge_search`).
+
+## No-args fallback
+
+If no argument is provided (and not `--mode draft`), list files from `thoughts/shared/ideas/` sorted by date (most recent first, max 10):
+
+```
+Recent ideas:
+
+1. 2026-05-22-feature-x.md — [first sentence of "The Idea" section]
+2. 2026-05-21-improve-y.md — [first sentence]
+...
+```
+
+Then wait for the user to pick by number, supply a path, or supply an inline description.

--- a/ralph/skills/form/intake-shapes.md
+++ b/ralph/skills/form/intake-shapes.md
@@ -21,7 +21,7 @@ The single positional argument (after `--mode draft` if present) determines `INP
 
 If `INPUT_TYPE == "research"` and the doc's frontmatter has `github_issue: NNN`, set `LINKED_ISSUE = NNN`. The research is already linked to an issue.
 
-Downstream behavior in Step 5 (output picker): when `LINKED_ISSUE` is set, default the picker to **"Implementation plan"** or **"Keep as refined idea"** rather than **"GitHub issue"** — creating a new issue would duplicate the existing link. Surface the existing issue link to the user so they can choose explicitly if they want to create a separate issue anyway.
+SKILL.md Step 5 is the source of truth for the picker default when `LINKED_ISSUE` is set — this skill is the source of truth for the routing rule (when to capture `LINKED_ISSUE`); SKILL.md is the source of truth for what the picker does with it.
 
 ## Per-input-type research routing
 

--- a/ralph/skills/form/intake-shapes.md
+++ b/ralph/skills/form/intake-shapes.md
@@ -54,3 +54,50 @@ Recent ideas:
 ```
 
 Then wait for the user to pick by number, supply a path, or supply an inline description.
+
+## Draft template
+
+Used by `--mode draft` Step 4 to write `thoughts/shared/ideas/YYYY-MM-DD-description.md`. Lightweight by design — drafts are pre-ticket and should be scannable in under a minute.
+
+```markdown
+---
+date: YYYY-MM-DD
+status: draft
+type: idea
+author: user
+tags: [relevant, tags]
+github_issue: null
+---
+
+# [Idea Title]
+
+## The Idea
+
+[2-4 sentence description of the core idea, written conversationally. Preserve the user's voice and framing — don't over-formalize.]
+
+## Why This Matters
+
+[1-3 bullet points on motivation or context]
+
+## Rough Shape
+
+[Sketch of what this might look like — bullet points, not detailed spec]
+- [Key aspect 1]
+- [Key aspect 2]
+- [Key aspect 3]
+
+## Open Questions
+
+- [Things to figure out later]
+
+## Related
+
+- [Any related files, tickets, or ideas mentioned during capture]
+```
+
+Filename derivation:
+
+- `YYYY-MM-DD` — today's date in UTC.
+- `description` — 3-6 hyphen-separated lowercase words derived from the title; strip punctuation.
+
+Tag generously — tags are how `/ralph:form` will rediscover related ideas later via knowledge-search and thoughts-locator. Aim for 3-5 tags drawn from the topic, the affected area, and any cross-cutting concerns (e.g., `[performance, dashboard, mvp]`).

--- a/ralph/skills/form/intake-shapes.md
+++ b/ralph/skills/form/intake-shapes.md
@@ -1,0 +1,3 @@
+# Intake shapes
+
+_Filled by Phase 2; draft template appended by Phase 4._

--- a/ralph/skills/form/issue-template.md
+++ b/ralph/skills/form/issue-template.md
@@ -1,3 +1,112 @@
 # Issue template
 
-_Filled by Phase 3._
+This reference is consulted by `/ralph:form` Step 6a (single issue) and Step 6b (ticket tree). It carries the issue body shape, the research-aware variant, the artifact-comment protocol, the tree structure, and the source-file frontmatter updates.
+
+## Single-issue body
+
+Use this template for the issue body. Show it to the user for approval before calling `create_issue`.
+
+```markdown
+## Summary
+
+[What and why — 1-3 sentences]
+
+## Acceptance Criteria
+
+- [ ] [Specific, testable criterion]
+- [ ] [Another criterion]
+- [ ] [Etc — keep these concrete and verifiable]
+
+## Context
+
+- Related: [links to related issues / docs found during dedup]
+- Idea source: [link to draft idea file, if applicable]
+```
+
+Alongside the body, propose:
+
+- **Title** — concise, actionable (≤ 70 chars).
+- **Labels** — based on dedup findings + idea content.
+- **Estimate** — XS / S / M / L / XL.
+- **Priority** — P0 / P1 / P2 / P3.
+
+## Research-aware variant
+
+When `INPUT_TYPE == "research"`, append a `## Research` section to the body:
+
+```markdown
+## Research
+
+See [research doc](https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/thoughts/shared/research/[filename].md)
+```
+
+This signals to downstream verbs that the research phase is already done; `/ralph:plan` can skip straight to planning.
+
+## Artifact comment (research inputs)
+
+After creating the issue from a research input, post a comment on the new issue using the Artifact Comment Protocol:
+
+```markdown
+## Research Document
+
+https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/thoughts/shared/research/[filename].md
+
+Key findings: [1-3 line summary from the research doc's Summary section]
+```
+
+This mirrors the protocol used by `/ralph:research` (and the legacy `/ralph-hero:research`) so the issue's comment history shows the artifact provenance in a consistent shape.
+
+## Ticket-tree shape
+
+For Step 6b:
+
+```
+Proposed ticket tree:
+
+**Parent**: [Epic title] (L)
+├── #??: [Sub-task 1] (XS)
+├── #??: [Sub-task 2] (XS)
+├── #??: [Sub-task 3] (S)
+└── #??: [Sub-task 4] (XS)
+
+Each sub-issue is scoped to XS/S for autonomous implementation.
+```
+
+Creation order:
+
+1. Parent: `create_issue` with `estimate: L`, `workflowState: "Backlog"`.
+2. Each child: `create_issue` with `estimate: XS` (occasionally `S`), `workflowState: "Backlog"`, then `add_sub_issue(parent_number, child_number)`.
+3. Sequential children only: `add_dependency(blocker_number, blocked_number)` in submission order. Independent children get no dependency edge — parallelism is the default.
+
+Estimate defaults — **L** for parent, **XS** for child. Bump to **S** for any child that touches >1 component or has nontrivial design surface; bump to **M** only if the child should probably be its own sub-tree.
+
+## Source-file frontmatter updates
+
+After Step 6a or 6b lands the issue(s):
+
+### For `INPUT_TYPE == "idea"`
+
+```yaml
+type: idea
+github_issue: NNN
+status: formed
+```
+
+### For `INPUT_TYPE == "research"`
+
+```yaml
+github_issue: NNN
+github_url: https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/issues/NNN
+```
+
+Do NOT overwrite the existing `type: research` — preserve it.
+
+### For Step 6c handoff
+
+Idea: `status: forming` (still in motion, awaiting plan/research).
+Research: no change (research docs don't have a `status` field).
+
+### For Step 6d refined draft
+
+Idea: `status: refined` (enriched but no GitHub artifact created yet).
+Research: no change.

--- a/ralph/skills/form/issue-template.md
+++ b/ralph/skills/form/issue-template.md
@@ -1,0 +1,3 @@
+# Issue template
+
+_Filled by Phase 3._

--- a/thoughts/shared/plans/2026-05-23-GH-1359-ralph-plan-2-form.md
+++ b/thoughts/shared/plans/2026-05-23-GH-1359-ralph-plan-2-form.md
@@ -197,6 +197,10 @@ _(Filled by Phase 4.)_
 
 - [ ] After `/reload-plugins`, `/ralph:form --help` returns the mode table.
 
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` (PR or branch diff) and `/skill-creator:skill-creator` (against the partial bundle under `ralph/skills/form/`) in parallel via two `Agent()` calls in a single message. Apply recommended fixes — or record why not in the friction log — before proceeding to Phase 2.
+
 ---
 
 ## Phase 2: Default flow front-half (research + context + picker)
@@ -262,6 +266,10 @@ Target ~70 lines.
 - [ ] `/ralph:form <inline description>` does the same with `INPUT_TYPE="idea"`.
 - [ ] `/ralph:form thoughts/shared/research/<some-research>.md` skips codebase-locator/analyzer and surfaces the linked-issue note when applicable.
 
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` and `/skill-creator:skill-creator` in parallel against the partial bundle. Apply recommended fixes — or record why not in the friction log — before proceeding to Phase 3.
+
 ---
 
 ## Phase 3: Default flow output paths
@@ -315,6 +323,10 @@ Target ~70 lines.
 - [ ] `/ralph:form <inline description>` → pick "Implementation plan" → source file gets `status: forming` and the handoff prompt suggests the next command.
 - [ ] `/ralph:form <inline description>` → pick "Keep as refined idea" → source file is enriched with research context and tags; no GitHub mutation.
 
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` and `/skill-creator:skill-creator` in parallel against the partial bundle. Apply recommended fixes — or record why not in the friction log — before proceeding to Phase 4.
+
 ---
 
 ## Phase 4: `--mode draft`
@@ -360,6 +372,10 @@ Target: +30 lines (intake-shapes.md grows to ~90 lines).
 - [ ] `/ralph:form --mode draft "feature idea X"` asks 2-3 questions, writes `thoughts/shared/ideas/YYYY-MM-DD-feature-idea-x.md`, suggests `/ralph:form <path>` as the next step. No GitHub call.
 - [ ] `/ralph:form --mode draft` (no topic) prompts "What's on your mind?" and proceeds after user input.
 - [ ] The written file matches the draft template (frontmatter with `type: idea, status: draft, github_issue: null` + the 4 prose sections).
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` and `/skill-creator:skill-creator` in parallel against the partial bundle. Apply recommended fixes — or record why not in the friction log — before proceeding to Phase 5.
 
 ---
 
@@ -412,6 +428,10 @@ Record observations in the friction-log entry.
 - [ ] Four real `/ralph:form` invocations completed (one per intake shape + one draft).
 - [ ] Each session produces equivalent output to the corresponding old skill.
 - [ ] No regressions in `/ralph-hero:form` or `/ralph-hero:draft`.
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Final audit against the complete bundle before opening the PR. Dispatch `/review` (now against the full PR) and `/skill-creator:skill-creator` (against the full `ralph/skills/form/` bundle) in parallel. Apply recommended fixes — or record why not in the friction log.
 
 ---
 

--- a/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+++ b/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
@@ -358,6 +358,7 @@ This is load-bearing. The risk of "build new plugin in parallel" is that the new
 3. **Hook coverage:** no enforcement logic in skill prose — all moved to hooks or MCP validation.
 4. **Local dev works:** edit `SKILL.md`, save, next invocation picks it up without `claude plugins` commands.
 5. **Old skill stays functional** for two weeks post-merge. Sunset is its own follow-up PR.
+6. **Per-phase audit applied:** after each phase passes its automated + manual verification, dispatch `/review` (against the open PR or branch diff) and `/skill-creator:skill-creator` (against the partial skill bundle) in parallel. Apply recommended fixes — or document why not — before proceeding to the next phase. Catches P2 leakage, missing tools, picker ambiguity, and trigger gaps while they're still cheap to fix; established by Plan 1's post-impl audit and made standard in Plan 2.
 
 ### Estimated timeline (to validate)
 

--- a/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+++ b/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
@@ -439,3 +439,29 @@ Open follow-ups (separate plans):
 
 - Plan 7 will introduce `/ralph:caretake`. At that point, `dashboard-render.md` should retarget its "remediation belongs to" line away from `/ralph-hero:hygiene/triage/hello` to the new verb.
 - Plan 10 owns sunset of the source skills (`hello`, `catch-up`, `status`, `report`, `cos` skill body). cos's scripts under `plugin/ralph-hero/scripts/cos/` are not part of the slash-command migration and have their own kill-or-extract decision.
+
+### Plan 2: `/ralph:form` (shipped 2026-05-23, branch `feature/GH-1359-form`)
+
+Final shape:
+
+- `ralph/skills/form/SKILL.md`: 186 lines (target ~150, max 200). Heavier than catch-up (137) because the default flow has a 5-option picker that branches into 4 distinct output paths (single issue / ticket tree / handoff / refined draft) plus the `--mode draft` quick-capture flow — six surfaces in one verb.
+- Three flat-sibling references: `intake-shapes.md` (103), `duplicate-detection.md` (52), `issue-template.md` (112). Total 267 lines of opinion content.
+- Combined: 453 lines (vs 510 in source draft + form). Reduction is modest; structural P2 compliance is the bigger win.
+- No hooks ported. Source draft and form had no enforcement to move; `ralph/hooks/hooks.json` unchanged from Plan 1.
+- Step 5 picker defaults change with `LINKED_ISSUE`: when intake routing detects a research doc with an existing `github_issue` in its frontmatter, the picker biases toward "Implementation plan" rather than "GitHub issue" (avoids duplicate issue creation against linked research).
+- Handoffs in Step 6c point at `/ralph:plan` and `/ralph:research` with `/ralph-hero:plan` and `/ralph-hero:research` as fallbacks. The new-verb names get unblocked when Plans 3 (research) and 4 (plan) ship — the fallbacks come out then.
+
+Real-session usage notes during the 2-week dogfooding window:
+
+- [ ] _(Add entries as you use it. Examples to watch for: research-doc auto-detection edge cases (`type: research` vs path glob), inline-description routing for very short inputs, ticket-tree estimate-default appropriateness, knowledge-search dedup false positives, frontmatter-update collisions when the source file is open in an editor.)_
+
+Inputs to feed into Plan 3 (`/ralph:research`):
+
+- _(TBD after 2 weeks of usage.)_
+- Pattern validator note: the flat-sibling reference layout worked again for a 2-skill fold with three references. Three references felt about right; four (the catch-up shape) is the upper end. If Plan 3 needs five+, that's a signal to revisit the convention.
+
+Open follow-ups (separate plans):
+
+- When Plan 3 ships, update SKILL.md Step 6c to drop the `/ralph-hero:research` fallback. Same for Plan 4 and `/ralph-hero:plan`.
+- Plan 7 (`/ralph:caretake`) doesn't directly affect this verb.
+- Plan 10 owns sunset of source `draft` + `form` skills.


### PR DESCRIPTION
## Summary

- Folds 2 source skills (`draft`, `form`) into one `/ralph:form` verb in the new `ralph/` plugin (Plan 2 of the slim-plugin migration).
- Default flow = heavyweight: intake routing → research + dedup → 5-option `AskUserQuestion` picker (single issue / ticket tree / plan handoff / research handoff / refined draft).
- `--mode draft` = lightweight quick-capture: 2-3 questions → write to `thoughts/shared/ideas/`, no GitHub.

Closes #1359. Builds on Plan 1 (#1358 merged as `c8876c04`).

## Shape

- `ralph/skills/form/SKILL.md` — 186 lines (target ~150, max 200).
- Three flat-sibling references — `intake-shapes.md` (103), `duplicate-detection.md` (52), `issue-template.md` (112). 267 lines of opinion content.
- No hook port (source `draft`/`form` have no enforcement to move).
- Five commits, one per phase.

Total bundle: 453 lines (vs 510 in source skills). Reduction is modest; structural P2 compliance is the win.

## Acceptance criteria (from spec)

1. **Functional parity** on ≥ 3 real invocations (4 planned: 3 intake shapes + 1 draft). Runs post-merge.
2. **Token budget**: SKILL.md 186 ≤ 200 ✓ (heavier than catch-up's 137 because the verb covers 6 surfaces in one skill).
3. **Hook coverage**: no enforcement in skill prose; no new hooks needed.
4. **Local dev**: works via existing symlink + version bump (`release-ralph.yml` from PR #1360 auto-bumps on merge).
5. **Old skills functional**: `plugin/ralph-hero/skills/{draft,form}/` untouched.

## Design calls baked in

- **`LINKED_ISSUE` biases the picker.** When intake detects a research doc with an existing `github_issue` in its frontmatter, the picker defaults to "Implementation plan" instead of "GitHub issue" — avoids duplicate issue creation against linked research.
- **Handoffs point at new-plugin verbs first.** `Step 6c` suggests `/ralph:plan` and `/ralph:research`, with `/ralph-hero:plan` / `/ralph-hero:research` as fallbacks until Plans 3-4 ship. Open follow-up to drop fallbacks at that point.
- **Tagging guidance for downstream rediscovery.** `intake-shapes.md` urges 3-5 tags per draft for `knowledge_search` / `thoughts-locator` discoverability.
- **Estimate defaults for ticket trees.** Parent L, child XS (bump to S only for cross-component children).

## Test plan

- [ ] Wait for `release-ralph.yml` to auto-bump to 0.1.2 and tag `ralph-v0.1.2`.
- [ ] `/plugin marketplace update ralph-hero && /plugin install ralph@ralph-hero && /reload-plugins` in a fresh session.
- [ ] `/ralph:form --help` returns the mode table.
- [ ] `/ralph:form <inline description>` → "GitHub issue" output. Verify against same-input `/ralph-hero:form` invocation.
- [ ] `/ralph:form <idea-file>` → "Ticket tree" output. Verify parent + children + estimates + `add_sub_issue` linkage.
- [ ] `/ralph:form <research-doc>` → "GitHub issue" output. Verify the `## Research Document` artifact comment is posted on the new issue.
- [ ] `/ralph:form --mode draft "<topic>"` → file in `thoughts/shared/ideas/`; verify against `/ralph-hero:draft "<topic>"`.

Plan doc: `thoughts/shared/plans/2026-05-23-GH-1359-ralph-plan-2-form.md`
Spec: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)