### PR TITLE
feat(ralph): Plan 7 — /ralph:caretake fold (GH-1370)

### DIFF
--- a/ralph/README.md
+++ b/ralph/README.md
@@ -4,7 +4,7 @@ Slim successor to `ralph-hero`. The naive hero, less ceremony.
 
 ## Status
 
-**Plan 6 of 11 (review shipped).** This plugin currently exposes six user-facing skills (`/ralph:catch-up`, `/ralph:form`, `/ralph:research`, `/ralph:plan`, `/ralph:impl`, `/ralph:review`). Verbs are migrated in one at a time per the plan-of-plans.
+**Plan 7 of 11 (caretake shipped).** This plugin currently exposes seven user-facing skills (`/ralph:catch-up`, `/ralph:form`, `/ralph:research`, `/ralph:plan`, `/ralph:impl`, `/ralph:review`, `/ralph:caretake`). Verbs are migrated in one at a time per the plan-of-plans.
 
 ## Design
 
@@ -28,7 +28,7 @@ Headline shape:
 | 4 | `/ralph:plan` | shipped |
 | 5 | `/ralph:impl` | shipped |
 | 6 | `/ralph:review` | shipped |
-| 7 | `/ralph:caretake` | pending |
+| 7 | `/ralph:caretake` | shipped |
 | 8 | `/ralph:hero` | pending |
 | 9 | `/ralph:setup` | pending |
 | 10 | sunset `plugin/ralph-hero/` | pending |

