### PR TITLE
feat(ralph): Plan 3 — /ralph:research fold (GH-1362)

### DIFF
--- a/ralph/README.md
+++ b/ralph/README.md
@@ -4,7 +4,7 @@ Slim successor to `ralph-hero`. The naive hero, less ceremony.
 
 ## Status
 
-**Plan 2 of 11 (form shipped).** This plugin currently exposes two user-facing skills (`/ralph:catch-up`, `/ralph:form`). Verbs are migrated in one at a time per the plan-of-plans.
+**Plan 3 of 11 (research shipped).** This plugin currently exposes three user-facing skills (`/ralph:catch-up`, `/ralph:form`, `/ralph:research`). Verbs are migrated in one at a time per the plan-of-plans.
 
 ## Design
 
@@ -24,7 +24,7 @@ Headline shape:
 | 0 | scaffold | shipped |
 | 1 | `/ralph:catch-up` | shipped |
 | 2 | `/ralph:form` | shipped |
-| 3 | `/ralph:research` | pending |
+| 3 | `/ralph:research` | shipped |
 | 4 | `/ralph:plan` | pending |
 | 5 | `/ralph:impl` | pending |
 | 6 | `/ralph:review` | pending |

--- a/ralph/hooks/scripts/branch-gate.sh
+++ b/ralph/hooks/scripts/branch-gate.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/branch-gate.sh
+# PreToolUse: Block if not on required branch
+#
+# Environment:
+#   RALPH_REQUIRED_BRANCH - Branch that must be active (default: main)
+#
+# Exit codes:
+#   0 - On correct branch
+#   2 - Wrong branch (blocks with instructions)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+# Cache input for both command extraction and potential check_branch use
+read_input > /dev/null
+
+# Get required branch and bash command
+required_branch="${RALPH_REQUIRED_BRANCH:-main}"
+command=$(get_field '.tool_input.command')
+
+# Allow git checkout/switch commands that target the required branch
+if [[ -n "$command" ]]; then
+  if [[ "$command" =~ ^[[:space:]]*git[[:space:]]+(checkout|switch)[[:space:]].*${required_branch}([[:space:]]|$|\"|\') ]]; then
+    allow
+  fi
+fi
+
+# For all other commands, enforce branch requirement
+check_branch
+allow

--- a/ralph/hooks/scripts/branch-gate.sh
+++ b/ralph/hooks/scripts/branch-gate.sh
@@ -3,10 +3,14 @@
 # PreToolUse: Block if not on required branch
 #
 # Environment:
-#   RALPH_REQUIRED_BRANCH - Branch that must be active (default: main)
+#   RALPH_REQUIRED_BRANCH - Branch that must be active. UNSET = no-op (allow all).
+#     Differs from the source ralph-hero copy, which defaulted to "main". The
+#     slim plugin keeps this gate inert in interactive + prove modes so feature
+#     branches don't trip every Bash call. The autonomous workflow exports
+#     RALPH_REQUIRED_BRANCH=main explicitly when it needs the gate active.
 #
 # Exit codes:
-#   0 - On correct branch
+#   0 - On correct branch (or env unset)
 #   2 - Wrong branch (blocks with instructions)
 
 set -euo pipefail
@@ -15,8 +19,12 @@ source "$(dirname "$0")/hook-utils.sh"
 # Cache input for both command extraction and potential check_branch use
 read_input > /dev/null
 
-# Get required branch and bash command
-required_branch="${RALPH_REQUIRED_BRANCH:-main}"
+# No-op when RALPH_REQUIRED_BRANCH is unset.
+if [[ -z "${RALPH_REQUIRED_BRANCH:-}" ]]; then
+  allow
+fi
+
+required_branch="$RALPH_REQUIRED_BRANCH"
 command=$(get_field '.tool_input.command')
 
 # Allow git checkout/switch commands that target the required branch

--- a/ralph/hooks/scripts/doc-structure-validator.sh
+++ b/ralph/hooks/scripts/doc-structure-validator.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/doc-structure-validator.sh
+# Stop: Validate required sections in documents created during the skill session
+#
+# Exit codes:
+#   0 - Structure valid or no recent document found
+#   2 - Missing required sections, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+command="${RALPH_COMMAND:-}"
+if [[ -z "$command" ]]; then
+  allow
+fi
+
+project_root="$(get_project_root)"
+
+case "$command" in
+  research)
+    artifact_dir="$project_root/thoughts/shared/research"
+    ;;
+  plan)
+    artifact_dir="$project_root/thoughts/shared/plans"
+    ;;
+  review)
+    artifact_dir="$project_root/thoughts/shared/reviews"
+    ;;
+  *)
+    allow
+    ;;
+esac
+
+# Find most recently modified markdown file in artifact dir (within last 60 min)
+doc=$(find "$artifact_dir" -name "*.md" -type f -mmin -60 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)
+
+if [[ -z "$doc" ]]; then
+  allow
+fi
+
+errors=()
+
+case "$command" in
+  research)
+    grep -qi "problem\|overview" "$doc" || errors+=("Missing: Problem statement (section with 'problem' or 'overview')")
+    grep -qi "analysis\|current state" "$doc" || errors+=("Missing: Analysis (section with 'analysis' or 'current state')")
+    grep -qi "discover\|finding" "$doc" || errors+=("Missing: Discoveries (section with 'discover' or 'finding')")
+    grep -qi "approach" "$doc" || errors+=("Missing: Approaches (section with 'approach')")
+    grep -qi "risk" "$doc" || errors+=("Missing: Risks (section with 'risk')")
+    grep -qi "next step\|recommendation" "$doc" || errors+=("Missing: Next steps (section with 'next step' or 'recommendation')")
+    ;;
+  plan)
+    grep -qE "^## Phase [0-9]" "$doc" || errors+=("Missing: ## Phase N: header pattern (e.g., '## Phase 1: ...')")
+    grep -qE "^\- \[ \] (Automated|Manual):" "$doc" || errors+=("Missing: Success criteria format '- [ ] Automated:' or '- [ ] Manual:'")
+    ;;
+  review)
+    grep -qE "APPROVED|NEEDS_ITERATION" "$doc" || errors+=("Missing: Verdict (APPROVED or NEEDS_ITERATION)")
+    ;;
+esac
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  error_list=$(printf '%s\n' "${errors[@]}")
+  block "Document structure validation failed
+
+Document: $doc
+
+Missing required sections:
+$error_list
+
+Fix the document to include all required sections before the skill can complete."
+fi
+
+echo "Document structure validated: $doc"
+allow

--- a/ralph/hooks/scripts/doc-structure-validator.sh
+++ b/ralph/hooks/scripts/doc-structure-validator.sh
@@ -33,8 +33,13 @@ case "$command" in
     ;;
 esac
 
-# Find most recently modified markdown file in artifact dir (within last 60 min)
-doc=$(find "$artifact_dir" -name "*.md" -type f -mmin -60 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)
+# Find a doc CREATED today by the autonomous research flow. The slim plugin
+# scopes this hook tighter than the source ralph-hero copy (which scanned the
+# last 60 min and could block on unrelated stale edits): we only validate a
+# file whose name starts with today's YYYY-MM-DD prefix and was modified in the
+# last 15 min (matching the autonomous flow's 15-minute budget).
+today=$(date +%Y-%m-%d)
+doc=$(find "$artifact_dir" -name "${today}-*.md" -type f -mmin -15 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)
 
 if [[ -z "$doc" ]]; then
   allow
@@ -44,12 +49,11 @@ errors=()
 
 case "$command" in
   research)
-    grep -qi "problem\|overview" "$doc" || errors+=("Missing: Problem statement (section with 'problem' or 'overview')")
-    grep -qi "analysis\|current state" "$doc" || errors+=("Missing: Analysis (section with 'analysis' or 'current state')")
-    grep -qi "discover\|finding" "$doc" || errors+=("Missing: Discoveries (section with 'discover' or 'finding')")
-    grep -qi "approach" "$doc" || errors+=("Missing: Approaches (section with 'approach')")
-    grep -qi "risk" "$doc" || errors+=("Missing: Risks (section with 'risk')")
-    grep -qi "next step\|recommendation" "$doc" || errors+=("Missing: Next steps (section with 'next step' or 'recommendation')")
+    # Section names match ralph/skills/research/findings-format.md § Section order.
+    grep -qiE "^## (Prior Work|Research Question)" "$doc" || errors+=("Missing: '## Prior Work' or '## Research Question' header")
+    grep -qiE "^## (Summary|Detailed Findings)" "$doc" || errors+=("Missing: '## Summary' or '## Detailed Findings' header")
+    grep -qiE "^## Files Affected" "$doc" || errors+=("Missing: '## Files Affected' header (required by --mode auto per findings-format.md)")
+    grep -qE '`[^`]+`' "$doc" || errors+=("Missing: backtick-wrapped file paths (e.g., \`src/file.ts\`) — referenced findings should use code-spans")
     ;;
   plan)
     grep -qE "^## Phase [0-9]" "$doc" || errors+=("Missing: ## Phase N: header pattern (e.g., '## Phase 1: ...')")

--- a/ralph/hooks/scripts/lock-release-on-failure.sh
+++ b/ralph/hooks/scripts/lock-release-on-failure.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/lock-release-on-failure.sh
+# Stop hook: Advise lock release when a skill stops with a lock state active
+#
+# When a skill that acquired a lock state (Research in Progress, Plan in Progress, In Progress)
+# stops unexpectedly, this hook advises releasing the lock back to its pre-lock state.
+#
+# Requires env vars set by skill:
+#   RALPH_COMMAND     - Current skill command (research, plan, impl)
+#   RALPH_TICKET_ID   - Issue identifier (GH-NNN or raw number)
+#   RALPH_LOCK_STATE  - Lock state acquired by this skill (optional; derived from RALPH_COMMAND if absent)
+#
+# Lock release mappings (per spec):
+#   Research in Progress -> Research Needed
+#   Plan in Progress     -> Ready for Plan
+#   In Progress          -> stays In Progress (spec: no rollback on impl failure)
+#
+# Exit codes:
+#   0 - No action needed or advisory output provided
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-utils.sh"
+
+STATE_MACHINE="$SCRIPT_DIR/ralph-state-machine.json"
+
+command="${RALPH_COMMAND:-}"
+ticket_id="${RALPH_TICKET_ID:-}"
+
+# Only run if we were in a skill context with a known ticket
+if [[ -z "$command" ]] || [[ -z "$ticket_id" ]]; then
+  exit 0
+fi
+
+if [[ ! -f "$STATE_MACHINE" ]]; then
+  exit 0
+fi
+
+# Determine the expected lock state for this command
+lock_state="${RALPH_LOCK_STATE:-}"
+if [[ -z "$lock_state" ]]; then
+  case "$command" in
+    research) lock_state="Research in Progress" ;;
+    plan)     lock_state="Plan in Progress" ;;
+    impl)     lock_state="In Progress" ;;
+    *)        exit 0 ;;
+  esac
+fi
+
+# Verify lock_state is actually a lock state in the state machine
+is_lock=$(jq -r --arg state "$lock_state" '.states[$state].is_lock_state // false' "$STATE_MACHINE")
+if [[ "$is_lock" != "true" ]]; then
+  exit 0
+fi
+
+# Determine the release target state
+case "$lock_state" in
+  "Research in Progress") release_state="Research Needed" ;;
+  "Plan in Progress")     release_state="Ready for Plan" ;;
+  "In Progress")
+    # Spec: In Progress stays In Progress on failure (no rollback)
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+
+# Extract issue number from ticket_id (GH-NNN -> NNN)
+issue_number=$(echo "$ticket_id" | grep -oE '[0-9]+' | head -1)
+if [[ -z "$issue_number" ]]; then
+  exit 0
+fi
+
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": "LOCK RELEASE NEEDED: Skill '${command}' stopped while issue ${ticket_id} was in lock state '${lock_state}'. The lock must be released to '${release_state}' to allow other agents to process this ticket.\n\nTo release: call ralph_hero__save_issue with issueNumber=${issue_number} and workflowState='${release_state}'"
+  }
+}
+EOF
+exit 0

