### PR TITLE
feat(ralph): Plan 4 — /ralph:plan fold (GH-1364)

### DIFF
--- a/ralph/README.md
+++ b/ralph/README.md
@@ -4,7 +4,7 @@ Slim successor to `ralph-hero`. The naive hero, less ceremony.
 
 ## Status
 
-**Plan 3 of 11 (research shipped).** This plugin currently exposes three user-facing skills (`/ralph:catch-up`, `/ralph:form`, `/ralph:research`). Verbs are migrated in one at a time per the plan-of-plans.
+**Plan 4 of 11 (plan shipped).** This plugin currently exposes four user-facing skills (`/ralph:catch-up`, `/ralph:form`, `/ralph:research`, `/ralph:plan`). Verbs are migrated in one at a time per the plan-of-plans.
 
 ## Design
 
@@ -25,7 +25,7 @@ Headline shape:
 | 1 | `/ralph:catch-up` | shipped |
 | 2 | `/ralph:form` | shipped |
 | 3 | `/ralph:research` | shipped |
-| 4 | `/ralph:plan` | pending |
+| 4 | `/ralph:plan` | shipped |
 | 5 | `/ralph:impl` | pending |
 | 6 | `/ralph:review` | pending |
 | 7 | `/ralph:caretake` | pending |

--- a/ralph/hooks/scripts/doc-structure-validator.sh
+++ b/ralph/hooks/scripts/doc-structure-validator.sh
@@ -11,35 +11,35 @@ source "$(dirname "$0")/hook-utils.sh"
 
 read_input > /dev/null
 
-command="${RALPH_COMMAND:-}"
-if [[ -z "$command" ]]; then
-  allow
-fi
-
 project_root="$(get_project_root)"
-
-case "$command" in
-  research)
-    artifact_dir="$project_root/thoughts/shared/research"
-    ;;
-  plan)
-    artifact_dir="$project_root/thoughts/shared/plans"
-    ;;
-  review)
-    artifact_dir="$project_root/thoughts/shared/reviews"
-    ;;
-  *)
-    allow
-    ;;
-esac
-
-# Find a doc CREATED today by the autonomous research flow. The slim plugin
-# scopes this hook tighter than the source ralph-hero copy (which scanned the
-# last 60 min and could block on unrelated stale edits): we only validate a
-# file whose name starts with today's YYYY-MM-DD prefix and was modified in the
-# last 15 min (matching the autonomous flow's 15-minute budget).
 today=$(date +%Y-%m-%d)
-doc=$(find "$artifact_dir" -name "${today}-*.md" -type f -mmin -15 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)
+
+# Slim plugin: discriminate validator branch by file PATH, not RALPH_COMMAND
+# env. The slim ralph multi-mode verbs (e.g., /ralph:plan in --mode review)
+# can't reliably flip RALPH_COMMAND mid-session because Bash-tool exports don't
+# propagate to hook subprocesses. Path-based discrimination is robust: a doc
+# under thoughts/shared/plans/ is a plan doc regardless of the active mode.
+#
+# Scan all three artifact dirs for a today-prefixed doc modified in the last
+# 15 min. Pick the branch by which dir the doc lives in. If multiple dirs have
+# fresh docs, the most-recently-modified wins.
+
+doc=""
+command=""
+for candidate_dir in "thoughts/shared/plans" "thoughts/shared/reviews" "thoughts/shared/research"; do
+  found=$(find "$project_root/$candidate_dir" -name "${today}-*.md" -type f -mmin -15 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)
+  if [[ -n "$found" ]]; then
+    # Pick the freshest across dirs.
+    if [[ -z "$doc" ]] || [[ "$found" -nt "$doc" ]]; then
+      doc="$found"
+      case "$candidate_dir" in
+        thoughts/shared/plans)    command="plan"    ;;
+        thoughts/shared/reviews)  command="review"  ;;
+        thoughts/shared/research) command="research" ;;
+      esac
+    fi
+  fi
+done
 
 if [[ -z "$doc" ]]; then
   allow

--- a/ralph/hooks/scripts/doc-structure-validator.sh
+++ b/ralph/hooks/scripts/doc-structure-validator.sh
@@ -56,8 +56,10 @@ case "$command" in
     grep -qE '`[^`]+`' "$doc" || errors+=("Missing: backtick-wrapped file paths (e.g., \`src/file.ts\`) — referenced findings should use code-spans")
     ;;
   plan)
-    grep -qE "^## Phase [0-9]" "$doc" || errors+=("Missing: ## Phase N: header pattern (e.g., '## Phase 1: ...')")
-    grep -qE "^\- \[ \] (Automated|Manual):" "$doc" || errors+=("Missing: Success criteria format '- [ ] Automated:' or '- [ ] Manual:'")
+    # Section names match ralph/skills/plan/plan-shapes.md § Section order.
+    grep -qE "^## Phase [0-9]" "$doc" || errors+=("Missing: '## Phase N:' header pattern (e.g., '## Phase 1: ...')")
+    grep -qE "^#### (Automated|Manual) Verification" "$doc" || errors+=("Missing: '#### Automated Verification' or '#### Manual Verification' subsections")
+    grep -qE "^- \[ \]" "$doc" || errors+=("Missing: success-criteria checkboxes '- [ ] ...'")
     ;;
   review)
     grep -qE "APPROVED|NEEDS_ITERATION" "$doc" || errors+=("Missing: Verdict (APPROVED or NEEDS_ITERATION)")

--- a/ralph/hooks/scripts/plan-postcondition.sh
+++ b/ralph/hooks/scripts/plan-postcondition.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/plan-postcondition.sh
+# Stop: Verify plan completed successfully
+#
+# Exit codes:
+#   0 - Postconditions met
+#   2 - Postconditions failed, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+# Cache stdin into RALPH_HOOK_INPUT so check_stop_hook_active and get_field
+# below can read it. Must NOT use command substitution (`INPUT=$(read_input)`)
+# because read_input's `export` would run in a subshell and not persist —
+# every other hook in this directory uses the `read_input > /dev/null` form.
+read_input > /dev/null
+check_stop_hook_active
+
+# Accept PLAN REUSED as a non-error terminal state so ralph-plan can short-
+# circuit child plan generation when the parent plan already covers the
+# phase (Step 3.5 in ralph-plan/SKILL.md). Mirrors impl-postcondition.sh:25-37
+# transcript-inspection pattern — read transcript_path from stdin JSON, grep
+# the raw transcript for the marker. Runs BEFORE the ticket/plan-doc check
+# so a REUSED early-exit (which does NOT write a plan file) does not trip the
+# missing-plan-doc block.
+TRANSCRIPT_PATH=$(get_field '.transcript_path')
+if [[ -n "$TRANSCRIPT_PATH" && -f "$TRANSCRIPT_PATH" ]]; then
+  # Match the marker anywhere in the transcript file (mirrors
+  # impl-postcondition.sh:33 which also greps the JSONL transcript without
+  # anchoring — the marker appears inside a JSON "text":"..." content field,
+  # never at column 0, so a "^PLAN REUSED " anchor would never fire).
+  if grep -qE 'PLAN REUSED ' "$TRANSCRIPT_PATH"; then
+    echo "plan-postcondition: PLAN REUSED terminal accepted (no new plan file written)"
+    exit 0
+  fi
+fi
+
+ticket_id="${RALPH_TICKET_ID:-}"
+if [[ -z "$ticket_id" ]]; then
+  allow
+fi
+
+plans_dir="$(get_project_root)/thoughts/shared/plans"
+doc=$(find "$plans_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+
+if [[ -z "$doc" ]]; then
+  alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
+  if [[ -n "$alt_ticket_id" ]]; then
+    doc=$(find "$plans_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+  fi
+fi
+
+if [[ -z "$doc" ]]; then
+  block "Plan postcondition failed
+
+Expected: Plan document for $ticket_id
+Found: None in $plans_dir
+
+The plan command must create a plan document.
+Check the command output for errors."
+fi
+
+if ! git log --oneline -1 --all -- "$doc" 2>/dev/null | grep -q .; then
+  warn "Plan doc exists but may not be committed: $doc"
+fi
+
+# Check for artifact comment marker (Gap 3: discovery sequence)
+marker_dir="/tmp/ralph-artifact-markers"
+issue_number=$(echo "$ticket_id" | grep -oE '[0-9]+' | head -1)
+if [[ -n "$issue_number" ]] && [[ ! -f "$marker_dir/artifact-comment-${issue_number}" ]]; then
+  echo "WARNING: Artifact comment marker absent for #${issue_number} — '## Implementation Plan' comment may not have been posted." >&2
+fi
+
+# --- Dependency graph sync check ---
+# If the plan has depends_on annotations, verify sync_plan_graph was called.
+# We check for a marker file that the sync_plan_graph tool creates on success,
+# since the hook runs in bash without MCP access.
+if grep -q 'depends_on.*\[' "$doc" 2>/dev/null; then
+  log_file="/tmp/ralph-plan-sync-${ticket_id}"
+  if [[ ! -f "$log_file" ]]; then
+    echo "WARNING: Plan has depends_on annotations but sync_plan_graph may not have been called." >&2
+    echo "   Run: ralph_hero__sync_plan_graph({ planPath: \"$doc\" })" >&2
+    # Non-blocking warning for now — upgrade to block once proven reliable
+  fi
+fi
+
+echo "Plan postcondition passed: $doc"
+allow

--- a/ralph/hooks/scripts/plan-research-required.sh
+++ b/ralph/hooks/scripts/plan-research-required.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/plan-research-required.sh
+# PreToolUse (Write): Block plan creation if no research doc
+#
+# Environment:
+#   RALPH_REQUIRES_RESEARCH - Whether research is required (default: true)
+#
+# Exit codes:
+#   0 - Research exists or not required
+#   2 - Research missing, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+file_path=$(get_field '.tool_input.file_path')
+
+if [[ "$file_path" != *"/plans/"* ]]; then
+  allow
+fi
+
+if [[ "${RALPH_REQUIRES_RESEARCH:-true}" != "true" ]]; then
+  allow
+fi
+
+ticket_id=$(echo "$file_path" | grep -oE 'GH-[0-9]+' | head -1)
+if [[ -z "$ticket_id" ]]; then
+  allow
+fi
+
+research_dir="$(get_project_root)/thoughts/shared/research"
+research_doc=$(find_existing_artifact "$research_dir" "$ticket_id")
+
+if [[ -z "$research_doc" ]]; then
+  block "Research required before planning
+
+Ticket: $ticket_id
+Expected: Research document in $research_dir
+Found: None
+
+The planning command requires a research document.
+Run /ralph-research $ticket_id first."
+fi
+
+allow

--- a/ralph/hooks/scripts/plan-state-gate.sh
+++ b/ralph/hooks/scripts/plan-state-gate.sh
@@ -19,11 +19,20 @@ if [[ -z "$new_state" ]]; then
   allow  # Not a state update
 fi
 
-valid_output="${RALPH_VALID_OUTPUT_STATES:-Plan in Review,Human Needed}"
+# Slim-plugin /ralph:plan covers 5 modes (default + auto + epic + iterate + review).
+# The union of legitimate target states across all modes:
+#   - "Plan in Progress" — lock for auto/epic; also NEEDS_ITERATION target from review
+#   - "Plan in Review"   — default/auto/epic advance after write
+#   - "In Progress"      — review-mode APPROVED transition
+#   - "Ready for Plan"   — auto-mode unlock on failure
+#   - "Human Needed"     — escalation in any mode
+# This is broader than the source plugin's per-skill gate; mode-specific narrowing
+# happens in workflow body / SKILL.md, not at the gate.
+valid_output="${RALPH_VALID_OUTPUT_STATES:-Plan in Progress,Plan in Review,In Progress,Ready for Plan,Human Needed}"
 
-# Allow lock state (Plan in Progress)
+# Allow lock state (Plan in Progress) with a context-attached note for auto/epic locks
 if [[ "$new_state" == "Plan in Progress" ]]; then
-  allow_with_context "Acquiring lock state: Plan in Progress. You now have exclusive ownership of this ticket."
+  allow_with_context "Plan in Progress transition allowed. (Lock acquisition for auto/epic, or NEEDS_ITERATION rollback for review.)"
 fi
 
 if ! validate_state "$new_state" "$valid_output"; then

--- a/ralph/hooks/scripts/plan-state-gate.sh
+++ b/ralph/hooks/scripts/plan-state-gate.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/plan-state-gate.sh
+# PreToolUse (ralph_hero__save_issue): Validate plan state transitions
+#
+# Environment:
+#   RALPH_VALID_OUTPUT_STATES - Valid target states
+#
+# Exit codes:
+#   0 - Valid transition
+#   2 - Invalid transition, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+new_state=$(get_field '.tool_input.workflowState')
+if [[ -z "$new_state" ]]; then
+  allow  # Not a state update
+fi
+
+valid_output="${RALPH_VALID_OUTPUT_STATES:-Plan in Review,Human Needed}"
+
+# Allow lock state (Plan in Progress)
+if [[ "$new_state" == "Plan in Progress" ]]; then
+  allow_with_context "Acquiring lock state: Plan in Progress. You now have exclusive ownership of this ticket."
+fi
+
+if ! validate_state "$new_state" "$valid_output"; then
+  block "Invalid plan state transition
+
+Command: ${RALPH_COMMAND:-plan}
+Attempted state: $new_state
+Valid output states: $valid_output
+
+This command can only transition to: $valid_output"
+fi
+
+allow

--- a/ralph/hooks/scripts/plan-tier-validator.sh
+++ b/ralph/hooks/scripts/plan-tier-validator.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/plan-tier-validator.sh
+# PreToolUse (ralph_hero__save_issue): Validate plan type matches issue tier
+#
+# Environment:
+#   RALPH_COMMAND - Must be "plan" or "plan_epic" for this hook to activate
+#   RALPH_PLAN_TYPE - "plan" or "plan-of-plans" (set by planning skill)
+#
+# Exit codes:
+#   0 - Valid or not applicable
+#   2 - Plan type mismatch, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+# Only activate for planning commands
+case "${RALPH_COMMAND:-}" in
+  plan|plan_epic) ;;
+  *) allow ;;
+esac
+
+read_input > /dev/null
+
+plan_type="${RALPH_PLAN_TYPE:-}"
+if [[ -z "$plan_type" ]]; then
+  allow  # Can't validate without plan type
+fi
+
+# Validate: ralph_plan_epic should produce plan-of-plans, ralph_plan should produce plan
+case "${RALPH_COMMAND}" in
+  plan_epic)
+    if [[ "$plan_type" != "plan-of-plans" ]]; then
+      block "Plan type mismatch: ralph_plan_epic should produce type 'plan-of-plans', not '$plan_type'"
+    fi
+    ;;
+  plan)
+    if [[ "$plan_type" == "plan-of-plans" ]]; then
+      block "Plan type mismatch: ralph_plan should produce type 'plan', not 'plan-of-plans'. Use ralph_plan_epic for plan-of-plans."
+    fi
+    ;;
+esac
+
+allow