--- a/ralph/hooks/scripts/postmortem-completeness.sh
+++ b/ralph/hooks/scripts/postmortem-completeness.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# ralph/hooks/scripts/postmortem-completeness.sh
+# Stop: Validate post-mortem content emitted by /ralph:caretake --mode postmortem.
+#
+# Renamed from team-postmortem-completeness.sh on Plan 7 port — the slim plugin
+# has no `team` concept; this gate runs against the artifact written by the
+# postmortem mode body. Drops the TeamDelete tool-name check (Stop-event, no tool
+# context) and the TEAM_MARKER tmp-file lookup (slim plugin uses the
+# RALPH_POSTMORTEM_PATH env var the mode body sets directly).
+#
+# Plan 6 hardening:
+#   - Scope-guarded (caretake + postmortem).
+#   - grep pipelines append `|| true` so missing-section matches don't crash
+#     under set -euo pipefail.
+#
+# Environment:
+#   RALPH_POSTMORTEM_PATH - Absolute path the mode body wrote to
+#   RALPH_FORCE_STOP      - If "true", allow stop even if postconditions fail
+#
+# Exit codes:
+#   0 - All required content present (or out of scope, or escape hatch active)
+#   2 - Missing required fields/sections, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "postmortem" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+check_stop_hook_active
+
+if [[ "${RALPH_FORCE_STOP:-}" == "true" ]]; then
+  warn "RALPH_FORCE_STOP=true - bypassing postmortem completeness check"
+fi
+
+POSTMORTEM="${RALPH_POSTMORTEM_PATH:-}"
+if [[ -z "$POSTMORTEM" ]]; then
+  # Mode body didn't write a doc — either POSTMORTEM SKIPPED was emitted or
+  # the body shortcut without setting the env var. Defer to the terminal-token
+  # check; allow here so postcondition checking happens at the token layer.
+  allow
+fi
+
+if [[ ! -f "$POSTMORTEM" ]]; then
+  block "Postmortem completeness: RALPH_POSTMORTEM_PATH points at a non-existent file.
+
+Path: $POSTMORTEM
+
+The mode body set RALPH_POSTMORTEM_PATH but the file is missing — likely a
+race or a write failure. Re-run the mode."
+fi
+
+# Check required frontmatter fields. The grep | head pipeline appends `|| true`
+# so a missing field flows to the array-build path under set -euo pipefail.
+MISSING_FIELDS=()
+for field in "type:" "status:" "github_issue:"; do
+  if ! grep -q "^${field}" "$POSTMORTEM" 2>/dev/null; then
+    MISSING_FIELDS+=("$field")
+  fi || true
+done
+
+# Check required body sections.
+MISSING_SECTIONS=()
+for section in "## Artifacts" "## Blockers" "## Impediments" "## Issues Processed" "## Worker Summary"; do
+  if ! grep -qF "$section" "$POSTMORTEM" 2>/dev/null; then
+    MISSING_SECTIONS+=("$section")
+  fi || true
+done
+
+if [[ ${#MISSING_FIELDS[@]} -gt 0 || ${#MISSING_SECTIONS[@]} -gt 0 ]]; then
+  MSG="Post-mortem at ${POSTMORTEM} is incomplete."
+  if [[ ${#MISSING_FIELDS[@]} -gt 0 ]]; then
+    MSG+=$'\n\n'"Missing frontmatter fields:"
+    for f in "${MISSING_FIELDS[@]}"; do
+      MSG+=$'\n'"  - ${f}"
+    done
+  fi
+  if [[ ${#MISSING_SECTIONS[@]} -gt 0 ]]; then
+    MSG+=$'\n\n'"Missing body sections:"
+    for s in "${MISSING_SECTIONS[@]}"; do
+      MSG+=$'\n'"  - ${s}"
+    done
+  fi
+  MSG+=$'\n\n'"Regenerate via /ralph:caretake --mode postmortem."
+  block "$MSG"
+fi
+
+echo "Postmortem completeness passed: $POSTMORTEM"
+allow

--- a/ralph/hooks/scripts/split-estimate-gate.sh
+++ b/ralph/hooks/scripts/split-estimate-gate.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# ralph/hooks/scripts/split-estimate-gate.sh
+# Dual-event hook for ralph_hero__get_issue under /ralph:caretake --mode split:
+#   - PreToolUse: surface a context message reminding the agent of the M/L/XL
+#     requirement.
+#   - PostToolUse: parse the get_issue response and BLOCK if the fetched issue's
+#     estimate is XS or S.
+#
+# Plan 6 hardening: RALPH_COMMAND scope guard (caretake only) + RALPH_SUBCOMMAND
+# scope check (split only). Pipeline-heavy jq stages append `|| true` so the
+# no-match path under `set -euo pipefail` flows to a controlled warn/allow.
+#
+# Environment:
+#   RALPH_MIN_ESTIMATE       - Minimum estimate for splitting (default: M).
+#                              The set of allowed estimates is computed from this:
+#                                M  -> M, L, XL
+#                                L  -> L, XL
+#                                XL -> XL
+#   RALPH_VALID_SUB_ESTIMATES - Sub-issue estimate set (informational only here)
+#
+# Exit codes:
+#   0 - Allowed (PreToolUse passthrough, PostToolUse confirmed M/L/XL, or out of scope)
+#   2 - Blocked (PostToolUse: fetched issue is XS/S — too small to split)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "split" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+
+min_estimate="${RALPH_MIN_ESTIMATE:-M}"
+
+# Compute allowed estimate set from RALPH_MIN_ESTIMATE
+case "$min_estimate" in
+  XS) allowed="XS,S,M,L,XL" ;;
+  S)  allowed="S,M,L,XL" ;;
+  M)  allowed="M,L,XL" ;;
+  L)  allowed="L,XL" ;;
+  XL) allowed="XL" ;;
+  *)  allowed="M,L,XL" ;;
+esac
+
+event_name=$(get_field '.hook_event_name')
+
+# ---- PreToolUse path: passthrough with context --------------------------------
+if [[ "$event_name" == "PreToolUse" ]] || [[ -z "$event_name" ]]; then
+  allow_with_context "Split command requires ticket estimate of $allowed. Estimate will be re-checked after fetch."
+fi
+
+# ---- PostToolUse path: inspect response and enforce ---------------------------
+if [[ "$event_name" != "PostToolUse" ]]; then
+  warn "split-estimate-gate.sh invoked for unexpected event '$event_name'; allowing."
+fi
+
+response_text=$(get_field '.tool_response.content[0].text')
+
+if [[ -z "$response_text" ]]; then
+  warn "split-estimate-gate.sh: no tool_response.content[0].text found; allowing."
+fi
+
+# Parse inner JSON. The `|| true`/`|| echo ""` shapes keep the pipeline alive
+# under set -euo pipefail when jq returns nothing.
+estimate=$(echo "$response_text" | jq -r '.estimate // empty' 2>/dev/null || echo "")
+issue_number=$(echo "$response_text" | jq -r '.number // empty' 2>/dev/null || echo "")
+issue_title=$(echo "$response_text" | jq -r '.title // empty' 2>/dev/null || echo "")
+
+if [[ -z "$estimate" ]]; then
+  warn "split-estimate-gate.sh: fetched issue #${issue_number:-unknown} has no estimate; agent should set one before proceeding."
+fi
+
+if validate_state "$estimate" "$allowed"; then
+  echo "split-estimate-gate.sh: #${issue_number} estimate=$estimate (allowed: $allowed) — split may proceed"
+  allow
+fi
+
+block "Split blocked: ticket too small
+
+Issue:    #${issue_number} — ${issue_title}
+Estimate: $estimate
+Required: one of $allowed (RALPH_MIN_ESTIMATE=$min_estimate)
+
+The split mode only operates on M/L/XL issues. For XS/S tickets, send the
+work to /ralph:impl directly — splitting an already-atomic ticket produces
+trivial children and wastes orchestrator turns.
+
+Recovery options:
+  1. If the estimate is wrong, run /ralph:caretake --mode triage with action
+     RE-ESTIMATE to bump it to M+ before retrying split.
+  2. If the ticket really is small, dispatch /ralph:impl instead.
+  3. If you need to bypass this gate for a special case, set
+     RALPH_FORCE_STOP=true (not recommended — leaves audit trail unclean)."

--- a/ralph/hooks/scripts/split-postcondition.sh
+++ b/ralph/hooks/scripts/split-postcondition.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ralph/hooks/scripts/split-postcondition.sh
-# Stop: Verify /ralph:caretake --mode split created ≥1 sub-issue.
+# Stop: Verify /ralph:caretake --mode split created ≥2 sub-issues.
 #
 # Plan 6 hardening: scope-guarded (caretake + split).
 #
@@ -37,18 +37,21 @@ fi
 
 split_count="${RALPH_SPLIT_COUNT:-0}"
 
-if [[ "$split_count" -gt 0 ]]; then
+if [[ "$split_count" -ge 2 ]]; then
   echo "Split postcondition passed: $split_count sub-issues created for $ticket_id"
   echo "  Parent $ticket_id should remain in Backlog (preserved as epic)"
   allow
 fi
 
-block "Split postcondition failed: no sub-issues verified
+block "Split postcondition failed: fewer than 2 sub-issues verified
 
 Ticket: $ticket_id
-Expected: At least 1 sub-issue created via ralph_hero__add_sub_issue
+Expected: At least 2 sub-issues created via ralph_hero__add_sub_issue
+         (a one-child split is a re-estimate, not a decomposition)
 Found: RALPH_SPLIT_COUNT=${split_count}
 
-The /ralph:caretake --mode split body must create sub-issues before completing.
+The /ralph:caretake --mode split body must create ≥2 sub-issues before
+completing — see ralph/skills/caretake/outcome-tokens.md (\"SPLIT <N>\" requires
+N ≥ 2) and ralph/skills/caretake/split-decomposition.md.
 If this is a false positive (sub-issues were created but not tracked),
 re-run with RALPH_FORCE_STOP=true to bypass this check."

--- a/ralph/hooks/scripts/split-postcondition.sh
+++ b/ralph/hooks/scripts/split-postcondition.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# ralph/hooks/scripts/split-postcondition.sh
+# Stop: Verify /ralph:caretake --mode split created ≥1 sub-issue.
+#
+# Plan 6 hardening: scope-guarded (caretake + split).
+#
+# Environment:
+#   RALPH_TICKET_ID   - Parent ticket being split
+#   RALPH_SPLIT_COUNT - Number of sub-issues created (set by mode body)
+#   RALPH_FORCE_STOP  - If "true", allow stop even if postconditions fail
+#
+# Exit codes:
+#   0 - Postconditions met (or out of scope, or escape hatch active)
+#   2 - Missing sub-issues, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "split" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+check_stop_hook_active
+
+if [[ "${RALPH_FORCE_STOP:-}" == "true" ]]; then
+  warn "RALPH_FORCE_STOP=true - bypassing split postcondition check"
+fi
+
+ticket_id="${RALPH_TICKET_ID:-}"
+if [[ -z "$ticket_id" ]]; then
+  allow
+fi
+
+split_count="${RALPH_SPLIT_COUNT:-0}"
+
+if [[ "$split_count" -gt 0 ]]; then
+  echo "Split postcondition passed: $split_count sub-issues created for $ticket_id"
+  echo "  Parent $ticket_id should remain in Backlog (preserved as epic)"
+  allow
+fi
+
+block "Split postcondition failed: no sub-issues verified
+
+Ticket: $ticket_id
+Expected: At least 1 sub-issue created via ralph_hero__add_sub_issue
+Found: RALPH_SPLIT_COUNT=${split_count}
+
+The /ralph:caretake --mode split body must create sub-issues before completing.
+If this is a false positive (sub-issues were created but not tracked),
+re-run with RALPH_FORCE_STOP=true to bypass this check."

--- a/ralph/hooks/scripts/split-size-gate.sh
+++ b/ralph/hooks/scripts/split-size-gate.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# ralph/hooks/scripts/split-size-gate.sh
+# PreToolUse (ralph_hero__create_issue): Validate that sub-tickets created
+# by /ralph:caretake --mode split are XS/S only.
+#
+# Plan 6 hardening: scope-guarded (caretake + split). Larger estimates would
+# undermine the atomic-decomposition contract — block them at the MCP boundary.
+#
+# Environment:
+#   RALPH_VALID_SUB_ESTIMATES - Valid estimates for sub-tickets (default: XS,S)
+#
+# Exit codes:
+#   0 - Sub-ticket estimate is valid (or out of scope)
+#   2 - Sub-ticket too large, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "split" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+
+valid_estimates="${RALPH_VALID_SUB_ESTIMATES:-XS,S}"
+
+estimate=$(get_field '.tool_input.estimate')
+if [[ -z "$estimate" ]]; then
+  allow  # No estimate specified, allow (command should set one)
+fi
+
+if ! validate_state "$estimate" "$valid_estimates"; then
+  block "Sub-ticket estimate too large
+
+Attempted estimate: $estimate
+Valid estimates: $valid_estimates
+
+/ralph:caretake --mode split must create XS or S sub-tickets only.
+If the work is larger, consider further decomposition."
+fi
+
+allow_with_context "Creating sub-ticket with estimate $estimate (valid: $valid_estimates)"

--- a/ralph/hooks/scripts/split-verify-sub-issue.sh
+++ b/ralph/hooks/scripts/split-verify-sub-issue.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# ralph/hooks/scripts/split-verify-sub-issue.sh
+# PostToolUse (ralph_hero__add_sub_issue): Verify sub-issue linkage took effect
+# for /ralph:caretake --mode split.
+#
+# Plan 6 hardening: scope-guarded (caretake + split).
+#
+# Exit codes:
+#   0 - Sub-issue properly linked (or out of scope)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "split" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+
+parent_number=$(get_field '.tool_input.parentNumber')
+child_number=$(get_field '.tool_input.childNumber')
+
+if [[ -z "$parent_number" ]]; then
+  warn "Sub-issue created without parentNumber. Should be linked to parent ticket."
+fi
+
+echo "Sub-issue linked: parent=#$parent_number child=#$child_number"
+allow

--- a/ralph/hooks/scripts/triage-postcondition.sh
+++ b/ralph/hooks/scripts/triage-postcondition.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# ralph/hooks/scripts/triage-postcondition.sh
+# Stop: Verify /ralph:caretake --mode triage emitted a terminal token.
+#
+# Plan 6 hardening: scope-guarded so non-triage caretake modes (hygiene, unblock,
+# split, postmortem, retro, trends, debug) pass through cleanly. Reads the
+# JSONL transcript for one of the documented TRIAGED tokens or `Queue empty.`
+# (see ralph/skills/caretake/outcome-tokens.md). The grep pipeline appends
+# `|| true` so the missing-match case under `set -euo pipefail` flows to the
+# conservative block path instead of hard-erroring.
+#
+# Environment:
+#   RALPH_FORCE_STOP - If "true", allow stop even if postconditions fail
+#
+# Exit codes:
+#   0 - Postconditions met (or out of scope, or escape hatch active)
+#   2 - No triage terminal token emitted, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+# Scope: /ralph:caretake --mode triage only.
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "triage" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+check_stop_hook_active
+
+# Escape hatch to prevent infinite loops
+if [[ "${RALPH_FORCE_STOP:-}" == "true" ]]; then
+  warn "RALPH_FORCE_STOP=true - bypassing triage postcondition check"
+fi
+
+transcript_path=$(get_field '.transcript_path')
+if [[ -z "$transcript_path" ]] || [[ ! -f "$transcript_path" ]]; then
+  warn "triage-postcondition: no transcript_path available; allowing"
+fi
+
+# Extract assistant text from the JSONL transcript. The grep + jq pipeline is
+# pipeline-heavy under set -euo pipefail; append `|| true` per Plan 6 lesson.
+transcript_text=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text' "$transcript_path" 2>/dev/null || true)
+
+# Match any of the documented terminal tokens.
+if echo "$transcript_text" | grep -qE '^TRIAGED (valid|duplicate|canceled|needs-split)|^Queue empty\.' ; then
+  echo "Triage postcondition passed: terminal token found in transcript"
+  allow
+fi
+
+block "Triage postcondition failed: no terminal token emitted
+
+Expected one of:
+  TRIAGED valid         (issue routed to Research Needed / Ready for Plan)
+  TRIAGED duplicate     (closed as duplicate)
+  TRIAGED canceled      (closed not_planned)
+  TRIAGED needs-split   (routed to split queue)
+  Queue empty.          (no untriaged Backlog issues)
+
+The /ralph:caretake --mode triage body must end by emitting one of these tokens.
+See ralph/skills/caretake/outcome-tokens.md for the full contract.
+
+If this is a false positive, re-run with RALPH_FORCE_STOP=true to bypass."

--- a/ralph/hooks/scripts/triage-postcondition.sh
+++ b/ralph/hooks/scripts/triage-postcondition.sh
@@ -45,7 +45,7 @@ fi
 transcript_text=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text' "$transcript_path" 2>/dev/null || true)
 
 # Match any of the documented terminal tokens.
-if echo "$transcript_text" | grep -qE '^TRIAGED (valid|duplicate|canceled|needs-split)|^Queue empty\.' ; then
+if echo "$transcript_text" | grep -qE '^TRIAGED (valid|duplicate|canceled|needs-split|skipped)|^Queue empty\.' ; then
   echo "Triage postcondition passed: terminal token found in transcript"
   allow
 fi
@@ -57,6 +57,7 @@ Expected one of:
   TRIAGED duplicate     (closed as duplicate)
   TRIAGED canceled      (closed not_planned)
   TRIAGED needs-split   (routed to split queue)
+  TRIAGED skipped …     (branch-gate short-circuit; non-main branch)
   Queue empty.          (no untriaged Backlog issues)
 
 The /ralph:caretake --mode triage body must end by emitting one of these tokens.

--- a/ralph/hooks/scripts/triage-state-gate.sh
+++ b/ralph/hooks/scripts/triage-state-gate.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# ralph/hooks/scripts/triage-state-gate.sh
+# PostToolUse (ralph_hero__save_issue): Validate triage state transitions for
+# /ralph:caretake --mode triage.
+#
+# Plan 6 hardening checklist applied:
+#   - RALPH_COMMAND scope guard (no-op unless invoked from /ralph:caretake).
+#   - RALPH_SUBCOMMAND scope check (no-op unless --mode triage active).
+#   - is_semantic_intent passthrough (__LOCK__, __ESCALATE__, __CLOSE__, etc.
+#     resolved server-side by the MCP save_issue tool).
+#
+# Environment:
+#   RALPH_VALID_OUTPUT_STATES - Valid target states
+#
+# Exit codes:
+#   0 - Valid transition (or out of scope)
+#   2 - Invalid transition, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+# Slim-plugin scope: only activate for /ralph:caretake.
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+
+# Mode scope: only activate for --mode triage. Other modes (hygiene, unblock,
+# split, etc.) have their own state-transition rules and run their own gates.
+if [[ "${RALPH_SUBCOMMAND:-}" != "triage" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+
+new_state=$(get_field '.tool_input.workflowState')
+if [[ -z "$new_state" ]]; then
+  allow  # Not a state update (e.g. label-only save)
+fi
+
+# Semantic-intent transitions resolved server-side by MCP.
+if is_semantic_intent "$new_state"; then
+  allow_with_context "Semantic intent '$new_state' is resolved server-side; triage-state-gate defers to MCP."
+fi
+
+valid_output="${RALPH_VALID_OUTPUT_STATES:-Research Needed,Ready for Plan,Done,Canceled,Human Needed,Backlog}"
+
+if ! validate_state "$new_state" "$valid_output"; then
+  block "Invalid triage state transition
+
+Command: /ralph:caretake --mode triage
+Attempted state: $new_state
+Valid output states: $valid_output
+
+Triage can move tickets to: $valid_output"
+fi
+
+allow

--- a/ralph/hooks/scripts/unblock-request-postcondition.sh
+++ b/ralph/hooks/scripts/unblock-request-postcondition.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# ralph/hooks/scripts/unblock-request-postcondition.sh
+# Stop: Verify /ralph:caretake --mode unblock --question (autonomous variant)
+# either posted a ## Unblock Request comment or declared an empty queue.
+#
+# Scope: ONLY the autonomous sub-mode. The interactive variant has its own
+# terminal-token expectation (UNBLOCK RESOLVED / UNBLOCK ESCALATED) — not
+# checked here. Other caretake modes pass through.
+#
+# Environment:
+#   RALPH_UNBLOCK_REQUEST_POSTED - "1" if a ## Unblock Request comment was posted
+#   RALPH_UNBLOCK_QUEUE_EMPTY    - "1" if there were no eligible issues
+#   RALPH_FORCE_STOP             - If "true", allow stop even if postconditions fail
+#
+# Exit codes:
+#   0 - Postconditions met (or out of scope, or escape hatch active)
+#   2 - Skill exited without posting a comment or declaring empty queue
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "unblock" ]]; then
+  allow
+fi
+# Only enforce on autonomous variant. Interactive sub-mode has different
+# terminal-token semantics that we do not gate here.
+if [[ "${RALPH_SUBCOMMAND_VARIANT:-interactive}" != "autonomous" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+check_stop_hook_active
+
+if [[ "${RALPH_FORCE_STOP:-}" == "true" ]]; then
+  warn "RALPH_FORCE_STOP=true - bypassing unblock-request postcondition check"
+fi
+
+if [[ "${RALPH_UNBLOCK_QUEUE_EMPTY:-0}" == "1" ]]; then
+  echo "Unblock-request postcondition: queue empty, allowing exit"
+  allow
+fi
+
+if [[ "${RALPH_UNBLOCK_REQUEST_POSTED:-0}" == "1" ]]; then
+  echo "Unblock-request postcondition: ## Unblock Request comment posted"
+  allow
+fi
+
+block "Unblock-request postcondition failed: no comment posted and no empty queue declared
+
+Expected one of:
+  RALPH_UNBLOCK_REQUEST_POSTED=1 (after posting ## Unblock Request comment)
+  RALPH_UNBLOCK_QUEUE_EMPTY=1    (no eligible Human Needed issues to process)
+
+Found: neither flag set.
+
+The /ralph:caretake --mode unblock --question body must either post a
+## Unblock Request comment on a Human Needed issue or declare the queue
+empty before exiting.
+
+If this is a false positive, re-run with RALPH_FORCE_STOP=true to bypass."

--- a/ralph/hooks/scripts/unblock-state-gate.sh
+++ b/ralph/hooks/scripts/unblock-state-gate.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ralph/hooks/scripts/unblock-state-gate.sh
+# PostToolUse (ralph_hero__save_issue): Validate /ralph:caretake --mode unblock
+# state transitions.
+#
+# Two sub-modes (Plan 5's interactive+autonomous fold pattern):
+#   - interactive (default): closes the escalation loop by routing a Human
+#     Needed issue back into the pipeline. Valid targets: Backlog, Research
+#     Needed, Ready for Plan, In Progress, Human Needed (no-op label saves).
+#   - autonomous (--question): must NOT transition state. The body only posts a
+#     ## Unblock Request comment and STOPS. Any workflowState write from this
+#     path is a bug and gets blocked.
+#
+# Plan 6 hardening applied: scope guards + is_semantic_intent passthrough.
+#
+# Exit codes:
+#   0 - Valid transition target (or out of scope)
+#   2 - Invalid transition, block
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "caretake" ]]; then
+  allow
+fi
+if [[ "${RALPH_SUBCOMMAND:-}" != "unblock" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+
+target_state=$(get_field '.tool_input.workflowState')
+if [[ -z "$target_state" ]]; then
+  allow  # Not a state update (e.g. label-only save)
+fi
+
+# Semantic intents resolved server-side; defer to MCP.
+if is_semantic_intent "$target_state"; then
+  allow_with_context "Semantic intent '$target_state' is resolved server-side; unblock-state-gate defers to MCP."
+fi
+
+variant="${RALPH_SUBCOMMAND_VARIANT:-interactive}"
+
+if [[ "$variant" == "autonomous" ]]; then
+  # Autonomous path: state mutation is a bug.
+  block "Invalid --mode unblock --question state transition
+
+The autonomous (--question) sub-mode posts a ## Unblock Request comment and
+STOPS. It must NOT call save_issue with a workflowState change.
+
+Attempted state: $target_state
+Variant:         autonomous (--question)
+
+If the issue legitimately needs a state change (e.g. routing back into the
+pipeline), use the interactive sub-mode (default) which transitions state
+after collecting AskUserQuestion answers."
+fi
+
+# Interactive path: route-back to one of the valid re-entry states.
+case "$target_state" in
+  "Backlog"|"Research Needed"|"Ready for Plan"|"In Progress"|"Human Needed")
+    allow
+    ;;
+  *)
+    block "Invalid /ralph:caretake --mode unblock state transition
+
+Command: /ralph:caretake --mode unblock (interactive)
+Attempted state: $target_state
+Valid output states: Backlog, Research Needed, Ready for Plan, In Progress, Human Needed
+
+Interactive unblock can only route Human Needed issues to one of the 4 valid
+re-entry states. Human Needed itself is allowed only for no-op saves (e.g.
+label updates).
+
+Note: Plan in Review is intentionally NOT a re-entry state. Issues that need
+re-review must route through Ready for Plan."
+    ;;
+esac

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -1,0 +1,165 @@
+---
+description: All board maintenance, grooming, and reflection in one verb. Triggers on "triage backlog", "clean up board", "scan for stale", "status check", "post-mortem", "capture friction", "retro the session", "trend report", "snapshot metrics", "unblock issue", "answer unblock questions", "collate debug errors", "filer Langfuse errors", "split this issue", "decompose ticket". Default mode is event-driven (reads `--issue NNN` labels and fans out via Skill). Named modes (triage/hygiene/unblock/postmortem/retro/trends/debug/split) each route to a dedicated mode body under `modes/`.
+argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|all>] [#NNN] [--since <window>] [--auto-confirm] [--question]"
+context: inline
+model: opus
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=caretake"
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/branch-gate.sh"
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-estimate-gate.sh"
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-size-gate.sh"
+  PostToolUse:
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-estimate-gate.sh"
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-verify-sub-issue.sh"
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/triage-state-gate.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/unblock-state-gate.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/triage-postcondition.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/unblock-request-postcondition.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-postcondition.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/postmortem-completeness.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/lock-release-on-failure.sh"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Skill
+  - Agent
+  - Task
+  - TaskList
+  - TaskGet
+  - AskUserQuestion
+  - PushNotification
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__project_hygiene
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__archive_items
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__capture_snapshot
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__metrics_trends
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
+---
+
+# /ralph:caretake — Board steward in one verb
+
+All board maintenance flows through this one entrypoint. Eight named modes plus a default event-driven dispatcher. Each mode is a separate body under `modes/`; this top-level SKILL.md only owns arg parsing, dispatch routing, and the heartbeat fan-out.
+
+| Mode | Trigger | Role |
+|---|---|---|
+| **default** | `/ralph:caretake --issue NNN` | Event-driven: read labels, dispatch the right mode via `Skill()` |
+| **all** | `/ralph:caretake` (no args) or `/ralph:caretake --mode all` | Heartbeat fan-out: hygiene + catch-up report + trends |
+| **triage** | `/ralph:caretake --mode triage [#NNN]` | Pick oldest untriaged Backlog, assess, route |
+| **hygiene** | `/ralph:caretake --mode hygiene` | Scan for archive candidates, stale items, WIP violations |
+| **unblock** | `/ralph:caretake --mode unblock [#NNN] [--question]` | Interactive answer OR autonomous request post |
+| **postmortem** | `/ralph:caretake --mode postmortem [--plan-doc <path>]` | TaskList-driven structured session post-mortem |
+| **retro** | `/ralph:caretake --mode retro` | Capture intra-session friction into research doc |
+| **trends** | `/ralph:caretake --mode trends [--since 30d]` | Snapshot + markdown trend report (read-only stdout) |
+| **debug** | `/ralph:caretake --mode debug [--since 24h] [--auto-confirm]` | Collate Langfuse errors → file `debug-auto` issues |
+| **split** | `/ralph:caretake --mode split [#NNN]` | Split M/L/XL → multiple XS/S sub-issues |
+
+References: [label-routing.md](label-routing.md) (default-mode dispatch table), [outcome-tokens.md](outcome-tokens.md) (per-mode terminal verdicts), [split-decomposition.md](split-decomposition.md) (split-mode strategy + hook contracts).
+
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+
+## Step 0: Parse arguments + set subcommand scope
+
+```bash
+# Parse $ARGUMENTS into mode + flags. Each mode body sets RALPH_SUBCOMMAND itself
+# (so per-mode hook scope picks up the right subcommand even when the caller
+# entered this skill via no-arg / --mode all fan-out). The top-level dispatch
+# only sets RALPH_SUBCOMMAND for the default-event and `all` paths.
+case "$ARGUMENTS" in
+  *--issue*)      export RALPH_SUBCOMMAND=default-event ;;
+  *--mode\ all*|"") export RALPH_SUBCOMMAND=all ;;
+  *)              : ;;  # Mode body sets it
+esac
+```
+
+## Step 1: Dispatch
+
+- **`--issue NNN`** → default-mode (event-driven). Fetch the issue, inspect labels, dispatch per [label-routing.md](label-routing.md). After dispatch, post a `## Caretaker Action` comment summarizing mode + outcome.
+- **`--mode <name>`** → read `modes/<name>.md` and follow its body. The mode body sets `RALPH_SUBCOMMAND=<name>` and runs.
+- **No args** or **`--mode all`** → heartbeat fan-out. Invoke serially:
+  1. `Skill("ralph:caretake", args="--mode hygiene")`
+  2. `Skill("ralph:catch-up", args="--mode report")`
+  3. `Skill("ralph:caretake", args="--mode trends")`
+  Report consolidated outcome (one line per child).
+
+## Step 2: Emit result line
+
+Each mode body ends by emitting its terminal token (see [outcome-tokens.md](outcome-tokens.md)). The dispatcher does not wrap or rewrite it. The harness extractor reads the token directly.
+
+## Mode bodies
+
+- [modes/triage.md](modes/triage.md) — pick + assess + route (autonomous)
+- [modes/hygiene.md](modes/hygiene.md) — scan + optional archive
+- [modes/unblock.md](modes/unblock.md) — interactive answer OR autonomous request
+- [modes/postmortem.md](modes/postmortem.md) — TaskList-driven session post-mortem
+- [modes/retro.md](modes/retro.md) — intra-session friction → research doc
+- [modes/trends.md](modes/trends.md) — snapshot + markdown trend report
+- [modes/debug.md](modes/debug.md) — collate Langfuse errors
+- [modes/split.md](modes/split.md) — M/L/XL → XS/S sub-issues
+
+## Per-mode terminal tokens
+
+The harness reads these from the transcript; do not paraphrase. Full table in [outcome-tokens.md](outcome-tokens.md). Quick reference:
+
+- triage: `TRIAGED <verdict>` | `Queue empty.`
+- hygiene: `HYGIENE COMPLETE <N>` | `HYGIENE BLOCKED <reason>`
+- unblock (interactive): `UNBLOCK RESOLVED` | `UNBLOCK ESCALATED`
+- unblock (autonomous): `UNBLOCK REQUEST POSTED` | `Queue empty.`
+- postmortem: `POSTMORTEM <path>` | `POSTMORTEM SKIPPED <reason>`
+- retro: `RETRO <path>` | `RETRO SKIPPED <reason>`
+- trends: no terminal token (markdown output is the deliverable)
+- debug: `DEBUG FILED <N>` | `DEBUG SKIPPED <reason>`
+- split: `SPLIT <N>` | `SPLIT SKIPPED <reason>`
+
+## Notes
+
+- **`RALPH_SUBCOMMAND` is set by each mode body** (not by SessionStart). Hooks discriminate against it to no-op when a different mode is active. SessionStart only sets `RALPH_COMMAND=caretake`, which guards all caretake-prefixed hooks at the plugin level.
+- **Mode bodies port source-skill workflows verbatim** where possible. Plan 7 is a structural fold; capability changes are out of scope.
+- **Old `/ralph-hero:*` caretaker-family skills remain functional** until Plan 10 sunset. Both paths can run side-by-side during the parallel period.

--- a/ralph/skills/caretake/label-routing.md
+++ b/ralph/skills/caretake/label-routing.md
@@ -1,1 +1,79 @@
-_Filled by Phase 2 (default-mode body + label-routing table)._
+# Label routing for `/ralph:caretake`
+
+The default-mode dispatcher reads this table when invoked as `/ralph:caretake --issue NNN`. After fetching the issue and inspecting its labels, it picks the **first matching row in declaration order** and invokes the listed `Skill()`. After the dispatch returns, the dispatcher consumes the `trigger:caretake` label (when present) and posts a `## Caretaker Action` comment summarizing what ran.
+
+## Routing table
+
+The dispatcher walks this table top-to-bottom and stops at the first matching label. Labels are checked in priority order — `trigger:caretake` always wins because it represents an explicit operator intent ("run the full fan-out on this issue").
+
+| Label present | Dispatch | Notes |
+|---|---|---|
+| `trigger:caretake` | Full fan-out (all 8 modes serially) | Operator override; consume after dispatch |
+| `stale` | `Skill("ralph:caretake", args="--mode hygiene")` | Hygiene mode finds stale items by definition |
+| `status-update-needed` | `Skill("ralph:catch-up", args="--mode report")` | Report lives in catch-up (Plan 1), not caretake |
+| `trends-check` | `Skill("ralph:caretake", args="--mode trends")` | Read-only — markdown to stdout |
+| `needs-triage` | `Skill("ralph:caretake", args="--mode triage #NNN")` | Pass through the issue number |
+| `human-needed` | `Skill("ralph:caretake", args="--mode unblock --question #NNN")` | Autonomous request — posts `## Unblock Request` |
+| `process-improvement` | `Skill("ralph:caretake", args="--mode retro")` | Manual retro flow scoped to the issue |
+| `debug-auto` | `Skill("ralph:caretake", args="--mode debug")` | Triggered by recurring-failure clustering |
+| `needs-split` | `Skill("ralph:caretake", args="--mode split #NNN")` | M/L/XL parent ready for decomposition |
+| (none / default) | `Skill("ralph:caretake", args="--mode triage #NNN")` | Untriaged issue with no explicit label hint |
+
+## Full fan-out (`trigger:caretake`)
+
+When `trigger:caretake` is present, the dispatcher invokes **all eight modes serially** so the operator gets a complete board sweep from one command. Order matters — modes that mutate state run before modes that read state:
+
+1. `Skill("ralph:caretake", args="--mode hygiene")` — archive candidates, WIP violations, field gaps
+2. `Skill("ralph:caretake", args="--mode triage #NNN")` — assess the issue that carries the trigger label
+3. `Skill("ralph:caretake", args="--mode split #NNN")` — only if the triage outcome was `TRIAGED needs-split`
+4. `Skill("ralph:caretake", args="--mode unblock --question")` — pick the oldest Human Needed and post a fresh `## Unblock Request` (autonomous path)
+5. `Skill("ralph:caretake", args="--mode debug")` — collate Langfuse errors (if `RALPH_DEBUG=true`)
+6. `Skill("ralph:caretake", args="--mode postmortem")` — only if a team session just finished (`TaskList` non-empty)
+7. `Skill("ralph:caretake", args="--mode retro")` — only if inline conversation context is available
+8. `Skill("ralph:catch-up", args="--mode report")` — final status update so the operator sees the consolidated outcome
+
+Skip modes that no-op cleanly (e.g., `postmortem` with no `TaskList` data); always run hygiene + triage + report.
+
+## Label consumption
+
+After dispatch (single-label or full fan-out), the dispatcher MUST remove the routing label so the issue is not re-picked on the next caretaker sweep. Use `save_issue` with the remaining label set:
+
+```
+save_issue(
+  number: NNN,
+  labels: [...remaining-labels-without-trigger:caretake]
+)
+```
+
+Idempotency rule: only `trigger:caretake` is consumed unconditionally. Other labels (`stale`, `debug-auto`, `process-improvement`, `needs-split`) describe issue **state** and are owned by other systems (hygiene scans, dream-reflect clustering, triage). The caretaker does not consume those — it acts on them and lets the owner system re-apply or clear them.
+
+## `## Caretaker Action` comment shape
+
+After dispatch (success or failure), post one comment on the issue:
+
+```
+## Caretaker Action
+
+Mode: <mode-or-fanout>
+Trigger: <label-name or "default">
+Dispatched: <comma-separated skill names>
+Outcome: <one-line summary pulled from the terminal token of the last skill>
+```
+
+Pull the outcome line from the dispatched skill's terminal token (see [outcome-tokens.md](outcome-tokens.md)) — do not paraphrase. For full fan-out, list one outcome line per child skill.
+
+## Adding a new label route
+
+The taxonomy is intentionally one-row-per-label so future automation can extend it without touching SKILL.md. To add a label:
+
+1. Append a new row to the routing table above (in priority order — earlier rows win).
+2. If the dispatch is a new mode body, scaffold the mode under `modes/<name>.md` and add a row to the mode-dispatch table in SKILL.md.
+3. If the label is operator-driven (e.g., a future `trigger:<team>`), make sure it gets consumed in the "Label consumption" rule.
+
+No code change required for routing additions — the dispatcher reads this table as prose and the SKILL.md frontmatter only declares the union of hook scopes.
+
+## Cross-references
+
+- [SKILL.md](SKILL.md) — top-level dispatch, arg parsing, heartbeat fan-out.
+- [outcome-tokens.md](outcome-tokens.md) — terminal-verdict strings each mode emits.
+- Director taxonomy at `plugin/ralph-hero/skills/director/event-classes.md` — same trigger-label conventions; future cleanups should keep both in sync.

--- a/ralph/skills/caretake/label-routing.md
+++ b/ralph/skills/caretake/label-routing.md
@@ -1,0 +1,1 @@
+_Filled by Phase 2 (default-mode body + label-routing table)._

--- a/ralph/skills/caretake/modes/debug.md
+++ b/ralph/skills/caretake/modes/debug.md
@@ -1,0 +1,1 @@
+_Filled by Phase 7 (`--mode debug`)._

--- a/ralph/skills/caretake/modes/debug.md
+++ b/ralph/skills/caretake/modes/debug.md
@@ -1,1 +1,194 @@
-_Filled by Phase 7 (`--mode debug`)._
+# `--mode debug`
+
+Collate errors from local Langfuse traces into GitHub `debug-auto` issues. Wraps the `ralph_hero__collate_debug` MCP tool with a preflight → dry-run → confirm → file → summarize workflow.
+
+Interactive by default: requires a human confirm before mutating GitHub. The `--auto-confirm` flag is opt-in and reserved for unattended schedules (Watcher heartbeat). Closes the OTel → Langfuse → GitHub feedback loop with a single command.
+
+```bash
+export RALPH_SUBCOMMAND=debug
+```
+
+## §Step 1: Preflight
+
+Verify the local environment is wired up before doing anything else.
+
+1. **`RALPH_DEBUG=true` must be active in the MCP-server environment.** The `ralph_hero__collate_debug` tool is only registered when this env var is `"true"` — see `plugin/ralph-hero/mcp-server/src/index.ts`. If the tool is not available, instruct the user to add the following to `~/.claude/settings.json` (or `<project>/.claude/settings.local.json`) and restart Claude Code:
+
+   ```json
+   {
+     "env": {
+       "RALPH_DEBUG": "true",
+       "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+       "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:3100/api/public/otel/v1/traces",
+       "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Basic cGstbGYtbG9jYWwtZGV2OnNrLWxmLWxvY2FsLWRldg==",
+       "OTEL_SERVICE_NAME": "ralph-hero"
+     }
+   }
+   ```
+
+   Then emit `DEBUG SKIPPED preflight: RALPH_DEBUG not active` and STOP — the user must restart Claude Code.
+
+2. **Langfuse reachability.** Probe the local stack:
+
+   ```bash
+   curl -fsS http://localhost:3100/api/public/health || exit 2
+   ```
+
+   If the health probe fails, instruct the user to start the local Langfuse stack:
+
+   ```bash
+   cd ~/projects/langfuse && ./scripts/up.sh
+   ```
+
+   Then emit `DEBUG SKIPPED preflight: Langfuse unreachable` and STOP.
+
+## §Step 2: Parse arguments
+
+Parse `$ARGUMENTS` for optional flags:
+
+- `--since <window>` — lower bound for the trace window. Accepts ISO dates (e.g., `2026-05-01`) or shorthand (`24h`, `7d`). Default: `24h`.
+- `--min-occurrences <n>` — minimum number of occurrences for a signature to be reported. Default: `3`.
+- `--auto-confirm` — skip the `AskUserQuestion` prompt in §Step 5 and proceed directly to filing. Reserved for the Watcher heartbeat. Do not use in interactive sessions.
+
+Resolve `--since` to an ISO timestamp before calling the tool (e.g., `24h` → 24 hours before now).
+
+## §Step 3: Dry-run
+
+Call `ralph_hero__collate_debug` with:
+
+- `since`: resolved ISO timestamp from §Step 2
+- `dryRun`: `true`
+- `minOccurrences`: parsed value (or default `3`)
+
+The tool returns a shape like:
+
+```json
+{
+  "since": "<ISO>",
+  "errorGroups": <number>,
+  "totalOccurrences": <number>,
+  "dryRun": true,
+  "groups": [
+    {
+      "signature": "...",
+      "hash": "...",
+      "count": <n>,
+      "firstSeen": "<ISO>",
+      "lastSeen": "<ISO>",
+      "exampleTraceUrl": "...",
+      "sampleSpans": [...]
+    }
+  ]
+}
+```
+
+## §Step 4: Render the dry-run report
+
+If `errorGroups === 0`, emit:
+
+```
+DEBUG SKIPPED no-errors-in-window
+```
+
+and STOP.
+
+Otherwise pretty-print the **top 5 by `count`**, one block per signature:
+
+```
+## Debug Collate — dry run
+
+Window: <since> → now
+Total error groups: <errorGroups>
+Total occurrences: <totalOccurrences>
+
+### Top 5 by occurrence
+
+1. `<hash>` (count: <n>, first: <firstSeen>, last: <lastSeen>)
+   Signature: <signature snippet, truncated to ~120 chars>
+   Trace: <exampleTraceUrl>
+
+2. ...
+```
+
+If there are more than 5 groups, append:
+
+```
+(+<errorGroups - 5> more not shown)
+```
+
+## §Step 5: Confirm
+
+**Auto-confirm path.** If `--auto-confirm` is present, skip the prompt and proceed directly to §Step 6. Emit a single line so the transcript records the intent:
+
+```
+auto-confirm active — filing debug-auto issues for <errorGroups> signature(s)
+```
+
+This path is exercised by the Watcher heartbeat. Interactive sessions must not pass `--auto-confirm` unless the intent is truly unattended.
+
+**Interactive path.** Otherwise invoke `AskUserQuestion` with a single question:
+
+- **question**: `File debug-auto issues for these <errorGroups> signatures?`
+- **header**: `File issues?`
+- **options**: `Yes — file all <errorGroups>` / `Skip — no issues filed`
+- **multiSelect**: `false`
+
+If the user picks `Skip`, emit:
+
+```
+DEBUG SKIPPED user-declined
+```
+
+and STOP. Do NOT call the tool with `dryRun: false`.
+
+## §Step 6: File issues + summarize
+
+On confirm, call `ralph_hero__collate_debug` again with the same `since` and `minOccurrences`, but `dryRun: false`. The tool returns:
+
+```json
+{
+  "since": "...",
+  "errorGroups": <n>,
+  "totalOccurrences": <n>,
+  "dryRun": false,
+  "issuesCreated": <n>,
+  "issuesUpdated": <n>,
+  "results": [...],
+  "groups": [...]
+}
+```
+
+Print a one-paragraph summary:
+
+```
+## Debug Collate — filed
+
+- <issuesCreated> new `debug-auto` issues created
+- <issuesUpdated> existing `debug-auto` issues commented
+
+### Top 3 by occurrence
+1. `<hash>` — <count> occurrences — <issue URL or "new">
+2. ...
+```
+
+Pull issue URLs from `results[]` when available.
+
+Then emit the terminal token (the harness reads this directly — see [outcome-tokens.md](../outcome-tokens.md)):
+
+```
+DEBUG FILED <issuesCreated + issuesUpdated>
+```
+
+Finally, suggest the next step:
+
+```
+Next: run `/ralph:caretake --mode triage` to prioritize the freshly-filed `debug-auto` issues.
+```
+
+## §Constraints
+
+- **Interactive by default.** Do not run from autopilot or unattended loops without `--auto-confirm`.
+- **Read-only on Langfuse.** The tool only queries observations; never mutates traces.
+- **Tool-gated by `RALPH_DEBUG=true`.** If the tool is not registered, §Step 1 STOPs.
+- **One Langfuse host.** Defaults to `http://localhost:3100`. To target a different host, set `LANGFUSE_HOST` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` in the MCP-server environment.
+- **No hook gates this mode.** Debug mode mutates GitHub only via `create_issue` (filtered by `split-size-gate.sh` — but `debug-auto` issues are XS by construction and pass the gate trivially). No state-transition hooks apply.

--- a/ralph/skills/caretake/modes/hygiene.md
+++ b/ralph/skills/caretake/modes/hygiene.md
@@ -1,0 +1,1 @@
+_Filled by Phase 4 (`--mode hygiene`)._

--- a/ralph/skills/caretake/modes/hygiene.md
+++ b/ralph/skills/caretake/modes/hygiene.md
@@ -1,1 +1,131 @@
-_Filled by Phase 4 (`--mode hygiene`)._
+# `--mode hygiene`
+
+Scan the project board for archive candidates, stale items, orphaned tickets, field gaps, WIP violations, and duplicate candidates. Optionally archive items that exceed the configured threshold. Read-only by default (dry-run); the auto-archive path is opt-in via `RALPH_HYGIENE_DRY_RUN=false`.
+
+```bash
+export RALPH_SUBCOMMAND=hygiene
+```
+
+No hook gates this mode beyond the plugin-level scope guard. Hygiene does not mutate workflow states and does not create or close issues — it only archives terminal items (Done/Canceled) when the threshold is met.
+
+## §Configuration (resolved at load time)
+
+- Hygiene threshold: `${RALPH_HYGIENE_THRESHOLD:-10}`
+- Dry run: `${RALPH_HYGIENE_DRY_RUN:-true}`
+- WIP limits: `${RALPH_HYGIENE_WIP_LIMITS:-<unset>}`
+
+`RALPH_HYGIENE_WIP_LIMITS` is a JSON object like `{"In Progress": 3, "In Review": 2}`. If unset, the WIP category in the hygiene report is empty (`findWipViolations()` has no built-in defaults).
+
+## §Step 1: Run project_hygiene (primary)
+
+Call `ralph_hero__project_hygiene` with:
+
+- `format: "markdown"`
+- `archiveAgeDays: 14`
+- `staleDays: 7`
+- `orphanDays: 14`
+- `wipLimits`: parsed JSON from `RALPH_HYGIENE_WIP_LIMITS` if set; otherwise omit.
+
+The tool returns seven categories in one response:
+
+- **Archive candidates** — Done/Canceled items stale beyond `archiveAgeDays`.
+- **Stale items** — non-terminal items not updated within `staleDays`.
+- **Orphaned items** — Backlog-only, no assignees, older than `orphanDays`.
+- **Field gaps** — non-terminal items missing `estimate` or `priority`.
+- **WIP violations** — states exceeding caller-supplied `wipLimits` (empty unless provided).
+- **Duplicate candidates** — non-terminal item pairs with title similarity ≥ 0.8.
+- **Summary stats** — aggregate counts + `fieldCoveragePercent`.
+
+## §Step 2: Report hygiene sections
+
+Print the full hygiene report from the `project_hygiene` response. Shape:
+
+```
+Hygiene Report
+==============
+
+Archive Candidates: N items (stale > 14 days)
+  #42 - Fix login timeout (Done, 21 days stale)
+  #38 - Update dependencies (Done, 18 days stale)
+
+Stale Items: N items (no update in > 7 days)
+  #51 - Refactor auth module (In Progress, 9 days stale)
+
+Orphaned Items: N items (Backlog, unassigned, > 14 days old)
+  #60 - Investigate cache thrash (Backlog, 21 days)
+
+Field Gaps: N items missing estimate/priority
+  #62 - Add settings page (missing: estimate, priority)
+
+WIP Violations: N (or "skipped — RALPH_HYGIENE_WIP_LIMITS not set")
+  In Progress: 5 items (limit: 3)
+
+Duplicate Candidates: N pairs (title similarity >= 0.8)
+  #71 / #72 - "Fix sidebar overflow" / "Fix sidebar layout overflow"
+
+Summary:
+  Field coverage: NN%
+  Total scanned: N
+```
+
+## §Step 3: Supplement with pipeline-health warnings
+
+`project_hygiene` does not generate pipeline-health warnings (lock collisions, oversized issues, etc). For those, call `ralph_hero__pipeline_dashboard` with:
+
+- `format: "markdown"`
+- `includeHealth: true`
+- `archiveAgeDays: 14`
+
+Append the dashboard's `health` section warnings to the report:
+
+```
+Health Warnings: [from dashboard health section]
+  [CRITICAL] lock_collision: #44 stuck in __LOCK__ state for 4 hours
+  [WARNING] oversized_in_pipeline: #55 (XL) in In Progress
+```
+
+If the dashboard returns no health warnings, omit this section.
+
+## §Step 4: Auto-archive (if configured)
+
+Use the resolved configuration above to decide:
+
+- **`RALPH_HYGIENE_DRY_RUN=true`** (default): report what would be archived. Do NOT call any archive tools.
+- **`RALPH_HYGIENE_DRY_RUN=false` AND eligible count > `RALPH_HYGIENE_THRESHOLD`**: call `ralph_hero__archive_items` with bulk-mode parameters:
+  - `workflowStates: ["Done", "Canceled"]`
+  - `updatedBefore: <ISO date 14 days ago>`
+  - `dryRun: false`
+
+  Report archived count from the response.
+
+If `archive_items` errors, do NOT retry blindly — emit `HYGIENE BLOCKED <reason>` (see [outcome-tokens.md](../outcome-tokens.md)) and surface the error in the summary.
+
+## §Step 5: Summary + terminal token
+
+Output the summary block and then emit exactly one terminal token (see [outcome-tokens.md](../outcome-tokens.md)).
+
+```
+Hygiene complete.
+  Items scanned: [totalScanned from project_hygiene]
+  Archive eligible: N
+  Stale: N
+  Orphaned: N
+  Field gaps: N
+  WIP violations: N (or "not checked")
+  Duplicate pairs: N
+  Archived: N (or "0 - dry run mode")
+  Health warnings: N
+```
+
+Then emit:
+
+- `HYGIENE COMPLETE <N archived>` — scan ran cleanly; `N` is the archived count (0 if dry-run or threshold not exceeded).
+- `HYGIENE BLOCKED <reason>` — scan failed (project not found, MCP error, archive call failed, etc.).
+
+## §Constraints
+
+- **Read-only by default.** The dry-run mode is the safe path; the operator must explicitly set `RALPH_HYGIENE_DRY_RUN=false` to mutate the board.
+- **No workflow-state changes.** Hygiene does not advance, regress, or close issues — it only archives Done/Canceled items.
+- **No issue creation or closure.** Surfacing duplicate candidates is the limit; the operator (or a triage sweep) decides whether to close.
+- **Archive confidence is timestamp-only.** `findArchiveCandidates()` does not currently filter items with open PRs or recent comments. Review the dry-run output before flipping to non-dry-run.
+- **No `Stop` hook for this mode.** Hygiene has no postcondition gate because it does not mutate semantic state — only archive bookkeeping.

--- a/ralph/skills/caretake/modes/postmortem.md
+++ b/ralph/skills/caretake/modes/postmortem.md
@@ -1,0 +1,1 @@
+_Filled by Phase 6 (`--mode postmortem`)._

--- a/ralph/skills/caretake/modes/postmortem.md
+++ b/ralph/skills/caretake/modes/postmortem.md
@@ -1,1 +1,187 @@
-_Filled by Phase 6 (`--mode postmortem`)._
+# `--mode postmortem`
+
+Generate a structured post-mortem report at the end of a ralph team session. Collects task data via `TaskList` + `TaskGet`, classifies blockers and impediments, writes an Obsidian-ready doc, optionally patches associated plan documents with `post_mortem::` edges, and auto-creates GitHub issues for blockers.
+
+```bash
+export RALPH_SUBCOMMAND=postmortem
+```
+
+`postmortem-completeness.sh` (Stop hook) gates on `RALPH_SUBCOMMAND=postmortem` and verifies the written doc carries the required frontmatter + section headings.
+
+## §Step 1: Collect session data
+
+Call `TaskList` to get all tasks. For each task, call `TaskGet` to read full metadata and description. Extract:
+
+- **Issues processed** — `issue_number`, `issue_url`, `estimate` from task metadata; final `workflowState` from the last integrator task result; PR number from the PR-creation task result.
+- **Worker assignments** — task `owner` → task `subject` mapping.
+- **Session events** — corrective actions, errors, notable observations from task descriptions / results.
+
+If `TaskList` is unavailable or returns nothing, emit `POSTMORTEM SKIPPED no-session-data` and STOP.
+
+## §Step 2: Find associated plans
+
+For each issue number processed, glob for the associated plan document:
+
+```
+Glob: thoughts/shared/plans/*GH-{issue_number}*
+```
+
+Collect the filename stem (without `.md`) of each matched plan — this becomes the `builds_on::` target. If no plan is found, skip the link for that issue.
+
+## §Step 3: Classify events
+
+Apply these rules to the session events from §Step 1:
+
+**Blocker** (goes in `## Blockers`, auto-creates a `process-improvement` issue):
+
+- A recovery task was created during the session (NEEDS_ITERATION re-plan, failed-validation re-implement).
+- A task result or description contains an explicit error, escalation, or Human Needed state.
+- The team lead sent a corrective `SendMessage` to redirect a worker mid-task.
+
+**Impediment** (goes in `## Impediments` only, no issue created):
+
+- Workarounds that self-resolved without creating a new task.
+- Slow-downs from idle message spam or delayed task unblocking.
+- Plan gaps fixed inline without retry.
+- Validation run against wrong path, self-corrected after a message.
+
+### Step 3.5: Record outcome events
+
+For each **blocker**: `event_type="blocker_recorded"`, `verdict="blocker"`, payload `{ blocker_type, description, created_issue_number }`.
+
+For each **impediment**: `event_type="impediment_recorded"`, `verdict="impediment"`, payload `{ impediment_type, description, self_resolved, workaround }`.
+
+If `knowledge_record_outcome` is unavailable, log to stderr and continue — do not block classification.
+
+## §Step 4: Write post-mortem
+
+Path: `thoughts/shared/reports/YYYY-MM-DD-ralph-team-{team-name}.md` (today's date).
+
+Template:
+
+```markdown
+---
+date: YYYY-MM-DD
+type: report
+status: completed
+tags: [ralph-team, session-report]
+team_name: {team-name}
+github_issue: {primary_issue_number}
+github_issues: [{all_issue_numbers}]
+github_urls:
+  - https://github.com/{owner}/{repo}/issues/{primary_issue_number}
+---
+
+# Ralph Team Session Report: {team-name}
+
+**Date**: YYYY-MM-DD
+
+## Artifacts
+
+{builds_on_links}
+
+## Issues Processed
+
+| Issue | Title | Estimate | Outcome | PR |
+|-------|-------|----------|---------|-----|
+{issues_table_rows}
+
+## Worker Summary
+
+| Worker | Tasks Completed |
+|--------|-----------------|
+{worker_rows}
+
+## Blockers
+
+{blocker_items or "None."}
+
+## Impediments
+
+{impediment_items or "None."}
+```
+
+Where:
+
+- `{primary_issue_number}`: first issue number in the session (lowest if multiple).
+- `{all_issue_numbers}`: comma-separated list.
+- `{owner}` / `{repo}`: from `RALPH_GH_OWNER` / `RALPH_GH_REPO`, or extract from collected `issue_url`s.
+- `{builds_on_links}`: one `- builds_on:: [[plan-slug]]` per plan found in §Step 2; omit content (keep heading) if none.
+- Blocker items: `- [issue created: #NNN] Description of what failed and the retry cost`.
+- Impediment items: `- Description of friction observed`.
+
+`postmortem-completeness.sh` requires the frontmatter block, all `##` section headings, and a non-empty `## Blockers` and `## Impediments` body (`None.` is acceptable).
+
+### Step 4.5: Record session_completed + postmortem_completed
+
+After the report file is written, record:
+
+- `event_type="session_completed"`, `issue_number=<primary>`, `verdict="completed"`, payload `{ issues_processed, issues_completed, workers, total_tokens }`.
+- `event_type="postmortem_completed"`, `issue_number=<primary>`, `verdict="filed"`, payload `{ postmortem_path, blocker_count, impediment_count }`.
+
+If either call fails, log to stderr and continue.
+
+## §Step 5: Patch plan documents
+
+For each plan found in §Step 2:
+
+1. Read the plan file.
+2. Find the `## Prior Work` section.
+   - If present: append `- post_mortem:: [[{report-slug}]]` as the last line of that section.
+   - If absent: insert `## Prior Work\n\n- post_mortem:: [[{report-slug}]]\n` immediately after `## Overview` (or as the first `##` section if `## Overview` is absent).
+3. Write the updated content back.
+
+`{report-slug}` is the filename stem of the post-mortem written in §Step 4 (without `.md`).
+
+## §Step 6: Auto-create blocker issues
+
+For each entry in `## Blockers` (skip if "None."):
+
+- `title`: `process: {brief description of the blocker}`
+- `body`: fuller description (what failed, retry cost, prevention).
+- `labels`: `["process-improvement"]`
+- `workflowState`: `"Backlog"`
+
+Update the blocker entry to include the created issue number: `[issue created: #NNN]`.
+
+## §Step 7: Drive push (iOS mode)
+
+iOS-mode is active when `${TMPDIR:-/tmp}/ralph-ios-mode` exists OR when `RALPH_IOS_MODE` is non-empty. The `push-artifact.sh` helper checks both. Best-effort:
+
+```bash
+DRIVE_URL=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/push-artifact.sh" \
+    "${REPORT_PATH}" \
+    "Postmortem: ${SESSION_SUMMARY}" 2>/dev/null || true)
+```
+
+If `DRIVE_URL` is non-empty, include a `Drive: <URL>` line in any `## Postmortem` comment posted on blocker issues.
+
+## §Step 8: Commit and push
+
+```bash
+git add thoughts/shared/reports/YYYY-MM-DD-ralph-team-{team-name}.md
+git add thoughts/shared/plans/  # patched plan files
+git commit -m "docs(report): {team-name} session post-mortem"
+git push origin main
+```
+
+## §Step 9: Emit terminal token
+
+```
+POSTMORTEM <path>
+```
+
+Where `<path>` is the absolute path written in §Step 4. On the no-session-data short-circuit:
+
+```
+POSTMORTEM SKIPPED no-session-data
+```
+
+`postmortem-completeness.sh` greps the transcript for one of these tokens.
+
+## §Constraints
+
+- **Inline by design** — invoked at the end of a team session that still holds `TaskList` data. A forked invocation has no task list to work with.
+- **Best-effort outcome recording.** All `knowledge_record_outcome` calls degrade silently if the tool is unavailable.
+- **Auto-created blockers are XS** — they describe process improvements, not features; the size-gate accepts XS unconditionally.
+- **Section heading invariants.** `postmortem-completeness.sh` verifies the frontmatter + all six `##` section headings (`Artifacts`, `Issues Processed`, `Worker Summary`, `Blockers`, `Impediments`).

--- a/ralph/skills/caretake/modes/retro.md
+++ b/ralph/skills/caretake/modes/retro.md
@@ -1,0 +1,1 @@
+_Filled by Phase 6 (`--mode retro`)._

--- a/ralph/skills/caretake/modes/retro.md
+++ b/ralph/skills/caretake/modes/retro.md
@@ -1,1 +1,294 @@
-_Filled by Phase 6 (`--mode retro`)._
+# `--mode retro`
+
+Capture intra-session friction (errors, retries, workarounds, confusion, repeated manual steps, scope ambiguity) into a `/form`-ingestible research document. Runs inline so it has access to the full conversation history — that history IS the data source.
+
+```bash
+export RALPH_SUBCOMMAND=retro
+```
+
+No hook gates retro — it writes a research doc, no GitHub state mutates. The terminal token (see [outcome-tokens.md](../outcome-tokens.md)) is reported for parity with other modes.
+
+Unlike `--mode postmortem` (team-session structured data via `TaskList`), retro analyzes free-form conversation context. The two are complementary — both can apply to the same session.
+
+## §Step 1: Initial response + postmortem dedup check
+
+1. **If a scope hint was provided** (via `$ARGUMENTS`): use it to scope the conversation slice analyzed. Note the hint in the doc frontmatter `tags` and `Summary`.
+
+2. **If no arguments provided**, respond briefly:
+
+   ```
+   Capturing pain points from this session. Scanning the conversation for friction signals...
+
+   (If you want to scope this to a specific section, re-run with a hint, e.g.,
+   `/ralph:caretake --mode retro "the worktree gate debugging part"`. Otherwise
+   I'll analyze the full conversation.)
+   ```
+
+### Postmortem dedup check
+
+Before scanning, detect whether the calling session is a team-mode session (in which case `--mode postmortem` is the better tool):
+
+1. Try `TaskList`. If it succeeds AND returns a non-empty list, set `TEAM_SESSION_DETECTED = true`.
+2. Otherwise set `TEAM_SESSION_DETECTED = false`.
+
+If `TEAM_SESSION_DETECTED == true`, surface a recommendation via `AskUserQuestion`:
+
+```
+AskUserQuestion(
+  questions=[{
+    "question": "A team session was detected. --mode postmortem captures structured task-level blockers and may be a better fit. What would you like to do?",
+    "header": "Postmortem vs. Retro",
+    "options": [
+      {"label": "Use --mode postmortem", "description": "Switch to /ralph:caretake --mode postmortem (designed for team sessions)"},
+      {"label": "Continue with retro", "description": "Keep capturing pain points from the conversation context — retro complements postmortem"}
+    ],
+    "multiSelect": false
+  }]
+)
+```
+
+- **"Use --mode postmortem"**: reply `Recommend running /ralph:caretake --mode postmortem instead — it captures TaskList-driven blockers that retro cannot see.` and STOP.
+- **"Continue with retro"**: note the team-session context in the eventual research doc and proceed to §Step 2.
+
+## §Step 2: Scan conversation context for pain points
+
+This is a summarization + classification task on the conversation already in your window. Scan for friction signals:
+
+- **Errors encountered** — tool failures, runtime errors, stack traces, lints, test failures.
+- **Retries** — re-attempted operations with adjusted inputs.
+- **Workarounds** — non-obvious paths taken because the obvious path didn't work.
+- **Confusion expressions** — "let me check…", "actually that's not right", "I'm not sure why this…".
+- **Repeated manual steps** — sequences that recurred 3+ times and could plausibly be automated.
+- **Unclear specifications** — ambiguity in the request caused rework.
+
+For each pain point, classify into one of six categories:
+
+1. **API confusion** — surprising behavior, missing docs, hidden side effects.
+2. **Missing tooling** — repeated manual steps that should be automated.
+3. **Error-prone workflows** — multi-step recipes with implicit ordering.
+4. **Missing abstractions** — patterns copy-pasted across the session.
+5. **Performance friction** — slow operations that interrupted flow.
+6. **Scope ambiguity** — issues, plans, or specs that were underspecified.
+
+For each pain point, also assign:
+
+- **Severity**: `blocking` (prevented progress) / `annoying` (slowed flow) / `minor`.
+- **Codebase anchor** (optional): a file path or component name if implicit in the conversation. If none, leave empty — §Step 3 skips sub-agent dispatch for that point.
+
+### Long-conversation guidance
+
+If the visible conversation exceeds ~200k tokens or ~150 turns, narrow the scan — either constrain to the most recent N turns where friction was concentrated, or ask the user via `AskUserQuestion` which slice to analyze. Do NOT skip the scan entirely.
+
+## §Step 3: Sub-agent grounding (conditional)
+
+For pain points with a clear codebase anchor, ground them via sub-agents. For pain points without an anchor (tooling, UX, conceptual), skip sub-agents — these will use `None` entries in `## Files Affected`.
+
+**When to dispatch:**
+
+- Pain point references a specific file path → `codebase-locator` to confirm + find related files.
+- Pain point references a specific component or behavior → `codebase-analyzer` to document how it works.
+
+**Dispatch shape (no `team_name`):**
+
+```
+Agent(subagent_type="ralph-hero:codebase-locator",
+      prompt="Find files related to [pain-point area]")
+
+Agent(subagent_type="ralph-hero:codebase-analyzer",
+      prompt="Analyze how [component] currently works (without critiquing)")
+```
+
+Dispatch in parallel where multiple anchored pain points reference different areas. Fold findings into the relevant pain-point sections.
+
+### Optional knowledge-graph dedup
+
+If `knowledge_recall` is available, run a brief dedup check for each high-severity pain point:
+
+```
+knowledge_recall(query="[pain point summary]", role="researcher", type="research", brief=true, limit=3)
+```
+
+If a close match is found, mention it in the `Prior Work` section. Fall back to `knowledge_search` if `knowledge_recall` is unavailable. Skip both gracefully if neither exists.
+
+## §Step 4: Present findings for review
+
+Display a concise summary (one line per pain point) and use `AskUserQuestion` to gather feedback. This catches misclassifications and gives the user a chance to drop or refine entries.
+
+```
+Found N pain points across this session:
+
+1. [API confusion / blocking] Plugin permissions don't propagate to subagent dispatches → plugin/ralph-hero/skills/research/SKILL.md
+2. [Missing tooling / annoying] Worktree creation and rebase is a 4-command dance — no one-shot automation
+...
+```
+
+Then:
+
+```
+AskUserQuestion(
+  questions=[{
+    "question": "How do these pain points look?",
+    "header": "Retro Findings Review",
+    "options": [
+      {"label": "Looks good, write it", "description": "Finalize the research document as-is"},
+      {"label": "Drop a pain point", "description": "Remove an entry that isn't really a pain point"},
+      {"label": "Add a pain point", "description": "Add an entry I noticed and you missed"},
+      {"label": "Re-classify a pain point", "description": "Change a category or severity"}
+    ],
+    "multiSelect": false
+  }]
+)
+```
+
+Routing: drop/add/re-classify re-displays the list and re-asks until the user picks "Looks good, write it".
+
+## §Step 5: Write research document
+
+Path: `thoughts/shared/research/YYYY-MM-DD-retro-[description].md` where `[description]` is a kebab-case slug from the dominant pain-point theme.
+
+```markdown
+---
+date: YYYY-MM-DD
+status: complete
+type: research
+github_issue: null
+tags: [retro, session-friction, [+ component tags]]
+---
+
+# Retro: [Session Theme]
+
+## Prior Work
+
+- builds_on:: [[any-related-research-doc]] (research — primary evidence)
+- builds_on:: [[any-related-postmortem]] (report — overlapping ground)
+
+(If no prior work found: `_No prior work found via knowledge graph or thoughts scan._`)
+
+## Summary
+
+[2-4 sentence narrative: what session this captures, dominant theme, most actionable finding]
+
+## Detailed Findings
+
+### API Confusion
+
+- **[Pain point title]** ([severity])
+  - What happened: [1-2 sentences]
+  - Anchor: `path/to/file.ext` (or "no specific code anchor")
+  - Sub-agent grounding: [one-line summary, or "n/a"]
+  - Suggested next step: [file an issue / explore in /research / propose tooling change]
+
+### Missing Tooling
+
+...
+
+### Error-Prone Workflows
+
+...
+
+### Missing Abstractions
+
+...
+
+### Performance Friction
+
+...
+
+### Scope Ambiguity
+
+...
+
+## Files Affected
+
+### Will Modify
+
+- [Files implicated by anchored pain points]
+- If none: `- None - this retro covers tooling/UX friction with no specific code files implicated.`
+
+### Will Read (Dependencies)
+
+- [Supporting files referenced during analysis]
+- If none: `- None.`
+
+## Recommended Next Steps
+
+[Concrete suggestions, one per pain point or grouped by theme]
+
+- For [pain point]: run `/ralph:form thoughts/shared/research/[this-filename].md` to create an issue
+- For [pain point]: explore further with `/ralph:research [topic]` before filing
+- For [pain point]: discuss with team — may not warrant a ticket
+```
+
+**Critical: `## Files Affected` MUST be present** — postcondition hooks validate section presence, not non-emptiness. Use explicit `None` entries when no code is implicated.
+
+After writing, confirm to the user:
+
+```
+Wrote retro to:
+`thoughts/shared/research/YYYY-MM-DD-retro-[description].md`
+
+Captured N pain points across [list categories that had findings].
+```
+
+## §Step 6: Next steps
+
+Offer downstream actions via `AskUserQuestion`:
+
+```
+AskUserQuestion(
+  questions=[{
+    "question": "Retro doc written. What would you like to do next?",
+    "header": "Next Steps",
+    "options": [
+      {"label": "Create issue from findings", "description": "Run /ralph:form on this research doc to crystallize findings into a GitHub issue"},
+      {"label": "Deep-dive a specific pain point", "description": "Spawn targeted research sub-agents to explore one finding further"},
+      {"label": "Save for later — done", "description": "No further action; the doc is on disk and ready for /form or /plan"}
+    ],
+    "multiSelect": false
+  }]
+)
+```
+
+Routing:
+
+- **"Create issue from findings"**: invoke `Skill("ralph:form", args="thoughts/shared/research/YYYY-MM-DD-retro-[description].md")`.
+- **"Deep-dive a specific pain point"**: ask which one, dispatch `Agent(subagent_type="ralph-hero:codebase-analyzer", ...)`, append findings to the same retro doc as `## Follow-up Investigation`.
+- **"Save for later — done"**: STOP.
+
+## §Step 7: Record outcome (optional)
+
+```
+knowledge_record_outcome(
+  event_type="retro_completed",
+  payload={
+    pain_point_count: <N>,
+    categories: [<list with findings>],
+    created_doc_path: "thoughts/shared/research/YYYY-MM-DD-retro-[description].md",
+    team_session_detected: <bool>
+  }
+)
+```
+
+If unavailable, skip silently.
+
+## §Step 8: Emit terminal token
+
+```
+RETRO <path>
+```
+
+Where `<path>` is the absolute path written in §Step 5. On the team-session-redirect or no-findings short-circuit:
+
+```
+RETRO SKIPPED <reason>
+```
+
+## §Constraints
+
+- **Inline context is non-negotiable** — retro MUST run inline (no `context: fork`). A forked retro has no conversation to analyze.
+- **Conditional sub-agent dispatch.** Only anchored pain points dispatch `codebase-locator` / `codebase-analyzer`. Tooling/UX/conceptual friction skips sub-agents and uses `None` entries.
+- **No `team_name`** on `Agent()` calls.
+- **Opus model for extraction quality** — declared at the SKILL.md frontmatter level.
+- **`## Files Affected` always present** even when no code is implicated.
+- **Long conversations are narrowed, not skipped.** Ask the user to scope or constrain.
+- **Research doc, not idea doc.** Output is `type: research` (not `idea`) so it flows through `/form`'s research-doc intake path.

--- a/ralph/skills/caretake/modes/split.md
+++ b/ralph/skills/caretake/modes/split.md
@@ -1,1 +1,209 @@
-_Filled by Phase 8 (`--mode split`)._
+# `--mode split`
+
+Take ONE large issue (M/L/XL), research its scope, and decompose it into XS/S sub-issues that can be implemented atomically. This is the non-epic side of decomposition — epic-tier work (3+ tiers) is handled by `/ralph:plan --mode epic` (Plan 4).
+
+```bash
+export RALPH_SUBCOMMAND=split
+```
+
+All four `split-*` hooks gate on `RALPH_SUBCOMMAND=split`. See [split-decomposition.md](../split-decomposition.md) for the full hook-contract table + decomposition heuristics.
+
+## §Step 1: Select issue
+
+**If issue number provided as argument**: fetch it directly.
+
+**If no issue number**: find the oldest M+ issue in Research Needed or Backlog. "Oldest" means earliest `createdAt` — pass `orderBy: "CREATED_AT"` ascending. Use a sub-agent to discover candidates:
+
+```
+Agent(subagent_type="ralph-hero:codebase-locator",
+      prompt="Find issues with M/L/XL estimates in Research Needed or Backlog workflow state. Return oldest first by createdAt.")
+```
+
+Or query directly: list Backlog + Research Needed issues filtered by estimate M, then L, then XL (`limit: 50`, `orderBy: "CREATED_AT"` ascending). Pick the oldest across all queries.
+
+Do NOT pass `team_name` to `Agent()` calls.
+
+If no eligible issues found, emit:
+
+```
+Queue empty.
+```
+
+and STOP.
+
+## §Step 2: Fetch and analyze
+
+1. **Get full issue details** including comments.
+2. **Read any linked research documents** from comments.
+3. **Verify estimate**: must be M, L, or XL.
+
+The `split-estimate-gate.sh` hook (PreToolUse on `get_issue` surfaces an M/L/XL reminder via stderr; PostToolUse parses `tool_response.content[0].text` and blocks with exit 2 if the estimate is XS or S). If the hook blocks, emit:
+
+```
+SPLIT SKIPPED already-atomic
+```
+
+and STOP — do NOT attempt to override the gate.
+
+## §Step 3: Discover existing children
+
+`list_sub_issues` on the parent. Record results:
+
+- **No children found**: proceed to §Step 4 (research scope) and §Step 6 (create all new).
+- **Children found**: read each child's title, description, estimate, and state. Carry forward to §Step 5 for scope comparison.
+
+If children exist, add a note to the analysis: "Found [N] existing children. Will compare against proposed split before creating new issues."
+
+## §Step 4: Research scope
+
+Spawn parallel sub-tasks to understand the full scope (no `team_name`):
+
+```
+Agent(subagent_type="ralph-hero:codebase-locator",
+      prompt="Find all files related to [issue topic]. What components are involved?")
+
+Agent(subagent_type="ralph-hero:codebase-analyzer",
+      prompt="Analyze [primary component]. What are the distinct pieces of work?")
+```
+
+**Goal**: identify natural boundaries — see [split-decomposition.md](../split-decomposition.md) §Decomposition heuristics for the strategy table.
+
+§Step 4 is **optional** if the issue body already enumerates the artifacts to split (a list of skills, fragments, files). Skip it in that case and decompose directly from the body.
+
+## §Step 5: Propose split
+
+Design XS/S sub-issues per the sizing rubric in [split-decomposition.md](../split-decomposition.md) §Sub-issue sizing.
+
+**If existing children were found in §Step 3**, compare proposed sub-issues against them:
+
+- **Match found**: mark the existing child for reuse (update its estimate/description/dependencies if needed).
+- **No match**: mark as net-new (will be created in §Step 6).
+- **Existing child with no matching proposal**: leave as-is.
+
+When unsure whether an existing child covers a proposed scope, prefer reusing the existing child and adjusting its description rather than creating a duplicate.
+
+Produce a split-plan summary:
+
+| Action | Issue | Title | Estimate |
+|---|---|---|---|
+| Reuse | #AA | [existing title] | S |
+| Update | #BB | [adjusted title] | XS |
+| Create | (new) | [new title] | XS |
+
+## §Step 6: Create or update sub-issues
+
+**Reuse**: update the existing child's body and/or estimate if the scope or sizing has been refined.
+
+**Create new** — three-step pattern:
+
+1. **`create_issue`** with descriptive title, scoped body (scope + references + acceptance criteria), labels inherited from parent.
+2. **`add_sub_issue`** to link under the parent. The `split-verify-sub-issue.sh` hook (PostToolUse on `add_sub_issue`) verifies the linkage took effect — if it didn't, retry once; if still failing, document the orphan in a comment on the parent.
+3. **Set estimate** per the sizing rubric. The `split-size-gate.sh` hook (PreToolUse on `create_issue`) blocks `M`/`L`/`XL` here — children MUST be XS or S.
+4. **Set initial workflow state**: advance to `Ready for Plan` (`command: "ralph_split"`) unless §Step 10's gating applies. Uniform across all children — including those blocked by a sibling via dependency.
+
+Sub-issue body template:
+
+```markdown
+## Summary
+[What this sub-issue accomplishes]
+
+## Scope
+[Specific files/components to modify]
+
+## Acceptance Criteria
+- [ ] [Specific criterion 1]
+- [ ] [Specific criterion 2]
+
+## References
+- Parent: #[parent-number]
+- Related: [File paths, documentation]
+
+## Out of Scope
+- [What's handled by sibling issues]
+```
+
+## §Step 7: Establish dependencies
+
+For each dependency pair, `add_dependency`: the dependent issue is blocked by the earlier-phase issue. See [split-decomposition.md](../split-decomposition.md) §Dependency wiring for rules.
+
+## §Step 8: Update original issue
+
+Add a split-summary comment on the parent:
+
+```markdown
+## Issue Split
+
+This issue has been decomposed into [N] sub-issues:
+
+| Order | Issue | Title | Estimate |
+|---|---|---|---|
+| 1 | #AA | [title] | XS |
+| 2 | #BB | [title] | S |
+| 3 | #CC | [title] | XS |
+
+**Dependency chain**: #AA -> #BB -> #CC
+
+Original estimate: [M/L/XL]
+Total after split: [sum] points across [N] issues
+
+---
+*Split by `/ralph:caretake --mode split`*
+```
+
+**Keep parent in Backlog** — do NOT change its workflow state. The auto-advance helper inside `save_issue` advances the parent only when ALL children reach a gate state; manually advancing the parent here races with that helper.
+
+Update the original issue body to prepend `## Split into Sub-Issues\nThis issue has been decomposed. See children and comments for details.\n\n` to the existing body. Do NOT call `save_issue` with a `workflowState` argument on the parent.
+
+## §Step 9: Push child-specific research notes
+
+Any context discovered during §Steps 2-5 that is specific to one child must be embedded in that child's body — not left only in the parent split-summary comment. For each child, scan your research output for notes naming a file, function, or fragment that this specific child will touch; append under a `## Research Notes` section via `save_issue`.
+
+## §Step 10: Set sub-issue workflow states
+
+Based on research done during splitting, set the workflow state for **every** child (including children with sibling `blockedBy` dependencies — §Step 7 dependencies are orthogonal to workflow state):
+
+- **Scope clear** → `Ready for Plan` (`command: "ralph_split"`).
+- **Scope needs more research** → keep in `Research Needed`.
+- **Blocked by issue OUTSIDE this split** → keep in `Backlog`.
+
+**Uniformity check**: after this step, `list_sub_issues` on the parent and verify every child has a non-null `workflowState`. The dependency-chain pattern (repo → service → router) is a common pitfall: agents sometimes advance only the unblocked head and leave the rest with no workflow state.
+
+## §Step 11: Emit terminal token
+
+```
+SPLIT <N>
+```
+
+Where `<N>` is the total number of children (created + reused). `split-postcondition.sh` (Stop hook) requires `N ≥ 2` — anything less fails the gate.
+
+On the already-atomic short-circuit (from §Step 2):
+
+```
+SPLIT SKIPPED already-atomic
+```
+
+On other graceful skips (decomposition failed, no natural boundary, parent already fully split):
+
+```
+SPLIT SKIPPED <reason>
+```
+
+## §Escalation
+
+| Situation | Action |
+|---|---|
+| Can't identify natural decomposition boundaries | Escalate via `## Escalation` comment: "Unable to decompose GH-NNN. Scope is atomic or unclear — no natural artifact, layer, or phase boundary found." |
+| Circular dependencies in proposed split | Escalate: "Proposed split has circular dependency. Need guidance." |
+| Issue is actually XS/Small after research | Update estimate instead of splitting (no escalation needed) |
+
+There is **no fixed cap** on sub-issue count. A skill audit epic may legitimately fan out to 10+ children; a fragment-extraction epic may fan out to 4-8. Escalate only when you cannot identify natural boundaries — not when the count is large.
+
+## §Constraints
+
+- **Work on ONE parent per invocation.**
+- **M/L/XL parents only** — `split-estimate-gate.sh` enforces.
+- **XS/S children only** — `split-size-gate.sh` enforces.
+- **No implementation, only issue creation.**
+- **Complete within 20 minutes** — rushing produces under-researched children.
+- **Parent stays in Backlog** — the auto-advance helper inside `save_issue` owns parent transitions.
+- **Sub-agent research is optional** when the issue body already enumerates artifacts (skill audits, fragment extractions).

--- a/ralph/skills/caretake/modes/split.md
+++ b/ralph/skills/caretake/modes/split.md
@@ -1,0 +1,1 @@
+_Filled by Phase 8 (`--mode split`)._

--- a/ralph/skills/caretake/modes/trends.md
+++ b/ralph/skills/caretake/modes/trends.md
@@ -1,1 +1,49 @@
-_Filled by Phase 6 (`--mode trends`)._
+# `--mode trends`
+
+Capture a fresh project snapshot, then render a markdown trends report (sparklines + 1d/7d/30d deltas) for velocity, riskScore, wipTotal, and leadTimeP50Hours. **Read-only output** — results print to stdout; nothing is posted to GitHub.
+
+```bash
+export RALPH_SUBCOMMAND=trends
+```
+
+No hook gates this mode and no terminal token is emitted — the markdown report itself is the deliverable. Trends is the only caretaker mode without a terminal verdict because no state transition or artifact creation happens that a postcondition could verify.
+
+## §Step 1: Parse arguments
+
+Parse `$ARGUMENTS` for optional flags:
+
+- `--since <window>` — lower bound for the trend window. Accepts ISO dates (e.g., `2026-04-01`) or date-math (`@today-30d`, `@now-24h`). Default: `7d` (interpreted as `@today-7d`).
+
+All arguments are optional. Default behavior: capture a fresh snapshot, then trend over the last 7 days.
+
+## §Step 2: Capture fresh snapshot
+
+Call `ralph_hero__capture_snapshot` with no arguments. The tool picks up the current project from `RALPH_GH_OWNER` / `RALPH_GH_PROJECT_NUMBER` and uses the default 7-day velocity window.
+
+This appends one row to `~/.ralph-hero/snapshots/<owner>/<projectNumber>.jsonl`. Capture is non-fatal — if the project has zero history, the row written by this call will be the first.
+
+## §Step 3: Query trends
+
+Call `ralph_hero__metrics_trends` with:
+
+- `format: "markdown"`
+- `since`: the parsed `--since` value, or `"@today-7d"` by default.
+
+The tool reads the local JSONL file, computes 1d/7d/30d deltas, and renders sparkline-augmented markdown for each metric.
+
+## §Step 4: Print output
+
+Print the returned `markdown` field directly to stdout. Do not post, do not summarize, do not edit.
+
+If `metrics_trends` returns an "insufficient history" payload (fewer than 2 snapshots in the window), print the markdown as-is. Do not error.
+
+## §Output contract
+
+The markdown report IS the terminal output. No `result:` line, no terminal token, no `## Trends` comment posted anywhere. Consumers (operators, the heartbeat fan-out, future iOS surfaces) read the markdown directly from stdout.
+
+## §Constraints
+
+- **Read-only.** Trends never mutates GitHub state or any file outside `~/.ralph-hero/snapshots/`.
+- **No terminal token.** Postcondition hooks ignore this mode.
+- **Haiku-class workload.** The source skill declares `model: haiku` because the work is two MCP calls + a stdout print. The caretake top-level `model: opus` covers all modes; haiku would be cheaper but the slim plugin runs all modes under the same model for arg-routing simplicity.
+- **Snapshot append is non-fatal.** If the snapshot file is missing or unreadable, `capture_snapshot` creates it; `metrics_trends` degrades to an "insufficient history" report.

--- a/ralph/skills/caretake/modes/trends.md
+++ b/ralph/skills/caretake/modes/trends.md
@@ -1,0 +1,1 @@
+_Filled by Phase 6 (`--mode trends`)._

--- a/ralph/skills/caretake/modes/triage.md
+++ b/ralph/skills/caretake/modes/triage.md
@@ -1,0 +1,1 @@
+_Filled by Phase 3 (`--mode triage`)._

--- a/ralph/skills/caretake/modes/triage.md
+++ b/ralph/skills/caretake/modes/triage.md
@@ -1,1 +1,149 @@
-_Filled by Phase 3 (`--mode triage`)._
+# `--mode triage`
+
+Pick ONE Backlog issue, assess its validity, and route it. Autonomous — no human prompts. The mode emits one terminal token per invocation (see [outcome-tokens.md](../outcome-tokens.md)).
+
+```bash
+export RALPH_SUBCOMMAND=triage
+```
+
+`triage-state-gate.sh` (PostToolUse on `save_issue`) gates state transitions on `RALPH_SUBCOMMAND=triage`. `triage-postcondition.sh` (Stop) verifies the transcript carries a `TRIAGED <verdict>` or `Queue empty.` line before allowing exit.
+
+## §Step 1: Verify branch
+
+```bash
+git branch --show-current
+```
+
+If NOT on `main`, STOP and emit:
+
+```
+TRIAGED skipped — branch <name> is not main
+```
+
+Triage must run from main to avoid accidental commits on feature branches.
+
+## §Step 2: Select issue
+
+**If issue number provided as argument**: fetch the full issue details for that issue number.
+
+**If no issue number**: pick the oldest untriaged Backlog issue via two queries:
+
+- **Query 1** — list Backlog issues that already carry the `ralph-triage` label (`profile: "analyst-triage"`, `label: "ralph-triage"`, `limit: 250`). Store the returned issue numbers as `triaged_numbers`.
+- **Query 2** — list all Backlog issues ordered by creation date ascending (`profile: "analyst-triage"`, `orderBy: "CREATED_AT"`, `limit: 250`). The ascending direction is required so the **first** result is the oldest.
+
+**Select** the first issue from Query 2 whose number is NOT in `triaged_numbers`. If no untriaged issue is found, emit:
+
+```
+Queue empty.
+```
+
+and STOP.
+
+## §Step 3: Assess
+
+1. **Read the issue body and comments thoroughly.**
+2. **Dispatch parallel sub-tasks for assessment.** Use the `Agent` tool to check the codebase and GitHub concurrently:
+
+   ```
+   Agent(subagent_type="ralph-hero:codebase-locator",
+         prompt="Search for [keywords from issue title]. Does this feature/fix already exist?")
+   ```
+
+   Do NOT pass `team_name` to `Agent()` calls — sub-agents must run outside any team context. Also search GitHub for similar issues by keywords from the title (limit 5).
+3. **Wait for sub-tasks to complete.**
+4. **Synthesize** based on the agent findings:
+   - Does the feature/fix already exist?
+   - Are there duplicate issues?
+   - What's the realistic scope (XS/S/M/L/XL)?
+
+## §Step 4: Determine action
+
+Choose ONE:
+
+- **CLOSE** — feature already implemented, bug already fixed, duplicate, or no longer applicable.
+- **SPLIT** — issue is too large or covers multiple distinct items. Recommend XS/S sub-issues.
+- **RE-ESTIMATE** — current estimate missing or wrong; propose new value with reasoning.
+- **RESEARCH** — issue is valid but needs investigation; move to "Research Needed".
+- **KEEP** — issue is valid as-is; leave in Backlog with a clarifying comment if helpful.
+
+When uncertain, prefer KEEP with a detailed comment over closing valid work.
+
+## §Step 5: Take action
+
+If `save_issue`, `create_issue`, `add_sub_issue`, or `add_dependency` returns an error, read the error message — it contains valid states/intents and a specific recovery action. Retry with corrected parameters. If the error indicates a permanent problem (invalid permissions, missing field, etc.), escalate per §Escalation below.
+
+**CLOSE.** Choose the destination state by closure reason:
+
+- **Done** — already implemented, already fixed, duplicate of completed work. Use `issueState: "CLOSED"` (reason: completed).
+- **Canceled** — no longer relevant (tech changed, product direction shifted). Use `issueState: "CLOSED_NOT_PLANNED"` (reason: not planned).
+
+Update workflow state accordingly (`command: "ralph_triage"`). Add a comment explaining the closure reason and chosen destination state.
+
+**SPLIT.** First, `list_sub_issues` on the parent. If children already exist and cover the proposed scope, add a comment noting the existing children — do NOT create duplicates. If coverage is partial, create only net-new sub-issues. If no children exist, create XS sub-issues via the three-step pattern:
+
+1. `create_issue` with a descriptive title.
+2. `add_sub_issue` to link under the original.
+3. Set estimate "XS" and workflow state "Backlog".
+
+Add a comment on the parent listing sub-issues (reused and/or created). **Do NOT close the original** — the parent stays in Backlog until all children reach Done.
+
+**RE-ESTIMATE.** Update the issue with the new estimate (XS/S/M/L/XL). Add a comment explaining the reasoning. Workflow state remains Backlog.
+
+**RESEARCH.** Set `workflowState: "Research Needed"` (`command: "ralph_triage"`). Add a comment: "Moved to Research Needed for investigation." Briefly note what needs research so downstream `/ralph:research` has actionable context.
+
+**KEEP.** Add a comment with any clarifications or context discovered. Leave workflow state as Backlog.
+
+**Before completing (REQUIRED for all branches):** export `RALPH_TRIAGE_ACTION` so `triage-postcondition.sh` can verify the action was taken:
+
+```bash
+export RALPH_TRIAGE_ACTION=RESEARCH   # or SPLIT, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE
+```
+
+Valid values: `RESEARCH`, `SPLIT`, `CLOSE`, `KEEP`, `HUMAN`, `CANCEL`, `RE-ESTIMATE`. The postcondition hook blocks exit if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
+
+## §Step 6: Mark issue as triaged
+
+After completing any action, update labels to include `ralph-triage` while preserving existing labels. Read current labels first, then include them all plus `ralph-triage` in the `save_issue` call.
+
+## §Step 7: Emit terminal token
+
+Emit exactly one of the five tokens defined in [outcome-tokens.md](../outcome-tokens.md):
+
+- `TRIAGED valid` — moved to Research Needed or Ready for Plan.
+- `TRIAGED duplicate` — closed as duplicate; references `## Duplicate Of` comment.
+- `TRIAGED canceled` — closed not-planned.
+- `TRIAGED needs-split` — left in Backlog with `needs-split` label so `--mode split` picks it up.
+- `Queue empty.` — no untriaged Backlog issues (emitted at §Step 2).
+
+`triage-postcondition.sh` greps the transcript for one of these tokens. Anything else fails the Stop hook with exit 2.
+
+## §Confidence levels
+
+- **High** (take action automatically): feature exists in codebase (CLOSE), exact duplicate found (CLOSE), issue explicitly marked "done" in comments (CLOSE).
+- **Medium** (act + note uncertainty): similar-but-not-identical feature, possibly-outdated issue, scope seems large but doable in phases.
+- **Low** (KEEP + comment): ambiguous requirements, can't determine if feature exists, unclear relevance.
+
+When uncertain, prefer KEEP over closing.
+
+## §Escalation
+
+If the agent cannot make a confident triage call, escalate by posting a `## Escalation` comment and setting `RALPH_TRIAGE_ACTION=HUMAN`. Common triggers:
+
+| Situation | Comment text |
+|---|---|
+| Can't determine if feature exists | "Unable to confirm if [feature] is implemented. Need human verification." |
+| Multiple potential duplicates | "Found [N] potential duplicates: [list]. Please clarify which to close." |
+| Requirements ambiguous | "Requirements ambiguous: [quote]. Cannot assess scope accurately." |
+| Cross-team dependency | "This issue depends on [external team/system]. Need coordination." |
+| Splitting decision unclear | "Multiple valid ways to split this issue. Need guidance." |
+
+After escalating, apply the `ralph-triage` label so the issue is not re-picked.
+
+## §Constraints
+
+- Work on ONE issue per invocation.
+- No estimate restrictions (triage assesses all sizes).
+- May close/split/update issues (unlike other ralph commands).
+- No code changes.
+- Complete within 10 minutes.
+- The `triage-state-gate.sh` hook validates state transitions; `triage-postcondition.sh` validates the terminal token.

--- a/ralph/skills/caretake/modes/unblock.md
+++ b/ralph/skills/caretake/modes/unblock.md
@@ -1,0 +1,1 @@
+_Filled by Phase 5 (`--mode unblock` interactive + autonomous)._

--- a/ralph/skills/caretake/modes/unblock.md
+++ b/ralph/skills/caretake/modes/unblock.md
@@ -1,1 +1,270 @@
-_Filled by Phase 5 (`--mode unblock` interactive + autonomous)._
+# `--mode unblock`
+
+Two execution paths inside one mode body. Both operate on the same artifact — the `## Unblock Request` comment on a Human Needed issue — but from opposite sides of the producer/consumer contract:
+
+- **Default (interactive)** — port of `unblock`. Read the `## Unblock Request` comment, walk a human through its questions via `AskUserQuestion`, post `## Unblock Resolution`, transition the issue back into the pipeline.
+- **`--question` (autonomous request)** — port of `ralph-unblock`. Pick the oldest Human Needed issue, compose 1-5 specific blocking questions, post `## Unblock Request`, STOP. Does NOT transition state.
+
+```bash
+if echo "$ARGUMENTS" | grep -q -- '--question'; then
+  export RALPH_SUBCOMMAND=unblock
+  export RALPH_SUBCOMMAND_VARIANT=autonomous
+else
+  export RALPH_SUBCOMMAND=unblock
+  export RALPH_SUBCOMMAND_VARIANT=interactive
+fi
+```
+
+`unblock-state-gate.sh` (PostToolUse on `save_issue`) fires on the interactive path only — autonomous never transitions state. `unblock-request-postcondition.sh` (Stop) fires on the autonomous path only — verifies a `## Unblock Request` comment was posted via `create_comment`. Each hook gates on `RALPH_SUBCOMMAND_VARIANT`.
+
+---
+
+## §Interactive path (default)
+
+The consumer side of the unblock contract. Walks a human through pre-posted questions and routes the issue back into the pipeline.
+
+### Step 1: Select issue
+
+**If issue number provided as argument**: fetch the full issue (with comments). If the issue is NOT in `workflowState: "Human Needed"`, STOP and emit:
+
+```
+UNBLOCK ESCALATED — issue #NNN is in <state> (expected: Human Needed)
+```
+
+**If no issue number**: list candidates with `workflowState: "Human Needed"`, `orderBy: "CREATED_AT"` ascending, `limit: 50`. For each candidate, fetch full details (with comments) and filter to those carrying a `## Unblock Request` comment.
+
+- **Zero candidates**: emit `Queue empty.` and STOP. (Run `--mode unblock --question` first to post questions.)
+- **One candidate**: auto-select. Print `Selected #NNN: [Title]` and continue.
+- **Multiple candidates**: present `AskUserQuestion` with one option per candidate. Label: `"#NNN · <title fragment>"` truncated to ≤30 chars (with `…` suffix when truncated). Description: short clause naming the originating skill if extractable from `## Escalation`.
+
+### Step 2: Load context
+
+For the selected issue:
+
+1. Re-read the issue body in full.
+2. Find the most recent `## Escalation` comment. If present, extract the reason text after `Escalation:` and the originating skill/command name (best effort). Otherwise set `originating_command = null`.
+3. Find the most recent `## Unblock Request` comment.
+   - **If present**: parse out the numbered questions (lines matching `^\d+\.\s`). Capture each question verbatim.
+   - **If absent**: synthesize 1-5 pointed questions inline, grounded in the `## Escalation` text + issue body. Print to the user:
+
+     ```
+     No `## Unblock Request` exists yet — I'll generate questions on the fly.
+     To pre-generate, run `/ralph:caretake --mode unblock --question` first next time.
+     ```
+
+### Step 3: Walk through questions
+
+For each question, in order:
+
+- **Multiple-choice phrasing present** (the question explicitly enumerates options like "A vs B", "(a) X (b) Y", or "either X or Y"): present `AskUserQuestion` with one option per enumerated choice plus a freeform `"Other (explain)"` fallback.
+- **Otherwise**: present `AskUserQuestion` with a single open-ended option labeled `"Answer"` and use the `description` field to surface the question text.
+
+Capture each `(question, answer)` pair in order. Quote each answer verbatim — do not paraphrase.
+
+### Step 4: Determine return state
+
+Apply the originating-command heuristic:
+
+| Originating command (from `## Escalation`) | Default return state |
+|---|---|
+| `ralph_research` | `Research Needed` |
+| `ralph_plan` / `ralph_plan_epic` | `Ready for Plan` |
+| `ralph_review` | `Ready for Plan` (re-plan with new direction) |
+| `ralph_impl` / `ralph_pr` / `ralph_merge` / `ralph_code_review` | `In Progress` |
+| `ralph_triage` | `Backlog` |
+| None / unknown | `In Progress` (most common case) |
+
+Always confirm via `AskUserQuestion` — never silently transition. Present exactly four options with the inferred default first:
+
+- `In Progress` — resume implementation
+- `Ready for Plan` — re-plan with new direction
+- `Research Needed` — gather more information first
+- `Backlog` — defer / not actionable now
+
+Capture the user's choice as `chosen_state`.
+
+### Step 5: Post `## Unblock Resolution` comment
+
+```markdown
+## Unblock Resolution
+
+### Q&A
+1. **Q**: [Question 1]
+   **A**: [Answer 1]
+2. **Q**: [Question 2]
+   **A**: [Answer 2]
+...
+
+Routing to: `[chosen_state]`
+```
+
+Numbering matches the original `## Unblock Request` numbering. Quote questions and answers verbatim. Post via `ralph_hero__create_comment`.
+
+### Step 6: Transition state
+
+Call `save_issue` with `number`, `workflowState: chosen_state` (one of `Backlog`, `Research Needed`, `Ready for Plan`, `In Progress`), and `command: "ralph_unblock"`.
+
+`unblock-state-gate.sh` validates `tool_input.workflowState` is one of the 5 allowed values (`Backlog`, `Research Needed`, `Ready for Plan`, `In Progress`, `Human Needed`). If a buggy attempt sets `Done` or `Plan in Review`, the hook blocks with exit 2 — abort, do NOT retry blindly.
+
+If `save_issue` errors for any other reason, surface the error and STOP. The `## Unblock Resolution` comment was already posted, so re-running would duplicate it — ask the human to manually transition from the GitHub Projects board.
+
+### Step 7: Record outcome event
+
+Call `knowledge_record_outcome`:
+
+```
+knowledge_record_outcome(
+  event_type="unblock_resolved",
+  issue_number=NNN,
+  agent_type="ralph_unblock",
+  payload={
+    "question_count": <N>,
+    "return_state": "<chosen_state>",
+    "originating_command": <"ralph_impl" | ... | null>
+  }
+)
+```
+
+If unavailable, skip silently — the comment + state transition are the source of truth.
+
+### Step 8: Emit terminal token
+
+```
+UNBLOCK RESOLVED
+```
+
+On any pre-resolution failure (wrong-state arg, missing `## Unblock Request`, user abort):
+
+```
+UNBLOCK ESCALATED <reason>
+```
+
+---
+
+## §Autonomous path (`--question`)
+
+The producer side. Picks the oldest Human Needed issue and posts a `## Unblock Request` comment containing 1-5 specific questions. Does NOT transition state.
+
+### Step 1: Verify branch
+
+```bash
+git branch --show-current
+```
+
+If NOT on `main`, STOP and emit `UNBLOCK REQUEST SKIPPED — branch <name> is not main`.
+
+### Step 2: Select Human Needed issue
+
+**If issue number provided as argument**: fetch the full issue. If NOT in `workflowState: "Human Needed"`, set `RALPH_UNBLOCK_QUEUE_EMPTY=1` and emit `Queue empty.`.
+
+**If no issue number**: list candidates with `workflowState: "Human Needed"`, `orderBy: "CREATED_AT"` ascending (oldest first), `limit: 50`.
+
+For each candidate, in order:
+
+1. Fetch full issue (with comments).
+2. Find the most recent `## Escalation` comment; note its `createdAt`.
+3. Find the most recent `## Unblock Request` comment; note its `createdAt`.
+4. **Idempotency guard** — skip if a `## Unblock Request` exists AND one of:
+   - (a) An `## Escalation` exists AND its `createdAt` ≤ the `## Unblock Request`'s `createdAt`, OR
+   - (b) No `## Escalation` exists AND the issue's last transition into Human Needed is ≤ the `## Unblock Request`'s `createdAt`. Use this best-effort signal: most recent state-change comment mentioning "Human Needed", then `updatedAt` as fallback.
+
+5. Otherwise, this is the first eligible issue — use it.
+
+If no eligible issue found, export `RALPH_UNBLOCK_QUEUE_EMPTY=1` and emit `Queue empty.`. Then STOP.
+
+### Step 3: Read context (escalation optional)
+
+For the selected issue:
+
+1. Read the issue body in full.
+2. Read the most recent `## Escalation` comment if one exists. Extract the reason text after `Escalation:` and the originating skill (best effort). Track `context_source = "escalation"` (or `"mixed"` if combined with other sources).
+3. Read any linked artifacts (`## Research Document`, `## Implementation Plan`) referenced in comments. Track `context_source = "linked_artifact"` or `"mixed"`.
+4. Note the title and any obviously relevant labels.
+
+Set `context_source` to one of: `escalation`, `issue_body`, `linked_artifact`, `mixed`.
+
+### Step 4: Synthesize 1-5 questions
+
+Each question must be:
+
+- **Specific** — refer to concrete files, options, decisions, or constraints. Avoid "what should we do?".
+- **Answerable** — phrased so a one-sentence-to-one-paragraph reply is sufficient.
+- **Grounded** — drawn from the escalation text, issue body, or linked artifact.
+
+Cap at 5. Prefer fewer, pointier questions over many vague ones.
+
+### Step 5: Post `## Unblock Request` comment
+
+```markdown
+## Unblock Request
+
+This issue is in Human Needed. To unblock, please answer the following:
+
+1. [Question 1 — concrete and answerable]
+2. [Question 2 ...]
+3. [...]
+
+Originating skill: `[ralph_impl | ralph_plan | ... | (unknown)]` (parsed from ## Escalation)
+
+When ready, run `/ralph:caretake --mode unblock #NNN` to provide answers and route the issue back into the pipeline.
+```
+
+Always render the originating-skill line; use literal `(unknown)` when extraction fails. Numbering must use `1.`, `2.`, ... so the interactive path can parse mechanically.
+
+Post via `ralph_hero__create_comment`. After a successful create, export:
+
+```bash
+export RALPH_UNBLOCK_REQUEST_POSTED=1
+```
+
+If `create_comment` errors, do NOT set the flag — `unblock-request-postcondition.sh` will block exit and surface the error.
+
+Then fire a best-effort native push notification:
+
+```
+PushNotification(
+  title="Human Needed #${issue_number}",
+  body="${issue_title} — ${issue_url}"
+)
+```
+
+`PushNotification` failure does NOT fail the mode — the comment is the source of truth. No state mutation is performed; the issue remains in Human Needed.
+
+### Step 6: Record outcome event
+
+```
+knowledge_record_outcome(
+  event_type="unblock_requested",
+  issue_number=NNN,
+  agent_type="ralph_unblock",
+  payload={
+    "question_count": <N>,
+    "escalation_comment_present": <bool>,
+    "context_source": "<escalation|issue_body|linked_artifact|mixed>",
+    "originating_command": <"ralph_impl" | ... | null>
+  }
+)
+```
+
+If unavailable, skip silently. The `## Unblock Request` comment is the source of truth.
+
+### Step 7: Emit terminal token
+
+```
+UNBLOCK REQUEST POSTED
+```
+
+Or `Queue empty.` when no eligible issues remain (from Step 2).
+
+---
+
+## §Constraints
+
+- **Work on ONE issue per invocation** in either path.
+- **Interactive path always confirms** the return state via `AskUserQuestion` — never silently transition based on the heuristic.
+- **Autonomous path never transitions state** — `save_issue` is intentionally not used. The issue MUST stay in Human Needed.
+- **Idempotency on autonomous**: skip if a fresh `## Unblock Request` already covers the current Human Needed transition.
+- **Cap autonomous questions at 5.** Prefer fewer, pointier questions over many vague ones.
+- **Quote questions and answers verbatim** in the interactive `## Unblock Resolution` comment.
+- **`knowledge_record_outcome` failures are silent** in both paths. The comment + (interactive only) state transition are the source of truth.
+- **`unblock-state-gate.sh` and `unblock-request-postcondition.sh` are the enforcement boundary** — both gate on `RALPH_SUBCOMMAND_VARIANT`.

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -36,7 +36,26 @@ Unblock has two sub-modes selected by the `--question` flag; each emits its own 
 - `Queue empty.` — no eligible Human Needed issues (none exist OR all carry a fresh `## Unblock Request`).
 
 `unblock-state-gate.sh` (interactive only) and `unblock-request-postcondition.sh` (autonomous only) each gate on `RALPH_SUBCOMMAND_VARIANT` to discriminate which path is active.
-<!-- Phase 6 fills: ## Postmortem / Retro / Trends sections -->
+## Postmortem terminal tokens
+
+- `POSTMORTEM <path>` — doc written, `<path>` absolute (e.g., `/Users/dubiel/projects/ralph-hero/thoughts/shared/reports/2026-05-23-ralph-team-foo.md`). Plan documents patched with `post_mortem::` edges; `process-improvement` issues filed for blockers.
+- `POSTMORTEM SKIPPED no-session-data` — §Step 1 short-circuit; `TaskList` unavailable or returned empty.
+- `POSTMORTEM SKIPPED <reason>` — other graceful skips (missing primary issue, MCP failures during outcome recording, etc.).
+
+`postmortem-completeness.sh` (Stop hook) greps the transcript for one of these tokens and additionally validates the doc carries the required frontmatter + section headings.
+
+## Retro terminal tokens
+
+- `RETRO <path>` — doc written, `<path>` absolute (`thoughts/shared/research/YYYY-MM-DD-retro-<slug>.md`).
+- `RETRO SKIPPED team-session-redirect` — `TaskList` non-empty and user chose `--mode postmortem` from the dedup prompt.
+- `RETRO SKIPPED no-friction-signals` — scan returned zero pain points.
+- `RETRO SKIPPED <reason>` — other graceful skips (user aborted the findings-review loop, scope hint pointed to an empty slice, etc.).
+
+Retro has no Stop postcondition hook — the mode is an artifact-writer and does not mutate GitHub state. Tokens are reported for parity.
+
+## Trends
+
+Trends is read-only — the markdown report printed to stdout is the deliverable. **No terminal token is emitted** and no postcondition hook gates this mode. The harness extractor treats the entire stdout markdown payload as the result.
 
 ## Debug terminal tokens
 

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -14,7 +14,12 @@ Sections are filled across Plans 7 phases 3-8. Trends mode is read-only and emit
 - `Queue empty.` — no untriaged Backlog issues remain.
 
 `triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens. The hook also verifies `RALPH_TRIAGE_ACTION` is set to one of `RESEARCH | SPLIT | CLOSE | KEEP | HUMAN | CANCEL | RE-ESTIMATE`.
-<!-- Phase 4 fills: ## Hygiene terminal tokens -->
+## Hygiene terminal tokens
+
+- `HYGIENE COMPLETE <N archived>` — scan ran cleanly; `N` is the archive count (0 if dry-run or threshold not exceeded).
+- `HYGIENE BLOCKED <reason>` — scan failed (project not found, MCP error, archive call failed, etc.).
+
+Hygiene has no `Stop` postcondition hook because it does not mutate semantic workflow state. The terminal token is reported for parity with other modes; no automated verification is performed against it.
 <!-- Phase 5 fills: ## Unblock terminal tokens -->
 <!-- Phase 6 fills: ## Postmortem / Retro / Trends sections -->
 

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -1,0 +1,1 @@
+_Filled across Phases 3-8 — one section per mode body._

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -65,4 +65,11 @@ Trends is read-only — the markdown report printed to stdout is the deliverable
 - `DEBUG SKIPPED no-errors-in-window` — §Step 4; dry-run returned `errorGroups === 0`.
 - `DEBUG SKIPPED user-declined` — §Step 5; user picked `Skip` on the `AskUserQuestion` confirm prompt.
 
-<!-- Phase 8 fills: ## Split terminal tokens -->
+## Split terminal tokens
+
+- `SPLIT <N>` — `N ≥ 2` XS/S sub-issues created and linked. `split-postcondition.sh` requires N ≥ 2.
+- `SPLIT SKIPPED already-atomic` — `split-estimate-gate.sh` blocked the parent because its estimate was already XS or S.
+- `SPLIT SKIPPED <reason>` — other graceful skips (no natural decomposition boundary found, parent already fully split, decompose_feature returned no children, etc.).
+- `Queue empty.` — no M/L/XL issues exist in Backlog or Research Needed.
+
+`split-postcondition.sh` (Stop hook) greps the transcript for one of these tokens AND verifies via `list_sub_issues` that the parent has ≥ 2 children when `SPLIT <N>` is emitted.

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -1,1 +1,20 @@
-_Filled across Phases 3-8 — one section per mode body._
+# Caretake terminal tokens
+
+Each mode body emits exactly one terminal token on its final line. The harness extractor reads these from the transcript verbatim — do not paraphrase or wrap in prose. Postcondition hooks under `ralph/hooks/scripts/*-postcondition.sh` grep the transcript for the tokens listed here.
+
+Sections are filled across Plans 7 phases 3-8. Trends mode is read-only and emits no token.
+
+<!-- Phase 3 fills: ## Triage terminal tokens -->
+<!-- Phase 4 fills: ## Hygiene terminal tokens -->
+<!-- Phase 5 fills: ## Unblock terminal tokens -->
+<!-- Phase 6 fills: ## Postmortem / Retro / Trends sections -->
+
+## Debug terminal tokens
+
+- `DEBUG FILED <N>` — `N = issuesCreated + issuesUpdated`; emitted on the final line of §Step 6 after the tool returns `dryRun: false`.
+- `DEBUG SKIPPED preflight: RALPH_DEBUG not active` — §Step 1 short-circuit; user must restart Claude Code with `RALPH_DEBUG=true`.
+- `DEBUG SKIPPED preflight: Langfuse unreachable` — §Step 1 short-circuit; user must start the local Langfuse stack.
+- `DEBUG SKIPPED no-errors-in-window` — §Step 4; dry-run returned `errorGroups === 0`.
+- `DEBUG SKIPPED user-declined` — §Step 5; user picked `Skip` on the `AskUserQuestion` confirm prompt.
+
+<!-- Phase 8 fills: ## Split terminal tokens -->

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -20,7 +20,22 @@ Sections are filled across Plans 7 phases 3-8. Trends mode is read-only and emit
 - `HYGIENE BLOCKED <reason>` — scan failed (project not found, MCP error, archive call failed, etc.).
 
 Hygiene has no `Stop` postcondition hook because it does not mutate semantic workflow state. The terminal token is reported for parity with other modes; no automated verification is performed against it.
-<!-- Phase 5 fills: ## Unblock terminal tokens -->
+## Unblock terminal tokens
+
+Unblock has two sub-modes selected by the `--question` flag; each emits its own tokens.
+
+### Interactive path (default — consumer)
+
+- `UNBLOCK RESOLVED` — interactive Q&A flow completed; `## Unblock Resolution` posted and issue routed back to the pipeline.
+- `UNBLOCK ESCALATED <reason>` — flow failed before resolution (wrong-state arg, missing `## Unblock Request`, user abort, etc.). Issue stays in Human Needed.
+
+### Autonomous path (`--question` — producer)
+
+- `UNBLOCK REQUEST POSTED` — `## Unblock Request` comment posted via `create_comment`; `RALPH_UNBLOCK_REQUEST_POSTED=1` exported.
+- `UNBLOCK REQUEST SKIPPED — branch <name> is not main` — §Step 1 short-circuit.
+- `Queue empty.` — no eligible Human Needed issues (none exist OR all carry a fresh `## Unblock Request`).
+
+`unblock-state-gate.sh` (interactive only) and `unblock-request-postcondition.sh` (autonomous only) each gate on `RALPH_SUBCOMMAND_VARIANT` to discriminate which path is active.
 <!-- Phase 6 fills: ## Postmortem / Retro / Trends sections -->
 
 ## Debug terminal tokens

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -4,7 +4,16 @@ Each mode body emits exactly one terminal token on its final line. The harness e
 
 Sections are filled across Plans 7 phases 3-8. Trends mode is read-only and emits no token.
 
-<!-- Phase 3 fills: ## Triage terminal tokens -->
+## Triage terminal tokens
+
+- `TRIAGED valid` — issue moved to `Research Needed` or `Ready for Plan` (the agent decided the issue is actionable).
+- `TRIAGED duplicate` — closed as duplicate; references a `## Duplicate Of` comment naming the surviving issue.
+- `TRIAGED canceled` — closed not-planned (tech changed, product direction shifted, etc.).
+- `TRIAGED needs-split` — left in Backlog with the `needs-split` label so `--mode split` picks it up on the next sweep.
+- `TRIAGED skipped — branch <name> is not main` — §Step 1 short-circuit; triage refuses to run on a feature branch.
+- `Queue empty.` — no untriaged Backlog issues remain.
+
+`triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens. The hook also verifies `RALPH_TRIAGE_ACTION` is set to one of `RESEARCH | SPLIT | CLOSE | KEEP | HUMAN | CANCEL | RE-ESTIMATE`.
 <!-- Phase 4 fills: ## Hygiene terminal tokens -->
 <!-- Phase 5 fills: ## Unblock terminal tokens -->
 <!-- Phase 6 fills: ## Postmortem / Retro / Trends sections -->

--- a/ralph/skills/caretake/split-decomposition.md
+++ b/ralph/skills/caretake/split-decomposition.md
@@ -1,0 +1,1 @@
+_Filled by Phase 8 (`--mode split` decomposition strategy + hook contracts)._

--- a/ralph/skills/caretake/split-decomposition.md
+++ b/ralph/skills/caretake/split-decomposition.md
@@ -1,1 +1,104 @@
-_Filled by Phase 8 (`--mode split` decomposition strategy + hook contracts)._
+# Split decomposition reference
+
+Strategy + sizing rubric + dependency wiring + hook contracts for `/ralph:caretake --mode split`. The mode body in [modes/split.md](modes/split.md) references this file rather than inlining the rules so future tuning (e.g., adjusting sub-issue sizing thresholds, adding new split strategies) is a one-file edit.
+
+## §When to split
+
+Split when ALL of the following hold:
+
+- Parent estimate is M, L, or XL (XS/S is already atomic — `split-estimate-gate.sh` blocks).
+- The body has **clear sub-deliverables** — distinct files, layers, phases, or artifacts that can be implemented independently or in a defined order.
+- A reader can name 2+ children without inventing scope (if you have to invent scope to fill the second child, you're splitting for the sake of splitting).
+
+Do NOT split when:
+
+- The work is genuinely atomic (one file, one PR, one acceptance criterion).
+- The scope is unclear (route to `--mode triage` → Research Needed instead).
+- The parent is already fully split (children exist that cover the entire scope).
+
+## §Decomposition heuristics
+
+The dominant signal for decomposition is the **artifact boundary** named in the issue body. Read the body first and look for an enumerated list (skills, fragments, docs, patterns) before applying the strategy table.
+
+| Original type | Split strategy |
+|---|---|
+| Database schema | One issue per table/view |
+| ETL pipeline | Extract, Transform, Load as separate issues |
+| API endpoint | Repository, Service, Router as separate issues |
+| Multi-state feature | One issue per state |
+| Frontend feature | Component, State, Integration as separate issues |
+| Skill audit (multi-skill) | One issue per skill or skill family — each child owns its own SKILL.md / agent / hook updates and `eval-scenarios.md` |
+| Fragment extraction | One issue per fragment — each child names the fragment, the canonical home, and the consumer skills to update |
+| Documentation update | One issue per document or section — group by audience or surface, not by file size |
+| Cross-cutting refactor | One issue per pattern instance or call-site cluster — group by behavior preserved, not by file count |
+
+For non-code work (skill audits, fragment extractions, doc updates, refactors), the natural decomposition almost always follows the artifact boundary already named in the issue body.
+
+## §Sub-issue sizing
+
+Pick from the rubric — do NOT default every child to XS. The `split-size-gate.sh` hook accepts XS OR S, and reflexively picking XS is a frequent under-sizing failure mode:
+
+| Child scope signal | Estimate |
+|---|---|
+| Single file, < 2 hours, trivial multi-file edit | XS |
+| Multi-file content work (e.g., SKILL.md + eval-scenarios.md + hooks), 2-4 hours | S |
+| Service / repository / router layer with tests | S |
+| One-pattern audit or refactor with no new files | XS |
+| One-skill audit pass (read SKILL.md + author eval-scenarios.md + grade outputs + apply fixes) | S |
+| Fragment extraction with consumer-skill rewrites in 3+ files | S |
+
+When the strategy table maps to a per-artifact decomposition where each child owns multiple authored files (skill audits, fragment extractions, multi-file content updates), pick **S**. Reserve **XS** for genuinely single-file or one-edit children.
+
+## §Dependency wiring
+
+`add_dependency` sets `blockedBy` between sub-issues. Two patterns:
+
+- **Linear chain** — sequential execution order. `repo` blocks `service` blocks `router`. Use when each phase consumes the output of the previous.
+- **Fan-out** — parallel-safe siblings. Multiple children blocked by a single setup child but not by each other. Use when phases share a precondition but can run concurrently.
+
+Rules:
+
+- Schema issues block loader issues.
+- Loader issues block API issues.
+- Backend issues block frontend issues.
+- Config/setup issues block implementation issues.
+
+Dependencies are orthogonal to workflow state. A child blocked by a sibling still gets `Ready for Plan` set in §Step 10 — `blockedBy` enforces ordering, not state.
+
+## §Hook contracts
+
+Four `split-*` hooks gate this mode. Each scopes on `RALPH_SUBCOMMAND=split` (or legacy `RALPH_COMMAND=split` for the parallel period).
+
+| Hook | Event | Matcher | Purpose |
+|---|---|---|---|
+| `split-estimate-gate.sh` | PreToolUse | `ralph_hero__get_issue` | Surface M/L/XL reminder via stderr; exit 0 to allow. |
+| `split-estimate-gate.sh` | PostToolUse | `ralph_hero__get_issue` | Parse `tool_response.content[0].text`, extract estimate, exit 2 if XS or S. |
+| `split-size-gate.sh` | PreToolUse | `ralph_hero__create_issue` | Block child creation with estimate `M`/`L`/`XL`. |
+| `split-verify-sub-issue.sh` | PostToolUse | `ralph_hero__add_sub_issue` | Verify the linkage took effect on the GitHub side; flag missing parent link. |
+| `split-postcondition.sh` | Stop | (matcher-less) | Require ≥ 2 children created and a `SPLIT <N>` or `SPLIT SKIPPED <reason>` terminal token in the transcript. |
+
+The `split-estimate-gate.sh` Pre/Post pairing is the canonical example of the PostToolUse-for-response-inspection pattern documented in CLAUDE.md — PreToolUse cannot see what `get_issue` returned, so the gate uses PostToolUse to inspect the estimate field and block when XS/S.
+
+## §Quality guidelines
+
+Good splits have:
+
+- Clear boundaries between sub-issues.
+- Minimal coupling (each child understandable independently).
+- Logical dependency order.
+- Balanced sizing (avoid 1 XS + 4 S — re-examine the boundary if you see this pattern).
+- Preserved context from the original issue.
+
+Avoid:
+
+- **Artificial splits** — splitting for the sake of splitting.
+- **Forced granularity** — don't decompose past the natural artifact boundary; 10 children is fine if 10 artifacts genuinely exist.
+- **Missing dependencies** — sub-issues that should block each other but don't.
+- **Lost context** — sub-issues that don't reference original scope; child-specific research notes belong inside the child body, not the parent comment.
+
+## §Cross-references
+
+- [modes/split.md](modes/split.md) — the mode body that consumes this reference.
+- [outcome-tokens.md](outcome-tokens.md) — `SPLIT <N>` and `SPLIT SKIPPED <reason>` terminal tokens.
+- Hook scripts: `ralph/hooks/scripts/split-estimate-gate.sh`, `split-size-gate.sh`, `split-verify-sub-issue.sh`, `split-postcondition.sh`.
+- CLAUDE.md "Hook Patterns" section — the canonical PostToolUse-for-response-inspection pattern documented around `split-estimate-gate.sh`.

--- a/ralph/skills/catch-up/next-action-ranking.md
+++ b/ralph/skills/catch-up/next-action-ranking.md
@@ -96,7 +96,7 @@ Based on the user's pick, dispatch via `Agent()` or `Skill()`:
 | `pr` | — | `Agent(subagent_type="ralph-hero:merge-agent", prompt="Merge PR #NNN", description="Merge PR #NNN")` |
 | `tree-continue` | — | `Agent(subagent_type="ralph-hero:triage-agent", prompt="Continue tree work on issue #NNN", description="Triage GH-NNN")` |
 | `lock-stale` | — | `Agent(subagent_type="ralph-hero:triage-agent", prompt="Triage stalled issue #NNN", description="Triage GH-NNN")` |
-| `human-needed-unblock` | `Human Needed` | `Skill("ralph-hero:unblock", args="<NNN>")` |
+| `human-needed-unblock` | `Human Needed` | `Skill("ralph:caretake", args="--mode unblock #<NNN>")` |
 
 For the **Work through these in order** option: dispatch sequentially in `directions[]` order. Note before each subsequent dispatch: *"Earlier actions may have changed board state."*
 

--- a/ralph/skills/review/code-review-prompt.md
+++ b/ralph/skills/review/code-review-prompt.md
@@ -77,7 +77,7 @@ PR: PR_URL
 Escalating to Human Needed for manual review and resolution.
 ```
 
-**Second**, the canonical `## Escalation` comment so `ralph-unblock` / `/ralph-hero:unblock` can discover it by header prefix and parse `originating_command`:
+**Second**, the canonical `## Escalation` comment so `/ralph:caretake --mode unblock` (and the legacy `/ralph-hero:unblock` until Plan 10 sunset) can discover it by header prefix and parse `originating_command`:
 
 ```markdown
 ## Escalation

--- a/thoughts/shared/plans/2026-05-23-GH-1370-ralph-plan-7-caretake.md
+++ b/thoughts/shared/plans/2026-05-23-GH-1370-ralph-plan-7-caretake.md
@@ -1,0 +1,727 @@
+---
+date: 2026-05-23
+status: draft
+type: plan
+tags: [ralph, plugin-restructure, caretake, triage, hygiene, postmortem, retro, trends, unblock, debug, split, migration, plan-of-plans]
+github_issue: 1370
+github_issues: [1370]
+github_urls:
+  - https://github.com/cdubiel08/ralph-hero/issues/1370
+primary_issue: 1370
+---
+
+# Plan 7: `/ralph:caretake` — Caretaker Verb Implementation Plan
+
+## Prior Work
+
+- builds_on:: [[2026-05-22-ralph-slim-plugin-restructure]]
+- builds_on:: [[2026-05-23-GH-1357-ralph-plan-1-catch-up]] — scaffold + flat-sibling pattern
+- builds_on:: [[2026-05-23-GH-1359-ralph-plan-2-form]] — multi-surface fold heuristics
+- builds_on:: [[2026-05-23-GH-1362-ralph-plan-3-research]] — SKILL.md frontmatter `hooks:` pattern + slim-plugin hook scope fixes
+- builds_on:: [[2026-05-23-GH-1364-ralph-plan-4-plan]] — multi-mode fold + path-discrimination hook pattern + no-mid-flow-env-mutation lesson
+- builds_on:: [[2026-05-23-GH-1366-ralph-plan-5-impl]] — 9-hook ceiling + tool-input-shape mode-discrimination
+- builds_on:: [[2026-05-23-GH-1368-ralph-plan-6-review]] — `closeout-` hook prefix convention + `__CLOSE__` (not `__DONE__`) + RALPH_COMMAND scope guard + `|| true` under pipefail
+
+## Overview
+
+The widest fold yet. Ten `ralph-hero` skills collapse into one `/ralph:caretake` verb with eight named modes plus a default event-driven dispatcher. This is the only verb in the migration that warrants a `modes/` subfolder layout — spec §Skill Layout line 148.
+
+| Mode | Source | Role |
+|---|---|---|
+| (default) | `caretake` | Event-driven dispatcher: read `--issue NNN` labels, fan out via `Skill()` |
+| `--mode triage [#NNN]` | `ralph-triage` | Pick oldest untriaged Backlog issue, assess validity, close duplicates, route |
+| `--mode hygiene` | `ralph-hygiene` | Scan project for archive candidates, stale items, WIP violations, field gaps |
+| `--mode unblock [#NNN]` | `unblock` + `ralph-unblock` | Interactive answer-and-route OR autonomous `## Unblock Request` post |
+| `--mode postmortem` | `ralph-postmortem` | Generate structured post-mortem at end of team session — TaskList-driven |
+| `--mode retro` | `retro` | Capture intra-session friction into research doc |
+| `--mode trends [--since 30d]` | `trends` | Capture snapshot + render markdown trend report |
+| `--mode debug [--since 24h]` | `ralph-debug-collate` | Collate Langfuse errors → file `debug-auto` issues |
+| `--mode split [#NNN]` | `ralph-split` non-epic side | Split M/L/XL issues into XS/S atomic sub-issues |
+
+The eight modes split into three execution shapes:
+
+- **Board-scan modes** (`triage`, `hygiene`, `unblock`, `split`): mutate GitHub state; require hook gates for state transitions and side-effect verification.
+- **Reflection modes** (`postmortem`, `retro`, `trends`): produce artifacts (markdown docs, snapshots, reports); mostly read-only against GitHub; minimal hook surface.
+- **Diagnostic mode** (`debug`): wraps `ralph_hero__collate_debug` MCP tool; interactive confirm gate before mutating.
+
+The reference shape diverges from prior plans: instead of flat siblings, the verb uses a `modes/` subfolder (one body per mode) plus a small set of cross-mode flat siblings for shared opinion content (terminal-verdict tokens, label-routing table).
+
+## Current State Analysis
+
+Ten source skills total **2,258 lines** of SKILL.md prose:
+
+| Source | Lines | Shape |
+|---|---|---|
+| `plugin/ralph-hero/skills/caretake/SKILL.md` | 188 | Orchestrator: `--issue NNN` label-routed dispatch OR `--mode hygiene\|report\|trends` heartbeat OR no-args fan-out smoke check |
+| `plugin/ralph-hero/skills/ralph-triage/SKILL.md` | 326 | Autonomous: pick oldest untriaged Backlog → assess (valid? duplicate? too large?) → close duplicates, decompose, or route to research |
+| `plugin/ralph-hero/skills/ralph-hygiene/SKILL.md` | 142 | `project_hygiene` MCP call → optional `archive_items` when count > threshold; WIP violation detection via `RALPH_HYGIENE_WIP_LIMITS` JSON |
+| `plugin/ralph-hero/skills/ralph-postmortem/SKILL.md` | 207 | `TaskList` + `TaskGet` for session data → classify blockers → write Obsidian-ready doc → patch plan with `post_mortem::` edges → auto-create blocker issues |
+| `plugin/ralph-hero/skills/retro/SKILL.md` | 338 | Scan conversation context for friction signals → optional codebase cross-reference via sub-agents → write `/form`-ingestible research doc |
+| `plugin/ralph-hero/skills/trends/SKILL.md` | 55 | `capture_snapshot` → `metrics_trends(format=markdown)` → print to stdout; read-only |
+| `plugin/ralph-hero/skills/unblock/SKILL.md` | 195 | Interactive: read `## Unblock Request` → `AskUserQuestion` → post `## Unblock Resolution` → route issue back into pipeline |
+| `plugin/ralph-hero/skills/ralph-unblock/SKILL.md` | 254 | Autonomous: pick oldest Human Needed → compose `## Unblock Request` with 1-5 specific questions → STOP (does not transition state) |
+| `plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md` | 202 | Wrap `ralph_hero__collate_debug` MCP tool: preflight → dry-run → confirm → file → summarize |
+| `plugin/ralph-hero/skills/ralph-split/SKILL.md` | 351 | Pick M/L/XL parent → decompose via `decompose_feature` → create XS/S children → add sub-issue links → STOP |
+
+Hooks to consider porting (under `plugin/ralph-hero/hooks/scripts/`):
+
+| Hook | Trigger | Job | Port |
+|---|---|---|---|
+| `triage-state-gate.sh` | PostToolUse on `save_issue` | Validate triage workflow state transitions | yes |
+| `triage-postcondition.sh` | Stop | Verify triage terminal verdict | yes |
+| `unblock-state-gate.sh` | PostToolUse on `save_issue` | Validate interactive-unblock state transitions | yes |
+| `unblock-request-postcondition.sh` | Stop | Verify autonomous-unblock posted a `## Unblock Request` comment | yes |
+| `split-estimate-gate.sh` | PreToolUse + PostToolUse on `get_issue` | Block split on already-atomic (XS/S) issues — PostToolUse inspects estimate from response | yes |
+| `split-postcondition.sh` | Stop | Verify split created ≥2 sub-issues | yes |
+| `split-size-gate.sh` | PreToolUse on `create_issue` | Block sub-issue creation with non-XS/non-S estimate | yes |
+| `split-verify-sub-issue.sh` | PostToolUse on `add_sub_issue` | Verify the linkage took effect on GitHub side | yes |
+| `team-postmortem-completeness.sh` | Stop | Verify post-mortem doc has required sections | yes (rename to `postmortem-completeness.sh` — no team-skill semantics in slim plugin) |
+| `branch-gate.sh` | PreToolUse on Bash | Block destructive git ops on non-main | already ported in Plan 3 |
+| `merge-state-gate.sh` | PreToolUse on `save_issue` | Validate semantic-intent state mutations | already ported in Plan 6; reused by triage close-mode + unblock route-back paths per Plan 6 friction note |
+| `lock-release-on-failure.sh` | Stop | Release workflow lock on failure | already ported in Plan 3 |
+
+**Nine new hook ports + three reuses.** At the 9-hook ceiling Plan 5 established, but each hook is mode-scoped via `RALPH_SUBCOMMAND` (or skips when unset). The 9 ports include both `triage-` (2) and `split-` (4) groups that already use prefix-isolated scopes.
+
+### Key Discoveries
+
+- **`modes/` subfolder is justified by mode count alone.** Eight mode bodies × ~80-120 lines each ≈ 700-1000 lines of mode-specific content. Inlining into the SKILL.md body would push it past 800 lines; flat siblings without the subfolder would clutter the directory listing. Spec line 148-157 explicitly preauthorizes the layout for this verb.
+
+- **The default mode is a thin dispatcher.** `caretake` source SKILL.md is 188 lines but ~140 of those are the label-routing table + heartbeat dispatch + result-line emission. The default-mode body collapses to ~40 lines in slim SKILL.md, with the routing table extracted into a flat sibling (`label-routing.md`) so future mode additions (or label changes) don't require a SKILL.md edit.
+
+- **`unblock` and `ralph-unblock` follow Plan 5's interactive+autonomous pattern.** Both source skills operate on the same artifact (`## Unblock Request` comments on a Human Needed issue). One is human-facing (`AskUserQuestion`, posts `## Unblock Resolution`, transitions state); the other is autonomous (reads `## Escalation`, posts `## Unblock Request` with specific questions, STOPS without state transition). Fold both into `--mode unblock` with sub-mode discrimination via `--question` (autonomous) vs default (interactive) — mirrors Plan 5's `--mode auto` vs default split inside `/ralph:impl`.
+
+- **`ralph-split` is the non-epic side already after Plan 4.** Plan 4 (`/ralph:plan --mode epic`) absorbed the epic-decomposition surface. The remaining surface is atomic-issue splitting (M/L/XL → multiple XS/S). The four `split-*` hooks all gate on `RALPH_COMMAND=split`; in slim plugin we keep that contract and additionally scope on `RALPH_SUBCOMMAND=split` so the SKILL.md frontmatter can declare all nine hooks at once and let each one self-no-op for non-matching modes.
+
+- **`team-postmortem-completeness.sh` carries `team` semantics that no longer apply.** The source skill is `ralph-postmortem` (no team prefix), and the slim plugin has no team concept. Rename on port to `postmortem-completeness.sh` and drop the `team-` semantic-search references in the script body.
+
+- **`trends` has no hooks in source.** It's read-only by design (capture snapshot + render report → stdout). The slim port preserves that: no `Stop` hook needed because no state transition happens.
+
+- **`retro` produces a research doc, not a GitHub issue.** It writes `thoughts/shared/research/<date>-retro-<slug>.md` and stops. The doc is `/form`-ingestible so the user can later run `/ralph:form <path>` to convert promising friction items into issues. The retro mode does NOT call any state-mutating MCP tools — it's an artifact-writer.
+
+- **`debug-collate` requires an interactive confirm gate.** The source skill body's Step 3 is "present grouped error signatures and prompt user before mutating." `--auto-confirm` is supported but defaults to off. Preserve verbatim in `modes/debug.md`.
+
+- **Heartbeat fan-out (no-args caretake) collapses to a `--mode all` invocation.** Source caretake with no args fans out to `hygiene`, `report` (legacy), `trends`. In slim plugin, `report` is part of `/ralph:catch-up --mode report` (shipped in Plan 1). The fan-out becomes: `Skill("ralph:caretake --mode hygiene")` + `Skill("ralph:catch-up --mode report")` + `Skill("ralph:caretake --mode trends")`. Express the fan-out as `--mode all` (more discoverable than no-arg behavior) but keep no-arg as the same behavior for muscle-memory.
+
+- **Label-routing table in default mode is the only place modes are coupled.** When `--issue NNN` is passed and the issue has `trigger:caretake` (full fanout) or `stale` / `status-update-needed` / `trends-check` / `needs-triage` / `human-needed` labels, the dispatcher picks the right mode. Extract this table into `label-routing.md` so the SKILL.md body stays ~20 lines and the routing rules are reusable by future iOS/cloud routines that classify events the same way.
+
+- **Outcome tokens vary by mode.** Each mode emits a distinct terminal-verdict token for the harness extractor:
+  - triage: `TRIAGED <verdict>` or `Queue empty.`
+  - hygiene: `HYGIENE COMPLETE <N archived>` or `HYGIENE BLOCKED <reason>`
+  - unblock (autonomous): `UNBLOCK REQUEST POSTED` or `Queue empty.`
+  - unblock (interactive): `UNBLOCK RESOLVED` or `UNBLOCK ESCALATED`
+  - postmortem: `POSTMORTEM <path>` or `POSTMORTEM SKIPPED <reason>`
+  - retro: `RETRO <path>` or `RETRO SKIPPED <reason>`
+  - trends: (read-only — no terminal token)
+  - debug: `DEBUG FILED <N issues>` or `DEBUG SKIPPED <reason>`
+  - split: `SPLIT <N children>` or `SPLIT SKIPPED <reason>`
+  Extract into `outcome-tokens.md` so postcondition hooks have one source of truth.
+
+## Desired End State
+
+After Plan 7 merges:
+
+1. `/ralph:caretake` is discoverable. With no args → fan-out smoke check (hygiene + catch-up report + trends).
+2. `/ralph:caretake --issue NNN` → event-driven dispatch via label routing.
+3. `/ralph:caretake --mode <name>` → single-mode invocation for each of the 8 modes.
+4. Old `/ralph-hero:caretake`, `/ralph-hero:ralph-triage`, `/ralph-hero:ralph-hygiene`, `/ralph-hero:ralph-postmortem`, `/ralph-hero:retro`, `/ralph-hero:trends`, `/ralph-hero:unblock`, `/ralph-hero:ralph-unblock`, `/ralph-hero:ralph-debug-collate`, `/ralph-hero:ralph-split` remain functional. Sunset is Plan 10.
+5. `ralph/skills/caretake/SKILL.md` ≤ 200 lines (top-level dispatcher only).
+6. `ralph/skills/caretake/modes/` subfolder with 8 mode bodies.
+7. Three flat-sibling references: `label-routing.md`, `outcome-tokens.md`, plus one mode-shared opinion file per natural cluster (TBD as phases land — likely `split-decomposition.md` since split is the heaviest hook-wise).
+8. SKILL.md frontmatter `hooks:` block declares 9 mode-specific hooks scoped via `RALPH_COMMAND=caretake` (set once at SessionStart) and `RALPH_SUBCOMMAND=<mode>` (set at body entry per mode).
+9. `ralph/README.md` migration table → Plan 7 shipped.
+10. Friction-log entry appended to spec.
+
+### Verification
+
+- `/plugin marketplace update ralph-hero && /reload-plugins` discovers `/ralph:caretake`.
+- Eight real invocations: one per mode (`triage`, `hygiene`, `unblock` × 2 sub-modes, `postmortem`, `retro`, `trends`, `debug`, `split`).
+- `wc -l ralph/skills/caretake/SKILL.md` ≤ 200.
+- `ls ralph/skills/caretake/modes/` shows 8 files.
+- Old `/ralph-hero:*` caretaker-family skills still work.
+
+## What We're NOT Doing
+
+- **Not** absorbing the epic-decomposition side of `ralph-split` — already in Plan 4 (`/ralph:plan --mode epic`).
+- **Not** absorbing `report` (`/ralph-hero:report`) — already in Plan 1 (`/ralph:catch-up --mode report`).
+- **Not** changing the `## Unblock Request` / `## Unblock Resolution` comment shapes. Plan 10 sunset relies on prose stability.
+- **Not** changing the post-mortem doc structure (frontmatter + Section headings). Obsidian links + `post_mortem::` edges stay.
+- **Not** changing `ralph_hero__collate_debug` MCP tool surface. The mode body wraps it as-is.
+- **Not** changing the `decompose_feature` MCP tool surface used by split. The mode body calls it verbatim.
+- **Not** changing the `RALPH_HYGIENE_*` env var contract (`THRESHOLD`, `DRY_RUN`, `WIP_LIMITS`).
+- **Not** wiring `/ralph:caretake` → `/ralph:hero` orchestration. Orchestrator concern (Plan 8).
+- **Not** sunsetting source skills.
+
+## Implementation Approach
+
+Nine XS-sized phases, mirroring Plan 6's phase shape (one phase per mode body + scaffold/hook + parity):
+
+1. **Scaffold + hook ports** owns: `ralph/skills/caretake/SKILL.md` stub (frontmatter + mode-dispatch table + Step 0 arg parse), `ralph/skills/caretake/modes/` subfolder with eight empty mode-body stubs, three flat-sibling references (`label-routing.md`, `outcome-tokens.md`, `split-decomposition.md`), hook ports under `ralph/hooks/scripts/` for the nine new scripts.
+2. **Default mode + label-routing.md** owns: SKILL.md default-mode body (label-routed dispatch + heartbeat fan-out), `label-routing.md` (full routing table extracted from source caretake).
+3. **`--mode triage`** owns: `modes/triage.md` (full triage workflow), `outcome-tokens.md` triage section.
+4. **`--mode hygiene`** owns: `modes/hygiene.md`, `outcome-tokens.md` hygiene section.
+5. **`--mode unblock`** owns: `modes/unblock.md` (interactive + autonomous sub-modes), `outcome-tokens.md` unblock section.
+6. **`--mode postmortem` + `--mode retro` + `--mode trends`** owns: `modes/postmortem.md`, `modes/retro.md`, `modes/trends.md`, `outcome-tokens.md` postmortem/retro sections (trends has no terminal token).
+7. **`--mode debug`** owns: `modes/debug.md`, `outcome-tokens.md` debug section.
+8. **`--mode split` + `split-decomposition.md`** owns: `modes/split.md`, full `split-decomposition.md` reference (size-gate + sub-issue verification + decomposition strategy).
+9. **Parity validation + dogfooding** owns: `ralph/README.md`, spec friction-log entry, picker wiring (if any prior plan's picker references `ralph-hero:caretake` etc., retarget).
+
+Each mode body is a single-owner phase. SKILL.md is touched in Phase 1 (scaffold) and Phase 2 (default-mode body fill); reference files split between Phases 2-8.
+
+## Phase 1: Scaffold + hook ports
+
+### Overview
+
+Stand up directory + frontmatter + reference stubs + nine hook ports.
+
+### Changes Required
+
+#### 1. Skill scaffold
+
+`ralph/skills/caretake/SKILL.md`:
+
+- Description (covers all 8 modes + default-event dispatcher + natural-language trigger phrases — triage, hygiene cleanup, status check, post-mortem, retro, trends, unblock, debug errors, split issue).
+- `argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|all>] [#NNN] [--since <window>] [--auto-confirm]"`
+- `context: inline`, `model: opus`
+- `allowed-tools` union covering all 8 modes (Read, Write, Edit, Glob, Grep, Bash, Skill, Agent, Task, TaskList, TaskGet, AskUserQuestion, PushNotification, plus the MCP tools used in any mode — `get_issue`, `list_issues`, `save_issue`, `create_issue`, `create_comment`, `add_sub_issue`, `add_dependency`, `list_sub_issues`, `pipeline_dashboard`, `project_hygiene`, `archive_items`, `capture_snapshot`, `metrics_trends`, `collate_debug`, `knowledge_record_outcome`, `knowledge_search`, `knowledge_recall`).
+- `hooks:` block:
+  - SessionStart → `set-skill-env.sh RALPH_COMMAND=caretake` (subcommand env var is set inside SKILL.md body per mode entry).
+  - PreToolUse on Bash → `branch-gate.sh`
+  - PreToolUse on `get_issue` → `split-estimate-gate.sh`
+  - PreToolUse on `create_issue` → `split-size-gate.sh`
+  - PostToolUse on `get_issue` → `split-estimate-gate.sh` (same script, PostToolUse path)
+  - PostToolUse on `add_sub_issue` → `split-verify-sub-issue.sh`
+  - PostToolUse on `save_issue` → `triage-state-gate.sh`, `unblock-state-gate.sh`, `merge-state-gate.sh`
+  - Stop → `triage-postcondition.sh`, `unblock-request-postcondition.sh`, `split-postcondition.sh`, `postmortem-completeness.sh`, `lock-release-on-failure.sh`
+- Body: mode-dispatch table + Step 0 (arg parse + `RALPH_SUBCOMMAND` set).
+
+#### 2. Mode body stubs
+
+`ralph/skills/caretake/modes/triage.md`, `hygiene.md`, `unblock.md`, `postmortem.md`, `retro.md`, `trends.md`, `debug.md`, `split.md` — each `_Filled by Phase N._`
+
+#### 3. Reference stubs
+
+- `label-routing.md`, `outcome-tokens.md`, `split-decomposition.md` — `_Filled by Phase N._`
+
+#### 4. Hook ports
+
+Copy from `plugin/ralph-hero/hooks/scripts/`:
+- `triage-state-gate.sh`, `triage-postcondition.sh`
+- `unblock-state-gate.sh`, `unblock-request-postcondition.sh`
+- `split-estimate-gate.sh`, `split-postcondition.sh`, `split-size-gate.sh`, `split-verify-sub-issue.sh`
+- `team-postmortem-completeness.sh` → rename to `postmortem-completeness.sh` (drop `team-` semantics in port)
+
+Apply Plan 6's hook hardening checklist to each port:
+1. RALPH_COMMAND scope guard (no-op when `RALPH_COMMAND != caretake` AND `RALPH_COMMAND` doesn't match the legacy command name like `triage`/`split` — accept both during parallel period).
+2. RALPH_SUBCOMMAND scope check inside the script (e.g., `triage-state-gate.sh` no-ops unless `RALPH_SUBCOMMAND=triage` OR legacy `RALPH_COMMAND=triage`).
+3. `is_semantic_intent` passthrough on every state-gate script (mirror `ralph/hooks/scripts/impl-state-gate.sh`).
+4. Pipeline-heavy intermediates (any `grep | sed | awk` chain) append `|| true` under `set -euo pipefail`.
+5. PreToolUse vs PostToolUse discrimination via `.hook_event_name` (`split-estimate-gate.sh` already does this in source; preserve).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `test -f ralph/skills/caretake/SKILL.md`
+- [ ] `[ "$(wc -l < ralph/skills/caretake/SKILL.md)" -le 200 ]`
+- [ ] All 8 mode-body stubs present under `ralph/skills/caretake/modes/`.
+- [ ] All 3 flat-sibling reference stubs present.
+- [ ] All 9 new hooks present + executable.
+- [ ] Each hook script contains a `RALPH_COMMAND` scope guard (grep for `RALPH_COMMAND` in each ported `.sh`).
+- [ ] Each state-gate hook contains `is_semantic_intent` (grep `is_semantic_intent` returns 4 matches: triage-state-gate, unblock-state-gate, plus the two already present in impl-state-gate / merge-state-gate).
+
+#### Manual Verification
+
+- [ ] `/reload-plugins` discovers `/ralph:caretake --help` (or argument-hint).
+
+---
+
+## Phase 2: Default mode + `label-routing.md`
+
+### Overview
+
+Default-mode body (label-routed dispatch + heartbeat fan-out) + full `label-routing.md` reference.
+
+### Changes Required
+
+#### 1. SKILL.md default-mode body
+
+Compact list (≤25 lines):
+
+1. **Parse `$ARGUMENTS`** — if `--issue NNN`, set `RALPH_SUBCOMMAND=default-event`; if `--mode <name>`, set `RALPH_SUBCOMMAND=<name>` and dispatch to `modes/<name>.md`; if no args, set `RALPH_SUBCOMMAND=all` and fan out.
+2. **Event-driven dispatch** — `get_issue(NNN)`, inspect labels, dispatch per `label-routing.md` table.
+3. **Heartbeat fan-out (`--mode all` or no args)** — invoke three skills serially: `Skill("ralph:caretake", args="--mode hygiene")`, `Skill("ralph:catch-up", args="--mode report")`, `Skill("ralph:caretake", args="--mode trends")`. Report consolidated outcome.
+4. **Post-dispatch comment** — for `--issue NNN`, post `## Caretaker Action` comment on the issue (mode + dispatched skill + outcome line).
+5. **Emit result line** — `result: <outcome>` for harness extraction.
+
+#### 2. `label-routing.md`
+
+Extract from source caretake's Step 1 dispatch table. Single table:
+
+```
+| Label present | Dispatch |
+|---------------|----------|
+| `trigger:caretake` | Full fan-out (all 8 modes serially) |
+| `stale` | `Skill("ralph:caretake", args="--mode hygiene")` |
+| `status-update-needed` | `Skill("ralph:catch-up", args="--mode report")` |
+| `trends-check` | `Skill("ralph:caretake", args="--mode trends")` |
+| `needs-triage` | `Skill("ralph:caretake", args="--mode triage #NNN")` |
+| `human-needed` | `Skill("ralph:caretake", args="--mode unblock --question #NNN")` |
+| `process-improvement` | `Skill("ralph:caretake", args="--mode retro")` (dispatches manual retro flow with the issue as scope hint) |
+| `debug-auto` | `Skill("ralph:caretake", args="--mode debug")` |
+| (none / default) | `Skill("ralph:caretake", args="--mode triage #NNN")` |
+```
+
+Plus prose on label consumption (remove `trigger:caretake` after dispatch via `save_issue(labels: [...remaining])`).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `[ "$(wc -l < ralph/skills/caretake/SKILL.md)" -le 200 ]`
+- [ ] `label-routing.md` non-stub: `[ "$(wc -l < ralph/skills/caretake/label-routing.md)" -ge 40 ]`
+
+#### Manual Verification
+
+- [ ] `/ralph:caretake --issue NNN` against a `human-needed`-labeled issue → dispatches to `--mode unblock`.
+- [ ] `/ralph:caretake` (no args) → fans out to hygiene + catch-up report + trends.
+
+---
+
+## Phase 3: `--mode triage`
+
+### Overview
+
+Triage mode body — port `ralph-triage` Steps 1-7 verbatim into `modes/triage.md`.
+
+### Changes Required
+
+#### 1. `modes/triage.md`
+
+Source: `plugin/ralph-hero/skills/ralph-triage/SKILL.md` Steps 1-7. Port verbatim with two adjustments:
+
+- Replace any `Skill("ralph-hero:research")` / `Skill("ralph-hero:plan")` etc. with `Skill("ralph:research")` / `Skill("ralph:plan")`.
+- Insert `RALPH_SUBCOMMAND=triage` set as the first line of the mode body (Bash export) — picked up by `triage-state-gate.sh` for scope discrimination.
+
+Preserve verbatim:
+- Step 1: pick oldest untriaged Backlog (no `triaged` label).
+- Step 2: assess validity (clear ask? actionable? scoped?).
+- Step 3: duplicate detection via `list_issues` + `knowledge_search`.
+- Step 4: size check (XS/S → route to research; M/L/XL → split candidate).
+- Step 5: route to next state via `save_issue(workflowState=...)`.
+- Step 6: emit `TRIAGED <verdict>` or `Queue empty.` terminal token.
+
+#### 2. `outcome-tokens.md` — triage section
+
+```
+## Triage terminal tokens
+
+- `TRIAGED valid` — issue moved to `Research Needed` or `Ready for Plan`.
+- `TRIAGED duplicate` — closed as duplicate; references `## Duplicate Of` comment.
+- `TRIAGED canceled` — closed `not_planned`.
+- `TRIAGED needs-split` — moved to `Backlog` with `needs-split` label; `--mode split` queue picks it up.
+- `Queue empty.` — no untriaged Backlog issues.
+```
+
+`triage-postcondition.sh` greps the transcript for these tokens.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `modes/triage.md` ≥ 80 lines.
+- [ ] First non-comment line of `modes/triage.md` body sets `RALPH_SUBCOMMAND=triage`.
+- [ ] `outcome-tokens.md` references `TRIAGED` token.
+
+#### Manual Verification
+
+- [ ] `/ralph:caretake --mode triage` against a real Backlog with at least one untriaged issue → emits `TRIAGED <verdict>` or routes to research.
+
+---
+
+## Phase 4: `--mode hygiene`
+
+### Overview
+
+Hygiene mode body — port `ralph-hygiene` verbatim.
+
+### Changes Required
+
+#### 1. `modes/hygiene.md`
+
+Source: `plugin/ralph-hero/skills/ralph-hygiene/SKILL.md`. Port verbatim. Hygiene has no source hooks beyond `set-skill-env.sh`; the mode body only calls `project_hygiene` and optionally `archive_items`. No state transitions.
+
+Insert `RALPH_SUBCOMMAND=hygiene` at body entry (consistency with other modes; no hook depends on it but the convention is set).
+
+Preserve verbatim:
+- Config resolution (threshold, dry-run, WIP limits).
+- Step 1: `project_hygiene(format=markdown)`.
+- Step 2: parse output; if archive candidates > threshold, optionally `archive_items` (gated by `dry_run` env var).
+- Step 3: emit `HYGIENE COMPLETE <N archived>` or `HYGIENE BLOCKED <reason>`.
+
+#### 2. `outcome-tokens.md` — hygiene section
+
+Append:
+
+```
+## Hygiene terminal tokens
+
+- `HYGIENE COMPLETE <N archived>` — scan ran; N items archived (0 if dry-run or no candidates).
+- `HYGIENE BLOCKED <reason>` — scan failed (project not found, MCP error, etc.).
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `modes/hygiene.md` ≥ 60 lines.
+- [ ] `outcome-tokens.md` references `HYGIENE COMPLETE` and `HYGIENE BLOCKED`.
+
+#### Manual Verification
+
+- [ ] `/ralph:caretake --mode hygiene` against a real project → emits `HYGIENE COMPLETE N`.
+
+---
+
+## Phase 5: `--mode unblock` (interactive + autonomous)
+
+### Overview
+
+Unblock mode body — fold both source skills via sub-mode discrimination.
+
+### Changes Required
+
+#### 1. `modes/unblock.md`
+
+Two execution paths inside one mode body:
+
+- **Default (interactive)** — port `unblock/SKILL.md`. Read `## Unblock Request` comment, present questions via `AskUserQuestion`, post `## Unblock Resolution`, transition issue back into pipeline. Emit `UNBLOCK RESOLVED` or `UNBLOCK ESCALATED`.
+- **`--question` (autonomous request)** — port `ralph-unblock/SKILL.md`. Pick oldest Human Needed issue, compose 1-5 specific blocking questions, post `## Unblock Request` comment, STOP (no state transition). Emit `UNBLOCK REQUEST POSTED` or `Queue empty.`.
+
+Sub-mode discrimination in body entry:
+
+```bash
+if echo "$ARGUMENTS" | grep -q -- '--question'; then
+  export RALPH_SUBCOMMAND_VARIANT=autonomous
+else
+  export RALPH_SUBCOMMAND_VARIANT=interactive
+fi
+```
+
+`unblock-state-gate.sh` only fires on the interactive path (state transitions happen there). `unblock-request-postcondition.sh` only fires on the autonomous path (verifies the `## Unblock Request` comment was posted). Each hook gates on `RALPH_SUBCOMMAND_VARIANT`.
+
+#### 2. `outcome-tokens.md` — unblock section
+
+```
+## Unblock terminal tokens
+
+- `UNBLOCK RESOLVED` — interactive answer flow completed; issue routed back to pipeline.
+- `UNBLOCK ESCALATED` — interactive flow failed; issue stays Human Needed.
+- `UNBLOCK REQUEST POSTED` — autonomous request flow completed; `## Unblock Request` comment posted.
+- `Queue empty.` — no Human Needed issues (autonomous path only).
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `modes/unblock.md` ≥ 100 lines.
+- [ ] Mode body references both `--question` (autonomous) and default (interactive) sub-modes.
+- [ ] `outcome-tokens.md` references all four unblock tokens.
+
+#### Manual Verification
+
+- [ ] `/ralph:caretake --mode unblock #NNN` against an issue with an open `## Unblock Request` → interactive AskUserQuestion → posts `## Unblock Resolution` → issue moves out of Human Needed.
+- [ ] `/ralph:caretake --mode unblock --question` against a board with a Human Needed issue → posts `## Unblock Request` with 1-5 questions; issue stays Human Needed.
+
+---
+
+## Phase 6: `--mode postmortem` + `--mode retro` + `--mode trends`
+
+### Overview
+
+Three reflection-mode bodies in one phase (they share no opinion content but are each short).
+
+### Changes Required
+
+#### 1. `modes/postmortem.md`
+
+Source: `plugin/ralph-hero/skills/ralph-postmortem/SKILL.md`. Port verbatim. Set `RALPH_SUBCOMMAND=postmortem` at entry — `postmortem-completeness.sh` gates on it.
+
+Preserve verbatim:
+- Step 1: `TaskList` + `TaskGet` for session data.
+- Step 2: classify blockers and impediments.
+- Step 3: write Obsidian-ready doc to `thoughts/shared/research/postmortems/<date>-<slug>.md`.
+- Step 4: patch plan document with `post_mortem::` edges (if `--plan-doc <path>` provided).
+- Step 5: auto-create GitHub issues for blockers (`process-improvement` label).
+- Step 6: emit `POSTMORTEM <path>` or `POSTMORTEM SKIPPED <reason>`.
+
+#### 2. `modes/retro.md`
+
+Source: `plugin/ralph-hero/skills/retro/SKILL.md`. Port verbatim. No hooks gate retro mode — it's an artifact-writer with no state mutations.
+
+Preserve verbatim:
+- Step 1: scan conversation context for friction signals.
+- Step 2: optional sub-agent cross-reference (`Agent` dispatch).
+- Step 3: synthesize into `/form`-ingestible research doc.
+- Step 4: write to `thoughts/shared/research/<date>-retro-<slug>.md`.
+- Step 5: emit `RETRO <path>` or `RETRO SKIPPED <reason>`.
+
+#### 3. `modes/trends.md`
+
+Source: `plugin/ralph-hero/skills/trends/SKILL.md`. Port verbatim. Read-only — no terminal token.
+
+Preserve verbatim:
+- Step 1: parse `--since` flag (default `@today-7d`).
+- Step 2: `capture_snapshot` (no args).
+- Step 3: `metrics_trends(format=markdown, since=<value>)`.
+- Step 4: print markdown to stdout.
+
+#### 4. `outcome-tokens.md` — postmortem + retro sections
+
+```
+## Postmortem terminal tokens
+
+- `POSTMORTEM <path>` — doc written, path absolute.
+- `POSTMORTEM SKIPPED <reason>` — no session data or insufficient signal.
+
+## Retro terminal tokens
+
+- `RETRO <path>` — doc written, path absolute.
+- `RETRO SKIPPED <reason>` — no friction signals or scope unclear.
+
+## Trends
+
+Read-only — no terminal token (output is the markdown report itself).
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `modes/postmortem.md` ≥ 80 lines.
+- [ ] `modes/retro.md` ≥ 100 lines.
+- [ ] `modes/trends.md` ≥ 30 lines.
+- [ ] `outcome-tokens.md` references `POSTMORTEM`, `RETRO`, and explicit `Trends` no-token note.
+
+#### Manual Verification
+
+- [ ] `/ralph:caretake --mode postmortem` at end of a session with TaskList data → writes post-mortem doc, emits `POSTMORTEM <path>`.
+- [ ] `/ralph:caretake --mode retro` after a session with friction signals → writes retro doc, emits `RETRO <path>`.
+- [ ] `/ralph:caretake --mode trends --since 30d` → prints markdown trend report to stdout.
+
+---
+
+## Phase 7: `--mode debug`
+
+### Overview
+
+Debug mode body — wrap `ralph_hero__collate_debug` MCP tool.
+
+### Changes Required
+
+#### 1. `modes/debug.md`
+
+Source: `plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md`. Port verbatim. Interactive confirm gate is load-bearing — `--auto-confirm` is opt-in.
+
+Preserve verbatim:
+- Step 1: preflight (verify Langfuse OTEL env vars set, MCP server reachable).
+- Step 2: dry-run (`collate_debug(dry_run=true)`).
+- Step 3: present grouped error signatures + occurrence counts.
+- Step 4: `AskUserQuestion` confirm (unless `--auto-confirm`).
+- Step 5: on confirm, `collate_debug(dry_run=false)` — files `debug-auto` issues OR comments on existing ones.
+- Step 6: summarize: `DEBUG FILED <N issues>` or `DEBUG SKIPPED <reason>`.
+
+#### 2. `outcome-tokens.md` — debug section
+
+```
+## Debug terminal tokens
+
+- `DEBUG FILED <N issues>` — N issues filed or commented on.
+- `DEBUG SKIPPED <reason>` — preflight failed, user declined, or no errors above threshold.
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `modes/debug.md` ≥ 80 lines.
+- [ ] Mode body references `--auto-confirm`, `dry_run`, `AskUserQuestion`.
+- [ ] `outcome-tokens.md` references `DEBUG FILED` and `DEBUG SKIPPED`.
+
+#### Manual Verification
+
+- [ ] `/ralph:caretake --mode debug --since 24h` against a local Langfuse with errors → dry-runs, prompts confirm, files issues on confirm, emits `DEBUG FILED N`.
+
+---
+
+## Phase 8: `--mode split` + `split-decomposition.md`
+
+### Overview
+
+Split mode body + full decomposition reference. Heaviest hook surface (4 split-* hooks) of any mode.
+
+### Changes Required
+
+#### 1. `modes/split.md`
+
+Source: `plugin/ralph-hero/skills/ralph-split/SKILL.md`. Port verbatim with two adjustments:
+
+- Remove epic-decomposition surface (already in Plan 4 `/ralph:plan --mode epic`). The non-epic side is atomic M/L/XL → multiple XS/S sub-issues.
+- Set `RALPH_SUBCOMMAND=split` at entry — all 4 `split-*` hooks gate on it (in addition to the legacy `RALPH_COMMAND=split` env var ported from source).
+
+Preserve verbatim:
+- Step 1: pick target issue (`#NNN` or oldest `needs-split`-labeled).
+- Step 2: estimate gate — `split-estimate-gate.sh` blocks if XS/S (PreToolUse on `get_issue` surfaces reminder; PostToolUse on `get_issue` parses response and blocks with exit 2 if estimate is too small).
+- Step 3: read body + acceptance criteria.
+- Step 4: decompose via `decompose_feature` MCP tool OR manual breakdown per `split-decomposition.md` strategy.
+- Step 5: create XS/S children via `create_issue` (size-gate hook enforces estimate).
+- Step 6: link via `add_sub_issue` (verify-sub-issue hook checks linkage took).
+- Step 7: optional `add_dependency` between children for sequencing.
+- Step 8: transition parent to `Backlog` (post-decomposition state).
+- Step 9: emit `SPLIT <N children>` or `SPLIT SKIPPED <reason>`.
+
+#### 2. `split-decomposition.md`
+
+Full decomposition strategy reference. Sections:
+
+- §When to split: M/L/XL estimate + clear sub-deliverables.
+- §Decomposition heuristics: by file ownership, by acceptance criterion, by execution phase.
+- §Sub-issue sizing: XS = 1-2 files, S = 3-5 files.
+- §Dependency wiring: linear chain for execution order; fan-out for parallel-safe.
+- §Hook contracts: estimate-gate (XS/S only), size-gate (sub-issue creation), verify-sub-issue (linkage), postcondition (≥2 children).
+
+#### 3. `outcome-tokens.md` — split section
+
+```
+## Split terminal tokens
+
+- `SPLIT <N children>` — N (≥2) XS/S sub-issues created and linked.
+- `SPLIT SKIPPED <reason>` — parent too small (XS/S), already split, or decomposition failed.
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `modes/split.md` ≥ 100 lines.
+- [ ] `split-decomposition.md` ≥ 80 lines.
+- [ ] Mode body references all 4 split hooks.
+- [ ] `outcome-tokens.md` references `SPLIT` and `SPLIT SKIPPED`.
+
+#### Manual Verification
+
+- [ ] `/ralph:caretake --mode split #NNN` against a real M-estimated issue → creates ≥2 XS/S children, emits `SPLIT N`.
+- [ ] `/ralph:caretake --mode split #NNN` against an XS issue → blocked by estimate-gate hook with exit 2; mode body never reaches `create_issue`.
+
+---
+
+## Phase 9: Parity validation + dogfooding setup
+
+### Overview
+
+README + friction-log + 8-session parity validation.
+
+### Changes Required
+
+#### 1. README
+
+`ralph/README.md`:
+
+- `| 7 | \`/ralph:caretake\` | shipped |`
+- `## Status` paragraph updated.
+
+#### 2. Friction-log on the spec
+
+Append `### Plan 7: /ralph:caretake (shipped YYYY-MM-DD)` subsection to `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md`. Capture:
+
+- Hot-path stats (10 sources, 8 modes + default, 9+3 hooks, modes/ subfolder).
+- Design calls: modes/ subfolder layout justification, RALPH_SUBCOMMAND scope pattern, sub-mode discrimination inside `--mode unblock`, hook prefix conventions (`triage-` / `unblock-` / `split-` / `postmortem-` / `caretake-`).
+- Active-use checkboxes for each of the 8 modes.
+
+#### 3. Picker wiring
+
+Search prior shipped slim-plugin skills for any picker that dispatches `Skill("ralph-hero:caretake")` / `ralph-triage` / `ralph-hygiene` etc., and retarget to `Skill("ralph:caretake")` with the right `--mode`. Likely candidates (sweep, don't pre-declare): `ralph/skills/catch-up/SKILL.md` (next-action picker), `ralph/skills/form/SKILL.md` (Step 6 picker), `ralph/skills/plan/SKILL.md` (Step 6 picker), `ralph/skills/research/SKILL.md` (post-research picker).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] README shows Plan 7 shipped.
+- [ ] Friction-log section exists.
+- [ ] No remaining references to `ralph-hero:caretake` / `ralph-hero:ralph-triage` / `ralph-hero:ralph-hygiene` etc. in `ralph/skills/*/SKILL.md` (allow references in prose marked as "until Plan 10 sunset").
+
+#### Manual Verification
+
+- [ ] Eight sessions completed successfully (one per mode).
+- [ ] Default-mode label-routing dispatch works against a real `--issue NNN` with one of the recognized labels.
+- [ ] No regressions in any `ralph-hero:*` caretaker-family skill.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+None — markdown workflow. MCP tools covered by ralph-hero MCP server's existing tests. Hooks are bash scripts; coverage continues via the existing hook-gate snapshot tests (Plan 3 pattern).
+
+### Integration Tests
+
+The 8 parity sessions in Phase 9 are the integration test. The autonomous-unblock + split modes exercise the heaviest hook surface; the postmortem mode exercises TaskList integration; the debug mode exercises Langfuse MCP integration.
+
+### Manual Testing Steps
+
+Per Phase 9's list, plus per-hook smoke tests:
+
+1. Verify `triage-state-gate.sh` blocks invalid state transitions (e.g., direct Backlog → Done).
+2. Verify `triage-postcondition.sh` accepts all five terminal tokens.
+3. Verify `unblock-state-gate.sh` blocks autonomous path from transitioning state (it MUST stay Human Needed).
+4. Verify `unblock-request-postcondition.sh` accepts `## Unblock Request` posted via `create_comment`.
+5. Verify `split-estimate-gate.sh` (PreToolUse) surfaces an M/L/XL reminder for already-XS/S parents.
+6. Verify `split-estimate-gate.sh` (PostToolUse) blocks with exit 2 after `get_issue` returns XS estimate.
+7. Verify `split-size-gate.sh` blocks `create_issue` with estimate=M (sub-issues must be XS/S).
+8. Verify `split-verify-sub-issue.sh` accepts a successful `add_sub_issue` linkage; flags missing parent link.
+9. Verify `split-postcondition.sh` fails Stop when fewer than 2 children created.
+10. Verify `postmortem-completeness.sh` accepts a doc with all required frontmatter + section headings; flags missing sections.
+11. Verify default-mode label-routing for each of the 9 routing entries (8 labels + default).
+12. Verify heartbeat fan-out (`--mode all` or no-arg) executes all three child skills serially and reports outcomes.
+
+## Performance Considerations
+
+- Default mode: 1 issue fetch + 1 label-inspect + 1 child skill dispatch + 1 `create_comment`. Fast path.
+- Heartbeat fan-out: 3 serial child-skill dispatches. Slowest mode — bounded by trends + hygiene + report individual budgets.
+- triage: 1 list_issues + 1 get_issue + 0-N knowledge_search + 1 save_issue. Sub-1-second when no duplicates.
+- hygiene: 1 project_hygiene + optional N archive_items. ~10 seconds for typical project.
+- unblock (interactive): 1 get_issue + 1 AskUserQuestion + 1 create_comment + 1 save_issue. User-paced.
+- unblock (autonomous): 1 list_issues + 1 get_issue + 1 create_comment. Sub-2-second.
+- postmortem: TaskList + N × TaskGet + 1 Write + 1 Edit (plan patch) + N × create_issue. Scales with task count.
+- retro: 1 Read (conversation) + N Agent dispatches + 1 Write. ~30-60 seconds.
+- trends: 1 capture_snapshot + 1 metrics_trends. Sub-2-second.
+- debug: 1 dry-run collate_debug + AskUserQuestion + 1 collate_debug. User-paced.
+- split: 1 get_issue + 1 decompose_feature (or Agent) + N create_issue + N add_sub_issue. Scales with child count.
+
+## Migration Notes
+
+- Source skills remain functional alongside the new verb until Plan 10 batches sunsets.
+- Plan 8 (`/ralph:hero`) is the orchestrator that auto-dispatches `/ralph:caretake --mode <name>` based on Director event class. Plan 7 preserves the `--issue NNN` and `--mode <name>` arg surface so the orchestrator's existing dispatch pattern keeps working.
+- `process-improvement` issues (auto-created by `--mode postmortem`) continue to feed Director's autopilot loop — same label, same routing.
+- `debug-auto` issues (auto-created by `--mode debug`) continue to feed Director's watcher event class — same label, same routing.
+
+## References
+
+- Spec: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` (plan-of-plans row 7 at line ~339, `modes/` subfolder layout at line 148).
+- Plan 6: `thoughts/shared/plans/2026-05-23-GH-1368-ralph-plan-6-review.md` (`closeout-` hook prefix convention, `__CLOSE__` token, hook hardening checklist).
+- Plan 5: `thoughts/shared/plans/2026-05-23-GH-1366-ralph-plan-5-impl.md` (9-hook ceiling, interactive+autonomous fold pattern for `unblock`).
+- Plan 4: `thoughts/shared/plans/2026-05-23-GH-1364-ralph-plan-4-plan.md` (multi-mode fold, no-mid-flow-env-mutation lesson).
+- Source skills:
+  - `plugin/ralph-hero/skills/caretake/SKILL.md` (188)
+  - `plugin/ralph-hero/skills/ralph-triage/SKILL.md` (326)
+  - `plugin/ralph-hero/skills/ralph-hygiene/SKILL.md` (142)
+  - `plugin/ralph-hero/skills/ralph-postmortem/SKILL.md` (207)
+  - `plugin/ralph-hero/skills/retro/SKILL.md` (338)
+  - `plugin/ralph-hero/skills/trends/SKILL.md` (55)
+  - `plugin/ralph-hero/skills/unblock/SKILL.md` (195)
+  - `plugin/ralph-hero/skills/ralph-unblock/SKILL.md` (254)
+  - `plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md` (202)
+  - `plugin/ralph-hero/skills/ralph-split/SKILL.md` (351)
+- Source hook scripts under `plugin/ralph-hero/hooks/scripts/`: `triage-state-gate.sh`, `triage-postcondition.sh`, `unblock-state-gate.sh`, `unblock-request-postcondition.sh`, `split-estimate-gate.sh`, `split-postcondition.sh`, `split-size-gate.sh`, `split-verify-sub-issue.sh`, `team-postmortem-completeness.sh` (renamed on port).
+- ralph plugin state at Plan 7 start: `ralph/skills/{catch-up,form,research,plan,impl,review}/` (6 verbs shipped through Plan 6).

--- a/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+++ b/thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
@@ -604,6 +604,60 @@ Inputs to feed into Plan 7 (`/ralph:caretake`):
 
 Open follow-ups (separate plans):
 
-- Plan 7 (`/ralph:caretake`) folds the caretaker modes (triage, hygiene, postmortem, retro, trends, unblock, split). May reuse `merge-state-gate.sh` for the merge-adjacent caretaker actions.
 - Plan 8 (`/ralph:hero`) is the orchestrator that dispatches `/ralph:impl --mode auto` then `/ralph:review` (default) per issue. Plan 6's verdict-token contracts (`FINISHED`, `FINISH BLOCKED — <reason>`) are the boundary the hero parses to decide next action.
 - Plan 10 owns sunset of source `ralph-val`, `ralph-code-review`, `ralph-merge`, `finish` skills.
+
+### Plan 7: `/ralph:caretake` (shipped 2026-05-23, branch `worktree-ralph-plan-7-caretake`)
+
+The widest fold in the migration — 10 source skills (2,258 lines of SKILL.md prose) collapse into one verb with 8 named modes plus a default event-driven dispatcher. Only verb in the plan-of-plans that warrants a `modes/` subfolder layout (spec §Skill Layout line 148).
+
+Hot-path stats:
+
+- 10 source skills → 1 SKILL.md (166 lines) + 8 mode bodies under `modes/` (averaging ~150 lines each) + 3 flat-sibling references (`label-routing.md`, `outcome-tokens.md`, `split-decomposition.md`).
+- 9 new hook ports under `ralph/hooks/scripts/` + 3 reuses (`branch-gate.sh`, `merge-state-gate.sh`, `lock-release-on-failure.sh`).
+- 8 mode-specific terminal-token families consolidated into one `outcome-tokens.md`.
+- Modes split by execution shape: 4 board-scan (triage/hygiene/unblock/split mutate state); 3 reflection (postmortem/retro/trends produce artifacts); 1 diagnostic (debug wraps MCP tool with interactive confirm).
+
+Design calls:
+
+- **`modes/` subfolder layout justified by mode count alone.** 8 mode bodies × ~80-120 lines each ≈ 700-1000 lines of mode-specific content — inlining would push SKILL.md past 800 lines; flat siblings without the subfolder would clutter the directory listing.
+- **`RALPH_SUBCOMMAND` scope pattern.** SessionStart sets `RALPH_COMMAND=caretake`; each mode body sets `RALPH_SUBCOMMAND=<name>` at body entry. The 9 hooks all gate on the (command, subcommand) pair so the SKILL.md frontmatter declares the full union at the top and each hook self-no-ops when a different mode is active. Pattern transplants cleanly to future multi-mode folds.
+- **Sub-mode discrimination inside `--mode unblock`.** Interactive (consumer) and autonomous (producer/`--question`) paths share one mode body but split on `RALPH_SUBCOMMAND_VARIANT`. Mirrors Plan 5's `--mode auto` vs default split inside `/ralph:impl` — proves the pattern generalizes.
+- **`label-routing.md` extracted from SKILL.md.** The dispatcher's full table (10 routing rows + full-fan-out sequence + label-consumption rules) lives in the flat sibling. Future label additions are a one-row PR — SKILL.md does not need to change.
+- **Hook prefix conventions clarified.** Prefixes are now: `triage-` (2), `unblock-` (2), `split-` (4), `postmortem-` (1, renamed from source `team-postmortem-completeness.sh` since the slim plugin has no team concept), plus the plan-3 reuses. Each prefix gates on its own `RALPH_SUBCOMMAND` value so multiple modes can coexist under one SKILL.md frontmatter.
+- **`--mode trends` is the only token-less mode.** Read-only by design — markdown report IS the deliverable. No `Stop` hook, no terminal verdict. Documented explicitly in `outcome-tokens.md` so future contributors don't add a token retroactively.
+
+Friction notes (populated by active use):
+
+- [ ] _(Examples to watch for: full fan-out via `trigger:caretake` running all 8 modes serially without stalling; `RALPH_SUBCOMMAND_VARIANT` hook scoping picking the right gate for interactive vs autonomous unblock; `--mode split` correctly blocking on `split-estimate-gate.sh` PostToolUse when parent is XS/S; `--mode debug --auto-confirm` from the Watcher heartbeat skipping `AskUserQuestion` cleanly; default-event dispatch consuming `trigger:caretake` and posting `## Caretaker Action` exactly once.)_
+
+Active-use checkboxes (each mode):
+
+- [ ] `--mode triage` against a real Backlog with at least one untriaged issue — emits `TRIAGED <verdict>` or `Queue empty.`
+- [ ] `--mode hygiene` against a real project — emits `HYGIENE COMPLETE <N>`.
+- [ ] `--mode unblock` (interactive) against an issue with `## Unblock Request` — posts `## Unblock Resolution`, transitions out of Human Needed, emits `UNBLOCK RESOLVED`.
+- [ ] `--mode unblock --question` against a board with a Human Needed issue — posts `## Unblock Request`, leaves state untouched, emits `UNBLOCK REQUEST POSTED`.
+- [ ] `--mode postmortem` at end of a team session with TaskList data — writes Obsidian-ready report, patches plan with `post_mortem::`, files blocker issues, emits `POSTMORTEM <path>`.
+- [ ] `--mode retro` after a session with friction signals — writes research doc, emits `RETRO <path>`.
+- [ ] `--mode trends --since 30d` — prints markdown trend report to stdout (no terminal token).
+- [ ] `--mode debug --since 24h` against a local Langfuse with errors — dry-runs, AskUserQuestion confirms, files issues, emits `DEBUG FILED <N>`.
+- [ ] `--mode split #NNN` against a real M-estimated issue — creates ≥2 XS/S children, emits `SPLIT <N>`.
+- [ ] Default mode (`--issue NNN` with a routing label) — dispatches the right mode via `label-routing.md`, posts `## Caretaker Action`.
+
+Patterns to encode in future fold plans:
+
+- **`modes/` subfolder is the right layout when mode count × per-mode body length > ~600 lines.** Inline at 4 modes (Plan 4) is fine; inline at 5+ modes (Plan 6 was at the boundary) stops being fine; subfolder at 8 modes (Plan 7) is the right shape.
+- **Sub-mode discrimination via `RALPH_SUBCOMMAND_VARIANT`** (separate from `RALPH_SUBCOMMAND`) lets one mode body host interactive + autonomous paths without a `--mode interactive-unblock` / `--mode autonomous-unblock` split that would double the mode count.
+- **Extract any rules table that future contributors might extend** into a flat-sibling reference, not the SKILL.md body. Label routing, decomposition heuristics, terminal-token tables — each gets its own file.
+
+Inputs to feed into Plan 8 (`/ralph:hero`):
+
+- _(Populated by active use, not by waiting.)_
+- 9 new hook ports + 3 reuses = 12 total hook scope guards in Plan 7's SKILL.md frontmatter. The pattern scales but the frontmatter is dense; future plans should consider whether per-mode hook-frontmatter could be split into per-mode files if the dispatch supports it.
+- The `label-routing.md` table is the natural integration point for Director's `event-classes.md` taxonomy. Plan 8's orchestrator should reuse the same label set so triggers compose cleanly between caretaker and hero.
+- `--mode trends`'s no-terminal-token contract is the model for any future read-only verb. Future plans should NOT retrofit a terminal token onto trends — the markdown report is the deliverable.
+
+Open follow-ups (separate plans):
+
+- Plan 8 (`/ralph:hero`) is the orchestrator that dispatches `/ralph:impl --mode auto` then `/ralph:review` (default) per issue. Plan 6's verdict-token contracts (`FINISHED`, `FINISH BLOCKED — <reason>`) are the boundary the hero parses to decide next action. The Plan 7 `--mode <name>` arg surface is preserved so the hero's existing dispatch pattern keeps working.
+- Plan 10 owns sunset of source `ralph-val`, `ralph-code-review`, `ralph-merge`, `finish`, `caretake`, `ralph-triage`, `ralph-hygiene`, `ralph-postmortem`, `retro`, `trends`, `unblock`, `ralph-unblock`, `ralph-debug-collate`, `ralph-split` skills.


### PR DESCRIPTION
## Summary

- Folds 10 source `ralph-hero` caretaker-family skills (2,258 lines) into one `/ralph:caretake` verb with 8 named modes + a default event-driven dispatcher.
- Only verb in the plan-of-plans that uses a `modes/` subfolder layout (spec §Skill Layout justifies this at mode count × per-mode body length > ~600 lines).
- Sub-mode discrimination inside `--mode unblock` (interactive vs `--question` autonomous) via `RALPH_SUBCOMMAND_VARIANT` — same pattern as Plan 5's `--mode auto` split inside `/ralph:impl`.
- Plan 6's `closeout-` hook convention extends here with prefix-isolated scopes: `triage-` (2), `unblock-` (2), `split-` (4), `postmortem-` (1, renamed from `team-postmortem-completeness.sh` since the slim plugin has no team concept).

## What landed

| Phase | Commit | Contents |
|---|---|---|
| 1 | `9dadec28` | SKILL.md scaffold (165 lines) + 8 mode stubs + 3 flat-sibling stubs + 9 hook ports |
| 2 | `b73aaadf` | `label-routing.md` (79 lines) — routing table + full fan-out sequence + label consumption |
| 3 | `4576c8b2` | `modes/triage.md` (149) — port ralph-triage Steps 1-7 + outcome-tokens triage section |
| 4 | `0abeca15` | `modes/hygiene.md` (131) — port ralph-hygiene + outcome-tokens hygiene section |
| 5 | `9f7e39dc` | `modes/unblock.md` (270) — interactive + autonomous fold via `RALPH_SUBCOMMAND_VARIANT` |
| 6 | `c2de906b` | `modes/postmortem.md` (187) + `modes/retro.md` (294) + `modes/trends.md` (49) |
| 7 | `031406fa` | `modes/debug.md` (194) — wraps `ralph_hero__collate_debug` with `AskUserQuestion` confirm |
| 8 | `76b19ebf` | `modes/split.md` (209) + `split-decomposition.md` (104) — non-epic side only |
| 9 | `f2e25ade` | README → "Plan 7 of 11 (caretake shipped)"; friction-log § appended; picker sweep |

**Mode bodies total: 1,483 lines across 8 files. Verb total: 1,906 lines.**

## Modes shipped

- **default** (`--issue NNN`) — event-driven via [label-routing.md](https://github.com/cdubiel08/ralph-hero/blob/worktree-ralph-plan-7-caretake/ralph/skills/caretake/label-routing.md)
- **all** (no args or `--mode all`) — heartbeat fan-out: hygiene + catch-up report + trends
- **triage** — pick oldest untriaged Backlog, assess, route
- **hygiene** — scan for archive candidates, stale items, WIP violations
- **unblock** — interactive answer (default) OR autonomous request (`--question`)
- **postmortem** — TaskList-driven structured session post-mortem
- **retro** — capture intra-session friction → research doc
- **trends** — snapshot + markdown trend report (read-only stdout; no terminal token)
- **debug** — collate Langfuse errors → file `debug-auto` issues
- **split** — M/L/XL → multiple XS/S sub-issues

## Test plan

- [ ] `/plugin marketplace update ralph-hero && /reload-plugins` discovers `/ralph:caretake`
- [ ] `/ralph:caretake --mode triage` against a real Backlog with at least one untriaged issue → emits `TRIAGED <verdict>` or `Queue empty.`
- [ ] `/ralph:caretake --mode hygiene` against a real project → emits `HYGIENE COMPLETE <N>`
- [ ] `/ralph:caretake --mode unblock #NNN` against an issue with `## Unblock Request` → posts `## Unblock Resolution`, transitions out of Human Needed, emits `UNBLOCK RESOLVED`
- [ ] `/ralph:caretake --mode unblock --question` against a board with a Human Needed issue → posts `## Unblock Request`, leaves state untouched, emits `UNBLOCK REQUEST POSTED`
- [ ] `/ralph:caretake --mode postmortem` at end of a team session with TaskList data → writes Obsidian-ready report, patches plan with `post_mortem::`, files blocker issues, emits `POSTMORTEM <path>`
- [ ] `/ralph:caretake --mode retro` after a session with friction signals → writes retro doc, emits `RETRO <path>`
- [ ] `/ralph:caretake --mode trends --since 30d` → prints markdown trend report to stdout (no terminal token)
- [ ] `/ralph:caretake --mode debug --since 24h` against a local Langfuse with errors → dry-runs, AskUserQuestion confirms, files issues, emits `DEBUG FILED <N>`
- [ ] `/ralph:caretake --mode split #NNN` against a real M-estimated issue → creates ≥2 XS/S children, emits `SPLIT <N>`
- [ ] `/ralph:caretake --mode split #NNN` against an XS issue → blocked by `split-estimate-gate.sh` (PostToolUse) with exit 2; mode body never reaches `create_issue`
- [ ] Default-mode label-routing dispatch works against a real `--issue NNN` with each of the recognized labels (`stale`, `status-update-needed`, `trends-check`, `needs-triage`, `human-needed`, `process-improvement`, `debug-auto`, `needs-split`, `trigger:caretake`)
- [ ] Heartbeat fan-out (no-arg or `--mode all`) executes hygiene + catch-up report + trends serially
- [ ] Old `/ralph-hero:*` caretaker-family skills (caretake, ralph-triage, ralph-hygiene, ralph-postmortem, retro, trends, unblock, ralph-unblock, ralph-debug-collate, ralph-split) remain functional during the parallel period (Plan 10 owns sunset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)