--- a/ralph/hooks/scripts/ralph-state-machine.json
+++ b/ralph/hooks/scripts/ralph-state-machine.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Ralph GitHub workflow state machine - defines valid state transitions and validation rules",
+  "version": "1.0.0",
+
+  "states": {
+    "Backlog": {
+      "description": "Ticket awaiting triage",
+      "allowed_transitions": ["Research Needed", "Ready for Plan", "Done", "Canceled"],
+      "required_by_commands": [],
+      "produces_for_commands": ["ralph_triage", "ralph_split", "ralph_unblock"]
+    },
+    "Research Needed": {
+      "description": "Ticket needs investigation before planning",
+      "allowed_transitions": ["Research in Progress", "Ready for Plan", "Human Needed"],
+      "required_by_commands": ["ralph_research", "ralph_split"],
+      "produces_for_commands": ["ralph_triage", "ralph_unblock"]
+    },
+    "Research in Progress": {
+      "description": "Research actively being conducted (LOCKED)",
+      "allowed_transitions": ["Ready for Plan", "Human Needed"],
+      "required_by_commands": [],
+      "produces_for_commands": ["ralph_research"],
+      "is_lock_state": true
+    },
+    "Ready for Plan": {
+      "description": "Research complete, ready for implementation planning",
+      "allowed_transitions": ["Plan in Progress", "Human Needed"],
+      "required_by_commands": ["ralph_plan", "ralph_plan_epic"],
+      "produces_for_commands": ["ralph_research", "ralph_split", "ralph_unblock"]
+    },
+    "Plan in Progress": {
+      "description": "Plan actively being created (LOCKED)",
+      "allowed_transitions": ["Plan in Review", "In Progress", "Human Needed"],
+      "required_by_commands": [],
+      "produces_for_commands": ["ralph_plan", "ralph_plan_epic"],
+      "is_lock_state": true
+    },
+    "Plan in Review": {
+      "description": "Plan awaiting human approval or split into children",
+      "allowed_transitions": ["In Progress", "Ready for Plan", "Human Needed"],
+      "required_by_commands": ["ralph_review", "ralph_split"],
+      "produces_for_commands": ["ralph_plan", "ralph_review"],
+      "requires_human_action": true
+    },
+    "In Progress": {
+      "description": "Implementation actively underway or children being worked",
+      "allowed_transitions": ["In Review", "Human Needed"],
+      "required_by_commands": ["ralph_impl"],
+      "produces_for_commands": ["ralph_plan_epic", "ralph_plan", "ralph_review", "ralph_split", "ralph_unblock"]
+    },
+    "In Review": {
+      "description": "PR created, awaiting code review",
+      "allowed_transitions": ["Done", "In Progress", "Human Needed"],
+      "required_by_commands": [],
+      "produces_for_commands": ["ralph_impl", "ralph_pr"],
+      "requires_human_action": true
+    },
+    "Human Needed": {
+      "description": "Escalated - requires human intervention",
+      "allowed_transitions": ["Backlog", "Research Needed", "Ready for Plan", "In Progress"],
+      "required_by_commands": ["ralph_unblock"],
+      "produces_for_commands": ["*"],
+      "requires_human_action": true
+    },
+    "Done": {
+      "description": "Ticket completed",
+      "allowed_transitions": [],
+      "required_by_commands": [],
+      "produces_for_commands": ["ralph_triage", "ralph_impl", "ralph_merge"],
+      "is_terminal": true
+    },
+    "Canceled": {
+      "description": "Ticket canceled/superseded",
+      "allowed_transitions": [],
+      "required_by_commands": [],
+      "produces_for_commands": ["ralph_triage"],
+      "is_terminal": true
+    }
+  },
+
+  "lock_states": {
+    "description": "States that indicate exclusive ownership - another agent should not claim",
+    "states": ["Research in Progress", "Plan in Progress", "In Progress"]
+  },
+
+  "commands": {
+    "ralph_triage": {
+      "description": "Assess and route backlog tickets",
+      "valid_input_states": ["Backlog"],
+      "valid_output_states": ["Research Needed", "Ready for Plan", "Done", "Canceled", "Human Needed"],
+      "can_create_tickets": true,
+      "can_modify_blocks": true,
+      "preconditions": [
+        "Must be on main branch",
+        "Ticket must be in Backlog state"
+      ],
+      "postconditions": [
+        "Ticket state changed from Backlog",
+        "Comment added explaining action taken"
+      ]
+    },
+    "ralph_split": {
+      "description": "Decompose large tickets into sub-tickets. When splitting from a plan, children enter at appropriate states based on parent plan context.",
+      "valid_input_states": ["Backlog", "Research Needed", "Plan in Review"],
+      "valid_output_states": ["Backlog", "In Progress", "Ready for Plan"],
+      "valid_input_estimates": ["M", "L", "XL"],
+      "can_create_tickets": true,
+      "can_modify_blocks": true,
+      "preconditions": [
+        "Must be on main branch",
+        "Ticket estimate must be M/L/XL",
+        "Ticket must be in Backlog, Research Needed, or Plan in Review"
+      ],
+      "postconditions": [
+        "Sub-tickets created with appropriate estimates",
+        "Parent ticket state updated",
+        "Blocking relationships established",
+        "If parent has plan: children get Plan Reference comments"
+      ]
+    },
+    "ralph_research": {
+      "description": "Investigate ticket scope and document findings",
+      "valid_input_states": ["Research Needed"],
+      "valid_output_states": ["Ready for Plan", "Human Needed"],
+      "valid_input_estimates": ["XS", "S"],
+      "lock_state": "Research in Progress",
+      "creates_artifacts": ["thoughts/shared/research/YYYY-MM-DD-GH-NNN-*.md"],
+      "preconditions": [
+        "Must be on main branch",
+        "Ticket must be in Research Needed state",
+        "Ticket estimate must be XS/S",
+        "No existing research document attached"
+      ],
+      "postconditions": [
+        "Research document created and committed",
+        "Document URL posted as comment on ticket",
+        "Ticket moved to Ready for Plan"
+      ]
+    },
+    "ralph_plan": {
+      "description": "Create implementation plan from research. For M issues with children, splits after planning and exits to In Progress.",
+      "valid_input_states": ["Ready for Plan"],
+      "valid_output_states": ["Plan in Review", "In Progress", "Human Needed"],
+      "valid_input_estimates": ["XS", "S", "M"],
+      "lock_state": "Plan in Progress",
+      "requires_artifacts": ["Research document attached"],
+      "creates_artifacts": ["thoughts/shared/plans/YYYY-MM-DD-GH-NNN-*.md"],
+      "preconditions": [
+        "Must be on main branch",
+        "Ticket must be in Ready for Plan state",
+        "Research document must be attached",
+        "No existing plan document attached"
+      ],
+      "postconditions": [
+        "Plan document created and committed",
+        "Plan URL posted as comment on ticket",
+        "If standalone: ticket moved to Plan in Review",
+        "If splitting: children created, ticket moved to In Progress"
+      ]
+    },
+    "ralph_pr": {
+      "description": "Create PR and transition issue to In Review",
+      "valid_input_states": ["In Progress"],
+      "valid_output_states": ["In Review", "Human Needed"],
+      "preconditions": [
+        "Implementation must be complete in worktree",
+        "All plan phases must be implemented",
+        "Branch must be pushed to remote"
+      ],
+      "postconditions": [
+        "PR created via gh pr create",
+        "Ticket moved to In Review",
+        "Worktree preserved for potential follow-up"
+      ]
+    },
+    "ralph_plan_epic": {
+      "description": "Strategic planning for 3+ tier work — writes plan-of-plans, orchestrates feature planning",
+      "valid_input_states": ["Ready for Plan"],
+      "valid_output_states": ["In Progress", "Human Needed"],
+      "lock_state": "Plan in Progress",
+      "creates_artifacts": ["thoughts/shared/plans/YYYY-MM-DD-GH-NNN-*.md"],
+      "preconditions": [
+        "Must be on main branch",
+        "Issue must be in Ready for Plan state",
+        "Research document must be attached"
+      ],
+      "postconditions": [
+        "Plan-of-plans document created and committed",
+        "Feature children created via ralph_split",
+        "Feature children planned via ralph_plan",
+        "Issue moved to In Progress (children being worked)"
+      ]
+    },
+    "ralph_impl": {
+      "description": "Execute implementation plan phases",
+      "valid_input_states": ["Plan in Review", "In Progress"],
+      "valid_output_states": ["In Progress", "In Review", "Human Needed"],
+      "valid_input_estimates": ["XS", "S"],
+      "requires_artifacts": ["Plan document attached"],
+      "creates_artifacts": ["Worktree", "Feature branch", "PR"],
+      "preconditions": [
+        "Plan document must be attached",
+        "For Plan in Review: human must have approved",
+        "Worktree must be available (create or reuse)"
+      ],
+      "postconditions": [
+        "At least one phase completed",
+        "Changes committed and pushed",
+        "If final phase: PR created, ticket In Review"
+      ]
+    },
+    "ralph_hero": {
+      "description": "Orchestrate full ticket lifecycle",
+      "valid_input_states": ["Backlog", "Research Needed", "Ready for Plan", "Plan in Review", "In Progress"],
+      "valid_output_states": ["In Review", "Human Needed"],
+      "delegates_to": ["ralph_split", "ralph_research", "ralph_plan", "ralph_review", "ralph_impl"],
+      "uses_task_system": true,
+      "preconditions": [
+        "Must be on main branch",
+        "Ticket number must be provided",
+        "No other ralph_hero running on same ticket (check tasks)"
+      ],
+      "postconditions": [
+        "Ticket reached In Review or escalated to Human Needed"
+      ]
+    },
+    "ralph_merge": {
+      "description": "Transition issues to Done after PR merge",
+      "valid_input_states": ["In Review"],
+      "valid_output_states": ["Done", "Human Needed"],
+      "preconditions": [
+        "PR must be merged",
+        "Ticket must be in In Review state"
+      ],
+      "postconditions": [
+        "Ticket moved to Done",
+        "GitHub issue closed via PR auto-link"
+      ]
+    },
+    "ralph_code_review": {
+      "description": "Run code review on a PR and address feedback via impl-agent address mode (up to 3 rounds before escalating to Human Needed)",
+      "valid_input_states": ["In Review"],
+      "valid_output_states": ["In Review", "Human Needed"],
+      "preconditions": [
+        "Ticket must be in In Review state",
+        "Open PR must exist on the issue's feature branch",
+        "code-review:code-review skill must be available"
+      ],
+      "postconditions": [
+        "If review clean: ticket remains In Review",
+        "If review found issues and impl-agent fixed them: ticket remains In Review",
+        "If 3 review rounds exhausted: ticket moved to Human Needed with ## Code Review comment posted"
+      ]
+    },
+    "ralph_review": {
+      "description": "Review implementation plans before execution",
+      "valid_input_states": ["Plan in Review"],
+      "valid_output_states": ["In Progress", "Ready for Plan", "Human Needed"],
+      "valid_input_estimates": ["XS", "S"],
+      "creates_artifacts": ["thoughts/shared/reviews/YYYY-MM-DD-GH-NNN-critique.md"],
+      "optional": true,
+      "modes": ["interactive", "auto"],
+      "preconditions": [
+        "Must be on main branch",
+        "Ticket must be in Plan in Review state",
+        "Ticket estimate must be XS/S",
+        "Plan document must be attached"
+      ],
+      "postconditions": [
+        "Ticket state changed to In Progress (approved) or Ready for Plan (needs-iteration)",
+        "If AUTO mode: critique document created and committed",
+        "If rejected: needs-iteration label added"
+      ]
+    },
+    "ralph_unblock": {
+      "description": "Bridge Human Needed issues back into the pipeline by capturing missing context",
+      "valid_input_states": ["Human Needed"],
+      "valid_output_states": ["Backlog", "Research Needed", "Ready for Plan", "In Progress", "Human Needed"],
+      "modes": ["autonomous", "interactive"],
+      "preconditions": [
+        "Must be on main branch",
+        "Ticket must be in Human Needed state"
+      ],
+      "postconditions": [
+        "Autonomous mode: ## Unblock Request comment posted, ticket remains Human Needed",
+        "Interactive mode: ## Unblock Resolution comment posted, ticket transitioned to one of the 4 valid re-entry states"
+      ]
+    }
+  },
+
+  "artifact_patterns": {
+    "research_document": {
+      "path_pattern": "thoughts/shared/research/YYYY-MM-DD-GH-{issue_number}-*.md",
+      "uniqueness": "One per ticket per day",
+      "created_by": ["ralph_research", "ralph_hero"]
+    },
+    "plan_document": {
+      "path_pattern": "thoughts/shared/plans/YYYY-MM-DD-GH-{issue_number}-*.md",
+      "path_pattern_group": "thoughts/shared/plans/YYYY-MM-DD-group-GH-{issue_number}-*.md",
+      "uniqueness": "One per ticket/group per day",
+      "created_by": ["ralph_plan", "ralph_hero"]
+    },
+    "worktree": {
+      "path_pattern": "../worktrees/GH-{issue_number}",
+      "uniqueness": "One per ticket",
+      "created_by": ["ralph_impl", "ralph_hero"]
+    },
+    "critique_document": {
+      "path_pattern": "thoughts/shared/reviews/YYYY-MM-DD-GH-{issue_number}-critique.md",
+      "uniqueness": "One per ticket per day",
+      "created_by": ["ralph_review"]
+    }
+  },
+
+  "conflict_rules": {
+    "description": "Rules for detecting and preventing conflicts",
+    "same_ticket_different_commands": {
+      "allowed": false,
+      "detection": "Check if ticket is in a lock_state",
+      "resolution": "Skip ticket, report 'already being processed'"
+    },
+    "same_ticket_same_command": {
+      "allowed": false,
+      "detection": "Check if ticket is in lock_state matching command's lock_state",
+      "resolution": "Skip ticket"
+    },
+    "duplicate_artifacts": {
+      "allowed": false,
+      "detection": "Check if artifact already attached to ticket",
+      "resolution": "Skip creation, report 'artifact already exists'"
+    },
+    "worktree_collision": {
+      "allowed": false,
+      "detection": "Check if worktree directory exists",
+      "resolution": "Reuse existing worktree if on correct branch"
+    }
+  },
+
+  "semantic_states": {
+    "description": "Mappings from semantic intents to actual states per command",
+    "__LOCK__": {
+      "ralph_research": "Research in Progress",
+      "ralph_plan": "Plan in Progress",
+      "ralph_plan_epic": "Plan in Progress",
+      "ralph_impl": "In Progress"
+    },
+    "__COMPLETE__": {
+      "ralph_triage": null,
+      "ralph_research": "Ready for Plan",
+      "ralph_plan": "Plan in Review",
+      "ralph_plan_epic": "In Progress",
+      "ralph_impl": "In Review",
+      "ralph_review": "In Progress",
+      "ralph_split": "Backlog",
+      "ralph_merge": "Done"
+    },
+    "__ESCALATE__": {
+      "*": "Human Needed"
+    },
+    "__CLOSE__": {
+      "*": "Done"
+    },
+    "__CANCEL__": {
+      "*": "Canceled"
+    }
+  },
+
+  "triage_actions": {
+    "description": "Special mappings for triage which has multiple output paths",
+    "RESEARCH": "Research Needed",
+    "PLAN": "Ready for Plan",
+    "CLOSE": "Done",
+    "KEEP": null,
+    "SPLIT": null
+  }
+}