--- a/ralph/hooks/scripts/review-no-dup.sh
+++ b/ralph/hooks/scripts/review-no-dup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/review-no-dup.sh
+# PreToolUse (Write): Prevent duplicate critique documents
+#
+# Exit codes:
+#   0 - No duplicate, allow
+#   2 - Duplicate exists, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+file_path=$(get_field '.tool_input.file_path')
+
+if [[ ! "$file_path" =~ thoughts/shared/reviews/ ]]; then
+  allow
+fi
+
+ticket_id=$(echo "$file_path" | grep -oE 'GH-[0-9]+' | head -1)
+
+if [[ -z "$ticket_id" ]]; then
+  allow
+fi
+
+project_root=$(get_project_root)
+existing=$(find_existing_artifact "$project_root/thoughts/shared/reviews" "$ticket_id")
+
+if [[ -n "$existing" ]]; then
+  block "DUPLICATE CRITIQUE BLOCKED
+
+A critique document for $ticket_id already exists:
+  $existing
+
+Actions:
+1. If updating existing critique: Use Edit tool instead of Write
+2. If re-reviewing: Delete existing critique first
+3. If different review: Use unique filename suffix"
+fi
+
+allow_with_context "No existing critique for $ticket_id. Proceeding with creation."

--- a/ralph/hooks/scripts/review-plan-gate.sh
+++ b/ralph/hooks/scripts/review-plan-gate.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# PreToolUse:AskUserQuestion — Blocks human prompts when RALPH_REVIEW_PLAN=auto.
+#
+# When the plan review mode is "auto", the pipeline should use the review-agent
+# and escalation protocol instead of prompting the human. This hook enforces that.
+#
+# If RALPH_REVIEW_PLAN is unset, allows (skill hasn't declared a review plan mode).
+#
+# Exit codes:
+#   0 - Allowed (not set, or interactive mode)
+#   2 - Blocked (auto mode — should not prompt human)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+review_plan="${RALPH_REVIEW_PLAN:-}"
+
+# If not set, allow (skill hasn't declared a review plan mode)
+[[ -n "$review_plan" ]] || { allow; }
+
+if [[ "$review_plan" == "auto" ]]; then
+  block "Review plan gate: plan review is auto — use automated review, not human prompts.
+
+If this is an escalation (architecture, permissions, scope), use the escalation protocol instead:
+  ralph_hero__save_issue(number=N, workflowState=\"__ESCALATE__\", command=\"...\")
+
+If you need to report results to the user, use text output instead of AskUserQuestion."
+fi
+
+allow

--- a/ralph/hooks/scripts/review-postcondition.sh
+++ b/ralph/hooks/scripts/review-postcondition.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/review-postcondition.sh
+# Stop: Verify ralph-review completed successfully
+#
+# Exit codes:
+#   0 - Postconditions met
+#   2 - Postconditions failed, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+COMMAND="${RALPH_COMMAND:-review}"
+TICKET_ID="${RALPH_TICKET_ID:-}"
+REVIEW_PLAN="${RALPH_REVIEW_PLAN:-auto}"
+ARTIFACT_DIR="${RALPH_ARTIFACT_DIR:-thoughts/shared/reviews}"
+
+PASSED=()
+FAILED=()
+WARNINGS=()
+
+if [[ -z "$TICKET_ID" ]]; then
+  WARNINGS+=("No ticket ID tracked - cannot verify postconditions")
+else
+  if [[ "$REVIEW_PLAN" != "interactive" ]]; then
+    project_root=$(get_project_root)
+    critique=$(find "$project_root/$ARTIFACT_DIR" -name "*${TICKET_ID}*" -type f 2>/dev/null | head -1)
+    if [[ -n "$critique" ]]; then
+      PASSED+=("Critique document created: $critique")
+    else
+      FAILED+=("AUTO mode requires critique document - none found for $TICKET_ID")
+    fi
+  else
+    PASSED+=("INTERACTIVE mode - no critique document required")
+  fi
+fi
+
+project_root=$(get_project_root)
+uncommitted=$(cd "$project_root" && git status --porcelain "$ARTIFACT_DIR" 2>/dev/null | head -5)
+if [[ -n "$uncommitted" ]]; then
+  WARNINGS+=("Uncommitted changes in $ARTIFACT_DIR")
+fi
+
+echo "==================================================================="
+echo "              ralph-review Postcondition Check"
+echo "==================================================================="
+echo ""
+echo "Ticket: ${TICKET_ID:-unknown}"
+echo "Mode: $([ "$REVIEW_PLAN" = "interactive" ] && echo "INTERACTIVE" || echo "AUTO")"
+echo ""
+
+if [[ ${#PASSED[@]} -gt 0 ]]; then
+  echo "PASSED:"
+  for item in "${PASSED[@]}"; do
+    echo "  [OK] $item"
+  done
+  echo ""
+fi
+
+if [[ ${#WARNINGS[@]} -gt 0 ]]; then
+  echo "WARNINGS:"
+  for item in "${WARNINGS[@]}"; do
+    echo "  [WARN] $item"
+  done
+  echo ""
+fi
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "FAILED:" >&2
+  for item in "${FAILED[@]}"; do
+    echo "  [FAIL] $item" >&2
+  done
+  echo "" >&2
+  echo "ACTION REQUIRED: Address failures before completing." >&2
+  echo "==================================================================" >&2
+  exit 2
+fi
+
+echo "==================================================================="
+exit 0

--- a/ralph/hooks/scripts/review-state-gate.sh
+++ b/ralph/hooks/scripts/review-state-gate.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/review-state-gate.sh
+# PreToolUse (ralph_hero__save_issue): Validate review state transitions
+#
+# Environment:
+#   RALPH_VALID_OUTPUT_STATES - Valid target states
+#
+# Exit codes:
+#   0 - Valid transition
+#   2 - Invalid transition, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+new_state=$(get_field '.tool_input.workflowState')
+if [[ -z "$new_state" ]]; then
+  allow  # Not a state update
+fi
+
+valid_output="${RALPH_VALID_OUTPUT_STATES:-In Progress,Ready for Plan,Human Needed}"
+
+if ! validate_state "$new_state" "$valid_output"; then
+  block "Invalid review state transition
+
+Command: ${RALPH_COMMAND:-review}
+Attempted state: $new_state
+Valid output states: $valid_output
+
+ralph-review can only transition to:
+- 'In Progress' (plan approved)
+- 'Ready for Plan' (needs iteration)
+- 'Human Needed' (escalation)"
+fi
+
+allow_with_context "State transition to '$new_state' is valid for ralph-review."

--- a/ralph/hooks/scripts/review-verify-doc.sh
+++ b/ralph/hooks/scripts/review-verify-doc.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/review-verify-doc.sh
+# PostToolUse (Write): Verify critique document was created correctly
+#
+# Exit codes:
+#   0 - Verified OK
+#   2 - Missing frontmatter fields, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+file_path=$(get_field '.tool_input.file_path')
+
+if [[ ! "$file_path" =~ thoughts/shared/reviews/ ]]; then
+  exit 0
+fi
+
+if [[ ! -f "$file_path" ]]; then
+  echo "WARNING: Critique file not found at $file_path" >&2
+  exit 0
+fi
+
+if ! head -20 "$file_path" | grep -q "^status:"; then
+  block "Critique missing 'status' in frontmatter: $file_path"
+fi
+
+if ! head -20 "$file_path" | grep -q "^github_issue:"; then
+  block "Critique missing 'github_issue' in frontmatter: $file_path"
+fi
+
+if ! head -20 "$file_path" | grep -q "^type: review"; then
+  block "Review document missing 'type: review' in frontmatter: $file_path"
+fi
+
+echo "Critique document verified: $file_path"
+exit 0

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -105,7 +105,40 @@ For `--mode review`, also export `RALPH_COMMAND=review` and `RALPH_ARTIFACT_DIR=
 
 ## Default flow
 
-_(Filled by Phase 2 and Phase 3.)_
+### Step 1: Intake
+
+Resolve `ARG` per `intake-routing.md`:
+
+- `#NNN` / `NNN` / `GH-NNNN` → `get_issue(number)`. Set `LINKED_ISSUE`. Read issue comments for `## Research Document` artifact link; if present, read the linked research doc FULLY.
+- Path to research doc (`thoughts/shared/research/*.md`) → read FULLY; extract `github_issue` from frontmatter; set `LINKED_ISSUE`.
+- Path to existing plan (`thoughts/shared/plans/*.md`) → route to `--mode iterate` automatically (warn the user once).
+- Free-form description → no linked issue; the user is planning ad-hoc.
+- No `ARG` → prompt for issue / file / description.
+
+Run the parent-plan reuse check per `intake-routing.md` § Parent-plan reuse. If the issue is a child of an epic whose plan-of-plans already covers this phase, post a `## Plan Reference` comment and advance the child to "In Progress" — STOP here.
+
+### Step 2: Research & discovery
+
+Knowledge-graph prior art (if available): `knowledge_recall(query="<topic>", role="planner", brief=true)` — planner tier policy `[reflection, wiki, doc]` surfaces synthesized + curated context.
+
+Spawn parallel sub-agents (single message, multiple `Agent()` calls):
+
+- `ralph-hero:codebase-locator` for WHERE files live.
+- `ralph-hero:codebase-analyzer` for HOW components work.
+- `ralph-hero:thoughts-locator` for prior research / plans / reviews.
+- `ralph-hero:thoughts-analyzer` on the most relevant thoughts findings.
+
+Wait for ALL. Read files identified by the locators FULLY (no offset/limit) into the main session.
+
+### Step 3: Plan structure development
+
+Propose phase shape based on research:
+
+- How many phases? (1-2 for XS, 2-5 for S, 5-10 for M.)
+- What does each phase own? (Tightly-scoped file sets; one concern per phase.)
+- Where are the verification points? (Automated commands + manual user checks.)
+
+Use `AskUserQuestion` to confirm structure with the user before drafting the full doc. Iterate on phase shape until the user approves. Consult `plan-shapes.md` § Phase-section anatomy for the shape each phase will take.
 
 ## --mode auto
 

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -132,7 +132,17 @@ Autonomous XS/S plan picker. No questions; one issue, locked, planned, advanced.
 
 ## --mode epic
 
-_(Filled by Phase 5.)_
+Strategic multi-tier decomposition. Folds `ralph-plan-epic` + epic-decomposition side of `ralph-split`. Writes a plan-of-plans doc + creates feature children with dependency edges.
+
+1. **Lock epic** — `save_issue(workflowState: "__LOCK__", command: "plan")` on the epic.
+2. **Context gathering** — read epic body + comments + any linked research. Spawn `codebase-locator` for affected areas; spawn `thoughts-locator` for prior plans on the same epic. Wait for ALL.
+3. **Write plan-of-plans** — per `decomposition.md` § Plan-of-plans shape. Required: Strategic Context, Shared Constraints, Feature Decomposition (3-7 features), Integration Strategy, Feature Sequencing, What We're NOT Doing.
+4. **Create feature children** — per `decomposition.md` § Child creation. For each feature: `create_issue` (Backlog state, estimate from decomposition) → `add_sub_issue(parent: <epic>, child: <new>)`. Apply `add_dependency` edges per `decomposition.md` § Dependency-edge rules.
+5. **Update plan-of-plans** — annotate each `### Feature` with the assigned child issue number + URL.
+6. **Commit + push** — `git add ... && git commit -m "docs(plan): GH-NNN plan-of-plans" && git push origin main`.
+7. **Post artifact + advance** — `create_comment(## Plan of Plans ...)` on the epic; `save_issue(workflowState: "Plan in Review", command: "plan")`.
+8. **Optional orchestration** — for each child in dependency order, optionally dispatch `--mode auto` to plan that feature. The user/orchestrator picks whether to chain — this mode does not auto-cascade by default.
+9. **Report** — *Plan-of-plans complete for #NNN: [Title] / Children: N created / Sequence: A → B → C*.
 
 ## --mode iterate
 

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -105,40 +105,13 @@ For `--mode review`, also export `RALPH_COMMAND=review` and `RALPH_ARTIFACT_DIR=
 
 ## Default flow
 
-### Step 1: Intake
-
-Resolve `ARG` per `intake-routing.md`:
-
-- `#NNN` / `NNN` / `GH-NNNN` → `get_issue(number)`. Set `LINKED_ISSUE`. Read issue comments for `## Research Document` artifact link; if present, read the linked research doc FULLY.
-- Path to research doc (`thoughts/shared/research/*.md`) → read FULLY; extract `github_issue` from frontmatter; set `LINKED_ISSUE`.
-- Path to existing plan (`thoughts/shared/plans/*.md`) → route to `--mode iterate` automatically (warn the user once).
-- Free-form description → no linked issue; the user is planning ad-hoc.
-- No `ARG` → prompt for issue / file / description.
-
-Run the parent-plan reuse check per `intake-routing.md` § Parent-plan reuse. If the issue is a child of an epic whose plan-of-plans already covers this phase, post a `## Plan Reference` comment and advance the child to "In Progress" — STOP here.
-
-### Step 2: Research & discovery
-
-Knowledge-graph prior art (if available): `knowledge_recall(query="<topic>", role="planner", brief=true)` — planner tier policy `[reflection, wiki, doc]` surfaces synthesized + curated context.
-
-Spawn parallel sub-agents (single message, multiple `Agent()` calls):
-
-- `ralph-hero:codebase-locator` for WHERE files live.
-- `ralph-hero:codebase-analyzer` for HOW components work.
-- `ralph-hero:thoughts-locator` for prior research / plans / reviews.
-- `ralph-hero:thoughts-analyzer` on the most relevant thoughts findings.
-
-Wait for ALL. Read files identified by the locators FULLY (no offset/limit) into the main session.
-
-### Step 3: Plan structure development
-
-Propose phase shape based on research:
-
-- How many phases? (1-2 for XS, 2-5 for S, 5-10 for M.)
-- What does each phase own? (Tightly-scoped file sets; one concern per phase.)
-- Where are the verification points? (Automated commands + manual user checks.)
-
-Use `AskUserQuestion` to confirm structure with the user before drafting the full doc. Iterate on phase shape until the user approves. Consult `plan-shapes.md` § Phase-section anatomy for the shape each phase will take.
+1. **Intake** — resolve `ARG` per `intake-routing.md` (issue / research-doc / plan-path / free-form / no-arg). Read mentioned files FULLY before any sub-agent dispatch. Run parent-plan reuse check — if it short-circuits, post `## Plan Reference` and STOP.
+2. **Research & discovery** — `knowledge_recall(role="planner", brief=true)` if available; dispatch codebase-locator / codebase-analyzer / thoughts-locator in parallel (one message, multiple `Agent()` calls). Wait for ALL, read identified files FULLY.
+3. **Plan structure development** — propose phase count + ownership + verification points. `AskUserQuestion` to confirm. Loop until approved. Consult `plan-shapes.md` § Phase-section anatomy.
+4. **Write the plan** — per `plan-shapes.md` (default-column required sections). Filename `thoughts/shared/plans/YYYY-MM-DD-[GH-NNNN-]description.md`.
+4a. **UI Validation Phase (conditional)** — skip if `--no-playwright`. Else consult `ui-validation-phase.md`; append `## Phase N: UI Validation` if frontend-relevant + ralph-playwright installed.
+5. **User review picker** — `AskUserQuestion` over *Approve* / *Approve with edits* / *Restart* / *Iterate*. `review-plan-gate.sh` hook enforces this picker runs before any state-advancing `save_issue`.
+6. **GitHub integration** — if `LINKED_ISSUE`: post `## Implementation Plan` artifact comment with doc URL + 1-line summary; update issue body if scope clarified; `save_issue(workflowState: "Plan in Review", command: "plan")`. Human reviews the plan; a separate `--mode review` or manual approval advances to "In Progress".
 
 ## --mode auto
 

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -146,11 +146,25 @@ Strategic multi-tier decomposition. Folds `ralph-plan-epic` + epic-decomposition
 
 ## --mode iterate
 
-_(Filled by Phase 6.)_
+Surgical updates to an existing plan. No state transitions (the plan stays in whatever workflow state it was in). Consult `iteration.md`.
+
+1. **Resolve plan** — `ARG=#NNN` → `get_issue` and follow the `## Implementation Plan` artifact comment. `ARG=<path>` → use directly. Read FULLY.
+2. **Understand feedback** — `ARG` extra positional or prompt for it. Restate the change in one sentence.
+3. **Confirm approach** — `AskUserQuestion`: *Apply as proposed* / *Adjust* / *Abort*. Loop on Adjust.
+4. **Apply surgical edits** — prefer `Edit` over `Write` per `iteration.md` § Surgical-update principle. Preserve phase numbering; add follow-up sections rather than renumbering.
+5. **Update issue** — post `## Plan Updated` comment summarizing what changed. Do NOT advance state (per `iteration.md` § State preservation).
 
 ## --mode review
 
-_(Filled by Phase 6.)_
+Critique an existing plan and emit APPROVED / NEEDS_ITERATION. Folds `ralph-review`. Export `RALPH_COMMAND=review` and `RALPH_ARTIFACT_DIR=thoughts/shared/reviews` at the start so the review-mode hooks activate. Consult `plan-review.md`.
+
+1. **Resolve plan + issue** — `ARG=#NNN` → `get_issue`; locate the `## Implementation Plan` artifact. `--plan-doc <path>` accepted as override.
+2. **Validate plan exists** — if absent, escalate the issue to "Human Needed". STOP.
+3. **Execute rubric** — read plan FULLY. Score against `plan-review.md` § Review rubric.
+4. **Pick mode (interactive vs auto)** — if `RALPH_REVIEW_PLAN=auto`, dispatch a sub-agent for delegated critique. Else `AskUserQuestion`: *Approve* / *Approve with edits* / *Reject* / *Need more info*.
+5. **Write critique doc** — `thoughts/shared/reviews/YYYY-MM-DD-GH-NNNN-critique.md` per `plan-review.md` § Critique-doc structure. `review-no-dup.sh` blocks if a critique already exists.
+6. **Verdict + transition** — APPROVED → `save_issue(workflowState: "In Progress", command: "review")` (impl can pick it up). NEEDS_ITERATION → `save_issue(workflowState: "Plan in Progress", command: "review")` + post critique as a comment on the issue with specific gap callouts.
+7. **Report** — *Plan reviewed for #NNN: [Title] / Verdict: APPROVED|NEEDS_ITERATION / Critique: [path]*.
 
 ## References
 

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -2,12 +2,15 @@
 description: Create, iterate on, or review an implementation plan. Use whenever the
   user says "plan this", "write a plan for X", "draft a spec", "decompose this
   epic", "split this into features", "iterate on the plan", "refine the plan",
-  "review the plan", "critique this plan", "approve/reject the plan", hands over
-  a plan path, or hands over a research doc to crystallize. Default flow is
-  interactive (collaborative phased plan creation with human review). --mode auto
-  is the autonomous XS/S picker. --mode epic is multi-tier strategic decomposition
-  that creates feature children. --mode iterate makes surgical updates to an
-  existing plan. --mode review produces an APPROVED/NEEDS_ITERATION verdict.
+  "tweak the plan", "update the plan", "amend the plan", "add a phase", "fix
+  phase N", "extend the plan", "the plan is missing X", "review the plan",
+  "critique this plan", "score the plan", "is this plan good?", "verdict on the
+  plan", "sign off on the plan", "approve/reject the plan", hands over a plan
+  path, or hands over a research doc to crystallize. Default is interactive
+  (collaborative phased plan creation with human review). --mode auto is the
+  autonomous XS/S picker. --mode epic is multi-tier strategic decomposition that
+  creates feature children. --mode iterate makes surgical updates to an existing
+  plan. --mode review produces an APPROVED/NEEDS_ITERATION verdict.
 argument-hint: "[--mode auto|epic|iterate|review] [<issue-number|plan-path|description>] [--playwright|--no-playwright]"
 context: inline
 model: opus
@@ -27,8 +30,6 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-tier-validator.sh"
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-state-gate.sh"
     - matcher: "AskUserQuestion"
       hooks:
         - type: command
@@ -42,12 +43,19 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-verify-doc.sh"
+  # review-state-gate and review-postcondition deliberately NOT declared here:
+  # the slim plugin can't reliably flip RALPH_COMMAND mid-session (Bash exports
+  # don't propagate to hook subprocesses), so review-mode is gated by:
+  #   - path discrimination on doc-structure-validator (auto-picks branch from
+  #     which artifact dir has the most recent today-prefixed doc),
+  #   - path discrimination on review-verify-doc + review-no-dup (already in
+  #     the script bodies — they no-op when file_path isn't under reviews/),
+  #   - the broadened valid-output set on plan-state-gate (accepts review-mode
+  #     transitions In Progress / Plan in Progress on top of plan-mode ones).
   Stop:
     - hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-postcondition.sh"
-        - type: command
-          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-postcondition.sh"
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/doc-structure-validator.sh"
         - type: command
@@ -101,7 +109,7 @@ critique-with-verdict.
 
 Set `MODE` ∈ `{default, auto, epic, iterate, review}` from `--mode` flag (default if absent). Capture `ARG` (remaining positional). Capture `--playwright` / `--no-playwright`. Bail with the mode table on `--help`.
 
-For `--mode review`, also export `RALPH_COMMAND=review` and `RALPH_ARTIFACT_DIR=thoughts/shared/reviews` via Bash before the first save_issue — this routes the gates (`review-state-gate.sh`, `review-postcondition.sh`, `review-verify-doc.sh`, `doc-structure-validator.sh` review branch) to the review-mode validation set.
+No env-flip is needed between modes: the hooks discriminate by the file path being written (review-no-dup / review-verify-doc no-op outside `thoughts/shared/reviews/`; doc-structure-validator picks its branch by which artifact dir has the most recent today-prefixed doc; plan-state-gate accepts the union of legitimate transitions across all modes).
 
 ## Default flow
 
@@ -151,8 +159,9 @@ Surgical updates to an existing plan. No state transitions (the plan stays in wh
 1. **Resolve plan** — `ARG=#NNN` → `get_issue` and follow the `## Implementation Plan` artifact comment. `ARG=<path>` → use directly. Read FULLY.
 2. **Understand feedback** — `ARG` extra positional or prompt for it. Restate the change in one sentence.
 3. **Confirm approach** — `AskUserQuestion`: *Apply as proposed* / *Adjust* / *Abort*. Loop on Adjust.
-4. **Apply surgical edits** — prefer `Edit` over `Write` per `iteration.md` § Surgical-update principle. Preserve phase numbering; add follow-up sections rather than renumbering.
-5. **Update issue** — post `## Plan Updated` comment summarizing what changed. Do NOT advance state (per `iteration.md` § State preservation).
+4. **Apply surgical edits** — prefer `Edit` over `Write` per `iteration.md` § Surgical-update principle. Preserve phase numbering; add follow-up sections rather than renumbering. Renumbering escape hatch: see `iteration.md` § Phase numbering preservation.
+5. **Update issue** — post `## Plan Updated` comment summarizing what changed. Do NOT advance state. Do NOT call `save_issue` for workflow transitions in iterate mode (`plan-state-gate.sh` validates transition legitimacy; iterate-mode workflow-body discipline keeps it out of the gate entirely).
+6. **Report** — *Plan iterated for #NNN: [Title] / Plan: [path] / Changes: [1-line summary]*.
 
 ## --mode review
 
@@ -163,7 +172,7 @@ Critique an existing plan and emit APPROVED / NEEDS_ITERATION. Folds `ralph-revi
 3. **Execute rubric** — read plan FULLY. Score against `plan-review.md` § Review rubric.
 4. **Pick mode (interactive vs auto)** — if `RALPH_REVIEW_PLAN=auto`, dispatch a sub-agent for delegated critique. Else `AskUserQuestion`: *Approve* / *Approve with edits* / *Reject* / *Need more info*.
 5. **Write critique doc** — `thoughts/shared/reviews/YYYY-MM-DD-GH-NNNN-critique.md` per `plan-review.md` § Critique-doc structure. `review-no-dup.sh` blocks if a critique already exists.
-6. **Verdict + transition** — APPROVED → `save_issue(workflowState: "In Progress", command: "review")` (impl can pick it up). NEEDS_ITERATION → `save_issue(workflowState: "Plan in Progress", command: "review")` + post critique as a comment on the issue with specific gap callouts.
+6. **Verdict + transition** — APPROVED → `save_issue(workflowState: "In Progress", command: "review")` (impl can pick it up). NEEDS_ITERATION → `save_issue(workflowState: "Plan in Progress", command: "review")` + post critique as a comment on the issue with specific gap callouts. `plan-state-gate.sh` is broad enough to accept both (see hook script header for the union-of-modes valid set).
 7. **Report** — *Plan reviewed for #NNN: [Title] / Verdict: APPROVED|NEEDS_ITERATION / Critique: [path]*.
 
 ## References

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -115,7 +115,20 @@ For `--mode review`, also export `RALPH_COMMAND=review` and `RALPH_ARTIFACT_DIR=
 
 ## --mode auto
 
-_(Filled by Phase 4.)_
+Autonomous XS/S plan picker. No questions; one issue, locked, planned, advanced. Frontmatter `hooks:` gate the flow (tier-validator, state-gate, postcondition, doc-validator, research-required, lock-release). XS/S only, 15-minute budget.
+
+1. **Branch check** — `git branch --show-current` must be `main`.
+2. **Select issue** — `ARG=#NNN` → `get_issue`; else `list_issues(profile: "analyst-plan", limit: 50)`, filter XS/S Ready-for-Plan + unblocked + has-linked-research, pick highest priority. None eligible → exit cleanly.
+3. **Lock + research lookup** — `save_issue(workflowState: "__LOCK__", command: "plan")`. Find linked research per `intake-routing.md` § Linked-research check. If none → escalate to "Human Needed".
+4. **Parent-plan reuse** — per `intake-routing.md` § Parent-plan reuse. If short-circuit: post `## Plan Reference`, advance child to "In Progress", report, STOP.
+5. **Knowledge graph + sub-agent research** — same dispatch as default Steps 2-3, no AskUserQuestion. Wait for ALL, synthesize.
+5a. **UI Validation Phase (conditional)** — per `ui-validation-phase.md`. No user prompt; heuristic-only.
+6. **Write plan doc** — per `plan-shapes.md` (auto-column required sections, including Files Affected). The `plan-research-required.sh` hook blocks Write if no linked research; `doc-structure-validator.sh` blocks Stop if required sections missing.
+7. **Commit + push** — `git add ... && git commit -m "docs(plan): GH-NNN implementation plan" && git push origin main`.
+8. **Post artifact + advance + outcome** — `create_comment(## Implementation Plan ...)` → `save_issue(workflowState: "__COMPLETE__", command: "plan")` (advances to "Plan in Review") → `knowledge_record_outcome(event_type: "plan_completed", ...)` if available.
+9. **Report** — single block: *Plan complete for #NNN: [Title] / Plan: [path] / Status: Plan in Review*.
+
+**Escalation triggers (auto only):** advance to "Human Needed" when (a) no linked research exists, (b) issue is M/L/XL on research (suggest `--mode epic`), or (c) sub-agents surface conflicting implementations.
 
 ## --mode epic
 

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -1,0 +1,133 @@
+---
+description: Create, iterate on, or review an implementation plan. Use whenever the
+  user says "plan this", "write a plan for X", "draft a spec", "decompose this
+  epic", "split this into features", "iterate on the plan", "refine the plan",
+  "review the plan", "critique this plan", "approve/reject the plan", hands over
+  a plan path, or hands over a research doc to crystallize. Default flow is
+  interactive (collaborative phased plan creation with human review). --mode auto
+  is the autonomous XS/S picker. --mode epic is multi-tier strategic decomposition
+  that creates feature children. --mode iterate makes surgical updates to an
+  existing plan. --mode review produces an APPROVED/NEEDS_ITERATION verdict.
+argument-hint: "[--mode auto|epic|iterate|review] [<issue-number|plan-path|description>] [--playwright|--no-playwright]"
+context: inline
+model: opus
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=plan"
+  PreToolUse:
+    - matcher: "Write"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-research-required.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-no-dup.sh"
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-tier-validator.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-state-gate.sh"
+    - matcher: "AskUserQuestion"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-plan-gate.sh"
+  PostToolUse:
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-state-gate.sh"
+    - matcher: "Write"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-verify-doc.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-postcondition.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-postcondition.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/doc-structure-validator.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/lock-release-on-failure.sh"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - AskUserQuestion
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_dependencies
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+---
+
+# /ralph:plan — Plan
+
+The unified planning verb. Default is interactive collaborative plan creation.
+`--mode auto` is the autonomous XS/S picker. `--mode epic` is strategic
+decomposition. `--mode iterate` is surgical refinement. `--mode review` is
+critique-with-verdict.
+
+## Mode dispatch
+
+| Mode | Behavior | Equivalent to |
+|---|---|---|
+| (default) | Interactive: intake → research → structure development → user review → write doc → post artifact | `/ralph-hero:plan` |
+| `--mode auto [#NNN]` | Autonomous: pick XS/S Ready-for-Plan issue → lock → write doc → advance to Plan in Review | `/ralph-hero:ralph-plan` |
+| `--mode epic [#NNN]` | Strategic: lock epic → write plan-of-plans → create feature children + dependency edges | `/ralph-hero:ralph-plan-epic` + epic-side of `/ralph-hero:ralph-split` |
+| `--mode iterate [#NNN \| <path>] [feedback]` | Surgical: read existing plan → confirm approach → apply targeted edits | `/ralph-hero:iterate` |
+| `--mode review [#NNN]` | Critique: read plan → execute rubric → write critique doc → APPROVED / NEEDS_ITERATION | `/ralph-hero:ralph-review` |
+| `--help` / `-h` | Print this table and exit | — |
+
+## Step 0: Parse args
+
+Set `MODE` ∈ `{default, auto, epic, iterate, review}` from `--mode` flag (default if absent). Capture `ARG` (remaining positional). Capture `--playwright` / `--no-playwright`. Bail with the mode table on `--help`.
+
+For `--mode review`, also export `RALPH_COMMAND=review` and `RALPH_ARTIFACT_DIR=thoughts/shared/reviews` via Bash before the first save_issue — this routes the gates (`review-state-gate.sh`, `review-postcondition.sh`, `review-verify-doc.sh`, `doc-structure-validator.sh` review branch) to the review-mode validation set.
+
+## Default flow
+
+_(Filled by Phase 2 and Phase 3.)_
+
+## --mode auto
+
+_(Filled by Phase 4.)_
+
+## --mode epic
+
+_(Filled by Phase 5.)_
+
+## --mode iterate
+
+_(Filled by Phase 6.)_
+
+## --mode review
+
+_(Filled by Phase 6.)_
+
+## References
+
+- `intake-routing.md` — issue / file-path / description detection + parent-plan reuse
+- `plan-shapes.md` — frontmatter, section order, Phase template, per-mode required-sections matrix
+- `decomposition.md` — epic → feature children, dependency-edge rules
+- `iteration.md` — surgical-update principles + state preservation
+- `plan-review.md` — review rubric + verdict shape + critique-doc structure
+- `ui-validation-phase.md` — conditional Playwright UI Validation phase

--- a/ralph/skills/plan/decomposition.md
+++ b/ralph/skills/plan/decomposition.md
@@ -1,3 +1,107 @@
 # Decomposition
 
-_Filled by Phase 5._
+Epic → feature decomposition for `/ralph:plan --mode epic`. Folds `ralph-plan-epic`'s plan-of-plans shape and the epic-decomposition side of `ralph-split`. Atomic splitting (M/L/XL → S/XS) is NOT here — that's `/ralph:caretake --mode split` (Plan 7).
+
+## When epic-mode applies
+
+- Issue labeled `kind:epic` or `kind:feature` with estimate L or XL.
+- Issue body describes 3+ distinct surfaces / capabilities / sub-features.
+- An existing parent issue has multiple in-flight children whose dependencies need clarifying.
+
+If the issue is just M and can be implemented as one plan with 5-7 phases, prefer default or auto mode — don't force epic decomposition.
+
+## Plan-of-plans shape
+
+Filename: `thoughts/shared/plans/YYYY-MM-DD-GH-NNNN-epic-<short-name>.md`. Frontmatter `type: plan-of-plans`.
+
+```markdown
+# [Epic title]
+
+## Prior Work
+[builds_on:: / tensions:: wikilinks]
+
+## Strategic Context
+[Why this epic exists; what success looks like at the epic level]
+
+## Shared Constraints
+[Cross-feature invariants: data shape, API contract, perf budget, security gates]
+
+## Feature Decomposition
+
+### Feature A: [name] (GH-NNN — to be assigned)
+- **Estimate**: S | M
+- **Owner files**: `path/to/area-A/...`
+- **Scope**: [1-2 sentences]
+- **Acceptance**: [bullet list of feature-level criteria]
+
+### Feature B: [name] (GH-NNN — to be assigned)
+...
+
+## Integration Strategy
+[How features compose. Shared interfaces, contract tests, integration points]
+
+## Feature Sequencing
+[Ordered dependency graph. A → B → C, with rationale for each edge]
+
+## What We're NOT Doing
+[Scope boundaries — what's deferred to a later epic]
+
+## References
+```
+
+## Child creation
+
+For each feature in the Feature Decomposition:
+
+1. `create_issue(title: "<feature title>", body: <feature scope + acceptance>, estimate: <S|M>, workflowState: "Backlog", labels: [...])`.
+2. `add_sub_issue(parent: <epic-number>, child: <new-number>)` to link the child under the epic.
+3. Record the assigned number in the plan-of-plans (replace `(GH-NNN — to be assigned)` with the real number + URL).
+
+Estimate defaults:
+
+| Epic estimate | Typical child estimates |
+|---|---|
+| L | 3-5 S children |
+| XL | 3-5 M children, OR 6-10 S children |
+
+Smaller children → easier autonomous planning + impl loops downstream. Prefer S children unless the feature is genuinely M-shaped (e.g., a new subsystem with its own model + API + UI).
+
+## Dependency-edge rules
+
+After all children are created, wire dependencies via `add_dependency(blocker: <A>, blocked: <B>)`:
+
+- **Sequential phases** (B requires A's API to exist): add edge A → B.
+- **Independent features** (can be parallelized): no edges between them.
+- **Shared foundation** (X is a prerequisite for all): X → A, X → B, X → C.
+
+Validate the graph for cycles before committing. If a cycle emerges, rework the feature decomposition (one feature is probably too coarse and should be split).
+
+## Re-decomposition
+
+When an epic was previously decomposed and you're re-running `--mode epic`:
+
+1. `list_sub_issues(epic-number)` — fetch existing children.
+2. Compare each existing child against the new Feature Decomposition.
+3. **Match by title-similarity** — keep existing children whose scope still aligns.
+4. **Mark obsolete children** — if a child is no longer in the decomposition: add a `## Re-scoped` comment on it, do NOT close (the user decides whether to close or salvage).
+5. **Create new children** — for features without an existing match.
+6. **Rewire dependencies** — `list_dependencies(epic-number)` and reconcile against the new Feature Sequencing.
+
+The plan-of-plans doc is overwritten with the new structure; the old version is in git history.
+
+## Cross-repo epic
+
+When the epic spans multiple repos (`.ralph-repos.yml` present, epic touches multiple registry entries):
+
+- Plan-of-plans includes a `## Cross-Repo Scope` section per `findings-format.md` § Cross-Repo Scope.
+- Children inherit the repo-qualified prefix in their `## Files Affected` (e.g., `ralph-hero:src/...`).
+- Dependency edges across repos use the same `add_dependency` MCP call — the substrate doesn't distinguish.
+- The epic itself may live in only one repo; children may live in others. The MCP `create_issue` call accepts `owner` / `repo` overrides for cross-repo child creation.
+
+## Anti-patterns
+
+1. **Over-decomposition** — 10+ children for an L epic. Usually means features are too granular; merge.
+2. **Under-decomposition** — 1-2 huge children. Defeats the point of epic-mode; should be a regular plan.
+3. **Cycles** — A → B and B → A. The decomposition is wrong; one feature must subsume the other or be split.
+4. **Shared mutable state across children** — if Features A and B both modify the same file, they're not really independent. Either sequence them or merge.
+5. **Plan-of-plans without sequencing** — listing features without a dependency order means downstream can't dispatch them. Always include `## Feature Sequencing` even if "all independent" (state that explicitly).

--- a/ralph/skills/plan/decomposition.md
+++ b/ralph/skills/plan/decomposition.md
@@ -1,0 +1,3 @@
+# Decomposition
+
+_Filled by Phase 5._

--- a/ralph/skills/plan/intake-routing.md
+++ b/ralph/skills/plan/intake-routing.md
@@ -1,3 +1,59 @@
 # Intake routing
 
-_Filled by Phase 2._
+How `/ralph:plan` resolves `ARG` into a planning target. Consulted by Step 1 of every mode except `--mode review` (which uses its own resolver in `plan-review.md`).
+
+## Detection rules
+
+Apply in priority order — first match wins. Rules 1-4 apply to `MODE ∈ {default, auto, epic, iterate}`. In `--mode review`, the rules narrow to issue-number / plan-path only.
+
+1. **Issue-number form** — `ARG` matches `#NNN`, `NNN` (digits-only), or `GH-NNNN`. Strip prefix. `get_issue(number, includeGroup: true)` to fetch context (title, body, comments, current workflow state, group data). Set `LINKED_ISSUE=NNN`. Read issue body + comments for any `## Research Document` artifact link and pull that research doc FULLY into the main session.
+
+2. **Research-doc path** — `ARG` is a path under `thoughts/shared/research/*.md` or has `type: research` in its frontmatter. Read FULLY. Extract `github_issue` from frontmatter; set `LINKED_ISSUE`. The research doc is the primary planning input.
+
+3. **Existing-plan path** — `ARG` is a path under `thoughts/shared/plans/*.md`. Route to `--mode iterate` automatically (warn once: *"This is an existing plan — switching to --mode iterate. Pass --mode auto explicitly to overwrite."*).
+
+4. **Free-form description** — anything else not starting with `--`. Treat as a one-line planning prompt. `LINKED_ISSUE` is unset. Useful for ad-hoc planning without prior issue/research.
+
+5. **No `ARG` (default flow only)** — prompt the user: *"What are we planning? Provide an issue number (#NNN), a research-doc path, or a description."* Wait for input, then re-route.
+
+## File reading rule
+
+When `ARG` resolves to a path, or when the user mentions specific files in a free-form description, **read those files FULLY (no `offset` / `limit`) before any sub-agent dispatch**. Sub-agents do not see the main session's prior reads. Reading in the main session also lets you sharpen the sub-agent prompts.
+
+## Linked-research check
+
+If `LINKED_ISSUE` is set and the issue has no linked research doc:
+
+- **Interactive mode** — surface to the user: *"This issue has no linked research. Plan anyway, or research first via `/ralph:research #NNN`?"* If the user chooses "research first", invoke that command and exit.
+- **Auto mode** — `plan-research-required.sh` is the hook-level enforcement. If no research doc is found, the Write of the plan doc will be blocked. Auto mode should detect this upfront in Step 3 and escalate to "Human Needed" rather than failing at the hook.
+- **Epic mode** — skipped (epics rarely have per-primary linked research; the plan-of-plans IS the research).
+- **Iterate / review modes** — skipped (these consume an existing plan; research is upstream).
+
+## Parent-plan reuse
+
+When `LINKED_ISSUE` is set and the issue is a child of a parent issue:
+
+1. Fetch the parent's group via `get_issue(parent, includePipeline: true)`.
+2. Search for an existing parent plan: `thoughts/shared/plans/*GH-NNNN-*.md` where NNNN is the parent issue number.
+3. If found, scan the parent plan for a phase matching the child by number or title.
+4. **If a matching phase exists**: skip child-plan creation. Post a `## Plan Reference` comment on the child issue:
+
+   ```markdown
+   ## Plan Reference
+
+   This child issue is implemented by Phase N of the parent plan at `thoughts/shared/plans/[parent-plan-path].md`.
+
+   No separate child plan needed.
+   ```
+
+   Advance the child issue from "Ready for Plan" → "In Progress" directly (skipping "Plan in Review"). STOP — no more steps.
+
+5. **If no matching phase**: continue with normal child-plan creation.
+
+Parent-plan reuse short-circuits the planning workflow when an epic's plan-of-plans already specifies how each child is implemented. Avoids duplicate child plans.
+
+## Mode-specific carve-outs
+
+- **`--mode iterate`** — `ARG` MUST be either `#NNN` (resolves to the linked plan via issue comments) or a path to an existing plan doc. Free-form descriptions error: *"--mode iterate requires an issue number or plan path."*
+- **`--mode review`** — `ARG` MUST be `#NNN` (review-mode resolves the plan from the issue's `## Implementation Plan` artifact comment). Plan-path is accepted as `--plan-doc <path>` flag in addition.
+- **`--mode epic`** — `ARG` SHOULD be `#NNN` of an epic-tier issue (M/L/XL or `kind:epic` labeled). Free-form descriptions work but produce a plan-of-plans not linked to GitHub state.

--- a/ralph/skills/plan/intake-routing.md
+++ b/ralph/skills/plan/intake-routing.md
@@ -1,0 +1,3 @@
+# Intake routing
+
+_Filled by Phase 2._

--- a/ralph/skills/plan/intake-routing.md
+++ b/ralph/skills/plan/intake-routing.md
@@ -10,7 +10,17 @@ Apply in priority order — first match wins. Rules 1-4 apply to `MODE ∈ {defa
 
 2. **Research-doc path** — `ARG` is a path under `thoughts/shared/research/*.md` or has `type: research` in its frontmatter. Read FULLY. Extract `github_issue` from frontmatter; set `LINKED_ISSUE`. The research doc is the primary planning input.
 
-3. **Existing-plan path** — `ARG` is a path under `thoughts/shared/plans/*.md`. Route to `--mode iterate` automatically (warn once: *"This is an existing plan — switching to --mode iterate. Pass --mode auto explicitly to overwrite."*).
+3. **Existing-plan path** — `ARG` is a path under `thoughts/shared/plans/*.md`. Prompt explicitly via `AskUserQuestion` (do NOT auto-route — preserving vs overwriting a plan is destructive enough to warrant confirmation):
+
+   ```
+   question: "This is an existing plan. What do you want to do?"
+   header: "Existing plan detected"
+   options:
+     - "Iterate on it"        → switch to --mode iterate
+     - "Re-plan from scratch" → default flow; will overwrite
+     - "Review it"            → switch to --mode review
+     - "Cancel"               → STOP
+   ```
 
 4. **Free-form description** — anything else not starting with `--`. Treat as a one-line planning prompt. `LINKED_ISSUE` is unset. Useful for ad-hoc planning without prior issue/research.
 

--- a/ralph/skills/plan/iteration.md
+++ b/ralph/skills/plan/iteration.md
@@ -1,3 +1,87 @@
 # Iteration
 
-_Filled by Phase 6._
+Surgical updates to an existing plan via `/ralph:plan --mode iterate`. Folds `ralph-hero:iterate`. Consumed by Step 4 of the iterate-mode body.
+
+## When iterate-mode applies
+
+- Plan is in any state (Plan in Progress / Plan in Review / Ready for Plan / In Progress / Done).
+- Feedback is targeted: clarify scope, add a phase, fix an inaccuracy, extend with a follow-up.
+- The plan structure is fundamentally OK — you're refining, not rewriting.
+
+If the user wants a totally different plan (scope shifted, approach was wrong), they should `--mode auto` / default to create a new plan instead. Iterate is for surgical, not wholesale.
+
+## Surgical-update principle
+
+Prefer `Edit` over `Write`. Why:
+
+- `Edit` produces a small diff that's easy to review.
+- `Write` rewrites the whole file, hiding what changed.
+- Plan docs are referenced by impl agents — wholesale rewrites can break in-flight implementations.
+
+When you genuinely need to restructure, do it in two commits: (1) the structural change with empty-stub content, (2) filling the content. This produces a reviewable diff history.
+
+## Phase numbering preservation
+
+Existing phases keep their numbers. Adding new phases:
+
+- **Insertion** — discouraged. Renumbering downstream phases breaks references from impl agents / sub-issues / comments.
+- **Append** — preferred. New phases go at the end (`## Phase N+1: ...`). The dependency order can still be expressed via `## Implementation Approach` prose.
+- **Sub-phase** — for additions inside an existing phase, add a new `### Task N.X` rather than a new `## Phase`.
+
+If renumbering is unavoidable, also update:
+
+1. Any `## Implementation Approach` references to the old phase numbers.
+2. Any sub-issue titles that reference the phase number.
+3. The `## Plan Updated` comment must call out the renumbering explicitly.
+
+## Follow-up sections
+
+For new requirements that surface during execution:
+
+- Add a `## Follow-up: [topic]` section at the end of the plan.
+- Don't backfill into existing phases — that masks what was added later.
+- Update frontmatter with `last_updated: YYYY-MM-DD` and `last_updated_note: "Added follow-up for X"`.
+
+## State preservation
+
+Iterate does NOT advance workflow state. Reasons:
+
+- The user may be iterating during impl ("we found this edge case; add a phase for it"). Advancing to "Ready for Plan" or back to "Plan in Progress" disrupts impl agents.
+- The plan's review status (APPROVED / NEEDS_ITERATION) is owned by `--mode review`, not iterate.
+
+If the iteration changes scope materially (e.g., adds a new feature), prompt the user: *"This iteration adds new scope. Re-review the plan via --mode review before continuing impl?"* — but don't auto-transition.
+
+## Feedback intake heuristics
+
+| Feedback shape | Action |
+|---|---|
+| "Add a phase for X" | Append `## Phase N+1: X` per shape in `plan-shapes.md` |
+| "Phase 3 is too vague" | Edit Phase 3's `### Changes Required` with concrete file paths |
+| "We need to support both A and B" | Update `## Desired End State` invariants; add Success Criteria checkboxes |
+| "Drop Y from scope" | Move Y from `## Implementation Approach` to `## What We're NOT Doing` |
+| "The estimate was wrong" | Update frontmatter `tags` if scope changed; add `## Re-scoped` section explaining |
+| "Phase 2 conflicts with Phase 3" | Re-sequence via prose in `## Implementation Approach`; do NOT renumber |
+
+## Update artifact
+
+After applying edits, post on the linked issue:
+
+```markdown
+## Plan Updated
+
+https://github.com/$RALPH_GH_OWNER/$RALPH_GH_REPO/blob/main/[plan-path]
+
+Changes:
+- [Section X]: [what changed and why]
+- [Section Y]: ...
+```
+
+The `## Plan Updated` header is load-bearing — downstream tooling discovers iteration history by grepping for it.
+
+## Anti-patterns
+
+1. **Wholesale rewrite via Write** — loses diff history. Always `Edit`.
+2. **Renumbering phases without updating references** — breaks impl-agent dispatch.
+3. **Advancing state on iterate** — iterate preserves state; `--mode review` is the gate.
+4. **Backfilling new requirements into old phases** — masks the iteration. Use follow-up sections.
+5. **Iterating instead of re-planning** — when scope shifted materially, the user should re-plan, not iterate.

--- a/ralph/skills/plan/iteration.md
+++ b/ralph/skills/plan/iteration.md
@@ -1,0 +1,3 @@
+# Iteration
+
+_Filled by Phase 6._

--- a/ralph/skills/plan/plan-review.md
+++ b/ralph/skills/plan/plan-review.md
@@ -1,0 +1,3 @@
+# Plan review
+
+_Filled by Phase 6._

--- a/ralph/skills/plan/plan-review.md
+++ b/ralph/skills/plan/plan-review.md
@@ -1,3 +1,131 @@
 # Plan review
 
-_Filled by Phase 6._
+Critique-with-verdict for `/ralph:plan --mode review`. Folds `ralph-hero:ralph-review`. Consulted by Steps 3-5 of the review-mode body.
+
+## Purpose
+
+Produce a structured critique of an implementation plan + a binary verdict (APPROVED / NEEDS_ITERATION) that gates whether impl can begin. Reviews are the human's escape valve from autonomous-mode plan drift.
+
+## Review rubric
+
+Score each dimension as PASS / GAP / FAIL. The final verdict aggregates:
+
+- Any **FAIL** → NEEDS_ITERATION.
+- More than 2 **GAP** → NEEDS_ITERATION.
+- 0-2 GAP + 0 FAIL → APPROVED.
+
+### Dimensions
+
+1. **Phase clarity** — does each `## Phase N:` have a clear Overview + Changes Required + Success Criteria? Vague phases ("clean up the code") fail.
+2. **File ownership** — does each phase name specific files? Phases that don't name files can't be implemented atomically.
+3. **Verification quality** — Automated Verification commands must be runnable as-is. Manual Verification must specify what the human is looking for (not just "test the feature").
+4. **Risk coverage** — does the plan call out at least one risk in `## What We're NOT Doing` or `## Migration Notes`? Risk-blind plans miss edge cases.
+5. **Plan-of-plans alignment** — for child plans, does it match the parent's Feature Decomposition + Sequencing? Misaligned child plans break the epic.
+6. **Estimate sanity** — does the plan size match the issue estimate? An L plan on an XS issue means scope crept; an XS plan on an L issue means the plan is under-scoped.
+7. **Linked research present** — `## Prior Work` references real research / review / plan docs? A plan with `None identified.` and no linked research is suspicious unless the issue is genuinely novel.
+
+## Verdict shape
+
+```markdown
+**Verdict**: APPROVED | NEEDS_ITERATION
+
+**Confidence**: high | medium | low — [1-sentence calibration]
+
+**Score**:
+- Phase clarity: PASS | GAP | FAIL
+- File ownership: PASS | GAP | FAIL
+- Verification quality: PASS | GAP | FAIL
+- Risk coverage: PASS | GAP | FAIL
+- Plan-of-plans alignment: PASS | GAP | FAIL | n/a
+- Estimate sanity: PASS | GAP | FAIL
+- Linked research present: PASS | GAP | FAIL | n/a
+```
+
+## Critique-doc structure
+
+Filename: `thoughts/shared/reviews/YYYY-MM-DD-GH-NNNN-critique.md`. Frontmatter:
+
+```yaml
+---
+date: YYYY-MM-DD
+github_issue: NNN
+github_url: https://github.com/OWNER/REPO/issues/NNN
+type: review
+status: complete
+verdict: APPROVED | NEEDS_ITERATION
+plan_doc: thoughts/shared/plans/[plan-path].md
+---
+```
+
+Sections:
+
+```markdown
+# Review: [Plan title]
+
+## Plan Reference
+[Link to the plan doc reviewed]
+
+## Strengths
+[2-4 bullets — what the plan gets right]
+
+## Gaps
+[Bulleted GAP findings, each with: dimension, what's missing, where in the plan to fix]
+
+## Failures
+[Bulleted FAIL findings — only if any]
+
+## Recommended Changes
+[Concrete edits the planner should apply to address gaps / failures]
+
+## Verdict
+[Per "Verdict shape" template above]
+
+## Caveats
+[Reviewer uncertainty: areas where you couldn't fully assess due to missing context]
+```
+
+The `doc-structure-validator.sh` review-branch checks for `APPROVED|NEEDS_ITERATION` in the doc body. The verdict line at the top of `## Verdict` satisfies this.
+
+## Interactive vs auto
+
+**Interactive** (default): `AskUserQuestion` after Step 3 rubric scoring:
+
+```
+question: "Plan review verdict?"
+header: "Plan Review"
+options:
+  - "Approve"             → write APPROVED critique, advance to "In Progress"
+  - "Approve with edits"  → write APPROVED critique, post specific edits as a comment, advance
+  - "Reject"              → write NEEDS_ITERATION critique, return to "Plan in Progress"
+  - "Need more info"      → STOP without writing; post a question comment
+```
+
+**Auto** (`--review-plan auto` or env `RALPH_REVIEW_PLAN=auto`): dispatch a sub-agent for delegated critique:
+
+```
+Agent(
+  subagent_type="general-purpose",
+  prompt="Review the implementation plan at <path> against the rubric in plan-review.md. Produce a verdict (APPROVED / NEEDS_ITERATION) with per-dimension scoring. Be specific about gaps."
+)
+```
+
+The sub-agent's output IS the critique doc (with the workflow body fixing the frontmatter + filename). Auto mode never opens an AskUserQuestion picker.
+
+## Transition rules
+
+| Verdict | Transition | Side effect |
+|---|---|---|
+| APPROVED | `save_issue(workflowState: "In Progress", command: "review")` | Impl can pick it up |
+| APPROVED with edits | Same as APPROVED, plus post `## Recommended Edits` comment | Impl agent should address before merge |
+| NEEDS_ITERATION | `save_issue(workflowState: "Plan in Progress", command: "review")` | Planner re-engages via `--mode iterate` |
+| Need more info | No transition; post `## Review Question` comment | Caller picks up the question |
+
+The `review-state-gate.sh` hook validates that the transition matches the verdict.
+
+## Anti-patterns
+
+1. **Approving plans with > 2 GAP** — drops the rubric's effective floor. If a plan is GAPpy, ask for iteration.
+2. **Rejecting without recommended changes** — a NEEDS_ITERATION verdict without specific edits is unactionable. Always list concrete fixes.
+3. **Reviewing without reading the plan FULLY** — common when the plan is long. Read it entirely; do not skim.
+4. **Auto-mode rubber-stamping** — the sub-agent prompt MUST emphasize the rubric. Loose prompts produce "looks good" reviews.
+5. **Letting "Need more info" loop indefinitely** — if asked twice and not resolved, escalate to "Human Needed".

--- a/ralph/skills/plan/plan-shapes.md
+++ b/ralph/skills/plan/plan-shapes.md
@@ -1,0 +1,3 @@
+# Plan shapes
+
+_Filled by Phase 2 and Phase 3._

--- a/ralph/skills/plan/plan-shapes.md
+++ b/ralph/skills/plan/plan-shapes.md
@@ -1,3 +1,150 @@
 # Plan shapes
 
-_Filled by Phase 2 and Phase 3._
+Plan-doc structure consumed by default, `--mode auto`, and `--mode epic` (with epic-specific variant). The `doc-structure-validator.sh` hook enforces a subset of these sections for plan-mode writes.
+
+## Filename convention
+
+`thoughts/shared/plans/YYYY-MM-DD-[GH-NNNN-]description.md` where:
+
+- `YYYY-MM-DD` is today's date.
+- `GH-NNNN` is the zero-padded primary issue number. Omit if no linked issue.
+- `description` is brief kebab-case.
+
+Examples:
+
+- With issue: `2026-05-23-GH-1364-ralph-plan-4-plan.md`
+- Without issue: `2026-05-23-multi-tenant-tokens.md`
+- Plan-of-plans (epic): `2026-05-23-GH-1300-epic-mobile-app-decomposition.md`
+
+## Frontmatter
+
+```yaml
+---
+date: YYYY-MM-DD
+status: draft                    # draft → ready → approved → in-progress → complete
+type: plan                       # or "plan-of-plans" for epic mode
+tags: [relevant, topic, tags]    # 2-5 lowercase-hyphenated
+github_issue: NNN                # optional
+github_issues: [NNN, NNN, ...]   # for multi-issue groups
+github_urls:
+  - https://github.com/OWNER/REPO/issues/NNN
+primary_issue: NNN
+---
+```
+
+## Section order (standard plan)
+
+```markdown
+# [Plan title — descriptive, references the work]
+
+## Prior Work
+[builds_on:: / tensions:: wikilinks with evidence weighting]
+
+## Overview
+[1-3 paragraphs: what + why]
+
+## Current State Analysis
+[What exists today, where the work lives, key constraints]
+
+### Key Discoveries
+[Bullet list of load-bearing facts the plan reacts to — file:line refs]
+
+## Desired End State
+[Numbered list of post-merge invariants]
+
+### Verification
+[Bullet list — automated and manual checks proving Desired End State]
+
+## What We're NOT Doing
+[Bullet list — scope boundaries]
+
+## Implementation Approach
+[1-2 paragraphs — high-level shape, phase count, file ownership intent]
+
+## Phase 1: [Descriptive name]
+### Overview
+[1-2 sentences]
+
+### Changes Required
+#### 1. [Component / File group]
+**File**: `relative/path.ts`
+**Changes**: [What changes]
+
+### Success Criteria
+#### Automated Verification
+- [ ] `command to run` returns expected result
+- [ ] tests pass
+
+#### Manual Verification
+- [ ] User-visible behavior matches
+
+## Phase 2: [...]
+...
+
+## Testing Strategy
+### Unit Tests
+### Integration Tests
+### Manual Testing Steps
+
+## Performance Considerations
+
+## Migration Notes
+
+## References
+```
+
+## Phase-section anatomy
+
+Each `## Phase N:` section MUST include:
+
+1. **Overview** — 1-2 sentences describing the phase's outcome.
+2. **Changes Required** — concrete file paths + what changes. Backtick-wrap each path.
+3. **Success Criteria** with TWO subsections:
+   - **`#### Automated Verification`** — commands / tests that prove correctness without human eyes. The `doc-structure-validator.sh` hook checks for this header pattern.
+   - **`#### Manual Verification`** — what the user must observe themselves (UI behavior, data integrity post-migration).
+
+File ownership rule: each phase owns a tightly-scoped file set. Phases should not stomp on each other's files. Document file ownership explicitly when a file is touched in multiple phases.
+
+## Plan-of-plans variant (epic mode)
+
+Epic mode writes a different shape — see `decomposition.md` § Plan-of-plans shape. Key differences:
+
+- No phases; instead `## Feature Decomposition` with `### Feature A`, `### Feature B`, etc.
+- `## Strategic Context` replaces `## Current State Analysis`.
+- `## Feature Sequencing` replaces phase ordering.
+- `## Integration Strategy` describes how features compose.
+
+## Estimate / complexity decision guide
+
+| Estimate | Phase count | When |
+|---|---|---|
+| XS | 1 phase | Single concern, < 100 LOC, no schema changes |
+| S | 2-3 phases | Single concern, < 500 LOC, optional schema |
+| M | 5-7 phases | Multiple concerns; needs `--mode epic` if there are independent features |
+| L | 7-10 phases | Multi-tier; `--mode epic` required |
+| XL | Plan of plans | Always `--mode epic` |
+
+Plan 4 default + auto modes target XS/S/M. L+ goes to epic mode. The `plan-tier-validator.sh` hook enforces the XS/S boundary for `--mode auto`.
+
+## Per-mode required-sections matrix
+
+| Section | default (interactive) | `--mode auto` | `--mode epic` |
+|---|---|---|---|
+| Frontmatter | required | required | required |
+| Prior Work | required | required | required |
+| Overview | required | required | required |
+| Current State Analysis | required | required | replaced by Strategic Context |
+| Desired End State | required | required | replaced by Integration Strategy |
+| What We're NOT Doing | required | required | required |
+| Implementation Approach | required | required | replaced by Feature Decomposition |
+| Phase N sections | required | required | n/a (no phases) |
+| Feature Decomposition | n/a | n/a | required |
+| Feature Sequencing | n/a | n/a | required |
+| Testing Strategy | recommended | required | optional |
+| Performance Considerations | optional | optional | optional |
+| Migration Notes | optional | required | required |
+| UI Validation Phase | conditional | conditional | n/a |
+
+`--mode iterate` consumes an existing plan and preserves its section shape — no new required sections.
+
+`--mode review` writes a separate critique doc per `plan-review.md` § Critique-doc structure.

--- a/ralph/skills/plan/plan-shapes.md
+++ b/ralph/skills/plan/plan-shapes.md
@@ -124,7 +124,7 @@ Epic mode writes a different shape — see `decomposition.md` § Plan-of-plans s
 | L | 7-10 phases | Multi-tier; `--mode epic` required |
 | XL | Plan of plans | Always `--mode epic` |
 
-Plan 4 default + auto modes target XS/S/M. L+ goes to epic mode. The `plan-tier-validator.sh` hook enforces the XS/S boundary for `--mode auto`.
+Plan 4 `--mode auto` targets XS/S only (enforced by `plan-tier-validator.sh`). Default and iterate modes accept M too. L+ requires `--mode epic`.
 
 ## Per-mode required-sections matrix
 

--- a/ralph/skills/plan/ui-validation-phase.md
+++ b/ralph/skills/plan/ui-validation-phase.md
@@ -1,3 +1,76 @@
-# UI validation phase
+# UI Validation Phase
 
-_Filled by Phase 3._
+Conditional `## Phase N: UI Validation` section appended to plan docs that touch frontend. Consulted by default-flow Step 4a and auto-flow Step 5a. Skipped when `--no-playwright` is set.
+
+## Detection
+
+1. **ralph-playwright installed?** — read `~/.claude/plugins/installed_plugins.json`, look for any key containing `ralph-playwright`. If absent and `--playwright` not forced, skip.
+2. **Frontend-relevant?** — `--playwright` overrides true. Otherwise scan the planned changes:
+   - File types: `.tsx`, `.jsx`, `.vue`, `.svelte`, `.html`, `.css`.
+   - Affected directories matching `components/`, `pages/`, `routes/`, `app/`, `web/`, `frontend/`, `client/`.
+   - Plan description mentions UI / UX / accessibility / visual / layout.
+   - Any keyword match → frontend-relevant.
+3. If both checks pass, append the `## Phase N: UI Validation` section.
+
+## Phase template
+
+```markdown
+## Phase N: UI Validation
+
+### Overview
+After functional implementation phases complete, validate UI behavior, accessibility, and visual regressions before merge.
+
+### Tasks
+
+#### Task N.1: Start dev server
+- [ ] Resolve start command (env `RALPH_PLAYWRIGHT_DEV_CMD` → memory → `package.json` autodetect).
+- [ ] Start via `Bash(command, run_in_background=true)`. Poll `curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>` every 2s, timeout 30s.
+- [ ] If startup fails: log warning, skip remaining UI tasks, continue.
+
+#### Task N.2: Accessibility audit
+- [ ] `Skill("ralph-playwright:a11y-scan", url="http://localhost:<port>")` against entry routes.
+- [ ] Compare violation count to research-doc UI Baseline (if present). Block merge on regression > 0 critical or > 2 serious.
+
+#### Task N.3: End-to-end story tests
+- [ ] `Skill("ralph-playwright:test-e2e", url="http://localhost:<port>", filter="<feature-tag>")`.
+- [ ] All happy-path and sad-path stories pass.
+
+#### Task N.4: Component tests (if Storybook present)
+- [ ] `Skill("ralph-playwright:storybook-test")`.
+- [ ] Skip silently if Storybook absent (detected via `package.json` `@storybook/*` deps).
+
+#### Task N.5: Visual regression (if Chromatic / Applitools configured)
+- [ ] `Skill("ralph-playwright:visual-diff")`.
+- [ ] Approve baseline diffs in the visual-regression tool.
+
+#### Task N.6: UX audit (--ux-audit flag only)
+- [ ] `Skill("ralph-playwright:explore", url="http://localhost:<port>", goal="Audit UX for [feature]")`.
+- [ ] Capture findings + screenshots into a follow-up research doc.
+
+#### Task N.last: Tear down dev server
+- [ ] Use `RALPH_PLAYWRIGHT_DEV_TEARDOWN_CMD` if set; otherwise kill background PID.
+
+### Phase Success Criteria
+
+#### Automated Verification
+- [ ] All a11y-scan results meet the regression threshold.
+- [ ] All test-e2e stories pass.
+- [ ] Storybook tests pass (if applicable).
+- [ ] Visual-diff approved (if configured).
+
+#### Manual Verification
+- [ ] Reviewer confirms the screenshots match expected UX.
+- [ ] Edge cases (empty states, error states) inspected.
+```
+
+## When to include
+
+- Default-mode: ask the user via picker after Step 4 if not obviously frontend (`AskUserQuestion: "Include UI Validation Phase? [Yes / No]"`).
+- Auto-mode: detect frontend-relevance heuristically; include without prompting. If marginal, skip — `--playwright` forces inclusion.
+- Epic-mode: include in the plan-of-plans as a separate feature child only when the epic has multiple frontend-touching features; otherwise let per-feature plans include it individually.
+- Iterate-mode: do not add unless the user explicitly requests it.
+- Review-mode: not applicable.
+
+## Cross-references with research-doc UI Baseline
+
+If the linked research doc has a `## UI Baseline` section (captured via `playwright-baseline.md` in `/ralph:research`), pull the baseline's violation counts into Task N.2's acceptance criteria. The plan's a11y-scan must not regress against that baseline.

--- a/ralph/skills/plan/ui-validation-phase.md
+++ b/ralph/skills/plan/ui-validation-phase.md
@@ -1,0 +1,3 @@
+# UI validation phase
+
+_Filled by Phase 3._

--- a/thoughts/shared/plans/2026-05-23-GH-1364-ralph-plan-4-plan.md
+++ b/thoughts/shared/plans/2026-05-23-GH-1364-ralph-plan-4-plan.md
@@ -1,0 +1,481 @@
+---
+date: 2026-05-23
+status: draft
+type: plan
+tags: [ralph, plugin-restructure, plan, iterate, review, epic, split, migration, plan-of-plans]
+github_issue: 1364
+github_issues: [1364]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/1364
+primary_issue: 1364
+---
+
+# Plan 4: `/ralph:plan` — Plan Verb Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-05-22-ralph-slim-plugin-restructure]]
+- builds_on:: [[2026-05-23-GH-1357-ralph-plan-1-catch-up]] — scaffold + flat-sibling pattern
+- builds_on:: [[2026-05-23-GH-1359-ralph-plan-2-form]] — multi-surface fold heuristics (4 references comfortable, 5 if a sub-mode is structurally distinct)
+- builds_on:: [[2026-05-23-GH-1362-ralph-plan-3-research]] — SKILL.md frontmatter `hooks:` pattern + slim-plugin scope fixes for ported hooks
+- builds_on:: PR #1363 (Plan 3 in review)
+
+## Overview
+
+Largest fold in the migration: six `ralph-hero` skills (`plan`, `ralph-plan`, `ralph-plan-epic`, `iterate`, `ralph-review`, and the epic-decomposition side of `ralph-split`) collapse into one `/ralph:plan` verb with five modes:
+
+| Mode | Source | Role |
+|---|---|---|
+| (default) | `plan` | Interactive collaborative planning |
+| `--mode auto [#NNN]` | `ralph-plan` | Autonomous XS/S, lock → write → advance, hooks-gated |
+| `--mode epic [#NNN]` | `ralph-plan-epic` + epic-side of `ralph-split` | Multi-tier strategic decomposition + child creation |
+| `--mode iterate [#NNN \| path]` | `iterate` | Surgical refinement of an existing plan |
+| `--mode review [#NNN]` | `ralph-review` | APPROVED / NEEDS_ITERATION verdict, gate before impl |
+
+Plan 3 established SKILL.md frontmatter `hooks:` and 5 references. Plan 4 extends both: ~9 hooks to port (with mode-scoping fixes inherited from Plan 3's audit) and 6 references — one more than Plan 3, justified by `--mode epic` and `--mode review` each having their own structurally distinct opinion content.
+
+## Current State Analysis
+
+Six source skills total **2,777 lines** of SKILL.md prose:
+
+| Source | Lines | Shape |
+|---|---|---|
+| `plugin/ralph-hero/skills/plan/SKILL.md` | 613 | Interactive: context-gathering → research-locator dispatch → Plan Structure Development → Step 5 user review picker → Step 6 GitHub integration |
+| `plugin/ralph-hero/skills/ralph-plan/SKILL.md` | 672 | Autonomous: pick issue group → lock → research lookup → write phased plan → advance to "Plan in Review" |
+| `plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md` | 351 | Strategic: lock epic → write plan-of-plans doc → create feature children via `add_sub_issue` → orchestrate feature planning in dependency waves |
+| `plugin/ralph-hero/skills/iterate/SKILL.md` | 320 | Surgical: read existing plan → understand feedback → confirm approach → update plan in place |
+| `plugin/ralph-hero/skills/ralph-review/SKILL.md` | 470 | Critique: read plan → execute review rubric → write review doc → APPROVED (advance to In Progress) / NEEDS_ITERATION (return to Plan in Progress) |
+| `plugin/ralph-hero/skills/ralph-split/SKILL.md` (epic side only) | 351 | Decompose M/L/XL → XS children via `decompose_feature` + `add_sub_issue` + `add_dependency` |
+
+`ralph-plan-epic` and `ralph-split`'s epic side overlap heavily — both create parent → children hierarchies with dependency edges. The fold collapses them into `--mode epic`. The atomic-splitting side of `ralph-split` (M/L/XL → S/XS) is a board-grooming activity and goes to Plan 7 (`/ralph:caretake`).
+
+Hooks to consider porting (under `plugin/ralph-hero/hooks/scripts/`):
+
+| Hook | Trigger | Job | Port |
+|---|---|---|---|
+| `plan-tier-validator.sh` | PreToolUse on `save_issue` | Reject plan creation for non-XS/S issues without `--mode epic` | yes (auto-mode) |
+| `plan-state-gate.sh` | PostToolUse on `save_issue` | Validate Plan workflow state transitions | yes (auto-mode) |
+| `plan-postcondition.sh` | Stop | Verify a plan doc was written | yes (auto-mode) |
+| `plan-research-required.sh` | PreToolUse on Write | Block plan-doc writes when no linked research exists | yes (auto-mode; also enforces in interactive when env is set) |
+| `review-state-gate.sh` | PreToolUse on `save_issue` | Validate review workflow state transitions | yes (review-mode) |
+| `review-no-dup.sh` | PreToolUse on Write | Block writing a duplicate review doc | yes (review-mode) |
+| `review-plan-gate.sh` | PreToolUse on `AskUserQuestion` | Gate the review picker in interactive review | yes (review-mode) |
+| `review-postcondition.sh` | Stop | Verify review doc + verdict | yes (review-mode) |
+| `review-verify-doc.sh` | PostToolUse on Write | Validate the review doc has required sections + verdict | yes (review-mode) |
+| `doc-structure-validator.sh` | Stop | Validate doc sections per command type | already ported in Plan 3; this plan re-uses its `plan)` branch unchanged |
+| `branch-gate.sh` | PreToolUse on Bash | Block off-main bash in auto / epic modes | already ported in Plan 3 (no-op when env unset) |
+| `lock-release-on-failure.sh` | Stop | Release workflow lock on failure | already ported in Plan 3 |
+
+Total of 7 new hook ports (plus 3 that Plan 3 already shipped). With Plan 3's scope-fix pattern carried forward, each new hook continues to gate on `RALPH_COMMAND` / `RALPH_TICKET_ID` env vars set by SessionStart.
+
+### Key Discoveries
+
+- **Five modes are structurally distinct.** Interactive plan creation, autonomous plan creation, epic decomposition, surgical iteration, and review-with-verdict each have non-overlapping core operations. Sharing the workflow body would be wasteful.
+- **`ralph-plan` and `ralph-plan-epic` share the SessionStart env shape** (`RALPH_COMMAND=plan RALPH_REQUIRED_BRANCH=main`). The difference is downstream — epic-mode skips `plan-tier-validator.sh` (epics are L/XL by definition).
+- **`ralph-review` has its own SessionStart env shape** (`RALPH_COMMAND=review RALPH_ARTIFACT_DIR=thoughts/shared/reviews`). The slim plugin handles per-mode env by having the workflow body export the var via Bash when entering the mode. Mirror Plan 3's pattern — `set-skill-env.sh` only sets `RALPH_COMMAND=plan` on SessionStart; mode-specific vars (`RALPH_ARTIFACT_DIR`, `RALPH_VALID_INPUT_STATES`, etc.) are set by the mode-specific workflow steps. The hooks gate on what they see.
+- **`iterate` does NOT lock or advance state.** It reads an existing plan, updates it, and updates the linked issue's comment — no workflow transition. So iterate doesn't need the state-gate or postcondition hooks. It does still need `RALPH_COMMAND=plan` for `doc-structure-validator.sh` to know which artifact dir to check.
+- **The interactive plan flow's Step 5 picker (Approve / Adjust / Restart) is load-bearing UX.** Survives verbatim into default-mode body. `review-plan-gate.sh` exists to enforce that this picker is shown before any save_issue advancing past "Plan in Progress" — confirming the human had a chance to review. The slim plugin keeps this gate.
+- **`plan-research-required.sh` is the strictest gate.** It blocks any Write to `thoughts/shared/plans/` unless a corresponding research doc exists at `thoughts/shared/research/...`. Auto and default modes both honor it. Epic mode writes a plan-of-plans which may not have linked research per primary issue — needs a carve-out flag (`RALPH_REQUIRES_RESEARCH=false` for epic-mode invocations, or skip the hook when `RALPH_PLAN_TYPE=epic`).
+- **`ralph-plan` Step 3.5 (Parent Plan Reuse Check)** handles the case where a child issue's planning maps to a phase in an existing parent plan — instead of writing a duplicate child plan, post a `## Plan Reference` comment and advance the child to "In Progress" directly. This is a meaningful behavior — preserve in `--mode auto`'s flow.
+- **`ralph-plan` Step 6.5 (Split Integration for M issues)** is the only place where the autonomous flow re-routes to ralph-split. In the slim plugin, this becomes "if the issue tier is M after research, escalate to Human Needed" — the slim plugin doesn't call out to the caretake-mode split from inside `/ralph:plan`; that's an orchestrator concern (Plan 8).
+- **`ralph-review` interactive mode uses an AskUserQuestion picker** with 4 options (Approve / Approve with edits / Reject / Need more info). Survives into `--mode review`'s body. Auto mode dispatches a sub-agent for delegated critique and produces the same verdict shape — picker is interactive-only.
+- **The plan-doc template** (Prior Work / Overview / Current State Analysis / Desired End State / What We're NOT Doing / Implementation Approach / Phase N sections with Success Criteria split into Automated + Manual / Testing Strategy / Performance Considerations / Migration Notes / References) is consistent across the source skills. Move into `plan-shapes.md` reference.
+- **The UI Validation Phase** (conditional, ralph-playwright integration) appears in both `plan` and `ralph-plan` but with slightly different shapes. Centralize into `ui-validation-phase.md` reference; both default and auto modes consult it.
+
+## Desired End State
+
+After Plan 4 merges:
+
+1. `/ralph:plan` is discoverable. With no args → prompts for issue / file / description.
+2. `/ralph:plan "<description>"` or `/ralph:plan #NNN` → default interactive flow.
+3. `/ralph:plan --mode auto [#NNN]` → autonomous XS/S flow.
+4. `/ralph:plan --mode epic [#NNN]` → strategic decomposition + child creation.
+5. `/ralph:plan --mode iterate [#NNN | path] [feedback]` → surgical update of an existing plan.
+6. `/ralph:plan --mode review [#NNN]` → APPROVED / NEEDS_ITERATION verdict on a plan.
+7. Old `/ralph-hero:plan`, `/ralph-hero:ralph-plan`, `/ralph-hero:ralph-plan-epic`, `/ralph-hero:iterate`, `/ralph-hero:ralph-review`, `/ralph-hero:ralph-split` (epic side) remain functional. Sunset is Plan 10.
+8. `ralph/skills/plan/SKILL.md` ≤ 200 lines (target ~190).
+9. Six flat-sibling references: `intake-routing.md`, `plan-shapes.md`, `decomposition.md`, `iteration.md`, `plan-review.md`, `ui-validation-phase.md`.
+10. SKILL.md frontmatter `hooks:` block declares 7 plan/review-specific hooks scoped to auto/epic/review modes.
+11. `ralph/README.md` migration table → Plan 4 shipped.
+12. Friction-log entry appended to spec.
+
+### Verification
+
+- `/plugin marketplace update ralph-hero && /reload-plugins` discovers `/ralph:plan`.
+- Five real invocations: default interactive, `--mode auto`, `--mode epic`, `--mode iterate`, `--mode review`.
+- `wc -l ralph/skills/plan/SKILL.md` ≤ 200.
+- Six reference siblings present, each non-stub.
+- Old `/ralph-hero:*` plan-family skills still work.
+
+## What We're NOT Doing
+
+- **Not** absorbing the atomic-splitting side of `ralph-split` (M/L/XL → S/XS). That's board grooming → Plan 7 (`/ralph:caretake --mode split`).
+- **Not** porting `remember-turn.sh`. Memory-tier writer is substrate concern, not verb concern.
+- **Not** introducing a `--mode interactive` flag. Default is interactive.
+- **Not** changing the plan-doc filename convention (`thoughts/shared/plans/YYYY-MM-DD-GH-NNNN-description.md`). Keeps Plan 10 sunset trivial.
+- **Not** introducing a separate `--mode split` flag for the epic-decomposition operation. The user types `--mode epic`; the workflow body internally invokes the decomposition primitives that source `ralph-split` exposed. The verb's mode surface stays at 5.
+- **Not** wiring `/ralph:plan` → `/ralph:impl` dispatch. That's an orchestrator concern (`/ralph:hero` in Plan 8).
+- **Not** porting `finish-review-verdict.sh`. That's a `/ralph:review` concern (Plan 6), not `/ralph:plan --mode review`.
+- **Not** sunsetting source skills.
+
+## Implementation Approach
+
+Seven XS-sized phases:
+
+1. **Scaffold + hook ports** owns: `ralph/skills/plan/SKILL.md` stub (frontmatter + mode-dispatch table + Step 0 arg parse), six empty reference stubs, hook ports under `ralph/hooks/scripts/` for the seven new scripts.
+2. **Default flow — research + structure** owns: SKILL.md default-mode Steps 1-3 (context-gathering + research + plan structure development), `intake-routing.md` (issue / file / description detection + parent-plan reuse), partial `plan-shapes.md`.
+3. **Default flow — write + GitHub + handoff** owns: SKILL.md default-mode Steps 4-6 (detailed writing + Step 5 picker + Step 6 GitHub integration), finish `plan-shapes.md`, `ui-validation-phase.md`.
+4. **`--mode auto`** owns: SKILL.md auto-mode body, SKILL.md frontmatter `hooks:` block.
+5. **`--mode epic`** owns: SKILL.md epic-mode body, `decomposition.md`.
+6. **`--mode iterate` + `--mode review`** owns: SKILL.md iterate-mode + review-mode bodies, `iteration.md`, `plan-review.md`.
+7. **Parity validation + dogfooding** owns: `ralph/README.md`, spec friction-log entry.
+
+Only `ralph/skills/plan/SKILL.md` is touched in multiple phases — each appends a section. The reference files are single-owner.
+
+## Phase 1: Scaffold + hook ports
+
+### Overview
+
+Stand up directory + frontmatter + reference stubs + hook ports.
+
+### Changes Required
+
+#### 1. Skill scaffold
+
+`ralph/skills/plan/SKILL.md`:
+
+- Description (covers all 5 modes + natural-language trigger phrases — plan, draft a plan, write a spec, decompose, iterate on, refine, review, critique, approve, reject).
+- `argument-hint: "[--mode auto|epic|iterate|review] [<issue-number|file-path|description>] [--playwright|--no-playwright]"`
+- `context: inline`, `model: opus`
+- `allowed-tools` union covering all five modes.
+- `hooks:` block:
+  - SessionStart → `set-skill-env.sh RALPH_COMMAND=plan` (slim-plugin no longer sets `RALPH_REQUIRED_BRANCH` at SessionStart; mode-specific workflow steps export it as needed).
+  - PreToolUse on Write → `plan-research-required.sh`
+  - PreToolUse on `save_issue` → `plan-tier-validator.sh`
+  - PreToolUse on `AskUserQuestion` → `review-plan-gate.sh`
+  - PostToolUse on `save_issue` → `plan-state-gate.sh`
+  - Stop → `plan-postcondition.sh`, `doc-structure-validator.sh`, `lock-release-on-failure.sh`
+  - review-mode hooks are wired via the same matchers — they self-gate on `RALPH_COMMAND=review` vs `plan` and on `RALPH_ARTIFACT_DIR`. Since SKILL.md sets `RALPH_COMMAND=plan` globally for this skill, the review-mode hooks need a workflow-body export of `RALPH_COMMAND=review` to activate. Alternatively: keep review-mode hooks separate by matching on the review-doc artifact dir. See Phase 6.
+- Body: mode-dispatch table + Step 0 (arg parse).
+
+#### 2. Reference stubs
+
+- `intake-routing.md`, `plan-shapes.md`, `decomposition.md`, `iteration.md`, `plan-review.md`, `ui-validation-phase.md` — `_Filled by Phase N._`
+
+#### 3. Hook ports
+
+Copy from `plugin/ralph-hero/hooks/scripts/`:
+- `plan-tier-validator.sh`, `plan-state-gate.sh`, `plan-postcondition.sh`, `plan-research-required.sh`
+- `review-state-gate.sh`, `review-no-dup.sh`, `review-plan-gate.sh`, `review-postcondition.sh`, `review-verify-doc.sh`
+
+Apply Plan 3's scope-fix pattern: each script gates on `RALPH_COMMAND` / `RALPH_TICKET_ID` env vars and no-ops when they're unset.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `test -f ralph/skills/plan/SKILL.md`
+- [ ] `[ "$(wc -l < ralph/skills/plan/SKILL.md)" -le 200 ]`
+- [ ] All six references present.
+- [ ] All seven new hooks present + executable.
+
+#### Manual Verification
+
+- [ ] `/reload-plugins` discovers `/ralph:plan --help`.
+
+---
+
+## Phase 2: Default flow — research + structure
+
+### Overview
+
+Default-mode body Steps 1-3 + intake-routing.md + partial plan-shapes.md.
+
+### Changes Required
+
+#### 1. SKILL.md default-mode Steps 1-3
+
+- **Step 1: Intake** — consult `intake-routing.md`. Detect `#NNN` issue / file path (idea, research doc, existing plan) / inline description. Read mentioned files FULLY.
+- **Step 2: Research & discovery** — knowledge-graph prior-art via `knowledge_recall` (planner tier `[reflection, wiki, doc]`); spawn parallel sub-agents (codebase-locator + codebase-analyzer + thoughts-locator + thoughts-analyzer); wait for all.
+- **Step 3: Plan structure development** — propose phase shape based on research. Use `AskUserQuestion` to confirm structure with the user before drafting.
+
+#### 2. `intake-routing.md`
+
+- Issue-number / file-path / description detection rules.
+- Linked-research check (if planning an issue with no linked research, surface to user — Plan 4 doesn't auto-spawn research, but flags the gap).
+- Parent-plan reuse check (Step 3.5 from source `ralph-plan`): if the issue maps to a phase in a parent plan, skip child-plan creation and post a `## Plan Reference` comment.
+- Mode-prove-style carve-out: `--mode iterate` and `--mode review` accept either `#NNN` or a path to an existing plan doc.
+
+#### 3. `plan-shapes.md` (partial)
+
+- Plan-doc structure section: frontmatter + Prior Work + Overview + Current State Analysis + Key Discoveries + Desired End State + Verification + What We're NOT Doing + Implementation Approach + Phase N section template.
+- Phase-section anatomy: Overview + Changes Required (with file paths) + Success Criteria (Automated + Manual).
+- Estimate / complexity decision guide (XS / S — Plan 4 default; M+ goes to epic).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `[ "$(wc -l < ralph/skills/plan/SKILL.md)" -le 200 ]`
+- [ ] `intake-routing.md` non-stub: `[ "$(wc -l < ralph/skills/plan/intake-routing.md)" -ge 40 ]`
+- [ ] SKILL.md references both.
+
+#### Manual Verification
+
+- [ ] `/ralph:plan "<description>"` runs research, surfaces structure for review.
+- [ ] `/ralph:plan #NNN` fetches the issue + linked research.
+
+---
+
+## Phase 3: Default flow — write + GitHub + handoff + UI validation
+
+### Overview
+
+Default-mode body Steps 4-6 + finish `plan-shapes.md` + `ui-validation-phase.md`.
+
+### Changes Required
+
+#### 1. SKILL.md default-mode Steps 4-6
+
+- **Step 4: Write plan** — generate phased plan doc per `plan-shapes.md`. Filename `thoughts/shared/plans/YYYY-MM-DD-[GH-NNNN-]description.md`.
+- **Step 5: User review picker** — `AskUserQuestion` with 4 options (Approve / Approve with edits / Restart / Iterate). Loop on adjust/restart.
+- **Step 6: GitHub integration** — post `## Implementation Plan` artifact comment on the issue; update issue frontmatter; advance to "Plan in Review" (interactive flow does NOT auto-advance past this — human approval is the gate).
+
+#### 2. Finish `plan-shapes.md`
+
+- Testing Strategy section template.
+- Performance Considerations section template.
+- Migration Notes section template.
+- References section template.
+- Per-mode required-sections matrix (interactive optional, auto required, epic plan-of-plans only requires Strategic Context + Feature Decomposition + Sequencing).
+
+#### 3. `ui-validation-phase.md`
+
+Port the UI Validation Phase template (Task N.1 start dev server → N.2 a11y audit → N.3 e2e stories → N.4 component tests → N.5 visual regression → N.6 UX audit → N.last teardown). Used by default and auto modes.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `plan-shapes.md` ≥ 80 lines.
+- [ ] `ui-validation-phase.md` ≥ 50 lines.
+
+#### Manual Verification
+
+- [ ] `/ralph:plan #NNN` produces a phased plan doc that matches `plan-shapes.md`.
+- [ ] Step 5 picker shows; Iterate / Restart loop back.
+
+---
+
+## Phase 4: `--mode auto`
+
+### Overview
+
+Autonomous XS/S flow. Mirrors `/ralph-hero:ralph-plan`.
+
+### Changes Required
+
+#### 1. SKILL.md auto-mode body
+
+Compact list — Plan 3-style:
+
+1. Branch check (workflow body does the check; `branch-gate.sh` reinforces).
+2. Select issue — `list_issues(profile: "analyst-plan")` → XS/S → unblocked → highest priority.
+3. Lock + research lookup (require linked research; if none, escalate to Human Needed).
+4. Parent-plan reuse check (per `intake-routing.md`) — if mapped, post `## Plan Reference` and skip to Step 8.
+5. Write plan doc per `plan-shapes.md`. Required: frontmatter, Prior Work, Overview, Phase 1+, Success Criteria.
+6. UI Validation Phase (conditional) per `ui-validation-phase.md`.
+7. Commit + push.
+8. Post `## Implementation Plan` artifact comment, advance to "Plan in Review".
+9. Report.
+
+#### 2. Frontmatter hooks already declared in Phase 1; this phase exercises them.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] SKILL.md auto-mode body references `__LOCK__`, `__COMPLETE__`, `Plan in Review`.
+
+#### Manual Verification
+
+- [ ] `/ralph:plan --mode auto` against a real Ready-for-Plan XS issue: locks → writes plan → posts artifact → advances. Hooks fire correctly.
+
+---
+
+## Phase 5: `--mode epic`
+
+### Overview
+
+Strategic multi-tier decomposition. Folds `ralph-plan-epic` + epic-side of `ralph-split`.
+
+### Changes Required
+
+#### 1. SKILL.md epic-mode body
+
+1. Lock epic.
+2. Write plan-of-plans doc per `decomposition.md` § Plan-of-plans shape. Required sections: Strategic Context, Shared Constraints, Feature Decomposition, Integration Strategy, Feature Sequencing, What We're NOT Doing.
+3. Create feature children via `create_issue` + `add_sub_issue`. Apply dependency edges via `add_dependency` based on the sequencing.
+4. Update plan-of-plans with assigned child issue numbers.
+5. Optionally orchestrate feature-level planning by dependency waves (delegate to `--mode auto` per child issue when the workflow demands).
+6. Transition epic to "Plan in Review" (or "Plan Complete" if substrate has the state).
+
+#### 2. `decomposition.md`
+
+- Plan-of-plans shape (sections + frontmatter).
+- Decomposition rules: how to chunk an epic into feature children (3-7 features typical; each XS/S/M depending on substrate).
+- Dependency-edge rules: when to use `add_dependency` (sequential phases) vs not (independent features).
+- Re-decompose triggers: when an epic was already split and needs re-splitting (existing children stay; new children added).
+- M/L/XL → S/XS split rules (formerly `ralph-split`'s epic side): the slim-plugin version focuses on epic → feature, not feature → atomic; atomic splitting is Plan 7.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `decomposition.md` ≥ 60 lines, includes Plan-of-plans shape + dependency-edge rules.
+
+#### Manual Verification
+
+- [ ] `/ralph:plan --mode epic #NNN` for a real epic: writes plan-of-plans → creates ≥2 feature children with `add_sub_issue` linkage → dependency edges added.
+
+---
+
+## Phase 6: `--mode iterate` + `--mode review`
+
+### Overview
+
+The two short modes that operate on an existing plan doc.
+
+### Changes Required
+
+#### 1. SKILL.md iterate-mode body
+
+1. Resolve plan — `#NNN` → fetch linked plan from issue comments; path → read directly.
+2. Read existing plan FULLY (no offset/limit).
+3. Understand feedback (from `ARG` or prompt user).
+4. Confirm approach via `AskUserQuestion`.
+5. Apply surgical updates via Edit / Write. Do NOT rewrite the doc wholesale.
+6. Update issue comment with `## Plan Updated` artifact (linking the changed sections).
+
+#### 2. SKILL.md review-mode body
+
+1. Resolve plan + issue.
+2. Validate plan exists. If not, escalate to "Human Needed".
+3. **Interactive review**: AskUserQuestion picker over 4 options (Approve / Approve with edits / Reject / Need more info). Apply chosen action.
+4. **Auto review**: dispatch a sub-agent for delegated critique; produce verdict.
+5. Write review doc to `thoughts/shared/reviews/YYYY-MM-DD-GH-NNNN-critique.md` per `plan-review.md`.
+6. Execute transition: APPROVED → advance issue to "In Progress"; NEEDS_ITERATION → return to "Plan in Progress" + post critique as comment.
+
+#### 3. `iteration.md`
+
+- Surgical-update principle: prefer Edit over Write; preserve phase numbering; add follow-up sections.
+- State preservation: don't change `status:` frontmatter on iterate unless the plan was Draft → Ready.
+- Feedback intake heuristics: scope clarification vs new requirement vs correction.
+
+#### 4. `plan-review.md`
+
+- Review rubric: Phase clarity, File ownership, Verification quality (Automated + Manual ratio), Risk coverage, Plan-of-plans alignment for child plans.
+- Verdict shape: APPROVED / NEEDS_ITERATION with specific gap callouts.
+- Critique-doc structure: Strengths, Gaps, Recommended changes, Verdict, Confidence.
+- Interactive picker shape (4 options), auto sub-agent dispatch prompt.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `iteration.md` ≥ 40 lines.
+- [ ] `plan-review.md` ≥ 70 lines; includes APPROVED / NEEDS_ITERATION + rubric.
+
+#### Manual Verification
+
+- [ ] `/ralph:plan --mode iterate <plan-path>` with feedback updates the plan in place.
+- [ ] `/ralph:plan --mode review #NNN` produces a verdict doc; APPROVED advances the issue.
+
+---
+
+## Phase 7: Parity validation + dogfooding setup
+
+### Overview
+
+README + friction-log + 5-session parity validation.
+
+### Changes Required
+
+#### 1. README
+
+- `| 4 | \`/ralph:plan\` | shipped |`
+- `## Status` paragraph updated.
+
+#### 2. Friction-log on the spec
+
+Append `### Plan 4: /ralph:plan (shipped YYYY-MM-DD)` subsection. Capture: largest-fold-yet stats (6 sources, 5 modes, 6 references, 7+3 hooks); design calls; active-use checkboxes.
+
+#### 3. Parity validation runs
+
+1. `/ralph:plan "<description>"` → default interactive.
+2. `/ralph:plan --mode auto` → autonomous.
+3. `/ralph:plan --mode epic #NNN` → strategic decomposition.
+4. `/ralph:plan --mode iterate <plan-path>` → surgical update.
+5. `/ralph:plan --mode review #NNN` → verdict.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] README shows Plan 4 shipped.
+- [ ] Friction-log section exists.
+
+#### Manual Verification
+
+- [ ] Five sessions completed successfully.
+- [ ] No regressions in any `ralph-hero:*` plan-family skill.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+None — markdown workflow. MCP tools covered by ralph-hero MCP server's existing tests.
+
+### Integration Tests
+
+The 5 parity sessions in Phase 7 are the integration test. Auto-mode session exercises all hooks end-to-end. Epic-mode session exercises `add_sub_issue` + `add_dependency` chains.
+
+### Manual Testing Steps
+
+Per Phase 7's list, plus:
+
+1. Verify auto-mode lock-release path: simulate mid-flow failure; confirm issue returns to "Ready for Plan".
+2. Verify epic-mode dependency-graph integrity: created children appear in the correct order via `list_dependencies`.
+3. Verify iterate-mode does NOT advance state (preserves Plan in Progress / Plan in Review).
+4. Verify review-mode AUTO writes the same critique-doc structure as INTERACTIVE.
+
+## Performance Considerations
+
+- Default flow: ~5 parallel sub-agent dispatches + 1-2 AskUserQuestion + 1 Write. Mirrors source `plan`.
+- Auto flow: same dispatch + 2 `save_issue` + 1 `create_comment` + optional `knowledge_record_outcome`. 15-minute budget.
+- Epic flow: 1 Write (plan-of-plans) + N `create_issue` + N `add_sub_issue` + N-1 `add_dependency`. Latency scales with N children (typically 3-7).
+- Iterate flow: 1-2 Read + 1-3 Edit. Fastest path.
+- Review flow: 1 Read (plan) + 1 Write (critique) + 1 picker + 1 `save_issue`. Auto sub-mode adds 1 Agent dispatch.
+
+## Migration Notes
+
+- Source skills remain functional alongside the new verb until Plan 10 batches sunsets after each new counterpart has handled the surfaces it replaces.
+- `--mode review` in Plan 4 is distinct from Plan 6's `/ralph:review` verb — Plan 4's is plan-doc review; Plan 6's is code+merge review. The naming is shared but the contexts differ.
+- Plan 5 (`/ralph:impl`) consumes plan docs produced here. Schema stability matters; this plan preserves the existing plan-doc shape verbatim.
+- Plan 7 (`/ralph:caretake --mode split`) absorbs the atomic-splitting side of `ralph-split`. The epic-decomposition side stays in `/ralph:plan --mode epic`.
+
+## References
+
+- Spec: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` (plan-of-plans row 4 at line 336).
+- Plan 3: `thoughts/shared/plans/2026-05-23-GH-1362-ralph-plan-3-research.md` (SKILL.md `hooks:` pattern + slim-plugin hook scope fixes).
+- Source skills:
+  - `plugin/ralph-hero/skills/plan/SKILL.md` (613)
+  - `plugin/ralph-hero/skills/ralph-plan/SKILL.md` (672)
+  - `plugin/ralph-hero/skills/ralph-plan-epic/SKILL.md` (351)
+  - `plugin/ralph-hero/skills/iterate/SKILL.md` (320)
+  - `plugin/ralph-hero/skills/ralph-review/SKILL.md` (470)
+  - `plugin/ralph-hero/skills/ralph-split/SKILL.md` (351; epic side only)
+- Source hook scripts under `plugin/ralph-hero/hooks/scripts/`: `plan-tier-validator.sh`, `plan-state-gate.sh`, `plan-postcondition.sh`, `plan-research-required.sh`, `review-state-gate.sh`, `review-no-dup.sh`, `review-plan-gate.sh`, `review-postcondition.sh`, `review-verify-doc.sh`.
+- ralph plugin state at Plan 4 start: `ralph/skills/{catch-up,form,research}/` (Plan 3 hooks declared in SKILL.md frontmatter; same pattern reused here).

--- a/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+++ b/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
@@ -495,3 +495,37 @@ Open follow-ups (separate plans):
 - When Plan 4 ships, drop the `/ralph-hero:plan` fallback in `/ralph:form` Step 6c (already a documented Plan 2 follow-up). `/ralph:research` Step 9 "Create issue from findings" already points at `/ralph:form` (no fallback needed since Plan 2 shipped).
 - Plan 7 (`/ralph:caretake`) doesn't directly affect this verb.
 - Plan 10 owns sunset of source `research`, `ralph-research`, `prove-claim` skills.
+
+### Plan 4: `/ralph:plan` (shipped 2026-05-23, branch `feature/GH-1364-plan`)
+
+Final shape:
+
+- `ralph/skills/plan/SKILL.md`: 176 lines (under the 200 budget). Holds 5 mode bodies (default, --mode auto, --mode epic, --mode iterate, --mode review) — heaviest verb yet by mode count.
+- Six flat-sibling references: `intake-routing.md` (59), `plan-shapes.md` (150), `decomposition.md` (107), `iteration.md` (87), `plan-review.md` (131), `ui-validation-phase.md` (76). Total 610 lines of opinion content.
+- Combined: 786 lines (vs 2,777 in source plan + ralph-plan + ralph-plan-epic + iterate + ralph-review + ralph-split epic-side). ~72% LOC reduction — largest absolute reduction across plans 1-4. Each surface remains addressable; the fold is structural, not feature-cutting.
+- Hook ports: 9 new (plan-tier-validator, plan-state-gate, plan-postcondition, plan-research-required, review-state-gate, review-no-dup, review-plan-gate, review-postcondition, review-verify-doc) + reuses Plan 3's branch-gate / doc-structure-validator / lock-release-on-failure. doc-structure-validator's plan branch updated to match the slim plan-shapes section style (`#### Automated Verification` / `#### Manual Verification` instead of source's `- [ ] Automated:` flat checkbox format).
+- **First plan to ship 6 references.** Plan 3 shipped 5; the comfort-upper-bound was originally 4. Plan 4's 6 is justified by `--mode epic` and `--mode review` each having structurally distinct content with no overlap with the other modes (decomposition graphs / verdict-shape critique). The pattern: one reference per mode-with-distinct-opinion-content, plus shared opinion (plan-shapes, intake-routing, ui-validation-phase).
+- **Hook discrimination by tool-input path**, not env var. Initial design tried `Bash export RALPH_COMMAND=review` at `--mode review` entry; final-bundle audit caught that Bash-tool exports don't propagate to hook subprocesses. Re-designed to use path-based discrimination:
+  - `doc-structure-validator.sh` scans all 3 artifact dirs (plans, reviews, research) for today-prefixed docs modified in the last 15 min and picks the branch by the dir containing the freshest doc.
+  - `review-no-dup.sh` and `review-verify-doc.sh` already no-op when `tool_input.file_path` isn't under `thoughts/shared/reviews/` — no change needed.
+  - `plan-state-gate.sh` broadened to accept the union of legitimate transitions across all 5 modes (`Plan in Progress, Plan in Review, In Progress, Ready for Plan, Human Needed`).
+  - `review-state-gate.sh` + `review-postcondition.sh` dropped from SKILL.md frontmatter entirely — the union-broadened plan-state-gate + path-discriminated doc-validator + write-path-discriminated review-no-dup/verify cover the surface without env-mode-flipping.
+- **Lesson for Plan 5+**: do NOT rely on env-var flipping across hook invocations. Either set env via SessionStart (one-shot) OR discriminate inside the hook by tool-input shape (file path, target state). Bash-tool exports are session-scoped and do NOT propagate to hook subprocesses.
+
+Friction notes (populated by active use):
+
+- [ ] _(Examples to watch for: review-mode env switching reliability across Bash subprocesses; epic-mode dependency-graph cycle detection in re-decomposition; iterate-mode phase-renumbering edge cases when a plan is in-flight; auto-mode escalation-to-Human-Needed when research is missing; default-mode picker loop UX when user picks Iterate repeatedly.)_
+
+Inputs to feed into Plan 5 (`/ralph:impl`):
+
+- _(Populated by active use, not by waiting.)_
+- Pattern validator note: 6 references worked. Plan 5 should hold at ≤4-5 unless a mode is structurally distinct enough to warrant its own (worktree + plan-compliance feel like the load-bearing references; PR creation might live in a third).
+- Hooks-in-frontmatter pattern continues to scale. Plan 5 will be the heaviest hook-wise (impl carries worktree-isolation + plan-compliance gates).
+- Per-mode env switching (review-mode resetting `RALPH_COMMAND`) needs operational verification — if Bash exports do not persist across hook subprocesses, the review-mode hooks won't activate. Plan 5 should also test this pattern if it adopts a multi-RALPH_COMMAND shape.
+
+Open follow-ups (separate plans):
+
+- Plan 5 consumes plan docs produced here. Schema stability: this plan preserves the existing plan-doc shape verbatim (Phase / Success Criteria with `#### Automated/Manual Verification` subsections).
+- Plan 6 (`/ralph:review`) absorbs `ralph-code-review`, `ralph-val`, `ralph-merge`, `finish` — the code-and-merge review surface, distinct from Plan 4's `--mode review` which is plan-doc review.
+- Plan 7 (`/ralph:caretake --mode split`) absorbs the atomic-splitting side of `ralph-split`.
+- Plan 10 owns sunset of source `plan`, `ralph-plan`, `ralph-plan-epic`, `iterate`, `ralph-review` skills (`ralph-split` straddles plans 4 and 7 — both sides need to be re-homed before sunset).


### PR DESCRIPTION
## Summary

Largest fold in the slim-plugin migration: 6 `ralph-hero` skills → 1 `/ralph:plan` verb with 5 modes.

- **(default)** = `/ralph-hero:plan` (interactive collaborative planning)
- **`--mode auto [#NNN]`** = `/ralph-hero:ralph-plan` (autonomous XS/S, hooks-gated)
- **`--mode epic [#NNN]`** = `/ralph-hero:ralph-plan-epic` + epic-decomposition side of `/ralph-hero:ralph-split` (multi-tier; plan-of-plans + feature children + dependency edges)
- **`--mode iterate [#NNN | <path>]`** = `/ralph-hero:iterate` (surgical refinement of an existing plan)
- **`--mode review [#NNN]`** = `/ralph-hero:ralph-review` (APPROVED / NEEDS_ITERATION verdict)

## Stacked on Plan 3 (PR #1363)

This branch is `feature/GH-1364-plan` stacked on `feature/GH-1362-research`. The diff against main includes both Plans 3 and 4 until Plan 3 merges. Compare against Plan 3's branch tip to see only Plan 4's changes: https://github.com/cdubiel08/ralph-hero/compare/feature/GH-1362-research...feature/GH-1364-plan

## Final shape

| File | Lines | Role |
|---|---|---|
| `ralph/skills/plan/SKILL.md` | 185 | Workflow body + frontmatter (5 modes) |
| `ralph/skills/plan/intake-routing.md` | 70 | Detection + parent-plan reuse + mode-specific carve-outs |
| `ralph/skills/plan/plan-shapes.md` | 150 | Frontmatter, section order, Phase template, per-mode required-sections matrix |
| `ralph/skills/plan/decomposition.md` | 107 | Epic → feature children, dependency-edge rules |
| `ralph/skills/plan/iteration.md` | 87 | Surgical-update principles + state preservation |
| `ralph/skills/plan/plan-review.md` | 131 | Review rubric + verdict shape + critique-doc structure |
| `ralph/skills/plan/ui-validation-phase.md` | 76 | Conditional Playwright UI Validation phase |
| **9 new hook ports** | ~370 | plan-tier-validator, plan-state-gate (broadened valid set), plan-postcondition, plan-research-required, review-state-gate, review-no-dup, review-plan-gate, review-postcondition, review-verify-doc |
| **doc-structure-validator.sh** | (patched) | Now path-discriminates across plans / reviews / research dirs |

Total fold: 786 lines (vs 2,777 in source) — ~72% LOC reduction.

## Audit-fix iteration before opening PR

The final-bundle audit (mirroring Plan 3's pattern: parallel `/review` + `/skill-creator` analogues) caught a load-bearing design flaw: the initial design relied on `Bash export RALPH_COMMAND=review` mid-session to flip hook gates between plan-mode and review-mode. Bash-tool exports do NOT propagate to hook subprocesses, so this is broken. Re-designed to gate-by-tool-input:

- `doc-structure-validator.sh` scans all 3 artifact dirs and picks branch by which has the freshest today-prefixed doc.
- `plan-state-gate.sh` broadened to accept the union of legitimate transitions across all 5 modes.
- `review-state-gate.sh` + `review-postcondition.sh` dropped from frontmatter (path-discriminated `review-verify-doc.sh` + `review-no-dup.sh` cover the surface).

The lesson is captured in the friction-log for Plan 5+: do NOT rely on env-var flipping across hook invocations. Either set env via SessionStart (one-shot) OR discriminate inside the hook by tool-input shape.

## Phases

1. Scaffold + 9 hook ports.
2. Default flow Steps 1-3 + intake-routing + partial plan-shapes.
3. Default flow Steps 4-6 + finish plan-shapes + ui-validation-phase.
4. `--mode auto` body.
5. `--mode epic` body + decomposition.md.
6. `--mode iterate` + `--mode review` bodies + iteration.md + plan-review.md.
7. README + friction-log + audit fixes.

## Test plan

Per the active-dogfooding rhythm (no calendar gate; sunset when surfaces are exercised):

- [ ] `/ralph:plan "<description>"` → default interactive
- [ ] `/ralph:plan --mode auto` → autonomous against a real Ready-for-Plan XS issue
- [ ] `/ralph:plan --mode epic #NNN` → strategic decomposition + child creation
- [ ] `/ralph:plan --mode iterate <plan-path>` → surgical update
- [ ] `/ralph:plan --mode review #NNN` → verdict (verify both APPROVED and NEEDS_ITERATION paths)

## Plan doc

`thoughts/shared/plans/2026-05-23-GH-1364-ralph-plan-4-plan.md`

Friction-log appended to spec at `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` § Plan 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)