--- a/ralph/hooks/scripts/research-postcondition.sh
+++ b/ralph/hooks/scripts/research-postcondition.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/research-postcondition.sh
+# Stop: Verify research completed successfully
+#
+# Exit codes:
+#   0 - Postconditions met
+#   2 - Postconditions failed, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+ticket_id="${RALPH_TICKET_ID:-}"
+if [[ -z "$ticket_id" ]]; then
+  allow
+fi
+
+research_dir="$(get_project_root)/thoughts/shared/research"
+doc=$(find "$research_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+
+if [[ -z "$doc" ]]; then
+  alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
+  if [[ -n "$alt_ticket_id" ]]; then
+    doc=$(find "$research_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+  fi
+fi
+
+if [[ -z "$doc" ]]; then
+  block "Research postcondition failed
+
+Expected: Research document for $ticket_id
+Found: None in $research_dir
+
+The research command must create a research document.
+Check the command output for errors."
+fi
+
+if ! grep -q "## Files Affected" "$doc"; then
+  block "Research postcondition failed
+
+Expected: '## Files Affected' section in research document
+Found: Section missing in $doc
+
+The research document must include a '## Files Affected' section with
+'### Will Modify' and '### Will Read (Dependencies)' subsections.
+See the research skill SKILL.md for the required format."
+fi
+
+if ! git log --oneline -1 --all -- "$doc" 2>/dev/null | grep -q .; then
+  warn "Research doc exists but may not be committed: $doc"
+fi
+
+# Check for artifact comment marker (Gap 3: discovery sequence)
+marker_dir="/tmp/ralph-artifact-markers"
+issue_number=$(echo "$ticket_id" | grep -oE '[0-9]+' | head -1)
+if [[ -n "$issue_number" ]] && [[ ! -f "$marker_dir/artifact-comment-${issue_number}" ]]; then
+  echo "WARNING: Artifact comment marker absent for #${issue_number} — '## Research Document' comment may not have been posted." >&2
+fi
+
+echo "Research postcondition passed: $doc"
+allow

--- a/ralph/hooks/scripts/research-state-gate.sh
+++ b/ralph/hooks/scripts/research-state-gate.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/research-state-gate.sh
+# PreToolUse (ralph_hero__save_issue): Validate research state transitions
+#
+# Environment:
+#   RALPH_VALID_INPUT_STATES - Valid source states (comma-separated)
+#   RALPH_VALID_OUTPUT_STATES - Valid target states (comma-separated)
+#
+# Exit codes:
+#   0 - Valid transition
+#   2 - Invalid transition, block with guidance
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+new_state=$(get_field '.tool_input.workflowState')
+if [[ -z "$new_state" ]]; then
+  allow  # Not a state update
+fi
+
+valid_input="${RALPH_VALID_INPUT_STATES:-Research Needed}"
+valid_output="${RALPH_VALID_OUTPUT_STATES:-Ready for Plan,Human Needed}"
+
+# Allow lock state (Research in Progress)
+if [[ "$new_state" == "Research in Progress" ]]; then
+  allow_with_context "Acquiring lock state: Research in Progress. You now have exclusive ownership of this ticket."
+fi
+
+if ! validate_state "$new_state" "$valid_output"; then
+  block "Invalid state transition
+
+Command: ${RALPH_COMMAND:-research}
+Attempted state: $new_state
+Valid output states: $valid_output
+
+This command can only transition to: $valid_output"
+fi
+
+allow

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -87,7 +87,40 @@ Capture `ARG` as the remaining positional. Capture `--playwright` /
 
 ## Default flow
 
-_(Filled by Phase 2 and Phase 3.)_
+### Step 1: Intake
+
+Resolve `ARG` per `intake-routing.md`:
+
+- `#NNN` / `NNN` / `GH-NNNN` → `get_issue(number)`, set `LINKED_ISSUE=NNN`, use the issue title/body as the research question.
+- Free-form string → treat as the research question directly.
+- No `ARG` → prompt: *"I'm ready to research the codebase. Provide a research question, an area of interest, or a `#NNN` issue number."* Wait for the user.
+
+If the user mentions specific files by path, **read them FULLY (no offset/limit) before any sub-agent dispatch**. This is load-bearing — sub-agents lack the main session's context. See `intake-routing.md` § File reading rule.
+
+### Step 2: Knowledge-graph prior art (optional)
+
+If `knowledge_recall` / `knowledge_search` / `knowledge_query_outcomes` MCP tools are available, run the brief-first prior-art dispatch per `research-shapes.md` § Knowledge-graph dispatch shape. Use results to skip dispatching `thoughts-locator` for well-documented topics and to target `thoughts-analyzer` at the highest-relevance documents.
+
+Skip silently if the tools are unavailable — degrade to `thoughts-locator` filesystem scan in Step 3.
+
+### Step 3: Parallel sub-agent dispatch
+
+Consult `research-shapes.md` for the sub-agent palette. Spawn the relevant agents in parallel via multiple `Agent()` calls in a single message:
+
+- `codebase-locator` for WHERE files live.
+- `codebase-analyzer` for HOW components work.
+- `codebase-pattern-finder` for similar implementations to model after.
+- `thoughts-locator` for prior research / plans / reviews / ideas.
+- `thoughts-analyzer` on the top thoughts-locator results.
+- `web-search-researcher` — only when the user explicitly asks for external research.
+
+If `.ralph-repos.yml` exists, read it (via `Read`, not `decompose_feature`), detect multi-repo signals from the question, and pass additional repo dirs to sub-agent prompts per `research-shapes.md` § Cross-repo addendum.
+
+Do NOT pass `team_name` to any sub-agent call. Sub-agents document what IS, not what SHOULD BE — restate the documentarian constraint when delegating in cases where the agent might drift.
+
+### Step 4: Wait + synthesize
+
+Wait for ALL sub-agents to complete before synthesizing. Prioritize live codebase findings as primary; treat thoughts-derived context as historical supplement. Hold the synthesis in the main session for Step 5 review — do not write the doc yet.
 
 ## --mode auto
 

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -152,7 +152,17 @@ Append to the SAME doc. Update frontmatter (`last_updated`, `last_updated_note`)
 
 ## --mode auto
 
-_(Filled by Phase 4.)_
+Autonomous Research-Needed picker. No questions; one issue, locked, researched, advanced. Frontmatter `hooks:` gates the flow (branch-gate, state-gate, postcondition + doc-validator + lock-release on Stop). XS/S only, 15-minute budget.
+
+1. **Branch check** — `git branch --show-current` must be `main`; `branch-gate.sh` also blocks non-allowlisted Bash.
+2. **Select issue** — `ARG=#NNN` → `get_issue`; else `list_issues(profile: "analyst-research", limit: 50)`, filter XS/Small + unblocked (per `intake-routing.md` § Blocker semantics — fetch each blocker, do not infer), pick highest priority. None eligible → exit cleanly.
+3. **Lock + registry + knowledge graph** — `save_issue(workflowState: "__LOCK__", command: "ralph_research")` → read `.ralph-repos.yml` if present (`research-shapes.md` § Cross-repo addendum) → knowledge-graph dispatch (`research-shapes.md` § Knowledge-graph dispatch shape); save `query_id` for Step 7.
+4. **Parallel sub-agent research** — same dispatch as default Step 3, no review picker. Wait for ALL, synthesize.
+5. **Write doc** — per `findings-format.md`. Required: frontmatter, Prior Work, Files Affected (hook-enforced), Detailed Findings. Optional: Pipeline History, Cross-Repo Scope.
+6. **Playwright baseline (conditional)** — per `playwright-baseline.md`, no user prompt. Commit per the autonomous-mode commit step in that reference.
+7. **Commit + push** — `git add ... && git commit -m "docs(research): GH-NNN research findings" && git push origin main`.
+8. **Artifact + advance + outcome** — `create_comment` (artifact per `findings-format.md` § Artifact comment) → `save_issue(workflowState: "__COMPLETE__", command: "ralph_research")` (advances to Ready for Plan) → `knowledge_record_outcome(event_type: "research_completed", ..., query_id: "<from Step 3>")` if available.
+9. **Report** — single block: *Research complete for #NNN: [Title] / Findings: [path] / Status: Ready for Plan / Key recommendation: [one sentence]*.
 
 ## --mode prove
 

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -1,0 +1,106 @@
+---
+description: Investigate a codebase question, a GitHub issue, or a claim. Use whenever
+  the user says "research X", "investigate this", "how does Y work", "find me
+  prior art on Z", hands over an issue number, or asks to "prove" / "verify" a
+  claim. Default flow is interactive (asks for the question, dispatches parallel
+  sub-agents, lets you review findings before writing the doc). --mode auto runs
+  the autonomous Research-Needed picker. --mode prove runs a 5-step knowledge-graph
+  claim investigation that produces a verdict + confidence + evidence chains.
+argument-hint: "[--mode auto|prove] [<question|#NNN|claim>] [--playwright|--no-playwright]"
+context: inline
+model: opus
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=research RALPH_REQUIRED_BRANCH=main"
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/branch-gate.sh"
+  PostToolUse:
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/research-state-gate.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/research-postcondition.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/doc-structure-validator.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/lock-release-on-failure.sh"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Task
+  - Agent
+  - AskUserQuestion
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_expert
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_paths
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_common
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_communities
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_central
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_bridges
+---
+
+# /ralph:research — Research
+
+The unified research verb. Default flow is interactive (collaborative
+codebase investigation with human review before doc write). `--mode auto`
+is the autonomous Research-Needed picker. `--mode prove` is a 5-step
+knowledge-graph claim investigation.
+
+## Mode dispatch
+
+| Mode | Behavior | Equivalent to |
+|---|---|---|
+| (default) | Interactive: question/issue intake → parallel sub-agents → findings review picker → write doc → optional artifact comment | `/ralph-hero:research` |
+| `--mode auto [#NNN]` | Autonomous: pick / lock XS/S Research-Needed issue → research → write findings → advance to Ready for Plan | `/ralph-hero:ralph-research` |
+| `--mode prove "<claim>"` | Knowledge-graph claim investigation: decompose → entities → paths → evidence → verdict | `/ralph-hero:prove-claim` |
+| `--help` / `-h` | Print this table and exit | — |
+
+## Step 0: Parse args
+
+Set `MODE` ∈ `{default, auto, prove}` from `--mode` flag (default if absent).
+Capture `ARG` as the remaining positional. Capture `--playwright` /
+`--no-playwright` overrides. Bail with the mode table on `--help` / `-h`.
+
+## Default flow
+
+_(Filled by Phase 2 and Phase 3.)_
+
+## --mode auto
+
+_(Filled by Phase 4.)_
+
+## --mode prove
+
+_(Filled by Phase 5.)_
+
+## References
+
+- `intake-routing.md` — issue / question / no-args detection, blocker semantics
+- `research-shapes.md` — sub-agent palette, parallel dispatch, knowledge-graph + cross-repo addenda
+- `findings-format.md` — doc frontmatter, section order, Prior Work, Files Affected, per-mode required-sections matrix
+- `playwright-baseline.md` — conditional UI baseline (default + auto modes)
+- `prove-claim.md` — 5-step claim investigation, evidence weighting, confidence calibration, anti-patterns

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -1,24 +1,25 @@
 ---
 description: Investigate a codebase question, a GitHub issue, or a claim. Use whenever
-  the user says "research X", "investigate this", "how does Y work", "find me
-  prior art on Z", hands over an issue number, or asks to "prove" / "verify" a
-  claim. Default flow is interactive (asks for the question, dispatches parallel
-  sub-agents, lets you review findings before writing the doc). --mode auto runs
-  the autonomous Research-Needed picker. --mode prove runs a 5-step knowledge-graph
+  the user says "research X", "investigate this", "look into Y", "dig into Z",
+  "explore the codebase for X", "how does Y work", "trace how X happens", "what
+  does X do", "find me prior art on Z", hands over an issue number (#NNN /
+  GH-NNNN), or asks to "prove" / "verify" / "is it true that" a claim. Default
+  flow is interactive (asks for the question, dispatches parallel sub-agents,
+  lets you review findings before writing the doc). --mode auto runs the
+  autonomous Research-Needed picker. --mode prove runs a 5-step knowledge-graph
   claim investigation that produces a verdict + confidence + evidence chains.
 argument-hint: "[--mode auto|prove] [<question|#NNN|claim>] [--playwright|--no-playwright]"
 context: inline
 model: opus
 hooks:
+  # branch-gate.sh is intentionally not declared here. In the slim plugin it's
+  # patched to no-op when RALPH_REQUIRED_BRANCH is unset, and the autonomous
+  # flow's Step 1 does its own explicit branch check via Bash anyway. Wiring it
+  # in frontmatter would also fire on interactive/prove Bash calls.
   SessionStart:
     - hooks:
         - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=research RALPH_REQUIRED_BRANCH=main"
-  PreToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/branch-gate.sh"
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=research"
   PostToolUse:
     - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
       hooks:
@@ -158,11 +159,14 @@ Autonomous Research-Needed picker. No questions; one issue, locked, researched, 
 2. **Select issue** — `ARG=#NNN` → `get_issue`; else `list_issues(profile: "analyst-research", limit: 50)`, filter XS/Small + unblocked (per `intake-routing.md` § Blocker semantics — fetch each blocker, do not infer), pick highest priority. None eligible → exit cleanly.
 3. **Lock + registry + knowledge graph** — `save_issue(workflowState: "__LOCK__", command: "ralph_research")` → read `.ralph-repos.yml` if present (`research-shapes.md` § Cross-repo addendum) → knowledge-graph dispatch (`research-shapes.md` § Knowledge-graph dispatch shape); save `query_id` for Step 7.
 4. **Parallel sub-agent research** — same dispatch as default Step 3, no review picker. Wait for ALL, synthesize.
+4a. **Refine group dependencies** — skip if single-issue group. Else analyze implementation order from code findings: which issue creates foundational code, which can be parallelized. Update `add_dependency` / `remove_dependency` edges if order differs from initial triage; post a comment on the primary issue summarizing the refined order.
 5. **Write doc** — per `findings-format.md`. Required: frontmatter, Prior Work, Files Affected (hook-enforced), Detailed Findings. Optional: Pipeline History, Cross-Repo Scope.
 6. **Playwright baseline (conditional)** — per `playwright-baseline.md`, no user prompt. Commit per the autonomous-mode commit step in that reference.
 7. **Commit + push** — `git add ... && git commit -m "docs(research): GH-NNN research findings" && git push origin main`.
 8. **Artifact + advance + outcome** — `create_comment` (artifact per `findings-format.md` § Artifact comment) → `save_issue(workflowState: "__COMPLETE__", command: "ralph_research")` (advances to Ready for Plan) → `knowledge_record_outcome(event_type: "research_completed", ..., query_id: "<from Step 3>")` if available.
 9. **Report** — single block: *Research complete for #NNN: [Title] / Findings: [path] / Status: Ready for Plan / Key recommendation: [one sentence]*.
+
+**Escalation triggers (autonomous only):** advance to `workflowState: "Human Needed"` (not "Ready for Plan") when (a) issue scope is M/L/XL on inspection (needs re-estimation or splitting), (b) no relevant codebase patterns can be located after broad search, or (c) sub-agents surface conflicting implementations and you cannot determine the canonical one. State the trigger explicitly in the issue comment so the unblock pipeline has context.
 
 ## --mode prove
 

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -166,7 +166,13 @@ Autonomous Research-Needed picker. No questions; one issue, locked, researched, 
 
 ## --mode prove
 
-_(Filled by Phase 5.)_
+5-step claim investigation over the knowledge graph. No codebase research; no doc write. Produces an inline verdict block. Consult `prove-claim.md` for evidence weighting, confidence calibration, anti-patterns, and the report template.
+
+1. **Decompose** — accept `ARG` as the claim. Break into 2-5 entities + a relationship (`prove-claim.md` § Decomposition).
+2. **Find entity documents** — `knowledge_search(brief: true)` per entity. Record top 3 doc IDs per entity. Prefer `research`/`review` types over `plan`/`idea` at similar relevance.
+3. **Find connections** — `knowledge_paths` / `knowledge_traverse` (filter by `builds_on`/`tensions`/`superseded_by`) / `knowledge_common` between entity-doc pairs. Degradation per `prove-claim.md` § Graceful degradation.
+4. **Read evidence** — `Read` the top 3-5 docs by path. Extract verbatim quotes. Note doc type / date / status. Cap at 5 docs.
+5. **Report** — produce the verdict block per `prove-claim.md` § Report template. No file write.
 
 ## References
 

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -122,6 +122,34 @@ Do NOT pass `team_name` to any sub-agent call. Sub-agents document what IS, not 
 
 Wait for ALL sub-agents to complete before synthesizing. Prioritize live codebase findings as primary; treat thoughts-derived context as historical supplement. Hold the synthesis in the main session for Step 5 review — do not write the doc yet.
 
+### Step 5: Findings review
+
+Display a concise synthesis summary with file refs. `AskUserQuestion` over: *Looks good, write it* / *Go deeper on a topic* / *Correct something*. Loop on the latter two (dispatch targeted sub-agents or incorporate corrections, re-present) until the user approves writing.
+
+### Step 6: Write doc
+
+Gather metadata (`git rev-parse HEAD`, `date +%Y-%m-%d`, `git branch --show-current`) in parallel, then write to `thoughts/shared/research/YYYY-MM-DD-[GH-NNNN-]description.md` per `findings-format.md`. Include `GH-NNNN-` only when `LINKED_ISSUE` is set.
+
+### Step 6.5: Playwright baseline (conditional)
+
+Skip if `--no-playwright`. Otherwise consult `playwright-baseline.md` — detect ralph-playwright, assess frontend relevance, optionally capture baseline and append `## UI Baseline` to the doc.
+
+### Step 7: GitHub permalinks
+
+If on `main` or the commit is pushed, convert local `path:line` references to GitHub permalinks per `findings-format.md` § Permalink format.
+
+### Step 8: Optional artifact comment
+
+If `LINKED_ISSUE` is set or the user asks to link mid-flow: rename the file to include `GH-NNNN-` (insert after the date prefix, zero-pad to 4 digits), update frontmatter (`github_issue`, `github_url`), and post a `## Research Document` comment per `findings-format.md` § Artifact comment.
+
+### Step 9: Next-steps picker
+
+`AskUserQuestion` over: *Create issue from findings* (suggest `/ralph:form <doc-path>`) / *Ask follow-up questions* (Step 10) / *Done* (STOP).
+
+### Step 10: Follow-up handling
+
+Append to the SAME doc. Update frontmatter (`last_updated`, `last_updated_note`). Add `## Follow-up Research [timestamp]` section. Dispatch targeted sub-agents per Step 3. Re-present Step 9 when done.
+
 ## --mode auto
 
 _(Filled by Phase 4.)_

--- a/ralph/skills/research/findings-format.md
+++ b/ralph/skills/research/findings-format.md
@@ -1,3 +1,187 @@
 # Findings format
 
-_Filled by Phase 3._
+Document structure consumed by both interactive and autonomous `/ralph:research` modes. The autonomous flow's `doc-structure-validator.sh` hook enforces a subset of these sections; the interactive flow doesn't enforce but follows the same shape for consistency.
+
+## Filename convention
+
+`thoughts/shared/research/YYYY-MM-DD-[GH-NNNN-]description.md` where:
+
+- `YYYY-MM-DD` is today's date (from `date +%Y-%m-%d`).
+- `GH-NNNN` is the GitHub issue number, zero-padded to 4 digits — present only when linked to an issue.
+- `description` is a brief kebab-case description of the research topic.
+
+Examples:
+
+- With issue: `2026-01-21-GH-0146-ticket-resolution.md`
+- Without issue: `2026-01-21-authentication-flow.md`
+- Rename when linking post-write: `mv 2026-03-06-auth.md 2026-03-06-GH-0042-auth.md` (insert `GH-NNNN-` after the date prefix).
+
+## Frontmatter
+
+```yaml
+---
+date: YYYY-MM-DD
+github_issue: NNN                                       # optional, only if linked
+github_url: https://github.com/OWNER/REPO/issues/NNN    # optional
+topic: "[Research question]"
+tags: [research, codebase, relevant-component-names]    # 2-5 tags, lowercase-hyphenated, reuse existing tags
+status: complete
+type: research
+last_updated: YYYY-MM-DD                                # only on follow-ups (Step 10)
+last_updated_note: "Added follow-up research for X"     # only on follow-ups
+---
+```
+
+## Section order
+
+```markdown
+# Research: [Question / Topic]
+
+## Prior Work
+[builds_on:: / tensions:: wikilinks with evidence weighting — see below]
+
+## Research Question
+[Original user query, verbatim]
+
+## Summary
+[High-level documentation of what was found]
+
+## Detailed Findings
+
+### [Component / Area 1]
+- Description of what exists (`file.ext:line` or [permalink](https://github.com/...))
+- How it connects to other components
+- Current implementation (no evaluation)
+
+### [Component / Area 2]
+...
+
+## Code References
+- `path/to/file.py:123` — Description
+- `another/file.ts:45-67` — Description
+
+## Architecture Documentation
+[Current patterns / conventions / design implementations found in the codebase]
+
+## Historical Context (from thoughts/)
+[Insights from thoughts/ directory with references]
+
+## Related Research
+[Links to other research docs in thoughts/shared/research/]
+
+## Open Questions
+[Areas needing further investigation]
+```
+
+## Prior Work + evidence weighting
+
+The `## Prior Work` section immediately follows the title (before `## Research Question`):
+
+```markdown
+## Prior Work
+
+- builds_on:: [[prior-research-doc]] (research — primary evidence)
+- builds_on:: [[prior-plan-doc]] (plan — describes intent, may not reflect outcome)
+- tensions:: [[conflicting-idea-doc]] (idea — unvetted, but flags a considered alternative)
+```
+
+Evidence-weight qualifiers signal evidence strength:
+
+| Doc type | Weight | Interpretation |
+|---|---|---|
+| `research` | Primary | Verified findings about what exists |
+| `review` | Secondary | Findings validated against actual implementation |
+| `plan` | Weak | Describes intent — may diverge from what was built |
+| `idea` | Weakest | Unvetted thinking, useful as alternative-considered context |
+
+Qualifiers are encouraged on new docs; existing Prior Work entries do not need retroactive annotation. Use filenames without `.md` extension as wikilink targets. If no relevant prior work exists, write `None identified.`.
+
+## Files Affected (required by `--mode auto`)
+
+```markdown
+## Files Affected
+
+### Will Modify
+- `src/auth/middleware.ts` — Add token refresh logic
+- `src/auth/types.ts` — New RefreshToken type
+
+### Will Read (Dependencies)
+- `src/config/auth-config.ts` — Token expiry settings
+- `src/lib/http-client.ts` — Existing request interceptor pattern
+```
+
+Rules:
+
+- Paths are relative to the repo root.
+- `Will Modify` = files this issue creates or changes.
+- `Will Read` = files this issue depends on but won't change.
+- Each path must be backtick-wrapped (`doc-structure-validator.sh` regex: `` `[^`]+` ``).
+- Both subsections required even if empty (use `None` if no files apply).
+- Cross-repo: prefix paths with repo key — `ralph-hero:plugin/ralph-hero/mcp-server/src/lib/repo-registry.ts`, `landcrawler-ai:src/api/client.ts`. Required for downstream work-stream detection.
+
+## Pipeline History (optional, autonomous-only)
+
+```markdown
+## Pipeline History
+Based on outcome_events for component area `[area]`:
+- N total events, X passed, Y failed
+- Average drift count: Z files
+- Estimate accuracy: [summary]
+- Most common blocker: [if patterns emerge]
+```
+
+Populated from `knowledge_query_outcomes` results in autonomous Step 3c. Omit entirely if no outcome data was retrieved. Do not invent data.
+
+## Cross-Repo Scope (optional)
+
+```markdown
+## Cross-Repo Scope
+
+Repos involved:
+- `ralph-hero` (~/projects/ralph-hero) — [what changes are needed]
+- `landcrawler-ai` (~/projects/landcrawler-ai) — [what changes are needed]
+
+Dependency relationship: ralph-hero → landcrawler-ai (landcrawler-ai imports from ralph-hero)
+```
+
+Consumed by plan and impl skills to set up per-repo worktrees and wire `blockedBy` dependencies.
+
+## Permalink format
+
+When converting local file references to permalinks (Step 7), the shape is:
+
+```
+https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/<commit>/<file>#L<line>
+```
+
+Use the commit SHA from `git rev-parse HEAD` at the time the doc was written. Only convert when on `main` or when the commit has been pushed — otherwise the permalink resolves to nothing.
+
+## Artifact comment
+
+When linking the doc to an issue (Step 8 interactive, Step 7 autonomous):
+
+```markdown
+## Research Document
+
+https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/thoughts/shared/research/[filename].md
+
+Key findings: [1-3 line summary of the most important discoveries]
+```
+
+Post via `create_comment(number: NNN, body: ...)`. The `## Research Document` header is load-bearing — downstream tools (hooks, dashboards) discover the doc by grepping for this exact heading.
+
+## Per-mode required-sections matrix
+
+| Section | Default (interactive) | `--mode auto` | `--mode prove` |
+|---|---|---|---|
+| Frontmatter | required | required | n/a (no doc) |
+| Prior Work | required | required | n/a |
+| Research Question | required | required | (Claim instead) |
+| Summary | required | required | (Verdict instead) |
+| Detailed Findings | required | required | (Evidence Chains instead) |
+| Files Affected | recommended | **required** (hook-enforced) | n/a |
+| Pipeline History | optional | optional | n/a |
+| Cross-Repo Scope | optional | optional | n/a |
+| UI Baseline | conditional | conditional | n/a |
+
+`--mode prove` does not write a doc — it produces an inline verdict block per `prove-claim.md` § Report template.

--- a/ralph/skills/research/findings-format.md
+++ b/ralph/skills/research/findings-format.md
@@ -1,0 +1,3 @@
+# Findings format
+
+_Filled by Phase 3._

--- a/ralph/skills/research/findings-format.md
+++ b/ralph/skills/research/findings-format.md
@@ -71,6 +71,8 @@ last_updated_note: "Added follow-up research for X"     # only on follow-ups
 
 ## Open Questions
 [Areas needing further investigation]
+
+## UI Baseline                                      # optional — appended after the main flow when Playwright baseline ran (see playwright-baseline.md)
 ```
 
 ## Prior Work + evidence weighting

--- a/ralph/skills/research/intake-routing.md
+++ b/ralph/skills/research/intake-routing.md
@@ -1,3 +1,46 @@
 # Intake routing
 
-_Filled by Phase 2._
+How `/ralph:research` resolves `ARG` into a research question + optional issue linkage. Consulted by Step 1 of the default flow and Step 2 of `--mode auto`.
+
+## Detection rules
+
+Apply in priority order — first match wins:
+
+1. **Issue-number form** — `ARG` matches one of `#NNN`, `NNN` (digits-only), or `GH-NNNN` (optionally zero-padded). Strip the prefix to get the bare number. Call `get_issue(number)` to fetch full context (title, body, current workflow state, comments, group data). Set `LINKED_ISSUE=NNN`. Use the issue title/body as the research question; the user may refine it interactively.
+
+2. **Free-form question** — `ARG` is any non-empty string not matching the issue-number form and not beginning with `--`. Treat the string as the research question verbatim. `LINKED_ISSUE` is unset.
+
+3. **No `ARG` (default flow only)** — prompt the user: *"I'm ready to research the codebase. Provide a research question, an area of interest, or a `#NNN` issue number."* Wait for input, then re-route through the detection rules above. (Autonomous mode does NOT prompt — it falls through to the picker in `--mode auto` Step 2.)
+
+## File reading rule
+
+If the user mentions specific files by path anywhere in the question (e.g., "how does `src/lib/cache.ts` interact with `query()`?"), read those files FULLY (no `offset` / `limit` arguments) **before** dispatching any sub-agents.
+
+Why this matters:
+
+- Sub-agents do not see the main session's prior reads — each agent starts with empty context.
+- A file the user named is load-bearing for the question. The synthesis in Step 4 needs that content directly, not a sub-agent's summary.
+- Reading the file in the main session also lets you spot specifics (function names, key types) that sharpen the sub-agent prompts in Step 3.
+
+Skip this rule only when the user explicitly says "don't read X yet" or when the named path doesn't exist.
+
+## Blocker semantics (autonomous mode picker)
+
+`--mode auto`'s Step 2 picker filters to unblocked issues. The slim plugin reuses the source rule:
+
+- An issue is blocked only if `blockedBy` points to issues **outside** its group that are not in a Done state.
+- Within-group `blockedBy` is for phase ordering, not blocking — it does not disqualify the issue from selection.
+- For each blocker, you MUST fetch its current workflow state via `get_issue` to determine Done-ness. Do not infer Done from the blocker's title or labels. This is the most common error source in autonomous selection — confirm explicitly.
+
+## Group context
+
+When `get_issue` is called with `includeGroup: true` (the default), the response includes `group` data with `isGroup`, `primary`, `members`, and `totalTickets`. For a multi-issue group, the research will cover the whole group context but a single research document is produced per primary issue. The Step 5 doc generation uses the primary's number for the `GH-NNNN` filename prefix.
+
+## Linked issue lifecycle
+
+When `LINKED_ISSUE` is set:
+
+- Default flow: Step 8 offers the user the choice to post a `## Research Document` artifact comment back on the issue and rename the doc filename to include `GH-NNNN-`.
+- Autonomous mode: the comment and rename are unconditional (no user prompt) — the autonomous flow always posts the artifact and advances the issue.
+
+If the user provides an inline question and then asks mid-flow to link it to an issue, route through the Step 8 path (rename + comment + frontmatter update) — see `findings-format.md` § Filename convention.

--- a/ralph/skills/research/intake-routing.md
+++ b/ralph/skills/research/intake-routing.md
@@ -4,7 +4,7 @@ How `/ralph:research` resolves `ARG` into a research question + optional issue l
 
 ## Detection rules
 
-Apply in priority order — first match wins:
+Apply in priority order — first match wins. Detection rules 1-3 run only when `MODE ∈ {default, auto}`. In `--mode prove`, `ARG` is treated **verbatim** as the claim string regardless of any leading `#NNN` / `GH-NNNN` substring — skip the issue-number rule entirely.
 
 1. **Issue-number form** — `ARG` matches one of `#NNN`, `NNN` (digits-only), or `GH-NNNN` (optionally zero-padded). Strip the prefix to get the bare number. Call `get_issue(number)` to fetch full context (title, body, current workflow state, comments, group data). Set `LINKED_ISSUE=NNN`. Use the issue title/body as the research question; the user may refine it interactively.
 

--- a/ralph/skills/research/intake-routing.md
+++ b/ralph/skills/research/intake-routing.md
@@ -1,0 +1,3 @@
+# Intake routing
+
+_Filled by Phase 2._

--- a/ralph/skills/research/playwright-baseline.md
+++ b/ralph/skills/research/playwright-baseline.md
@@ -1,3 +1,113 @@
 # Playwright baseline
 
-_Filled by Phase 3._
+Conditional UI baseline capture. Consulted by default-flow Step 6.5 and autonomous-flow Step 5.5. Skipped entirely when `--no-playwright` is set in args.
+
+## Detection
+
+1. Read `~/.claude/plugins/installed_plugins.json`.
+2. Check for a key containing `ralph-playwright` (e.g., `ralph-playwright@ralph-hero`).
+3. If not found and `--playwright` is not forced: skip silently — ralph-playwright is not installed.
+
+## Frontend-relevance heuristic
+
+If `--playwright` is set in args: always treat as frontend-relevant; skip the heuristic.
+
+Otherwise, assess the research findings just written. Signals:
+
+- Affected file types: `.tsx`, `.jsx`, `.css`, `.html`, `.vue`, `.svelte`.
+- Component / page / route directories.
+- UI / UX / visual / layout / accessibility concerns in the question or findings.
+
+If none of these signals match: skip baseline capture.
+
+## User prompt (interactive mode only)
+
+Before starting the dev server, ask:
+
+```
+This research involves frontend changes and ralph-playwright is installed.
+Would you like me to capture a UI baseline? This establishes:
+- Current accessibility violation count (for regression detection)
+- Key user flow state (screenshots + accessibility snapshots)
+- Available tooling (Storybook, Chromatic, existing user stories)
+
+I'll need to start the dev server. [Y/n]
+```
+
+Autonomous mode skips this prompt and proceeds when the heuristic matches.
+
+## Dev-server lifecycle
+
+Resolve the start command in priority order:
+
+1. Env var `RALPH_PLAYWRIGHT_DEV_CMD`.
+2. Memory — check whether a prior conversation saved the dev command for this project.
+3. Auto-detect from `package.json` — `dev`, `start`, or `serve` script.
+
+Start the dev server in the background: `Bash(command, run_in_background=true)`. Poll for readiness:
+
+```
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>
+```
+
+Every 2 seconds, timeout 30 seconds. If the dev server fails to start: log warning, skip baseline, continue with the rest of the flow — do not block the research.
+
+If this is the first successful auto-detection, offer to remember the command: *"Want me to remember `<command>` as this project's dev server for future sessions?"* Save to memory on yes.
+
+Teardown: use `RALPH_PLAYWRIGHT_DEV_TEARDOWN_CMD` if set; otherwise kill the background process PID.
+
+## Explorer-agent dispatch
+
+```
+Agent(
+  subagent_type="ralph-playwright:explorer-agent",
+  prompt="Explore http://localhost:<port> with goal: capture accessibility baseline and key user flows. Focus on routes identified in this research: [routes from findings]. Take accessibility snapshots at each page. Session: <date>-baseline-GH-<NNN>",
+  description="UI baseline GH-<NNN>"
+)
+```
+
+## Tooling detection (in parallel with explorer-agent)
+
+- `playwright-stories/` directory existence + file count: `ls playwright-stories/*.yaml 2>/dev/null | wc -l`
+- Storybook: `grep -E "@storybook/addon-vitest|@storybook/test-runner" package.json`
+- Visual regression: `grep -E "chromatic|@applitools" package.json`
+
+## Journey-trace synthesis
+
+After the explorer-agent completes, read the trace at `.playwright-cli/<session>/journey-trace.yaml`. Append a `## UI Baseline` section to the research doc:
+
+```markdown
+## UI Baseline
+
+**Captured**: YYYY-MM-DD
+**Dev server**: `<resolved command>` (port <port>)
+**Routes scanned**: /route1, /route2, ...
+
+### Accessibility
+- Total violations: N
+- Critical: N, Serious: N, Moderate: N
+- Categories: [category (count), ...]
+- Full report: [journey trace](.playwright-cli/<session>/journey-trace.yaml)
+
+### Flow State
+- Entry point: /route
+- Key flows: flow1 → flow2 → ...
+- Screenshots: [screenshots](.playwright-cli/<session>/)
+
+### Tooling Detected
+- Storybook: yes/no (addon name if yes)
+- Visual regression: chromatic / applitools / none
+- Existing user stories: N files in playwright-stories/
+```
+
+## Autonomous-mode commit
+
+In `--mode auto`, after appending the `## UI Baseline` section, commit the updated doc:
+
+```bash
+git add thoughts/shared/research/...
+git commit -m "docs(research): add UI baseline for GH-NNN"
+git push origin main
+```
+
+Interactive mode does NOT commit on the user's behalf — the doc-write commit (if any) is the user's call.

--- a/ralph/skills/research/playwright-baseline.md
+++ b/ralph/skills/research/playwright-baseline.md
@@ -1,0 +1,3 @@
+# Playwright baseline
+
+_Filled by Phase 3._

--- a/ralph/skills/research/prove-claim.md
+++ b/ralph/skills/research/prove-claim.md
@@ -1,6 +1,8 @@
 # Prove-claim investigation
 
-5-step evidence reasoning over the knowledge graph. Consulted by `/ralph:research --mode prove`. The skill does not write a doc — it produces an inline verdict report. Do not speculate beyond the documents.
+5-step evidence reasoning over the knowledge graph. Consulted by `/ralph:research --mode prove`. The skill does not write a doc — it produces an inline verdict report.
+
+You are an evidence-based investigator. Given a claim, systematically search the knowledge graph, trace document connections, read primary sources, and produce a structured verdict. **Do not speculate beyond what the documents say.**
 
 ## Evidence weighting
 

--- a/ralph/skills/research/prove-claim.md
+++ b/ralph/skills/research/prove-claim.md
@@ -1,0 +1,3 @@
+# Prove-claim investigation
+
+_Filled by Phase 5._

--- a/ralph/skills/research/prove-claim.md
+++ b/ralph/skills/research/prove-claim.md
@@ -1,3 +1,130 @@
 # Prove-claim investigation
 
-_Filled by Phase 5._
+5-step evidence reasoning over the knowledge graph. Consulted by `/ralph:research --mode prove`. The skill does not write a doc — it produces an inline verdict report. Do not speculate beyond the documents.
+
+## Evidence weighting
+
+Before investigating, understand which document types carry what evidentiary weight:
+
+| Type | Weight | Interpretation |
+|---|---|---|
+| `research` | Primary | Findings, prior art, discovered facts, decisions made. Strongest evidence of what is true or was decided. |
+| `review` | Secondary | Post-implementation observations. May confirm or contradict plans. More reliable than plans for "did it work?" questions. |
+| `plan` | Weak | Intended future state. A plan describing Feature X does NOT prove Feature X exists or works. Plans describe intent, not reality. |
+| `idea` | Weakest | Unvetted proposals. May never have been acted on. Use only to establish that a concept was considered. |
+
+Always qualify conclusions by the document type of the supporting evidence.
+
+## Decomposition
+
+Accept the claim as a string argument. Break it into 2-5 entities and the relationship to investigate.
+
+- **Entities**: concept names, document topics, technical terms, or system components likely to appear in documents in the knowledge base.
+- **Relationship**: what the claim asserts connects those entities (e.g., "A caused B", "A supersedes B", "A was decided because of B").
+
+Write out:
+
+```
+Claim: [original claim]
+Entities: [e1, e2, ...]
+Relationship to investigate: [...]
+Search terms per entity: [what to search for each]
+```
+
+## Step-by-step workflow detail
+
+### Step 1: Decompose the claim
+
+As above. Lock in entities + relationship before any search.
+
+### Step 2: Find entity documents
+
+For each entity:
+
+1. `knowledge_search(query: "<entity>", brief: true)` — try a specific term first; if zero results, broaden to related concepts.
+2. Record the top 3 document IDs per entity. Prefer `research` and `review` over `plan` and `idea` at similar relevance.
+3. If an entity produces zero matches after two attempts with different terms, note *"no documents found for [entity]"* and continue — this factors into the confidence score.
+
+### Step 3: Find connections
+
+For each pair of entity documents:
+
+1. `knowledge_paths(source, target)` — assess path quality. A path through topically relevant docs is stronger than one through generic hub nodes. Shorter relevant paths beat longer ones.
+2. `knowledge_traverse(start_doc, depth: 3, types: [builds_on, tensions, superseded_by])` from each entity doc in both `outgoing` and `incoming` directions — find direct typed connections.
+3. `knowledge_common(doc_a, doc_b)` — shared neighbors. Bridge documents that may explain the relationship.
+
+### Step 4: Read evidence
+
+Select the top 3-5 documents from the strongest paths and connections.
+
+For each selected document:
+
+1. `Read` the file at the `path` field from search results. Retrieve full content.
+2. Extract specific quotes that directly support or contradict the claim. Quotes must be verbatim, not paraphrased.
+3. Note the doc's type, date, and any status field (draft / approved / complete / superseded).
+
+Cap at 5 documents. If the top docs are all `plan` type, note the evidence weakness explicitly.
+
+### Step 5: Report
+
+Produce the structured verdict report. Do not speculate beyond the evidence. If evidence is sparse, say so.
+
+## Confidence calibration
+
+| Range | Meaning | Typical evidence profile |
+|---|---|---|
+| 0.8 – 1.0 | High | Multiple corroborating `research` documents with direct quotes; typed edges directly linking the entities; no contradicting documents found |
+| 0.5 – 0.7 | Medium | Some supporting evidence but gaps; key support from `review` or indirect paths; one weak contradicting signal |
+| 0.2 – 0.4 | Low | Sparse evidence; support mostly from `plan` or `idea` documents; long indirect paths; no direct typed relationships |
+| 0.0 – 0.1 | Insufficient | No meaningful evidence found; all entity searches failed; paths exist but intermediary documents are topically unrelated to the claim |
+
+## Anti-patterns
+
+1. **Community co-membership is not evidence.** Two documents appearing in the same Louvain community means they are structurally nearby in the graph — not that they are semantically related to the claim. Always read the actual documents.
+2. **Hub-node paths are weak.** If a path between two entity documents passes through a document with many connections (high betweenness), the path may be incidental. Prefer paths through documents whose titles and content are topically relevant.
+3. **Plan documents are not proof of reality.** A `plan` describing "Feature X will be implemented using approach Y" is evidence of intent, not outcome. Do not conclude Feature X works that way unless a `research` or `review` document confirms it.
+4. **Path existence is not evidence.** Finding a graph path between A and B does not confirm the claim. Read the documents on the path and verify the connection is semantically relevant.
+5. **Paraphrase is not evidence.** Only verbatim quotes from document content count. Summaries from search results are discovery aids, not proof.
+
+## Graceful degradation
+
+- **Graph-algorithm tools unavailable** (`knowledge_paths` / `knowledge_common` return tool-not-found): fall back entirely to `knowledge_traverse` with `builds_on`/`tensions`/`superseded_by` at depth 3 from each entity document. Supplement with `knowledge_search` using combined entity terms (e.g., `"entity1 entity2"`). Note in the report: *"Graph path analysis unavailable — results based on typed relationship traversal only."*
+- **Brief mode unsupported** (`brief: true` parameter rejected): proceed with full content results but cap each entity search at 5 results to manage context. Read titles and dates from results before deciding which to read in full.
+- **Entity searches return zero documents**: try 2-3 alternative search terms (synonyms, related concepts, abbreviated names). If still nothing: note the entity as *"not found in corpus"* and explain what was searched. Do not invent connections to compensate for missing documents — report *"insufficient evidence"*.
+- **Paths exist but intermediaries are unrelated**: report these paths as structurally present but semantically weak. Do not count path existence toward confidence; count only after reading and confirming relevance.
+
+## Report template
+
+```markdown
+## Claim Investigation Report
+
+**Claim**: [original claim]
+
+**Verdict**: [supported | contradicted | partially supported | insufficient evidence]
+
+**Confidence**: [0.0 – 1.0] — [brief calibration note]
+
+### Evidence Chains
+
+[For each supporting or contradicting piece:]
+- **Document**: [title] ([type], [date]) — [path]
+  > "[verbatim quote]"
+  **Relevance**: [one sentence on why this quote bears on the claim]
+
+### Document Type Qualifications
+
+[Note if key evidence comes from weak document types:]
+- [e.g., "The primary evidence is from plan documents, which describe intent not reality. No research documents confirm the outcome."]
+
+### Graph Connection Summary
+
+[Describe the structural relationship found — direct typed edge, multi-hop path, shared neighbors — and assess its strength relative to the claim.]
+
+### Caveats
+
+[List limitations: missing documents, failed searches, evidence gaps, alternative interpretations. Be specific.]
+
+### What Would Change This Verdict
+
+[State what additional evidence would shift the verdict and where it might be found.]
+```

--- a/ralph/skills/research/research-shapes.md
+++ b/ralph/skills/research/research-shapes.md
@@ -1,3 +1,78 @@
 # Research shapes
 
-_Filled by Phase 2._
+Sub-agent palette + dispatch patterns for `/ralph:research`. Consulted by Step 3 (default flow), Step 4 (autonomous flow), and Step 2 of `--mode prove` (only the knowledge-graph subset).
+
+## Sub-agent palette
+
+| Agent | Role | When to dispatch |
+|---|---|---|
+| `ralph-hero:codebase-locator` | Find WHERE files / components for a topic live | Always, when the question touches code |
+| `ralph-hero:codebase-analyzer` | Understand HOW a specific component works (no critique) | Always, when the question is "how does X work" |
+| `ralph-hero:codebase-pattern-finder` | Find similar implementations to model after | When researching a feature or refactor that needs precedent |
+| `ralph-hero:thoughts-locator` | Discover existing research / plans / reviews / ideas | Always — historical context matters |
+| `ralph-hero:thoughts-analyzer` | Extract key decisions / constraints / open questions from prior docs | When `thoughts-locator` returns documents worth deep-reading |
+| `ralph-hero:web-search-researcher` | External documentation, best practices, APIs | Only when the user explicitly asks for external research; instruct the agent to return LINKS |
+
+## Parallel dispatch rule
+
+Dispatch all relevant agents **in a single message** via multiple `Agent()` tool calls. They run in parallel. Wait for ALL to complete before synthesizing — never proceed on partial results.
+
+Do NOT pass `team_name` to any sub-agent call. Sub-agents must run outside any team context (ADR-001 — team isolation).
+
+## Documentarian-not-critic constraint
+
+Sub-agents document what IS, not what SHOULD BE. The agents themselves are coded to follow this rule, but restate the constraint in the dispatch prompt whenever you suspect the model might drift (e.g., when researching a known-problematic component the model might be tempted to flag instead of describe).
+
+Phrasing that works: *"Document the current implementation without suggesting improvements or identifying issues. Map what exists, where it lives, and how it connects."*
+
+## Knowledge-graph dispatch shape
+
+When the ralph-knowledge MCP tools are available, run prior-art discovery before the parallel sub-agent dispatch (Step 2 in default flow, Step 3c/3d in autonomous flow). Brief-first pattern keeps context tight.
+
+```
+knowledge_recall(query="<topic>", role="researcher", type="research", brief=true)
+knowledge_recall(query="<topic>", role="researcher", type="plan",     brief=true)
+knowledge_query_outcomes(component_area="<area>", aggregate=true)  # if a component area is identifiable
+knowledge_expert(domain="<domain>", issue_number=<NNN>, limit=5, recency_window_days=30)  # autonomous mode only; save the returned query_id for Step 8 outcome recording
+```
+
+Use results to:
+
+- Skip dispatching `thoughts-locator` for topics already comprehensively covered by prior research.
+- Target `thoughts-analyzer` at gap areas not covered by prior-art results.
+- Include outcome trends in the research doc's Prior Work / Pipeline History sections.
+
+If knowledge tools return zero results, broaden search terms (remove qualifiers, drop component prefixes), then fall back to `thoughts-locator` filesystem scan. Do NOT skip sub-agent dispatch on the basis of an empty knowledge result alone — the graph may be stale or sparsely indexed.
+
+## Cross-repo addendum
+
+If `.ralph-repos.yml` exists at the repo root, the issue may span multiple repos. Read the file (via `Read`, not `decompose_feature`) and parse the YAML for `localDir` paths and `pattern` definitions.
+
+Signals that the issue is cross-repo:
+
+- The issue body references files in other repos (e.g., "update the MCP server" when researching a skill issue).
+- The body mentions repo names from the registry.
+- Import paths or package references map to other repos.
+
+When cross-repo scope is detected:
+
+1. Pass the additional repo directories to sub-agents in their spawn prompts. Example:
+   ```
+   Additional repo directories to search:
+   - ralph-hero: ~/projects/ralph-hero
+   - landcrawler-ai: ~/projects/landcrawler-ai
+   ```
+2. Sub-agents use standard `Read`, `Grep`, `Glob` against those paths — no new tooling.
+3. For autonomous mode: also run a cross-repo dependency-detection pass. Grep for import/require statements referencing each repo's package name across the other repos. Compare against the registry's `dependency-flow` edges. Flag discrepancies in the research doc under `## Dependency Discrepancy`.
+4. File paths in the doc's `## Files Affected` section use the repo-qualified form (`ralph-hero:src/...`, `landcrawler-ai:src/...`) per `findings-format.md`.
+
+If `.ralph-repos.yml` does not exist, proceed in single-repo mode — no special handling.
+
+## Graceful degradation
+
+| Failure mode | Fallback |
+|---|---|
+| Knowledge MCP unavailable | Skip Step 2 / Step 3c entirely; rely on `thoughts-locator` filesystem scan. Add footnote to doc Prior Work: *"Knowledge graph unavailable — prior work discovery via file scan only."* |
+| `knowledge_recall` returns zero results | Broaden terms; fall back to grep over `thoughts/`. Do NOT skip sub-agent dispatch. |
+| `knowledge_expert` unavailable or no domain extractable | Skip silently. Note in doc if recurring per-domain gaps emerge. |
+| Web research requested but `web-search-researcher` agent unavailable | Run `WebSearch` / `WebFetch` directly from the main session; ensure links are captured in the doc. |

--- a/ralph/skills/research/research-shapes.md
+++ b/ralph/skills/research/research-shapes.md
@@ -1,0 +1,3 @@
+# Research shapes
+
+_Filled by Phase 2._

--- a/thoughts/shared/plans/2026-05-23-GH-1362-ralph-plan-3-research.md
+++ b/thoughts/shared/plans/2026-05-23-GH-1362-ralph-plan-3-research.md
@@ -113,7 +113,7 @@ After Plan 3 merges:
 - **Not** porting cross-repo dependency detection (autonomous Step 3b) into a top-level reference. It's mode-specific (auto only) and infrequent; lives as a section in `research-shapes.md` consulted conditionally.
 - **Not** adding a hook to validate prove-mode verdicts. The verdict format is opinion-content (in `prove-claim.md`); enforcing it in a hook would be P5 violation (references are content, not control flow).
 - **Not** absorbing `idea-hunt`. Per spec, `idea-hunt` is excluded from the new plugin.
-- **Not** sunsetting source skills. They remain functional for the 2-week dogfooding window. Plan 10 owns sunset.
+- **Not** sunsetting source skills. They remain functional alongside the new verb until Plan 10 batches sunsets after each new counterpart has handled the surfaces it replaces.
 
 ## Implementation Approach
 
@@ -492,7 +492,7 @@ Update the `## Status` paragraph to "Plan 3 of 11 (research shipped). This plugi
 #### 2. Friction-log entry on the spec
 
 **File**: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md`
-**Changes**: Append a `### Plan 3: /ralph:research (shipped YYYY-MM-DD)` subsection under `## Friction Log`. Capture final-shape stats, design calls (5-reference threshold, SKILL.md `hooks:` frontmatter pattern), TODO checkboxes for the 2-week dogfooding window.
+**Changes**: Append a `### Plan 3: /ralph:research (shipped YYYY-MM-DD)` subsection under `## Friction Log`. Capture final-shape stats, design calls (5-reference threshold, SKILL.md `hooks:` frontmatter pattern), TODO checkboxes for active-use observations.
 
 #### 3. Parity validation runs
 
@@ -553,7 +553,7 @@ Per Phase 6's verification list, plus:
 
 ## Migration Notes
 
-- Source skills (`research`, `ralph-research`, `prove-claim`) remain functional and unmodified for the 2-week dogfooding window. Plan 10 owns sunset.
+- Source skills (`research`, `ralph-research`, `prove-claim`) remain functional and unmodified alongside the new verb. Plan 10 batches sunsets once each new counterpart has handled the surfaces it replaces.
 - The auto-flow hooks (research-state-gate, research-postcondition, doc-structure-validator, branch-gate, lock-release-on-failure) are duplicated across the source and slim plugins during the migration window. Both ports gate on identical env vars, so duplicate firing is idempotent (each checks its own preconditions independently). Plan 10 deletes the source copies.
 - Plan 4 (`/ralph:plan`) and Plan 5 (`/ralph:impl`) will reuse the SKILL.md `hooks:` frontmatter pattern introduced here. Plan 3's friction log should record whether the pattern worked cleanly or hit harness quirks.
 - The Step 10 follow-up flow in default mode updates the SAME doc with `last_updated` frontmatter — this is the "append-only follow-up research" pattern from source. The Plan 2 `/ralph:form` handoff lands users at Plan 3's interactive flow, so the doc lifecycle here is shared with form.

--- a/thoughts/shared/plans/2026-05-23-GH-1362-ralph-plan-3-research.md
+++ b/thoughts/shared/plans/2026-05-23-GH-1362-ralph-plan-3-research.md
@@ -1,0 +1,576 @@
+---
+date: 2026-05-23
+status: draft
+type: plan
+tags: [ralph, plugin-restructure, research, prove-claim, migration, plan-of-plans]
+github_issue: 1362
+github_issues: [1362]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/1362
+primary_issue: 1362
+---
+
+# Plan 3: `/ralph:research` — Research Verb Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-05-22-ralph-slim-plugin-restructure]]
+- builds_on:: [[2026-05-23-GH-1357-ralph-plan-1-catch-up]] — validated the scaffold + flat-sibling references + cross-plugin MCP pattern.
+- builds_on:: [[2026-05-23-GH-1359-ralph-plan-2-form.md]] — validated the multi-surface fold (6 surfaces in one verb at 186 lines) and confirmed the "4 references is the upper end" heuristic. Plan 3 has 5 references; first plan to exceed that bar.
+- builds_on:: PR #1361 (Plan 2 form implementation, branch `feature/GH-1359-form`)
+
+## Overview
+
+Fold three existing `ralph-hero` skills (`research`, `ralph-research`, `prove-claim`) into one user-facing slash command `/ralph:research` in the new `ralph/` plugin. The default surface is the interactive research flow (today's `/ralph-hero:research` — ask for question or issue, dispatch parallel sub-agents, surface findings to the user for review, write doc, optional artifact comment + next-steps picker). `--mode auto` is today's autonomous `/ralph-hero:ralph-research` flow (pick XS/S issue from "Research Needed", lock, research, write findings, advance to "Ready for Plan", no questions). `--mode prove "<claim>"` is today's `/ralph-hero:prove-claim` (5-step structured claim investigation over the knowledge graph, produces a verdict + confidence + evidence-chain report).
+
+This is the third lifecycle migration plan (after catch-up and form). It is the first verb that exercises:
+
+- **Per-skill hooks in SKILL.md frontmatter** (the autonomous flow needs `research-state-gate.sh`, `research-postcondition.sh`, `doc-structure-validator.sh`, `branch-gate.sh`, `lock-release-on-failure.sh`). The interactive and prove modes do not invoke these — hooks are scoped to `--mode auto`.
+- **Five reference siblings** (Plan 2's friction log flagged four as the comfort upper-bound). The fifth is `prove-claim.md`, which is a structurally distinct sub-flow with its own evidence-weighting, confidence-calibration, and anti-patterns content.
+- **Conditional Playwright baseline integration** (used by default + auto flows when ralph-playwright is installed and the work is frontend-relevant).
+
+The plan-of-plans positions Plan 3 as "medium risk — first lifecycle verb with well-defined I/O; exercises subagent dispatch via `Skill()`/`Agent()`."
+
+## Current State Analysis
+
+Three source skills total **1,089 lines** of SKILL.md prose:
+
+| Source | Lines | Shape | Side effects | Model |
+|---|---|---|---|---|
+| `plugin/ralph-hero/skills/research/SKILL.md` | 406 | Interactive: question/issue intake → parallel Agent dispatch → human review picker → write doc → optional artifact comment → next-steps picker | Writes research doc; optional issue comment | opus |
+| `plugin/ralph-hero/skills/ralph-research/SKILL.md` | 506 | Autonomous: pick XS/S Research-Needed issue → lock → registry lookup → knowledge-graph prior-art → parallel Agent dispatch → write findings → advance to Ready for Plan | Writes research doc; **writes** to project board (lock + advance) | sonnet |
+| `plugin/ralph-hero/skills/prove-claim/SKILL.md` | 177 | 5-step: decompose claim → find entity docs → trace graph paths → read evidence → produce verdict + confidence + evidence chains | Read-only over knowledge graph | opus |
+
+The autonomous flow (`ralph-research`) has five hook scripts under `plugin/ralph-hero/hooks/scripts/` (total 292 lines):
+
+| Hook | Trigger | Job |
+|---|---|---|
+| `research-state-gate.sh` | PostToolUse on `ralph_hero__get_issue` | Validate the fetched issue is in a state allowed for research-lock (default: "Research Needed") |
+| `research-postcondition.sh` | Stop | Verify a research doc with the locked ticket ID was written in the last 30 min |
+| `doc-structure-validator.sh` | Stop | Validate required sections in the generated doc — frontmatter, Prior Work, Files Affected |
+| `branch-gate.sh` | PreToolUse on Bash | Refuse non-allowlisted git commands while the autonomous flow is on a non-main branch |
+| `lock-release-on-failure.sh` | Stop | Release the workflow lock if research failed mid-flow (returns issue to "Research Needed") |
+
+Each script gates on `RALPH_COMMAND` and/or `RALPH_TICKET_ID` env vars (set by the SessionStart hook), so they no-op when the autonomous flow is not active. That's exactly the property we need to scope them to `--mode auto`.
+
+Plan 2's `ralph/` plugin state at start of Plan 3:
+
+- `ralph/skills/{catch-up,form}/` shipped (Plan 1 + Plan 2).
+- `ralph/hooks/hooks.json` declares one plugin-wide SessionStart (`set-skill-env.sh`) and one plugin-wide PostToolUse (`cursor-advance-catch-up.sh` on recent_activity).
+- `ralph/hooks/scripts/{set-skill-env.sh, cursor-advance-catch-up.sh, hook-utils.sh}` ported from the source plugin.
+- No per-skill SKILL.md `hooks:` frontmatter used yet. Plan 3 introduces this pattern (skills CAN declare hooks; only agents are restricted per `ralph-hero/CLAUDE.md`).
+
+### Key Discoveries
+
+- **The three modes are structurally separable.** Interactive flow asks for input + uses AskUserQuestion for finding review. Autonomous flow picks an issue, locks, never asks. Prove-claim accepts a single claim string + does no codebase research. Sharing the workflow body is wasteful; a `--mode` dispatcher with distinct sub-flows is cleaner.
+- **The interactive Step 6 (AskUserQuestion findings review) and Step 10 (next-steps picker) are the load-bearing UX in `research`.** They survive verbatim into the default-mode body.
+- **`ralph-research` Step 3c-3d (knowledge-graph prior art + domain expert primer)** is structurally identical to `research` Step 2.5. Both should consult the same `research-shapes.md` reference for the knowledge-graph dispatch shape, with the distinction (autonomous never asks, interactive may surface to user) carried in the workflow body, not the reference.
+- **`prove-claim`'s 5-step workflow is its own animal.** It does NOT invoke codebase-locator/analyzer agents — it lives entirely in the knowledge graph. Evidence weighting, confidence calibration, and anti-patterns are stable content that move verbatim into `prove-claim.md`.
+- **`research-postcondition.sh` and `doc-structure-validator.sh` both fire on Stop.** They depend on `RALPH_TICKET_ID` (set by the autonomous flow's lock step) and `RALPH_COMMAND=research`. Interactive flow never sets these env vars; prove-mode doesn't either. So porting the hooks to fire on Stop is safe even though Stop fires for every mode — the hooks themselves are guarded.
+- **`branch-gate.sh` only fires when `RALPH_REQUIRED_BRANCH` is set.** Same gating pattern.
+- **Playwright baseline (Step 6.5 in interactive / Step 7.5 in autonomous) is shared.** Move into `playwright-baseline.md` — both modes consult the same reference for dev-server lifecycle + journey-trace synthesis + tooling detection.
+- **No shared code between research and form/catch-up.** The cross-plugin MCP tools used (`get_issue`, `save_issue`, `list_issues`, `create_comment`) are also used by form's intake, so the cross-plugin pattern is established. No new MCP tools needed.
+- **Cross-repo registry lookup** (autonomous Step 3a, `.ralph-repos.yml`) is a real production feature. Port into `research-shapes.md` as an optional section consulted only when the issue may span multiple repos.
+- **Outcome recording (`knowledge_record_outcome`) is autonomous-only.** The interactive flow does not advance state or record outcomes — the human owns those transitions. Keeps the autonomous-mode body distinct.
+- **The `## Files Affected` section is autonomous-flow-validated** (by `doc-structure-validator.sh`). Interactive flow does not require it. So findings-format.md must call out which sections are required by which mode.
+
+## Desired End State
+
+After Plan 3 merges:
+
+1. `/ralph:research` is discoverable in any fresh Claude Code session under the ralph plugin.
+2. `/ralph:research` with no args prompts the user for a research question or issue number, mirroring today's `/ralph-hero:research` interactive flow.
+3. `/ralph:research "<question>"` runs the interactive flow on the question.
+4. `/ralph:research #NNN` (or `NNN`) fetches the issue and uses its title/body as the research question; supports linking back via artifact comment in Step 9.
+5. `/ralph:research --no-playwright` (or `--playwright`) overrides the Playwright baseline detection.
+6. `/ralph:research --mode auto [#NNN]` runs the autonomous flow: picks an XS/S issue in "Research Needed" (or uses the explicit issue), locks it, researches, writes findings, advances to "Ready for Plan". No human questions. The five autonomous hooks gate the flow.
+7. `/ralph:research --mode prove "<claim>"` runs the 5-step claim investigation: produces a verdict (supported / contradicted / partially supported / insufficient evidence), confidence score, and evidence chains with verbatim quotes. No codebase research, knowledge-graph only.
+8. `/ralph:research --help` / `-h` prints the mode table.
+9. Old `ralph-hero:*` skills (`research`, `ralph-research`, `prove-claim`) remain functional and untouched. Sunset is Plan 10.
+10. `ralph/skills/research/SKILL.md` is ≤ 200 lines (target ~170 — the multi-mode dispatcher carries more workflow than catch-up/form).
+11. Opinion content lives in five flat-sibling reference files: `intake-routing.md`, `research-shapes.md`, `findings-format.md`, `prove-claim.md`, `playwright-baseline.md`.
+12. SKILL.md `hooks:` frontmatter declares five hooks scoped to `--mode auto` only (state gate, postcondition, doc validator, branch gate, lock release).
+13. `ralph/README.md` migration table shows Plan 3 as "shipped".
+14. Friction-log entry appended to the spec doc.
+
+### Verification
+
+- `/plugin marketplace update ralph-hero && /reload-plugins` discovers `/ralph:research` without errors.
+- Three real interactive `/ralph:research` invocations: one with a free-form question, one with an issue number, one mid-flow correction via the Step 6 picker.
+- One `/ralph:research --mode auto` invocation against a real XS issue in "Research Needed" — verify lock, doc, advance to "Ready for Plan", outcome recording.
+- One `/ralph:research --mode prove "<claim>"` invocation — verify verdict shape, confidence calibration, evidence chains.
+- `wc -l ralph/skills/research/SKILL.md` reports ≤ 200.
+- Five reference siblings present, each non-stub.
+- Old `/ralph-hero:research`, `/ralph-hero:ralph-research`, `/ralph-hero:prove-claim` still work unchanged.
+- `ralph/hooks/scripts/{research-state-gate,research-postcondition,doc-structure-validator,branch-gate,lock-release-on-failure}.sh` present and executable.
+
+## What We're NOT Doing
+
+- **Not** porting `remember-turn.sh` (the source ralph-research Stop hook). It's a memory-tier writer that depends on host-process memory paths; that's substrate concern, not verb concern. Plan 3 leaves memory writes to the catch-up cursor model and the dream-loop pipeline.
+- **Not** consolidating the knowledge-graph step body across interactive and autonomous modes into a shared step block. The two modes legitimately differ (interactive may skip, autonomous always runs). Keep them in separate workflow sections; share only the reference.
+- **Not** introducing a `--mode interactive` flag. Default is interactive; `--mode auto` / `--mode prove` are the explicit non-defaults. Mirrors `/ralph:form`'s `--mode draft` shape (default + one alternative).
+- **Not** changing the doc filename convention (`YYYY-MM-DD-GH-NNNN-description.md`). Keeps Plan 10 sunset trivial.
+- **Not** porting cross-repo dependency detection (autonomous Step 3b) into a top-level reference. It's mode-specific (auto only) and infrequent; lives as a section in `research-shapes.md` consulted conditionally.
+- **Not** adding a hook to validate prove-mode verdicts. The verdict format is opinion-content (in `prove-claim.md`); enforcing it in a hook would be P5 violation (references are content, not control flow).
+- **Not** absorbing `idea-hunt`. Per spec, `idea-hunt` is excluded from the new plugin.
+- **Not** sunsetting source skills. They remain functional for the 2-week dogfooding window. Plan 10 owns sunset.
+
+## Implementation Approach
+
+Six XS-sized phases, each owning a tightly-scoped file set:
+
+1. **Scaffold + dispatch skeleton** owns: `ralph/skills/research/SKILL.md` (stub with frontmatter + mode-dispatch table + Step 0 arg parse), five empty reference stubs, `ralph/hooks/scripts/{research-state-gate,research-postcondition,doc-structure-validator,branch-gate,lock-release-on-failure}.sh` ports.
+2. **Default flow — intake + parallel research** owns: `ralph/skills/research/SKILL.md` (default-mode Steps 1-4: intake → knowledge graph → parallel sub-agent dispatch → wait), `ralph/skills/research/intake-routing.md` (issue vs question vs no-args fallback), `ralph/skills/research/research-shapes.md` (sub-agent palette + dispatch patterns + cross-repo addendum).
+3. **Default flow — review, doc, handoff** owns: `ralph/skills/research/SKILL.md` (default-mode Steps 5-10: AskUserQuestion findings review → doc generation → optional artifact comment → next-steps picker), `ralph/skills/research/findings-format.md` (doc shape, frontmatter, Prior Work, Files Affected, Cross-Repo Scope, Pipeline History — including a per-mode required-sections matrix), `ralph/skills/research/playwright-baseline.md` (dev-server lifecycle + explorer-agent dispatch + journey-trace synthesis).
+4. **`--mode auto`** owns: `ralph/skills/research/SKILL.md` (auto-mode body: pick issue → lock → research → write → advance + outcome record), SKILL.md frontmatter `hooks:` block scoped to auto-mode triggers.
+5. **`--mode prove`** owns: `ralph/skills/research/SKILL.md` (prove-mode body: 5-step claim investigation), `ralph/skills/research/prove-claim.md` (evidence weighting + 5-step workflow + confidence calibration + anti-patterns + graceful degradation).
+6. **Parity validation + dogfooding** owns: `ralph/README.md`, `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` (append-only friction-log entry).
+
+Only `ralph/skills/research/SKILL.md` is touched in multiple phases — each appends a discrete section. The reference files are single-owner.
+
+## Phase 1: Scaffold + dispatch skeleton
+
+### Overview
+
+Stand up the directory structure with the skill stub + five reference siblings + five autonomous-flow hook scripts. The stub carries frontmatter (including the `hooks:` block scoped to `--mode auto`), the mode-dispatch table, and arg-parse skeleton.
+
+### Changes Required
+
+#### 1. Skill scaffold
+
+**File**: `ralph/skills/research/SKILL.md`
+
+Stub carries:
+
+- Description (covers all three modes + trigger phrasing for natural-language invocation).
+- `argument-hint: "[--mode auto|prove] [<question|#NNN|claim>] [--playwright|--no-playwright]"`
+- `context: inline`
+- `model: opus` (matches source for interactive + prove; auto-mode runs at the same model — opus → sonnet downgrade for autonomous is a separate model-tier-policy decision, not load-bearing for the fold).
+- `allowed-tools` union: `Read, Write, Edit, Glob, Grep, Bash, Task, Agent, AskUserQuestion, WebSearch, WebFetch`, plus the cross-plugin MCP tools (`get_issue`, `list_issues`, `save_issue`, `create_comment`, `add_dependency`, `remove_dependency`) and knowledge-graph tools (`knowledge_search`, `knowledge_recall`, `knowledge_traverse`, `knowledge_query_outcomes`, `knowledge_record_outcome`, `knowledge_expert`, `knowledge_communities`, `knowledge_central`, `knowledge_bridges`, `knowledge_paths`, `knowledge_common`).
+- `hooks:` block (declared in skill frontmatter):
+  - SessionStart → `set-skill-env.sh RALPH_COMMAND=research RALPH_REQUIRED_BRANCH=main` (only when `--mode auto` is the invocation; if `set-skill-env.sh` already handles the no-args path as a no-op, the hook can fire unconditionally and the script self-gates).
+  - PreToolUse on Bash → `branch-gate.sh`
+  - PostToolUse on `ralph_hero__get_issue` → `research-state-gate.sh`
+  - Stop → `research-postcondition.sh`, `doc-structure-validator.sh`, `lock-release-on-failure.sh`
+- Body: mode-dispatch table + Step 0 (arg parse) + section placeholders for the three modes.
+
+The mode-dispatch table:
+
+```markdown
+| Mode | Behavior | Equivalent to |
+|---|---|---|
+| (default) | Interactive: question/issue intake → parallel sub-agents → findings review → write doc → optional artifact comment | `/ralph-hero:research` |
+| `--mode auto [#NNN]` | Autonomous: pick / lock XS/S Research-Needed issue → research → write findings → advance to Ready for Plan | `/ralph-hero:ralph-research` |
+| `--mode prove "<claim>"` | Knowledge-graph claim investigation: 5-step evidence reasoning → verdict + confidence + evidence chains | `/ralph-hero:prove-claim` |
+| `--help` / `-h` | Print this table and exit | — |
+```
+
+Step 0 (arg parse) sets `MODE` ∈ `{default, auto, prove}`, captures `ARG` (question / issue number / claim), and the `--playwright` / `--no-playwright` flags. Default to `MODE=default` if no flag given.
+
+#### 2. Reference siblings (empty stubs)
+
+- `ralph/skills/research/intake-routing.md` — `# Intake routing\n\n_Filled by Phase 2._`
+- `ralph/skills/research/research-shapes.md` — `# Research shapes\n\n_Filled by Phase 2._`
+- `ralph/skills/research/findings-format.md` — `# Findings format\n\n_Filled by Phase 3._`
+- `ralph/skills/research/playwright-baseline.md` — `# Playwright baseline\n\n_Filled by Phase 3._`
+- `ralph/skills/research/prove-claim.md` — `# Prove-claim investigation\n\n_Filled by Phase 5._`
+
+#### 3. Hook script ports
+
+Copy from `plugin/ralph-hero/hooks/scripts/` into `ralph/hooks/scripts/`:
+
+- `research-state-gate.sh`
+- `research-postcondition.sh`
+- `doc-structure-validator.sh`
+- `branch-gate.sh`
+- `lock-release-on-failure.sh`
+
+The scripts source `hook-utils.sh` (already present in `ralph/hooks/scripts/`). Verify each script sources via `$(dirname "$0")/hook-utils.sh` so the ported path works.
+
+#### 4. No changes to `ralph/hooks/hooks.json`
+
+The plugin-root hooks file stays scoped to plugin-wide concerns (SessionStart `set-skill-env.sh` + PostToolUse `cursor-advance-catch-up.sh`). Per-skill hooks live in `ralph/skills/research/SKILL.md` frontmatter.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `test -f ralph/skills/research/SKILL.md`
+- [ ] `[ "$(wc -l < ralph/skills/research/SKILL.md)" -le 200 ]`
+- [ ] All five references present: `for f in intake-routing research-shapes findings-format playwright-baseline prove-claim; do test -f "ralph/skills/research/$f.md" || exit 1; done`
+- [ ] All five hooks present and executable: `for h in research-state-gate research-postcondition doc-structure-validator branch-gate lock-release-on-failure; do test -x "ralph/hooks/scripts/$h.sh" || exit 1; done`
+- [ ] SKILL.md frontmatter references the hooks: `grep -q 'research-state-gate.sh' ralph/skills/research/SKILL.md && grep -q 'research-postcondition.sh' ralph/skills/research/SKILL.md`
+
+#### Manual Verification
+
+- [ ] After `/reload-plugins`, `/ralph:research --help` returns the mode table.
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` (PR or branch diff) and `/skill-creator:skill-creator` (against the partial bundle under `ralph/skills/research/`) in parallel via two `Agent()` calls in a single message. Apply recommended fixes — or record why not in the friction log — before proceeding to Phase 2.
+
+---
+
+## Phase 2: Default flow — intake + parallel research
+
+### Overview
+
+Wire the default (interactive) flow's first half: intake routing, knowledge-graph prior-art (when ralph-knowledge is available), and parallel sub-agent dispatch.
+
+### Changes Required
+
+#### 1. Default-flow Steps 1-4 body in SKILL.md
+
+**File**: `ralph/skills/research/SKILL.md`
+
+Sections to add (~40 lines):
+
+- **Step 1: Intake** — if `ARG` is `#NNN` or `NNN`, fetch via `get_issue`, set `LINKED_ISSUE=NNN`, use title/body as the question. If `ARG` is a free-form string, treat as the question. If no `ARG`, prompt the user (mirrors source Step 1 fallback). Read mentioned files (`Read`, no offset/limit) before any sub-agent dispatch — keeps full context in the main session. Consult `intake-routing.md` for full detection rules.
+- **Step 2: Knowledge-graph prior art (optional)** — if `knowledge_recall` / `knowledge_search` / `knowledge_query_outcomes` are available, run the brief-first prior-art dispatch per `research-shapes.md`. Skip silently if unavailable.
+- **Step 3: Parallel sub-agent dispatch** — consult `research-shapes.md` for the sub-agent palette (codebase-locator, codebase-analyzer, codebase-pattern-finder, thoughts-locator, thoughts-analyzer, web-search-researcher when explicitly requested). Spawn in parallel via multiple `Agent()` calls in a single message. Pass cross-repo paths in the prompt when the registry lookup flags multi-repo scope (consult `research-shapes.md` § Cross-repo addendum).
+- **Step 4: Wait + synthesize** — wait for ALL sub-agents to complete. Synthesize findings, prioritizing live codebase findings over thoughts-derived historical context. Hold synthesis in the main session for Step 5 review.
+
+#### 2. `intake-routing.md` — replace stub
+
+Port the source-`research`-Steps-1-2 detection rules + Step 1 source's no-args prompt. Sections:
+
+- **Issue-number detection**: `#NNN`, `NNN`, or `GH-NNNN` arg → `get_issue`, set `LINKED_ISSUE`.
+- **Free-form question detection**: anything else not starting with `--` → treat as the question.
+- **No-args fallback**: prompt with the source's "I'm ready to research…" message and wait for input.
+- **File reading rule**: when the user mentions specific files by path, read them FULLY (no offset/limit) before any sub-agent dispatch. This is load-bearing — sub-agents lack the main session's context.
+
+Target ~50 lines.
+
+#### 3. `research-shapes.md` — replace stub
+
+Port the source's sub-agent palette + parallel-dispatch guidance + cross-repo addendum + knowledge-graph dispatch shape. Sections:
+
+- **Sub-agent palette**: codebase-locator (WHERE), codebase-analyzer (HOW), codebase-pattern-finder (similar implementations), thoughts-locator (existing docs), thoughts-analyzer (extract key findings), web-search-researcher (external — explicit request only).
+- **Parallel dispatch rule**: dispatch all relevant agents in a single message via multiple `Agent()` calls. Wait for ALL before synthesizing. Do NOT pass `team_name` to sub-agent calls (team-isolation per ADR).
+- **Documentarian-not-critic constraint**: sub-agents document what IS, not what SHOULD BE. Restate this constraint when delegating in cases the agent might drift.
+- **Knowledge-graph dispatch shape** (used by Step 2 in default, Step 3c-3d in auto): brief-first `knowledge_recall` per role / type, `knowledge_query_outcomes` when a component area is identifiable, `knowledge_expert` when a domain can be extracted.
+- **Cross-repo addendum**: when `.ralph-repos.yml` exists, read it (via `Read`, not `decompose_feature`), detect multi-repo signals, pass additional repo dirs to sub-agent prompts. Repo-qualified file paths (`ralph-hero:src/...`) required for cross-repo Files Affected entries.
+
+Target ~80 lines.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] SKILL.md line count: `[ "$(wc -l < ralph/skills/research/SKILL.md)" -le 200 ]`
+- [ ] `intake-routing.md` non-stub: `[ "$(wc -l < ralph/skills/research/intake-routing.md)" -ge 30 ]`
+- [ ] `research-shapes.md` non-stub: `[ "$(wc -l < ralph/skills/research/research-shapes.md)" -ge 50 ]`
+- [ ] SKILL.md references both: `grep -q 'intake-routing.md' ralph/skills/research/SKILL.md && grep -q 'research-shapes.md' ralph/skills/research/SKILL.md`
+
+#### Manual Verification
+
+- [ ] `/ralph:research "how does the catch-up cursor work?"` triggers parallel sub-agent dispatch; agents complete; synthesis is held in the main session for review.
+- [ ] `/ralph:research #1357` fetches the issue and uses it as the question.
+- [ ] `/ralph:research` with no args prompts for input.
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` and `/skill-creator:skill-creator` in parallel against the partial bundle. Apply fixes — or record why not — before proceeding to Phase 3.
+
+---
+
+## Phase 3: Default flow — review, doc, handoff + Playwright baseline
+
+### Overview
+
+Wire the default flow's back half: AskUserQuestion findings review, doc generation, optional Playwright UI baseline, optional artifact comment, next-steps picker.
+
+### Changes Required
+
+#### 1. Default-flow Steps 5-10 body in SKILL.md
+
+**File**: `ralph/skills/research/SKILL.md`
+
+Sections to add (~50 lines):
+
+- **Step 5: Present findings for review** — `AskUserQuestion` with 3 options (Looks good, write it / Go deeper on a topic / Correct something). Route: write proceeds to Step 6; deeper or correction loops back to additional sub-agent dispatch then re-presents.
+- **Step 6: Gather metadata + write doc** — `git rev-parse HEAD`, `date +%Y-%m-%d`, `git branch --show-current`. Write to `thoughts/shared/research/YYYY-MM-DD-[GH-NNNN-]description.md` per `findings-format.md`.
+- **Step 6.5: Playwright UI baseline (conditional)** — consult `playwright-baseline.md`. Skip if `--no-playwright`. If `--playwright` or frontend-relevant findings + ralph-playwright installed: detect, prompt user, capture, append `## UI Baseline` section.
+- **Step 7: GitHub permalinks** — if on main/pushed, convert local file references to permalinks per `findings-format.md`.
+- **Step 8: Optional artifact comment** — if `LINKED_ISSUE` set or user asks to link: rename file to include `GH-NNNN`, update frontmatter, post `## Research Document` comment on the issue.
+- **Step 9: Next-steps picker** — `AskUserQuestion` with 3 options (Create issue from findings → `/ralph:form <path>` / Ask follow-up questions / Done). Loop on follow-ups via Step 10.
+- **Step 10: Follow-up handling** — append to the same doc, update `last_updated` frontmatter, spawn targeted sub-agents.
+
+#### 2. `findings-format.md` — replace stub
+
+Port the source's doc structure + frontmatter + Prior Work + Files Affected + Cross-Repo Scope sections. Sections:
+
+- **Frontmatter shape**: `date`, `github_issue` (optional), `github_url` (optional), `topic`, `tags`, `status: complete`, `type: research`.
+- **Filename convention**: `YYYY-MM-DD-[GH-NNNN-]description.md`; rename rules when linking post-write.
+- **Section order**: Title → Prior Work → Research Question → Summary → Detailed Findings → Code References → Architecture Documentation → Historical Context → Related Research → Open Questions.
+- **Prior Work section**: `builds_on::` / `tensions::` wikilinks, evidence-weighting qualifiers (research / review / plan / idea — primary / secondary / weak / weakest).
+- **Files Affected section** (required by autonomous flow; recommended for interactive): `### Will Modify` and `### Will Read (Dependencies)` subsections, backtick-wrapped paths, cross-repo prefixing rule.
+- **Pipeline History section** (optional, autonomous-only): populated from `knowledge_query_outcomes` results.
+- **Cross-Repo Scope section** (optional): repos involved, dependency relationship.
+- **Per-mode required-sections matrix**: which sections are required vs optional per mode. The `doc-structure-validator.sh` hook enforces this for `--mode auto` only.
+
+Target ~90 lines.
+
+#### 3. `playwright-baseline.md` — replace stub
+
+Port the source's Step 6.5 / Step 7.5 baseline-capture flow (identical content in both source skills). Sections:
+
+- **Detection**: read `~/.claude/plugins/installed_plugins.json`, check for a key containing `ralph-playwright`.
+- **Frontend-relevance heuristic**: affected file types (`.tsx`/`.jsx`/`.css`/`.html`/`.vue`/`.svelte`), component directories, route/page modifications, UI/UX/visual/accessibility concerns. `--playwright` overrides; `--no-playwright` skips.
+- **Dev-server lifecycle**: resolve via `RALPH_PLAYWRIGHT_DEV_CMD` env → memory → `package.json` autodetect. Start via `Bash(command, run_in_background=true)`; poll via curl every 2s, timeout 30s. Teardown via `RALPH_PLAYWRIGHT_DEV_TEARDOWN_CMD` or kill PID.
+- **Explorer-agent dispatch**: `Agent(subagent_type="ralph-playwright:explorer-agent", prompt="Explore http://localhost:<port> with goal: capture accessibility baseline and key user flows. Session: <date>-baseline-GH-NNN", description="UI baseline GH-NNN")`.
+- **Tooling detection** (in parallel): `playwright-stories/` count, storybook addon presence, visual-regression tool presence.
+- **Journey-trace synthesis**: read `.playwright-cli/<session>/journey-trace.yaml`, append `## UI Baseline` section to the research doc with accessibility / flow state / tooling subsections.
+
+Target ~70 lines.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] SKILL.md line count: `[ "$(wc -l < ralph/skills/research/SKILL.md)" -le 200 ]`
+- [ ] `findings-format.md` non-stub: `[ "$(wc -l < ralph/skills/research/findings-format.md)" -ge 60 ]`
+- [ ] `playwright-baseline.md` non-stub: `[ "$(wc -l < ralph/skills/research/playwright-baseline.md)" -ge 40 ]`
+- [ ] `findings-format.md` carries Files Affected template: `grep -q 'Will Modify' ralph/skills/research/findings-format.md && grep -q 'Will Read' ralph/skills/research/findings-format.md`
+- [ ] SKILL.md references both: `grep -q 'findings-format.md' ralph/skills/research/SKILL.md && grep -q 'playwright-baseline.md' ralph/skills/research/SKILL.md`
+
+#### Manual Verification
+
+- [ ] `/ralph:research "<some question>"` runs end-to-end through the default flow: synth → AskUserQuestion review → doc write → next-steps picker.
+- [ ] `/ralph:research #1357` produces a doc with proper `GH-1357` filename, frontmatter linking, and posts the artifact comment when the user agrees.
+- [ ] `/ralph:research --no-playwright "<frontend topic>"` skips the baseline section even when frontend-relevant.
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` and `/skill-creator:skill-creator` in parallel. Apply fixes — or record why not — before proceeding to Phase 4.
+
+---
+
+## Phase 4: `--mode auto` (autonomous flow)
+
+### Overview
+
+Wire the autonomous-mode body. Mirrors today's `/ralph-hero:ralph-research` — no questions, picks an issue, locks, researches, writes, advances, records outcome.
+
+### Changes Required
+
+#### 1. Auto-mode body in SKILL.md
+
+**File**: `ralph/skills/research/SKILL.md`
+
+Sections to add (~40 lines):
+
+- **Auto Step 1: Branch check** — verify `git branch --show-current == main`. If not, STOP. (Also enforced by `branch-gate.sh`, but the workflow body documents the precondition.)
+- **Auto Step 2: Select issue** — if `ARG` is `#NNN`, fetch it. Else `list_issues` with `profile: "analyst-research"`, filter to XS/Small, filter unblocked (consult `intake-routing.md` § Blocker semantics), pick highest priority. If none eligible, exit cleanly.
+- **Auto Step 3: Lock + registry + knowledge-graph** — `save_issue(number, workflowState: "__LOCK__", command: "ralph_research")`. Then registry lookup per `research-shapes.md` § Cross-repo addendum; then knowledge-graph prior art per `research-shapes.md` § Knowledge-graph dispatch shape.
+- **Auto Step 4: Parallel sub-agent research** — same dispatch shape as default Step 3, but no AskUserQuestion review. Sub-agents complete → synthesize → write.
+- **Auto Step 5: Write doc** — per `findings-format.md` (including required Files Affected + optional Pipeline History + optional Cross-Repo Scope).
+- **Auto Step 5.5: Playwright baseline (conditional)** — same conditional logic as default Step 6.5. Commit the updated doc if baseline is appended.
+- **Auto Step 6: Commit + push** — `git add thoughts/shared/research/...` → `git commit -m "docs(research): GH-NNN research findings"` → `git push origin main`.
+- **Auto Step 7: Post artifact comment + advance + record outcome** — `create_comment` with `## Research Document` linking the pushed doc → `save_issue(number, workflowState: "__COMPLETE__", command: "ralph_research")` (moves to Ready for Plan) → `knowledge_record_outcome(event_type: "research_completed", issue_number: NNN, component_area: "<area>", verdict: "complete", model: "<model>", agent_type: "analyst", query_id: "<from-step-3-if-set>")` if available.
+- **Auto Step 8: Report** — terse single-block summary (no AskUserQuestion).
+
+#### 2. SKILL.md frontmatter `hooks:` block (added in Phase 1, validated here)
+
+Verify Phase 1's hook block fires correctly under `--mode auto`:
+
+- The five hook scripts are present (Phase 1 verification).
+- Each script gates on `RALPH_COMMAND` / `RALPH_TICKET_ID` / `RALPH_REQUIRED_BRANCH` so they no-op when invoked outside auto-mode.
+- `set-skill-env.sh` is called via SessionStart with `RALPH_COMMAND=research RALPH_REQUIRED_BRANCH=main` args; need to verify the slim plugin's `set-skill-env.sh` correctly parses those.
+
+If `set-skill-env.sh` requires modification to handle the args robustly (Phase 1 left it as-is), patch in this phase. Verify by running the auto flow against a real issue and confirming the env vars are exported.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] SKILL.md line count: `[ "$(wc -l < ralph/skills/research/SKILL.md)" -le 200 ]`
+- [ ] SKILL.md auto-mode body present: `awk '/^## --mode auto/,/^## --mode prove/' ralph/skills/research/SKILL.md | grep -q 'workflowState' && grep -q '__LOCK__'`
+- [ ] Frontmatter hooks block carries all five hooks: `grep -c 'hooks/scripts/' ralph/skills/research/SKILL.md | xargs -I {} test {} -ge 5`
+
+#### Manual Verification
+
+- [ ] `/ralph:research --mode auto` against a real XS issue in "Research Needed":
+  - Issue locks (workflowState moves to "Research in Progress").
+  - Sub-agents dispatch in parallel.
+  - Doc is written with required sections (frontmatter, Prior Work, Files Affected, Detailed Findings).
+  - `doc-structure-validator.sh` passes (Stop exit 0).
+  - Doc is committed + pushed to main.
+  - `## Research Document` artifact comment posted on the issue.
+  - Issue advances to "Ready for Plan".
+  - `knowledge_record_outcome` records the event (when the tool is available).
+- [ ] `/ralph:research --mode auto` from a non-main branch fails fast with the branch-gate message.
+- [ ] If the auto flow fails mid-way, `lock-release-on-failure.sh` releases the issue back to "Research Needed".
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` and `/skill-creator:skill-creator` in parallel. Apply fixes — or record why not — before proceeding to Phase 5.
+
+---
+
+## Phase 5: `--mode prove` (claim investigation)
+
+### Overview
+
+Wire the prove-claim mode. No codebase research — pure knowledge-graph reasoning.
+
+### Changes Required
+
+#### 1. Prove-mode body in SKILL.md
+
+**File**: `ralph/skills/research/SKILL.md`
+
+Sections to add (~15 lines):
+
+- **Prove Step 1: Decompose claim** — accept `ARG` as the claim string. Decompose into 2-5 entities + a relationship per `prove-claim.md` § Decomposition.
+- **Prove Step 2: Find entity documents** — `knowledge_search` per entity (brief mode); record top 3 doc IDs per entity. Skip codebase-locator/analyzer entirely.
+- **Prove Step 3: Find connections** — `knowledge_paths`, `knowledge_traverse`, `knowledge_common` to trace paths between entity documents. Degradation per `prove-claim.md` § Graceful degradation.
+- **Prove Step 4: Read evidence** — `Read` top 3-5 docs by path. Extract verbatim quotes. Note doc type / date / status.
+- **Prove Step 5: Report** — produce verdict per `prove-claim.md` § Report template. No file write; output the verdict block inline.
+
+The body is thin — most content lives in `prove-claim.md`.
+
+#### 2. `prove-claim.md` — replace stub
+
+Port the source `prove-claim/SKILL.md` workflow + evidence-weighting + confidence-calibration + anti-patterns + graceful-degradation sections. Sections:
+
+- **Evidence weighting**: research (primary) / review (secondary) / plan (weak) / idea (weakest) — verbatim from source lines 25-35.
+- **Decomposition rules**: how to break a claim into entities + relationship.
+- **Step-by-step workflow detail**: what each of the 5 steps does, what tools to use, what to record.
+- **Confidence calibration**: 0.8-1.0 / 0.5-0.7 / 0.2-0.4 / 0.0-0.1 table with typical evidence profiles.
+- **Anti-patterns**: community co-membership / hub-node paths / plan documents as proof / path existence / paraphrase-as-evidence.
+- **Graceful degradation**: graph algorithm unavailable → fall back to traversal; brief mode unsupported → limit results; entity search zero results → broaden / report "not found"; paths exist but irrelevant intermediaries → structurally weak.
+- **Report template**: `## Claim Investigation Report` with Claim / Verdict / Confidence / Evidence Chains / Document Type Qualifications / Graph Connection Summary / Caveats / What Would Change This Verdict.
+
+Target ~120 lines (matches source content closely; this is the densest reference).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] SKILL.md line count: `[ "$(wc -l < ralph/skills/research/SKILL.md)" -le 200 ]`
+- [ ] `prove-claim.md` non-stub: `[ "$(wc -l < ralph/skills/research/prove-claim.md)" -ge 80 ]`
+- [ ] `prove-claim.md` carries the evidence-weighting table: `grep -q 'Primary' ralph/skills/research/prove-claim.md && grep -q 'Weakest' ralph/skills/research/prove-claim.md`
+- [ ] `prove-claim.md` carries the report template: `grep -q 'Claim Investigation Report' ralph/skills/research/prove-claim.md && grep -q 'What Would Change This Verdict' ralph/skills/research/prove-claim.md`
+- [ ] SKILL.md prove-mode references `prove-claim.md`: `awk '/^## --mode prove/,/^## References/' ralph/skills/research/SKILL.md | grep -q 'prove-claim.md'`
+
+#### Manual Verification
+
+- [ ] `/ralph:research --mode prove "<a claim>"` produces:
+  - 2-5 entity decomposition.
+  - knowledge_search dispatch (skips codebase-locator/analyzer).
+  - Verdict block with verdict + confidence + ≥1 evidence chain with verbatim quote.
+  - Anti-patterns avoided (no community co-membership, no path-existence-as-proof).
+- [ ] `/ralph:research --mode prove "<claim against missing entities>"` reports "insufficient evidence" rather than inventing.
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Dispatch `/review` and `/skill-creator:skill-creator` in parallel. Apply fixes — or record why not — before proceeding to Phase 6.
+
+---
+
+## Phase 6: Parity validation + dogfooding setup
+
+### Overview
+
+Final parity validation across real sessions, README update, friction-log entry.
+
+### Changes Required
+
+#### 1. README migration table
+
+**File**: `ralph/README.md`
+**Changes**:
+
+```diff
+-| 3 | `/ralph:research` | pending |
++| 3 | `/ralph:research` | shipped |
+```
+
+Update the `## Status` paragraph to "Plan 3 of 11 (research shipped). This plugin currently exposes three user-facing skills (`/ralph:catch-up`, `/ralph:form`, `/ralph:research`)."
+
+#### 2. Friction-log entry on the spec
+
+**File**: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md`
+**Changes**: Append a `### Plan 3: /ralph:research (shipped YYYY-MM-DD)` subsection under `## Friction Log`. Capture final-shape stats, design calls (5-reference threshold, SKILL.md `hooks:` frontmatter pattern), TODO checkboxes for the 2-week dogfooding window.
+
+#### 3. Parity validation runs
+
+No file changes. Execute five real `/ralph:research` invocations:
+
+1. `/ralph:research "<some question>"` → default flow, no linked issue, no Playwright.
+2. `/ralph:research #<some-issue>` → default flow, linked-issue path, artifact comment.
+3. `/ralph:research "<frontend-relevant question>"` → default flow, Playwright baseline captured.
+4. `/ralph:research --mode auto` → autonomous flow against a real Research-Needed XS issue. Verify lock + advance + outcome record.
+5. `/ralph:research --mode prove "<claim>"` → verdict report.
+
+Record observations in the friction-log entry.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `grep -q '| 3 | \`/ralph:research\` | shipped |' ralph/README.md`
+- [ ] `grep -q 'Plan 3 of 11' ralph/README.md`
+- [ ] Plan 3 friction-log subsection exists: `grep -q '### Plan 3:' thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md`
+
+#### Manual Verification
+
+- [ ] Five real `/ralph:research` invocations completed (one per mode + parameter shape).
+- [ ] Each session produces equivalent output to the corresponding old skill.
+- [ ] No regressions in `/ralph-hero:research`, `/ralph-hero:ralph-research`, `/ralph-hero:prove-claim`.
+
+#### Per-phase audit (spec criterion #6)
+
+- [ ] Final audit against the complete bundle before opening the PR. Dispatch `/review` (full PR) and `/skill-creator:skill-creator` (full `ralph/skills/research/` bundle) in parallel. Apply fixes — or record why not.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+None. Skill is markdown workflow; MCP tools it consumes are covered by the ralph-hero MCP server's existing test suite.
+
+### Integration Tests
+
+The "5 real sessions" parity check in Phase 6 is the integration test. The autonomous-mode session exercises the five hooks end-to-end (state gate on lock, postcondition on doc, doc-structure-validator on Stop, branch-gate on bash, lock-release on a forced failure).
+
+### Manual Testing Steps
+
+Per Phase 6's verification list, plus:
+
+1. Verify the autonomous flow's lock-release-on-failure path: simulate a mid-flow failure (e.g., raise a non-zero exit inside the skill body) and confirm the issue returns to "Research Needed".
+2. Verify the doc-structure-validator catches a missing `## Files Affected` section in auto-mode (write a doc without it; confirm Stop exits 2).
+3. Verify the branch-gate refuses to run from a non-main branch.
+4. Verify the knowledge-graph degradation paths: temporarily disable the ralph-knowledge MCP server; confirm the default + auto flows complete via `thoughts-locator` only, with the "Knowledge graph unavailable" footnote in Prior Work; confirm prove-mode falls back to traversal + combined-term searches.
+
+## Performance Considerations
+
+- Default flow: 4-6 parallel sub-agent dispatches + 1-2 AskUserQuestion calls + 1 Write + optional Playwright explorer-agent. Mirrors today's `/ralph-hero:research`. No new latency.
+- Auto flow: same dispatch profile + 2 `save_issue` mutations + 1 `create_comment` + optional `knowledge_record_outcome`. Mirrors today's `/ralph-hero:ralph-research`. Constrained to 15 minutes per source convention.
+- Prove flow: 2-5 `knowledge_search` calls + 1-3 `knowledge_paths/traverse/common` calls + 1-5 `Read` calls. Fastest path; no codebase research. No new latency.
+
+## Migration Notes
+
+- Source skills (`research`, `ralph-research`, `prove-claim`) remain functional and unmodified for the 2-week dogfooding window. Plan 10 owns sunset.
+- The auto-flow hooks (research-state-gate, research-postcondition, doc-structure-validator, branch-gate, lock-release-on-failure) are duplicated across the source and slim plugins during the migration window. Both ports gate on identical env vars, so duplicate firing is idempotent (each checks its own preconditions independently). Plan 10 deletes the source copies.
+- Plan 4 (`/ralph:plan`) and Plan 5 (`/ralph:impl`) will reuse the SKILL.md `hooks:` frontmatter pattern introduced here. Plan 3's friction log should record whether the pattern worked cleanly or hit harness quirks.
+- The Step 10 follow-up flow in default mode updates the SAME doc with `last_updated` frontmatter — this is the "append-only follow-up research" pattern from source. The Plan 2 `/ralph:form` handoff lands users at Plan 3's interactive flow, so the doc lifecycle here is shared with form.
+
+## References
+
+- Spec: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` (plan-of-plans row 3 at line 335).
+- Plan 1: `thoughts/shared/plans/2026-05-23-GH-1357-ralph-plan-1-catch-up.md` (validated scaffold + flat-sibling + cross-plugin MCP). PR #1358.
+- Plan 2: `thoughts/shared/plans/2026-05-23-GH-1359-ralph-plan-2-form.md` (validated multi-surface fold at 186 lines + 3 references). PR #1361.
+- Source skill bodies:
+  - `plugin/ralph-hero/skills/research/SKILL.md` (406 lines)
+  - `plugin/ralph-hero/skills/ralph-research/SKILL.md` (506 lines)
+  - `plugin/ralph-hero/skills/prove-claim/SKILL.md` (177 lines)
+- Source hook scripts:
+  - `plugin/ralph-hero/hooks/scripts/research-state-gate.sh` (41 lines)
+  - `plugin/ralph-hero/hooks/scripts/research-postcondition.sh` (62 lines)
+  - `plugin/ralph-hero/hooks/scripts/doc-structure-validator.sh` (76 lines)
+  - `plugin/ralph-hero/hooks/scripts/branch-gate.sh` (31 lines)
+  - `plugin/ralph-hero/hooks/scripts/lock-release-on-failure.sh` (82 lines)
+- ralph plugin scaffold + Plan 2 state: `ralph/.claude-plugin/plugin.json`, `ralph/hooks/hooks.json`, `ralph/skills/{catch-up,form}/`.

--- a/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+++ b/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
@@ -466,3 +466,32 @@ Open follow-ups (separate plans):
 - When Plan 3 ships, update SKILL.md Step 6c to drop the `/ralph-hero:research` fallback. Same for Plan 4 and `/ralph-hero:plan`.
 - Plan 7 (`/ralph:caretake`) doesn't directly affect this verb.
 - Plan 10 owns sunset of source `draft` + `form` skills.
+
+### Plan 3: `/ralph:research` (shipped 2026-05-23, branch `feature/GH-1362-research`)
+
+Final shape:
+
+- `ralph/skills/research/SKILL.md`: 183 lines (target ~170, max 200). Heavier than catch-up (137) and form (186) because the verb folds three structurally distinct sub-flows (interactive 10 steps + autonomous 9 steps + prove 5 steps) plus the `hooks:` frontmatter block declaring 5 auto-mode hooks.
+- Five flat-sibling references: `intake-routing.md` (46), `research-shapes.md` (78), `findings-format.md` (187), `playwright-baseline.md` (113), `prove-claim.md` (130). Total 554 lines of opinion content.
+- Combined: 737 lines (vs 1,089 in source research + ralph-research + prove-claim). ~32% LOC reduction; the larger structural win is collapsing 3 user-facing verbs into 1 with `--mode` dispatch.
+- Hook ports: five scripts ported verbatim from the source plugin (`research-state-gate.sh`, `research-postcondition.sh`, `doc-structure-validator.sh`, `branch-gate.sh`, `lock-release-on-failure.sh`) plus `ralph-state-machine.json` (required by lock-release). All gate on `RALPH_COMMAND` / `RALPH_TICKET_ID` env vars set by `set-skill-env.sh` on SessionStart, so they no-op outside `--mode auto`.
+- **First plan to introduce SKILL.md frontmatter `hooks:` block in the slim plugin.** Catch-up and form had no enforcement to port; research is the first verb where Hooks Own Enforcement (P6) is exercised end-to-end. The slim-plugin pattern: plugin-root `hooks.json` for cross-skill concerns (cursor advance, env setup); per-skill `hooks:` frontmatter for skill-specific enforcement (state gates, postconditions, doc validators, branch gates, lock releases). This pattern will be re-used by Plans 4 (`/ralph:plan`) and 5 (`/ralph:impl`).
+- **First plan to ship 5 reference siblings** — above Plan 2's "four is the upper end" comfort heuristic. The fifth (`prove-claim.md`) is justified by prove-mode's structural distinctness from codebase research (no Agent dispatch, knowledge-graph only, evidence-weighting opinion content with no analog in the other modes).
+- Playwright baseline content centralized: both default Step 6.5 and autonomous Step 5.5 consult the same `playwright-baseline.md`. The two source skills duplicated this block verbatim — the fold deduplicates it.
+- The autonomous-mode commit step lives in `playwright-baseline.md` rather than the SKILL.md auto-mode list because it's specific to the baseline-append path. Keeps SKILL.md auto-mode tight (one-liners per step).
+
+Real-session usage notes during the 2-week dogfooding window:
+
+- [ ] _(Add entries as you use it. Examples to watch for: hooks correctly no-op in interactive/prove modes; auto-mode state-gate behavior on out-of-band issue moves; prove-mode degradation when knowledge tools are partial; cross-repo registry lookup with newly-added repos; AskUserQuestion findings-review loop iterations.)_
+
+Inputs to feed into Plan 4 (`/ralph:plan`):
+
+- _(TBD after 2 weeks of usage.)_
+- Pattern validator note: SKILL.md frontmatter `hooks:` worked for scoping enforcement to a single mode within a multi-mode verb. Plan 4 will reuse for `/ralph:plan` (plan-state-gate + plan-postcondition).
+- Reference-count note: 5 references felt structurally justified by prove-mode's distinctness. For verbs without a structurally-distinct sub-mode, 4 stays the comfortable upper end. Plan 4 should aim for 4 references unless a comparable sub-mode emerges.
+
+Open follow-ups (separate plans):
+
+- When Plan 4 ships, drop the `/ralph-hero:plan` fallback in `/ralph:form` Step 6c (already a documented Plan 2 follow-up). `/ralph:research` Step 9 "Create issue from findings" already points at `/ralph:form` (no fallback needed since Plan 2 shipped).
+- Plan 7 (`/ralph:caretake`) doesn't directly affect this verb.
+- Plan 10 owns sunset of source `research`, `ralph-research`, `prove-claim` skills.

--- a/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+++ b/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
@@ -12,7 +12,7 @@ tags: [ralph, plugin-restructure, skills, references, migration, plan-of-plans]
 
 `ralph-hero` has grown to **52 skills, ~28k lines of plugin markdown, 18 active worktrees**, three overlapping orchestrators (`hero`, `team`, `autopilot`/`director`), and a documented dead code path (`RemoteTrigger` producer). Each skill invocation re-tokenizes a large prelude. The chain-prompting pattern that made sense early now duplicates work the harness (Claude Code, MCP server, hooks) already does.
 
-This document specifies a parallel-plugin restructure: a new plugin **`ralph`** (no `-hero` suffix) sitting at `ralph-hero/ralph/`, with **9 fat skills**, opinion content moved to flat reference siblings, and enforcement moved to hooks + MCP. Migration ships across **11 independent plans** over ~2-3 months with no period where the system is broken — the old plugin keeps working until each verb has been dogfooded for two weeks.
+This document specifies a parallel-plugin restructure: a new plugin **`ralph`** (no `-hero` suffix) sitting at `ralph-hero/ralph/`, with **9 fat skills**, opinion content moved to flat reference siblings, and enforcement moved to hooks + MCP. Migration ships across **11 independent plans** with no period where the system is broken — the old plugin keeps working alongside the new one, and each verb is sunset only when the new counterpart has handled the workflows it replaces.
 
 Expected outcomes: ~80% reduction in user-visible skill surface, ~3-4k lines of enforcement prose absorbed into hooks, dramatically lower per-invocation token cost, and a fast-track ladder for trivial fixes (typos, doc changes, repro-ready bugs) that skips the full research→plan→review→impl pipeline.
 
@@ -345,11 +345,11 @@ Approximately **3-4k lines of enforcement prose** disappear from skill bodies ac
 
 After each plan merges:
 
-1. Switch one real workflow to the new verb (e.g., after Plan 3 ships, do all your next research with `/ralph:research`).
-2. Friction log in the spec for the next plan — lessons from using the new verb feed the next design.
-3. Don't sunset the old skill until **two consecutive weeks without invoking it.**
+1. **Switch to the new verb immediately** for the workflows it covers. `/ralph:research` replaces `/ralph-hero:research` etc. starting the next session.
+2. **Use it, find what breaks, fix it.** Active dogfooding produces signal; passive waiting does not.
+3. **Sunset the old skill when the new counterpart has handled each surface it replaces** (not on a calendar). One real-session pass through each mode / branch of the new verb is enough.
 
-This is load-bearing. The risk of "build new plugin in parallel" is that the new plugin becomes a museum piece. The forcing function is: ship one verb → use it for two weeks → ship the next.
+The forcing function is active use, not elapsed time. The risk of "build new plugin in parallel" is that the new plugin becomes a museum piece; the mitigation is using it, not waiting.
 
 ### Acceptance criteria (consistent across all 9 verb plans)
 
@@ -357,7 +357,7 @@ This is load-bearing. The risk of "build new plugin in parallel" is that the new
 2. **Token budget:** new `SKILL.md` is ≤ 200 lines (target ~150). Opinion content lives in references.
 3. **Hook coverage:** no enforcement logic in skill prose — all moved to hooks or MCP validation.
 4. **Local dev works:** edit `SKILL.md`, save, next invocation picks it up without `claude plugins` commands.
-5. **Old skill stays functional** for two weeks post-merge. Sunset is its own follow-up PR.
+5. **Old skill stays functional** until its new counterpart has been actively used through each surface it covers. Sunset is a follow-up PR — Plan 10 batches the remaining ones.
 6. **Per-phase audit applied:** after each phase passes its automated + manual verification, dispatch `/review` (against the open PR or branch diff) and `/skill-creator:skill-creator` (against the partial skill bundle) in parallel. Apply recommended fixes — or document why not — before proceeding to the next phase. Catches P2 leakage, missing tools, picker ambiguity, and trigger gaps while they're still cheap to fix; established by Plan 1's post-impl audit and made standard in Plan 2.
 
 ### Estimated timeline (to validate)
@@ -375,8 +375,8 @@ Total elapsed: **2-3 months**, with no period of "ralph is broken." Worst case: 
 
 | Risk | Mitigation |
 |---|---|
-| New plugin becomes a museum piece you don't adopt | Dogfooding rhythm: switch one workflow per plan, sunset only after 2 weeks of disuse on old |
-| Folded skill turns out to be load-bearing in a way I missed | Old skills remain functional for the 2-week sunset window; Plan 10 is reversible |
+| New plugin becomes a museum piece you don't adopt | Switch to the new verb immediately on ship; sunset only after the new counterpart has been actively exercised on every surface it replaces |
+| Folded skill turns out to be load-bearing in a way I missed | Old skills remain functional alongside the new ones until sunset (Plan 10); a regression caught during active dogfooding is a fix on the new verb, not a rollback |
 | Local-dev symlink doesn't work cleanly with Claude Code's plugin cache | Plan 0 acceptance includes verifying the symlink mechanism. Fallback: local marketplace via `file://` URL |
 | Scope creep during migration | Each plan's acceptance #1 is "functional parity on 3 real issues" — capability additions are separate plans, post-migration |
 | Inlined shared content drifts | Accepted per P9. If drift causes a real bug, promote to top-level docs/, owned-by-one-skill, or extract |
@@ -406,7 +406,7 @@ Total elapsed: **2-3 months**, with no period of "ralph is broken." Worst case: 
 Migration is complete when:
 
 1. All 9 verbs (`/ralph:hero`, `/ralph:research`, `/ralph:plan`, `/ralph:impl`, `/ralph:review`, `/ralph:caretake`, `/ralph:catch-up`, `/ralph:form`, `/ralph:setup`) exist and meet the 5 acceptance criteria.
-2. No `/ralph-hero:*` slash command has been invoked for ≥ 2 weeks.
+2. Every `/ralph-hero:*` slash command being sunset has a `/ralph:*` counterpart that has handled at least one real-session instance of each surface it replaces.
 3. `plugin/ralph-hero/skills/` is empty or removed.
 4. The MCP server is reachable from `ralph` (either still in `plugin/ralph-hero/mcp/` or relocated to `ralph/mcp/`).
 5. README documents the new plugin as the canonical entry point.
@@ -415,7 +415,7 @@ Expected end-state surface: 9 user-facing slash commands, ~1,500 lines of SKILL.
 
 ## Friction Log
 
-The dogfooding rhythm depends on capturing lessons-learned from each shipped verb to feed the next plan's design. Append per-plan entries here as the 2-week dogfooding window plays out.
+The dogfooding rhythm depends on capturing lessons from each shipped verb to feed the next plan's design. Populate per-plan entries by *using* the verb — not by waiting for a calendar window. When you find something broken or awkward, fix it (small follow-up PR) and record what you fixed and why.
 
 ### Plan 1: `/ralph:catch-up` (shipped 2026-05-23, branch `feature/GH-1357-catch-up`)
 
@@ -427,13 +427,13 @@ Final shape:
 - Hook port: `cursor-advance-catch-up.sh` ported verbatim. Both plugins now fire it on the same `recent_activity` PostToolUse matcher; cursor writes are idempotent (last write wins), so the duplicate firing is benign during the migration window.
 - cos's `desk`/`remote`/`unattended` modes deliberately stayed as `ralph cos {...}` CLI subcommands. Their zero-Claude-Code-on-the-call-chain property would have inverted if absorbed into the slash skill.
 
-Real-session usage notes during the 2-week dogfooding window:
+Friction notes (populated by active use):
 
 - [ ] _(Add entries as you use it. Examples to watch for: edge cases in narrative synthesis, picker label truncation, dashboard JSON-mode quirks, --mode report posting permissions, cursor advance timing under multi-plugin firing.)_
 
 Inputs to feed into Plan 2 (`/ralph:form`):
 
-- _(TBD after 2 weeks of usage.)_
+- _(Populated by active use, not by waiting.)_
 - Pattern validator note: the flat-sibling reference layout (no `references/` subfolder, no nested `Skill()` dispatch) worked cleanly for a 5-skill fold. Plan 2 should follow the same shape unless friction emerges.
 
 Open follow-ups (separate plans):
@@ -452,13 +452,13 @@ Final shape:
 - Step 5 picker defaults change with `LINKED_ISSUE`: when intake routing detects a research doc with an existing `github_issue` in its frontmatter, the picker biases toward "Implementation plan" rather than "GitHub issue" (avoids duplicate issue creation against linked research).
 - Handoffs in Step 6c point at `/ralph:plan` and `/ralph:research` with `/ralph-hero:plan` and `/ralph-hero:research` as fallbacks. The new-verb names get unblocked when Plans 3 (research) and 4 (plan) ship — the fallbacks come out then.
 
-Real-session usage notes during the 2-week dogfooding window:
+Friction notes (populated by active use):
 
 - [ ] _(Add entries as you use it. Examples to watch for: research-doc auto-detection edge cases (`type: research` vs path glob), inline-description routing for very short inputs, ticket-tree estimate-default appropriateness, knowledge-search dedup false positives, frontmatter-update collisions when the source file is open in an editor.)_
 
 Inputs to feed into Plan 3 (`/ralph:research`):
 
-- _(TBD after 2 weeks of usage.)_
+- _(Populated by active use, not by waiting.)_
 - Pattern validator note: the flat-sibling reference layout worked again for a 2-skill fold with three references. Three references felt about right; four (the catch-up shape) is the upper end. If Plan 3 needs five+, that's a signal to revisit the convention.
 
 Open follow-ups (separate plans):
@@ -480,13 +480,13 @@ Final shape:
 - Playwright baseline content centralized: both default Step 6.5 and autonomous Step 5.5 consult the same `playwright-baseline.md`. The two source skills duplicated this block verbatim — the fold deduplicates it.
 - The autonomous-mode commit step lives in `playwright-baseline.md` rather than the SKILL.md auto-mode list because it's specific to the baseline-append path. Keeps SKILL.md auto-mode tight (one-liners per step).
 
-Real-session usage notes during the 2-week dogfooding window:
+Friction notes (populated by active use):
 
 - [ ] _(Add entries as you use it. Examples to watch for: hooks correctly no-op in interactive/prove modes; auto-mode state-gate behavior on out-of-band issue moves; prove-mode degradation when knowledge tools are partial; cross-repo registry lookup with newly-added repos; AskUserQuestion findings-review loop iterations.)_
 
 Inputs to feed into Plan 4 (`/ralph:plan`):
 
-- _(TBD after 2 weeks of usage.)_
+- _(Populated by active use, not by waiting.)_
 - Pattern validator note: SKILL.md frontmatter `hooks:` worked for scoping enforcement to a single mode within a multi-mode verb. Plan 4 will reuse for `/ralph:plan` (plan-state-gate + plan-postcondition).
 - Reference-count note: 5 references felt structurally justified by prove-mode's distinctness. For verbs without a structurally-distinct sub-mode, 4 stays the comfortable upper end. Plan 4 should aim for 4 references unless a comparable sub-mode emerges.
 


### PR DESCRIPTION
## Summary

Folds 3 ralph-hero skills (`research` interactive + `ralph-research` autonomous + `prove-claim` evidence reasoning) into one user-facing `/ralph:research` verb in the slim `ralph/` plugin.

- **(default)** = today's `/ralph-hero:research` (interactive: question/issue → parallel sub-agents → findings-review picker → write doc → optional artifact comment + next-steps picker)
- **`--mode auto [#NNN]`** = today's `/ralph-hero:ralph-research` (autonomous: pick XS/S Research-Needed issue → lock → research → write findings → advance to Ready for Plan)
- **`--mode prove "<claim>"`** = today's `/ralph-hero:prove-claim` (5-step knowledge-graph claim investigation → verdict + confidence + evidence chains)

## Final shape

| File | Lines | Role |
|---|---|---|
| `ralph/skills/research/SKILL.md` | 187 | Workflow body + frontmatter |
| `ralph/skills/research/intake-routing.md` | 50 | Detection rules + blocker semantics + group context |
| `ralph/skills/research/research-shapes.md` | 78 | Sub-agent palette + knowledge-graph dispatch + cross-repo |
| `ralph/skills/research/findings-format.md` | 190 | Frontmatter + sections + Files Affected + per-mode matrix |
| `ralph/skills/research/playwright-baseline.md` | 113 | Conditional UI baseline |
| `ralph/skills/research/prove-claim.md` | 133 | 5-step evidence reasoning + confidence + anti-patterns |
| **5 hook ports** | 292 | research-state-gate, research-postcondition, doc-structure-validator (regex re-targeted to slim sections), branch-gate (no-op when env unset), lock-release-on-failure |

## What's new in the slim plugin

- **First skill to use SKILL.md frontmatter `hooks:`** in the slim plugin. Plan 4/5 will reuse the pattern.
- **First skill to ship 5 references** — Plan 2's friction log flagged 4 as the upper end. The 5th (`prove-claim.md`) is structurally distinct (no Agent dispatch, knowledge-graph only).
- Slim-plugin scope fixes vs source hooks: validator regex matches the new section names + only fires on today-prefixed docs modified in the last 15 min; branch-gate no-ops when `RALPH_REQUIRED_BRANCH` is unset (was defaulting to "main").

## Phases

1. Scaffold + hook ports (5 hooks + state machine).
2. Default flow Steps 1-4 + intake-routing + research-shapes.
3. Default flow Steps 5-10 + findings-format + playwright-baseline.
4. `--mode auto` (with group dep refinement + escalation triggers).
5. `--mode prove` + prove-claim reference.
6. README + friction-log + audit fixes (blockers from /review + /skill-creator analogues).

## Test plan

Per the plan-of-plans dogfooding rhythm — old `ralph-hero:*` skills remain functional for 2 weeks. Sunset is Plan 10.

- [ ] `/ralph:research "<some question>"` → default interactive flow
- [ ] `/ralph:research #NNN` → default flow, linked-issue path, artifact comment
- [ ] `/ralph:research "<frontend-relevant question>"` → default flow, Playwright baseline captured
- [ ] `/ralph:research --mode auto` → autonomous flow against a real XS Research-Needed issue
- [ ] `/ralph:research --mode prove "<claim>"` → verdict report

## Plan doc

`thoughts/shared/plans/2026-05-23-GH-1362-ralph-plan-3-research.md`

Friction-log entry appended to spec at `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` § Plan 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)