### PR TITLE
feat(ralph): Plan 8 — /ralph:hero fold (GH-1390)

### DIFF
--- a/ralph/hooks/scripts/autopilot-director-postcheck.sh
+++ b/ralph/hooks/scripts/autopilot-director-postcheck.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/autopilot-director-postcheck.sh
+# PostToolUse:Skill — when Director returns inside an autopilot /loop turn,
+# write or clear a sentinel file that the Stop hook reads to detect the
+# silent-drop failure mode (non-terminal Director result + omitted
+# ScheduleWakeup → /loop interprets absent wakeup as "task complete").
+#
+# See GH-1346 and thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md
+# for the failure mode this guards against.
+#
+# Self-discriminates on RALPH_COMMAND=autopilot — passes through silently
+# for any other skill that uses Skill().
+#
+# Exit codes:
+#   0 - Always (observer, never blocks)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Pass through for non-autopilot sessions.
+# Slim plugin: RALPH_COMMAND=hero + RALPH_SUBCOMMAND=auto is the new autopilot.
+# Legacy plugin: RALPH_COMMAND=autopilot.
+if [[ "${RALPH_COMMAND:-}" != "autopilot" \
+      && ! ( "${RALPH_COMMAND:-}" == "hero" && "${RALPH_SUBCOMMAND:-}" == "auto" ) ]]; then
+  exit 0
+fi
+
+# Only act on the classify/Director dispatch. Skill name may be:
+#   - legacy `director` / `ralph-hero:director`
+#   - slim `ralph:hero` invoked with --mode classify in args
+skill_name=$(get_field '.tool_input.skill')
+skill_args=$(get_field '.tool_input.args')
+case "${skill_name##*:}" in
+  director)
+    ;;
+  hero)
+    # Slim plugin: only the classify sub-mode is the loop's dispatch step.
+    if [[ "$skill_args" != *--mode\ classify* ]]; then
+      exit 0
+    fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# Sentinel path is session-scoped. session_id is part of the standard hook
+# payload; fall back to PPID if missing so the hook still functions in tests.
+session_id=$(get_field '.session_id')
+sentinel_dir="${TMPDIR:-/tmp}"
+sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+
+# Skill returns the model's final synthesis from the inner skill run.
+# Shape varies: MCP-style { content: [{ text }] } for some tools, plain string
+# for the built-in Skill tool. Use a single defensive jq expression that
+# handles both without crashing on type mismatch.
+response_text=$(printf '%s' "$RALPH_HOOK_INPUT" | jq -r '
+  .tool_response
+  | if type == "object" then (.content // [{}])[0].text // ""
+    elif type == "string" then .
+    else . | tostring
+    end // ""
+' 2>/dev/null || echo "")
+
+# Extract the last line beginning with `result:` (Director can emit several
+# intermediate lines; the final `result:` is the operative one).
+result_line=$(printf '%s\n' "$response_text" | grep -E '^result:' | tail -n 1 || true)
+
+if [[ -z "$result_line" ]]; then
+  # No `result:` line found — response wasn't from Director (maybe an error
+  # or a non-director Skill call we don't recognize). Leave the sentinel
+  # alone; the next valid Director response will resolve it.
+  exit 0
+fi
+
+if printf '%s' "$result_line" | grep -qE 'Queue empty'; then
+  # Terminal — autopilot is allowed to end without a ScheduleWakeup call.
+  rm -f -- "$sentinel" 2>/dev/null || true
+else
+  # Non-terminal — Director returned forward-progress, skip, or classification
+  # text. Autopilot's contract requires a follow-up ScheduleWakeup. Record the
+  # pending state; the wakeup-clear hook will rm it if ScheduleWakeup fires,
+  # otherwise the Stop hook will surface the omission.
+  printf '%s\n' "$result_line" > "$sentinel" 2>/dev/null || true
+fi
+
+exit 0

--- a/ralph/hooks/scripts/autopilot-enable-gate.sh
+++ b/ralph/hooks/scripts/autopilot-enable-gate.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/autopilot-enable-gate.sh
+# PreToolUse:Skill gate for /ralph-hero:autopilot.
+#
+# Refuses to dispatch the inner /loop /hero unless RALPH_AUTOPILOT_ENABLE=true.
+# Deterministic — no LLM in the loop. Invisible on success.
+#
+# Why a hook (not a Step 0 LLM check):
+# - The opt-in gate is a binary precondition; the LLM should never be the one
+#   reading the env var and deciding whether to proceed.
+# - Failure messages must be deterministic so users get the same instruction
+#   every time, not a paraphrase.
+#
+# Exit codes:
+#   0 - Allowed (env var is "true", or this Skill call is not autopilot's
+#       /loop dispatch — we pass through silently)
+#   2 - Blocked (autopilot active but env var not set)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Only fires for autopilot. Other skills using Skill() pass through.
+# Legacy: RALPH_COMMAND=autopilot. Slim: RALPH_COMMAND=hero + RALPH_SUBCOMMAND=auto.
+if [[ "${RALPH_COMMAND:-}" != "autopilot" \
+      && ! ( "${RALPH_COMMAND:-}" == "hero" && "${RALPH_SUBCOMMAND:-}" == "auto" ) ]]; then
+  exit 0
+fi
+
+if [[ "${RALPH_AUTOPILOT_ENABLE:-false}" != "true" ]]; then
+  cat >&2 <<'EOF'
+═══════════════════════════════════════════════════════════════
+ Autopilot is opt-in.
+
+ Set RALPH_AUTOPILOT_ENABLE=true before invoking, e.g.:
+
+   export RALPH_AUTOPILOT_ENABLE=true
+   /ralph:hero --mode auto
+
+ Unattended automation is opt-in by design.
+═══════════════════════════════════════════════════════════════
+EOF
+  exit 2
+fi
+
+exit 0

--- a/ralph/hooks/scripts/autopilot-stop-gate.sh
+++ b/ralph/hooks/scripts/autopilot-stop-gate.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/autopilot-stop-gate.sh
+# Stop — if a sentinel file exists indicating Director emitted a non-terminal
+# result without a subsequent ScheduleWakeup, block stop with a loud message
+# so the silent-drop failure mode becomes a noisy, recoverable one.
+#
+# See GH-1346 and thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md.
+#
+# Self-discriminates on RALPH_COMMAND=autopilot — passes through silently
+# for any other skill. Uses stop_hook_active for re-entry safety following
+# the pattern in team-stop-gate.sh.
+#
+# Exit codes:
+#   0 - No pending wakeup, allow stop
+#   2 - Pending wakeup detected, block stop and surface omission
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Pass through for non-autopilot sessions.
+# Legacy: RALPH_COMMAND=autopilot. Slim: RALPH_COMMAND=hero + RALPH_SUBCOMMAND=auto.
+if [[ "${RALPH_COMMAND:-}" != "autopilot" \
+      && ! ( "${RALPH_COMMAND:-}" == "hero" && "${RALPH_SUBCOMMAND:-}" == "auto" ) ]]; then
+  exit 0
+fi
+
+# Re-entry safety: if we already fired once and the model still wants to stop,
+# we've made our case — let it stop. Otherwise we'd loop forever.
+stop_hook_active=$(get_field '.stop_hook_active')
+if [[ "$stop_hook_active" == "true" ]]; then
+  # Clean up the sentinel so it doesn't bleed into a future autopilot run.
+  session_id=$(get_field '.session_id')
+  sentinel_dir="${TMPDIR:-/tmp}"
+  sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+  rm -f -- "$sentinel" 2>/dev/null || true
+  exit 0
+fi
+
+session_id=$(get_field '.session_id')
+sentinel_dir="${TMPDIR:-/tmp}"
+sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+
+[[ -f "$sentinel" ]] || exit 0
+
+pending_result=$(cat -- "$sentinel" 2>/dev/null || echo "(unreadable)")
+
+cat >&2 <<EOF
+═══════════════════════════════════════════════════════════════
+ Autopilot stop blocked: pending ScheduleWakeup not observed
+
+ Director returned a non-terminal result, but no ScheduleWakeup
+ call followed. Without one, /loop interprets the absent wakeup
+ as "task complete" and the autopilot drops silently.
+
+ Last Director result:
+   $pending_result
+
+ Required next action:
+   Call ScheduleWakeup with delaySeconds in [60,270] (warm-cache
+   continuation, work likely to resume soon) or [1200,1800] (idle
+   retry window). Avoid 300s.
+
+   prompt: pass back the same /ralph:hero --mode auto continuation
+   prompt or the <<autonomous-loop-dynamic>> sentinel.
+
+ If you genuinely intend to stop (queue is drained, Director just
+ hasn't said so), invoke Director once more and confirm it emits
+ 'result: Queue empty' before exiting.
+═══════════════════════════════════════════════════════════════
+EOF
+
+exit 2

--- a/ralph/hooks/scripts/autopilot-wakeup-clear.sh
+++ b/ralph/hooks/scripts/autopilot-wakeup-clear.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# ralph-hero/hooks/scripts/autopilot-wakeup-clear.sh
+# PreToolUse:ScheduleWakeup — validate the wakeup call and clear the sentinel
+# that autopilot-director-postcheck.sh wrote after a non-terminal Director
+# result. Combines the GH-1140 anti-pattern checks (delaySeconds != 300,
+# autopilot-shaped prompt) with the post-GH-1267 sentinel-clear behavior.
+#
+# See GH-1346 and thoughts/shared/research/2026-05-21-autopilot-loop-handoff.md.
+#
+# Self-discriminates on RALPH_COMMAND=autopilot — passes through silently
+# for any other skill that uses ScheduleWakeup().
+#
+# Exit codes:
+#   0 - Allowed (sentinel cleared)
+#   2 - Blocked (delaySeconds=300 cache-window anti-pattern)
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Pass through for non-autopilot sessions.
+# Legacy: RALPH_COMMAND=autopilot. Slim: RALPH_COMMAND=hero + RALPH_SUBCOMMAND=auto.
+if [[ "${RALPH_COMMAND:-}" != "autopilot" \
+      && ! ( "${RALPH_COMMAND:-}" == "hero" && "${RALPH_SUBCOMMAND:-}" == "auto" ) ]]; then
+  exit 0
+fi
+
+delay_seconds=$(get_field '.tool_input.delaySeconds')
+
+# Cache-window anti-pattern: 300s falls outside both the warm-cache window
+# (<=270s) and the cost-amortized committed window (>=1200s). Reject loudly.
+if [[ "$delay_seconds" == "300" ]]; then
+  cat >&2 <<'EOF'
+═══════════════════════════════════════════════════════════════
+ Autopilot ScheduleWakeup blocked: delaySeconds=300
+
+ 300s is the 5-minute cache-window anti-pattern — it pays the
+ prompt-cache miss without amortizing the cost across a longer
+ idle period.
+
+ Pick <=270s (warm-cache continuation, work likely to resume) or
+ >=1200s (committed idle wait, cache miss amortized).
+═══════════════════════════════════════════════════════════════
+EOF
+  exit 2
+fi
+
+# The wakeup is going through. Clear the sentinel so the Stop hook lets the
+# session end cleanly. Sentinel path mirrors autopilot-director-postcheck.sh.
+session_id=$(get_field '.session_id')
+sentinel_dir="${TMPDIR:-/tmp}"
+sentinel="${sentinel_dir%/}/ralph-autopilot-pending-wakeup-${session_id:-$PPID}"
+rm -f -- "$sentinel" 2>/dev/null || true
+
+exit 0

--- a/ralph/hooks/scripts/hero-dispatch-log.sh
+++ b/ralph/hooks/scripts/hero-dispatch-log.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Plan 8: Append one line per /ralph:hero -> child-verb dispatch to the activity
+# log for observability. Mirrors record-activity.sh's shape but scoped to Skill()
+# dispatches issued under RALPH_COMMAND=hero. The activity log is consumed by
+# /ralph:catch-up and friends.
+#
+# Exit codes:
+#   0 - Always (observer; never blocks)
+
+set -euo pipefail
+
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Scope guard — no-op outside /ralph:hero
+[[ "${RALPH_COMMAND:-}" == "hero" ]] || exit 0
+
+skill_name=$(get_field '.tool_input.skill')
+[[ -z "$skill_name" ]] && exit 0
+
+# Only log dispatches to child verbs and well-known orchestration helpers.
+case "${skill_name##*:}" in
+  research|plan|impl|review|caretake|loop|code-review)
+    ;;
+  hero)
+    # Sub-mode dispatches (auto → classify, etc.) are interesting too
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+today=$(date +%Y/%m/%d)
+log_dir="${RALPH_ACTIVITY_DIR:-$HOME/.ralph-hero/activity}/$today"
+mkdir -p "$log_dir" 2>/dev/null || exit 0
+
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+sub="${RALPH_SUBCOMMAND:-default}"
+printf '{"ts":"%s","category":"work","kind":"hero-dispatch","subcommand":"%s","target":"%s"}\n' \
+  "$ts" "$sub" "$skill_name" >> "$log_dir/$(date +%H).jsonl" 2>/dev/null || true
+
+exit 0

--- a/ralph/hooks/scripts/hero-state-gate.sh
+++ b/ralph/hooks/scripts/hero-state-gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Plan 8: Validate state transitions issued by /ralph:hero.
+# Mirrors impl-state-gate.sh:
+#   - RALPH_COMMAND scope guard (no-op outside /ralph:hero)
+#   - is_semantic_intent passthrough (let __LOCK__, __COMPLETE__, __ESCALATE__,
+#     __CLOSE__, __CANCEL__ flow to state-resolution)
+#   - valid state allowlist for hero orchestration transitions
+#
+# Exit codes:
+#   0 - Allowed (out of scope, semantic intent, or valid state)
+#   2 - Blocked (workflowState not in allowlist)
+
+set -euo pipefail
+
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Scope guard — no-op outside /ralph:hero
+[[ "${RALPH_COMMAND:-}" == "hero" ]] || exit 0
+
+target_state=$(get_field '.tool_input.workflowState')
+
+# No workflowState change — allow (label-only save_issue, etc.)
+[[ -z "$target_state" ]] && exit 0
+
+# Semantic-intent passthrough — state-resolution.ts handles these
+if is_semantic_intent "$target_state"; then
+  exit 0
+fi
+
+# Valid state allowlist for hero orchestration. Matches the workflow phases
+# the orchestrator legitimately drives issues through.
+valid_states=(
+  "Research Needed"
+  "Research in Progress"
+  "Ready for Plan"
+  "Plan in Progress"
+  "Plan in Review"
+  "In Progress"
+  "In Review"
+  "Done"
+  "Human Needed"
+)
+
+for s in "${valid_states[@]}"; do
+  [[ "$target_state" == "$s" ]] && exit 0
+done
+
+cat >&2 <<EOF
+═══════════════════════════════════════════════════════════════
+ [hero-state-gate] BLOCKED
+
+ workflowState='$target_state' is not a valid transition for
+ /ralph:hero. Use a semantic intent (__LOCK__, __COMPLETE__,
+ __ESCALATE__, __CLOSE__, __CANCEL__) or one of:
+
+ ${valid_states[*]}
+═══════════════════════════════════════════════════════════════
+EOF
+exit 2

--- a/ralph/hooks/scripts/hero-state-gate.sh
+++ b/ralph/hooks/scripts/hero-state-gate.sh
@@ -19,9 +19,14 @@ read_input > /dev/null
 # Scope guard — no-op outside /ralph:hero
 [[ "${RALPH_COMMAND:-}" == "hero" ]] || exit 0
 
+# save_issue uses `workflowState`; advance_issue uses `targetState`. Try both
+# so the hook gates BOTH MCP tools it's registered against (PR #1391 review).
 target_state=$(get_field '.tool_input.workflowState')
+if [[ -z "$target_state" ]]; then
+  target_state=$(get_field '.tool_input.targetState')
+fi
 
-# No workflowState change — allow (label-only save_issue, etc.)
+# No state change — allow (label-only save_issue, advance_issue without targetState, etc.)
 [[ -z "$target_state" ]] && exit 0
 
 # Semantic-intent passthrough — state-resolution.ts handles these

--- a/ralph/hooks/scripts/pr-drain-state-gate.sh
+++ b/ralph/hooks/scripts/pr-drain-state-gate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Plan 8: Validate state transitions issued by /ralph:hero --mode pr-drain.
+# Synth issues (kind:pr-drain label) may only transition to:
+#   - "In Progress"  (initial — create_issue sets this directly)
+#   - "Done"          (terminal-success classes)
+#   - "Human Needed"  (terminal-handoff classes: needs-human / merge-failed)
+#
+# Exit codes:
+#   0 - Allowed (out of scope or valid synth transition or semantic intent)
+#   2 - Blocked (target state outside the pr-drain allowlist)
+
+set -euo pipefail
+
+source "$(dirname "$0")/hook-utils.sh"
+
+read_input > /dev/null
+
+# Scope guard — only fires for /ralph:hero --mode pr-drain
+if [[ "${RALPH_COMMAND:-}" != "hero" || "${RALPH_SUBCOMMAND:-}" != "pr-drain" ]]; then
+  exit 0
+fi
+
+target_state=$(get_field '.tool_input.workflowState')
+[[ -z "$target_state" ]] && exit 0
+
+case "$target_state" in
+  "In Progress"|"Done"|"Human Needed")
+    exit 0
+    ;;
+esac
+
+# Semantic-intent passthrough (state-resolution.ts handles these)
+if is_semantic_intent "$target_state"; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+═══════════════════════════════════════════════════════════════
+ [pr-drain-state-gate] BLOCKED
+
+ workflowState='$target_state' is not allowed in pr-drain mode.
+ Synth issues may only move to: In Progress, Done, Human Needed.
+═══════════════════════════════════════════════════════════════
+EOF
+exit 2

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -166,7 +166,59 @@ result: Hero paused at <phase> — <reason>. Resume: /ralph:hero NNN
 
 ## --mode classify
 
-(Phase 3 — filled in next.)
+Director-only mode: classify one issue and dispatch the correct verb. Does NOT implement work. Useful for iOS shortcuts and manual override paths. Full taxonomy in [event-classes.md](event-classes.md).
+
+### Step 1: Parse arguments + detect input source
+
+Parse `$ARGUMENTS` for `--issue NNN`.
+
+- If present → set `TARGET_ISSUE=NNN`, skip to Step 2b.
+- If a `RemoteTrigger` tool input is present (deprecated — see [event-classes.md](event-classes.md) §iOS-mode sentinel) → extract `issue_number` + `team`, set `TARGET_ISSUE` + `FORCED_TEAM` + `DISPATCH_REASON=RemoteTrigger`, skip to Step 4.
+- Otherwise → Step 2a.
+
+### Step 2a: Read next_actions
+
+Call `next_actions({})`. If queue empty: emit `result: Queue empty. No events to dispatch.` and STOP.
+
+Pick the top-ranked direction. Resolve `TARGET_ISSUE` per [event-classes.md](event-classes.md) (kind rules — `issue`/`tree-continue`/`lock-stale`/`human-needed-unblock` use `direction.issue.number`; `pr` uses `direction.signals.linkedIssueNumber`).
+
+### Step 2b: Fetch issue
+
+`get_issue({ number: TARGET_ISSUE })`. Store `ISSUE_WORKFLOW_STATE`, `ISSUE_LABELS[]`.
+
+### Step 3: Classify via taxonomy
+
+Read [event-classes.md](event-classes.md). Apply priority order: `trigger:*` labels → automation labels → workflow_state fallback. Set `TEAM`, `ENTRYPOINT`, `DISPATCH_REASON`, `CONSUMED_LABEL`.
+
+### Step 4: Dispatch via Skill()
+
+iOS-mode sentinel: if `DISPATCH_REASON` starts with `trigger:` OR equals `RemoteTrigger`, write the sentinel before dispatch:
+
+```bash
+touch "${TMPDIR:-/tmp}/ralph-ios-mode"
+```
+
+Workflow_state-driven dispatches (Priority 3) do NOT write the sentinel — only Priority 1 (`trigger:*`) and `RemoteTrigger` paths do.
+
+If entrypoint exists: `Skill(ENTRYPOINT, args="NNN")` and emit `Classified #NNN as <team> (reason: <DISPATCH_REASON>). Dispatching <entrypoint>.`
+
+If entrypoint does not exist (memorykeepers): emit `needs input: team <name> not yet implemented; skipping dispatch.`
+
+### Step 5: Consume trigger:* label (if applicable)
+
+If `CONSUMED_LABEL` is set: `save_issue({ number: TARGET_ISSUE, labels: ISSUE_LABELS minus CONSUMED_LABEL })`. Automation labels (`watcher-auto`, `debug-auto`, `scout-auto`, `process-improvement`) are NOT consumed — their producers manage their own lifecycle. `RemoteTrigger`-sourced events: no label to consume; skip.
+
+### Step 6: Emit result marker
+
+```
+result: Dispatched #NNN to <team> via <entrypoint>. (reason: <DISPATCH_REASON>)
+```
+
+Or, if no dispatch was made (unimplemented team):
+
+```
+result: #NNN classified as <team> (reason: <DISPATCH_REASON>). No dispatch — team not yet implemented.
+```
 
 ## --mode auto
 

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -1,0 +1,186 @@
+---
+description: Autonomous orchestrator for the ralph slim plugin. Drives a GitHub issue through the full lifecycle (research → plan → impl → review → merge) with a human plan-approval gate by default. Five modes:default(one-shot), --mode auto (autopilot drain via /loop), --mode classify (director-only dispatch), --mode watch (watcher heartbeat), --mode pr-drain (PR triage). Triggers on "run the hero", "drain the backlog", "classify this issue", "dispatch this", "watch the alerts", "drain this PR", "auto mode", "ship this ticket".
+argument-hint: "[<issue-number> | --mode <auto|classify|watch|pr-drain>] [--issue NNN] [--pr NNN] [--since <window>]"
+context: inline
+model: opus
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=hero"
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/branch-gate.sh"
+    - matcher: "Skill"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-enable-gate.sh"
+    - matcher: "ScheduleWakeup"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-wakeup-clear.sh"
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hero-state-gate.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pr-drain-state-gate.sh"
+    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hero-state-gate.sh"
+  PostToolUse:
+    - matcher: "Skill"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hero-dispatch-log.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-director-postcheck.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-stop-gate.sh"
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/lock-release-on-failure.sh"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - Skill
+  - Task
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+  - AskUserQuestion
+  - PushNotification
+  - ScheduleWakeup
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__detect_stream_positions
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__next_actions
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
+  - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
+---
+
+# /ralph:hero — Orchestrator in one verb
+
+The only autonomous entrypoint in the ralph slim plugin. Drives one issue end-to-end by default, or fans out to four mode-specific orchestrations.
+
+| Mode | Trigger | Role |
+|---|---|---|
+| **default** | `/ralph:hero NNN` or `/ralph:hero` (picks top-ranked) | One-shot: research → plan → review → impl → PR → merge |
+| **`--mode auto`** | `/ralph:hero --mode auto` | Drain the backlog via `/loop` (dynamic) + classify each event |
+| **`--mode classify`** | `/ralph:hero --mode classify [--issue NNN]` | Director-only: classify one event, dispatch correct verb, stop |
+| **`--mode watch`** | `/ralph:hero --mode watch [--issue NNN]` | Watcher heartbeat — dispatch gcp-incident-triage / debug-collate / log-reader / sre-fixit |
+| **`--mode pr-drain`** | `/ralph:hero --mode pr-drain --pr NNN` | Drain a PR (Dependabot/stale/unlinked) — classify, gate, act |
+
+References: [state-machine.md](state-machine.md), [task-graph.md](task-graph.md), [dispatch.md](dispatch.md), [event-classes.md](event-classes.md), [watch-dispatch.md](watch-dispatch.md), [pr-drain.md](pr-drain.md).
+
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+- Plan review: !`echo ${RALPH_REVIEW_PLAN:-auto}`
+- Merge review: !`echo ${RALPH_REVIEW_MODE:-interactive}`
+- Impl model: !`echo ${RALPH_IMPL_MODEL:-sonnet}`
+- Autopilot enabled: !`echo ${RALPH_AUTOPILOT_ENABLE:-unset}`
+
+## Step 0: Parse arguments + set subcommand scope
+
+```bash
+case "$ARGUMENTS" in
+  --mode\ auto*)        export RALPH_SUBCOMMAND=auto ;;
+  --mode\ classify*)    export RALPH_SUBCOMMAND=classify ;;
+  --mode\ watch*)       export RALPH_SUBCOMMAND=watch ;;
+  --mode\ pr-drain*)    export RALPH_SUBCOMMAND=pr-drain ;;
+  *)                    export RALPH_SUBCOMMAND=default ;;
+esac
+```
+
+## Step 1: Dispatch
+
+Route to the matching mode body below:
+
+- `RALPH_SUBCOMMAND=default` → **Default mode** (this section)
+- `RALPH_SUBCOMMAND=auto` → **--mode auto** (Phase 4)
+- `RALPH_SUBCOMMAND=classify` → **--mode classify** (Phase 3)
+- `RALPH_SUBCOMMAND=watch` → **--mode watch** (Phase 5)
+- `RALPH_SUBCOMMAND=pr-drain` → **--mode pr-drain** (Phase 6)
+
+## Default mode — one-shot orchestrator
+
+### Step 1: Detect pipeline position
+
+Parse `$ARGUMENTS` for a bare issue number. If none provided, call `next_actions({})`, present the top actionable direction via `AskUserQuestion`, and resolve `TARGET_ISSUE` from the user's response.
+
+Call `get_issue({ number: TARGET_ISSUE, includePipeline: true })`. Trust the returned `phase` — do NOT interpret workflow states yourself. Convergence rules + ASCII state machine live in [state-machine.md](state-machine.md).
+
+### Step 1a: Registry lookup
+
+Read `.ralph-repos.yml` (single-repo mode if absent). Store `registryAvailable`, `repoEntries`, `patterns` for cross-repo decomposition during SPLIT.
+
+### Step 1.5: Resumability check
+
+`TaskList()` — if tasks already exist for this pipeline (subjects start with "Research GH-" / "Plan group GH-" / etc.), skip task creation and resume from Step 3.
+
+### Step 2: Create upfront task list
+
+Build the task graph per starting `phase`. Shape per starting phase + dependency-graph-aware impl ordering live in [task-graph.md](task-graph.md). Pattern is two-step: `TaskCreate` then `TaskUpdate(addBlockedBy=[...])`.
+
+### Step 3: Execution loop
+
+Loop `TaskList → filter pending+unblocked → dispatch → mark completed` until all tasks are completed. Phase-specific dispatch (verb mapping, `Skill()` vs `Agent()`, model selection via `${RALPH_IMPL_MODEL:-sonnet}`, BLOCKED escalation, plan-review gate, merge gate) lives in [dispatch.md](dispatch.md).
+
+### Step 4: Report final status
+
+After INTEGRATE completes, report issue numbers, PR URLs, merge status, CI results.
+
+```
+result: Hero complete — GH-NNN merged via PR #<N>, CI <status>.
+```
+
+Or on STOP (interactive gate / Human Needed / failure):
+
+```
+result: Hero paused at <phase> — <reason>. Resume: /ralph:hero NNN
+```
+
+## --mode classify
+
+(Phase 3 — filled in next.)
+
+## --mode auto
+
+(Phase 4 — filled in next.)
+
+## --mode watch
+
+(Phase 5 — filled in next.)
+
+## --mode pr-drain
+
+(Phase 6 — filled in next.)
+
+## Notes
+
+- **`RALPH_SUBCOMMAND` is set at Step 0**, once. Hooks discriminate against it to no-op when a different mode is active. SessionStart only sets `RALPH_COMMAND=hero`, which guards all hero-prefixed hooks.
+- **Old `/ralph-hero:*` orchestrator skills remain functional** until Plan 10 sunset. Both paths can run side-by-side during the parallel period.

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -116,123 +116,79 @@ case "$ARGUMENTS" in
 esac
 ```
 
-## Step 1: Dispatch
+## Step 1: Dispatch by `RALPH_SUBCOMMAND`
 
-Route to the matching mode body below:
-
-- `RALPH_SUBCOMMAND=default` → **Default mode** (this section)
-- `RALPH_SUBCOMMAND=auto` → **--mode auto** (Phase 4)
-- `RALPH_SUBCOMMAND=classify` → **--mode classify** (Phase 3)
-- `RALPH_SUBCOMMAND=watch` → **--mode watch** (Phase 5)
-- `RALPH_SUBCOMMAND=pr-drain` → **--mode pr-drain** (Phase 6)
+Route to the matching mode section below. The dispatcher does NOT rewrite terminal `result:` lines — the harness reads them directly.
 
 ## Default mode — one-shot orchestrator
 
-### Step 1: Detect pipeline position
-
-Parse `$ARGUMENTS` for a bare issue number. If none provided, call `next_actions({})`, present the top actionable direction via `AskUserQuestion`, and resolve `TARGET_ISSUE` from the user's response.
-
-Call `get_issue({ number: TARGET_ISSUE, includePipeline: true })`. Trust the returned `phase` — do NOT interpret workflow states yourself. Convergence rules + ASCII state machine live in [state-machine.md](state-machine.md).
-
-### Step 1a: Registry lookup
-
-Read `.ralph-repos.yml` (single-repo mode if absent). Store `registryAvailable`, `repoEntries`, `patterns` for cross-repo decomposition during SPLIT.
-
-### Step 1.5: Resumability check
-
-`TaskList()` — if tasks already exist for this pipeline (subjects start with "Research GH-" / "Plan group GH-" / etc.), skip task creation and resume from Step 3.
-
-### Step 2: Create upfront task list
-
-Build the task graph per starting `phase`. Shape per starting phase + dependency-graph-aware impl ordering live in [task-graph.md](task-graph.md). Pattern is two-step: `TaskCreate` then `TaskUpdate(addBlockedBy=[...])`.
-
-### Step 3: Execution loop
-
-Loop `TaskList → filter pending+unblocked → dispatch → mark completed` until all tasks are completed. Phase-specific dispatch (verb mapping, `Skill()` vs `Agent()`, model selection via `${RALPH_IMPL_MODEL:-sonnet}`, BLOCKED escalation, plan-review gate, merge gate) lives in [dispatch.md](dispatch.md).
-
-### Step 4: Report final status
-
-After INTEGRATE completes, report issue numbers, PR URLs, merge status, CI results.
-
-```
-result: Hero complete — GH-NNN merged via PR #<N>, CI <status>.
-```
-
-Or on STOP (interactive gate / Human Needed / failure):
-
-```
-result: Hero paused at <phase> — <reason>. Resume: /ralph:hero NNN
-```
+1. **Detect phase.** Parse `$ARGUMENTS` for an issue number; if none, pick from `next_actions({})` via `AskUserQuestion`. Call `get_issue({ number: TARGET, includePipeline: true })` — trust the returned `phase`. State machine + convergence rules in [state-machine.md](state-machine.md).
+2. **Registry lookup.** Read `.ralph-repos.yml` (single-repo if absent) for cross-repo decomposition.
+3. **Resumability.** `TaskList()` — if tasks match the pipeline shape, skip task creation and resume from the execution loop.
+4. **Build upfront task list** per starting `phase`. Shape + dependency-graph-aware impl ordering in [task-graph.md](task-graph.md).
+5. **Execution loop.** `TaskList → filter pending+unblocked → dispatch → mark completed`. Per-phase verb mapping, `Skill()`/`Agent()` choice, `${RALPH_IMPL_MODEL:-sonnet}` selection, BLOCKED escalation, plan-review gate, merge gate all in [dispatch.md](dispatch.md).
+6. **Report final status.** On COMPLETE: `result: Hero complete — GH-NNN merged via PR #<N>, CI <status>.` On STOP: `result: Hero paused at <phase> — <reason>. Resume: /ralph:hero NNN`.
 
 ## --mode classify
 
-Director-only mode: classify one issue and dispatch the correct verb. Does NOT implement work. Useful for iOS shortcuts and manual override paths. Full taxonomy in [event-classes.md](event-classes.md).
+Director-only mode: classify one event, dispatch the correct verb, stop. Full taxonomy in [event-classes.md](event-classes.md).
 
-### Step 1: Parse arguments + detect input source
-
-Parse `$ARGUMENTS` for `--issue NNN`.
-
-- If present → set `TARGET_ISSUE=NNN`, skip to Step 2b.
-- If a `RemoteTrigger` tool input is present (deprecated — see [event-classes.md](event-classes.md) §iOS-mode sentinel) → extract `issue_number` + `team`, set `TARGET_ISSUE` + `FORCED_TEAM` + `DISPATCH_REASON=RemoteTrigger`, skip to Step 4.
-- Otherwise → Step 2a.
-
-### Step 2a: Read next_actions
-
-Call `next_actions({})`. If queue empty: emit `result: Queue empty. No events to dispatch.` and STOP.
-
-Pick the top-ranked direction. Resolve `TARGET_ISSUE` per [event-classes.md](event-classes.md) (kind rules — `issue`/`tree-continue`/`lock-stale`/`human-needed-unblock` use `direction.issue.number`; `pr` uses `direction.signals.linkedIssueNumber`).
-
-### Step 2b: Fetch issue
-
-`get_issue({ number: TARGET_ISSUE })`. Store `ISSUE_WORKFLOW_STATE`, `ISSUE_LABELS[]`.
-
-### Step 3: Classify via taxonomy
-
-Read [event-classes.md](event-classes.md). Apply priority order: `trigger:*` labels → automation labels → workflow_state fallback. Set `TEAM`, `ENTRYPOINT`, `DISPATCH_REASON`, `CONSUMED_LABEL`.
-
-### Step 4: Dispatch via Skill()
-
-iOS-mode sentinel: if `DISPATCH_REASON` starts with `trigger:` OR equals `RemoteTrigger`, write the sentinel before dispatch:
-
-```bash
-touch "${TMPDIR:-/tmp}/ralph-ios-mode"
-```
-
-Workflow_state-driven dispatches (Priority 3) do NOT write the sentinel — only Priority 1 (`trigger:*`) and `RemoteTrigger` paths do.
-
-If entrypoint exists: `Skill(ENTRYPOINT, args="NNN")` and emit `Classified #NNN as <team> (reason: <DISPATCH_REASON>). Dispatching <entrypoint>.`
-
-If entrypoint does not exist (memorykeepers): emit `needs input: team <name> not yet implemented; skipping dispatch.`
-
-### Step 5: Consume trigger:* label (if applicable)
-
-If `CONSUMED_LABEL` is set: `save_issue({ number: TARGET_ISSUE, labels: ISSUE_LABELS minus CONSUMED_LABEL })`. Automation labels (`watcher-auto`, `debug-auto`, `scout-auto`, `process-improvement`) are NOT consumed — their producers manage their own lifecycle. `RemoteTrigger`-sourced events: no label to consume; skip.
-
-### Step 6: Emit result marker
-
-```
-result: Dispatched #NNN to <team> via <entrypoint>. (reason: <DISPATCH_REASON>)
-```
-
-Or, if no dispatch was made (unimplemented team):
-
-```
-result: #NNN classified as <team> (reason: <DISPATCH_REASON>). No dispatch — team not yet implemented.
-```
+1. **Parse + detect input source.** `--issue NNN` → `TARGET_ISSUE=NNN`, skip to step 3. `RemoteTrigger` tool input (deprecated) → extract `issue_number`+`team`, set `DISPATCH_REASON=RemoteTrigger`, skip to step 4. Otherwise → step 2.
+2. **Read `next_actions({})`.** Empty queue → emit `result: Queue empty. No events to dispatch.` STOP. Pick top-ranked direction; resolve `TARGET_ISSUE` per [event-classes.md](event-classes.md) (kind rules).
+3. **Fetch + classify.** `get_issue({ number: TARGET_ISSUE })`. Apply [event-classes.md](event-classes.md) priority order: `trigger:*` labels → automation labels → `workflow_state`. Set `TEAM`, `ENTRYPOINT`, `DISPATCH_REASON`, `CONSUMED_LABEL`.
+4. **Dispatch.** If `DISPATCH_REASON` matches `trigger:*` or `RemoteTrigger`, write iOS-mode sentinel: `touch "${TMPDIR:-/tmp}/ralph-ios-mode"`. Then `Skill(ENTRYPOINT, args="NNN")`. Unimplemented team (memorykeepers) → emit `needs input: team <name> not yet implemented; skipping dispatch.`
+5. **Consume label.** If `CONSUMED_LABEL` set: `save_issue({ number: TARGET_ISSUE, labels: ISSUE_LABELS minus CONSUMED_LABEL })`. Automation labels and `RemoteTrigger` paths skip this step.
+6. **Emit result marker:** `result: Dispatched #NNN to <team> via <entrypoint>. (reason: <DISPATCH_REASON>)`.
 
 ## --mode auto
 
-(Phase 4 — filled in next.)
+Autonomous backlog drain via `/loop` dynamic mode. Opt-in enforced by `autopilot-enable-gate.sh` — if `RALPH_AUTOPILOT_ENABLE != true`, the `Skill("loop", …)` call exits 2 with a deterministic message.
+
+```
+Skill("loop", args="Run /ralph:hero --mode classify on the next-most-important event on the project queue. Classify reads next_actions, picks the top-ranked event, handles trigger:<team> label consumption, and dispatches the right team.
+
+Continuation rule (LOAD-BEARING — enforced by autopilot-stop-gate.sh):
+  • classify emits 'result: Queue empty'  → end the loop, do NOT call ScheduleWakeup.
+  • classify emits ANY OTHER result line  → you MUST call ScheduleWakeup before returning.
+
+Pick delays:
+  • 60-270s when classify made forward progress (stays in prompt cache)
+  • 1200-1800s when the queue has only stuck or in-review items
+  • NEVER 300s (rejected by autopilot-wakeup-clear.sh — cache-window anti-pattern)
+
+Trust classify's decisions. Human Needed issues are filtered out automatically — run /ralph:caretake --mode unblock in a separate loop to drain them.")
+```
+
+Do not maintain your own iteration counter or termination gate — `/loop` and `--mode classify` own that. Cancel via `/tasks` → delete pending wakeup.
 
 ## --mode watch
 
-(Phase 5 — filled in next.)
+Watcher team entrypoint. Full dispatch table + SOUL refusal preconditions + heartbeat shape in [watch-dispatch.md](watch-dispatch.md).
+
+```bash
+# Argument parse: --issue NNN or bare NNN → direct mode; no arg → heartbeat mode
+case "$ARGUMENTS" in
+  --issue\ [0-9]*|[0-9]*) WATCH_MODE=direct  ;;
+  *)                      WATCH_MODE=heartbeat ;;
+esac
+```
+
+- **Direct (`--issue NNN` or bare number):** fetch issue → SOUL refusal preconditions ([watch-dispatch.md](watch-dispatch.md) §SOUL refusal) → dispatch table first-match-wins ([watch-dispatch.md](watch-dispatch.md) §Dispatch table) → sre-fixit pre-check if applicable → emit terminal result line.
+- **Heartbeat (no arg):** follow [watch-dispatch.md](watch-dispatch.md) §Heartbeat mode. Bounded loop — only processes issues from the initial `list_issues` call.
 
 ## --mode pr-drain
 
-(Phase 6 — filled in next.)
+Drain a pull request that `--mode classify` cannot dispatch (Dependabot bumps, stale unlinked PRs). Full rules, per-class actions, audit trail, and synth-issue threading in [pr-drain.md](pr-drain.md).
+
+1. **Parse + idempotency.** Require `--pr <N>` (else `needs input:`). Check the `pr-drained` label via `gh pr view` — if present, emit `result: PR #<N> already drained. Skipping.` STOP.
+2. **Fetch PR** via `gh pr view <N> --json number,url,title,author,statusCheckRollup,mergeable,headRefName,createdAt,updatedAt,body,state,mergedAt`. Skip if PR no longer accessible or already MERGED/CLOSED.
+3. **Classify** per [pr-drain.md](pr-drain.md) §Classification. The pre-classification guard exits early if CI is still pending.
+4. **Create-or-reuse synth issue** per [pr-drain.md](pr-drain.md) §Synthetic Ralph issue. Synth is created BEFORE PR mutation.
+5. **Act per CLASS** per [pr-drain.md](pr-drain.md) §Per-class actions. Set `FINAL_CLASS`, `REVIEW_VERDICT`.
+6. **Audit trail** per [pr-drain.md](pr-drain.md) §Audit trail. Skip entirely for `needs-human` class.
+7. **Advance synth + record outcome** per [pr-drain.md](pr-drain.md) §Synth advance + outcome record.
+8. **Emit result marker** per [pr-drain.md](pr-drain.md) §Result marker.
 
 ## Notes
 
-- **`RALPH_SUBCOMMAND` is set at Step 0**, once. Hooks discriminate against it to no-op when a different mode is active. SessionStart only sets `RALPH_COMMAND=hero`, which guards all hero-prefixed hooks.
-- **Old `/ralph-hero:*` orchestrator skills remain functional** until Plan 10 sunset. Both paths can run side-by-side during the parallel period.
+`RALPH_SUBCOMMAND` is set once at Step 0. Hooks discriminate against it to no-op when a different mode is active. Old `/ralph-hero:*` orchestrator skills remain functional until Plan 10 sunset; both paths can run side-by-side.

--- a/ralph/skills/hero/dispatch.md
+++ b/ralph/skills/hero/dispatch.md
@@ -1,0 +1,133 @@
+# Hero Dispatch Contract
+
+> Consulted by `/ralph:hero` default mode Step 3 (execution loop) and `--mode classify` (single dispatch). Maps each phase to the verb that runs it.
+
+## Phase → verb mapping
+
+| Phase | Verb | Args |
+|---|---|---|
+| SPLIT | `/ralph:caretake --mode split` | `#NNN` |
+| RESEARCH | `/ralph:research --auto` | `NNN` (or `NNN --mode prove` for claim-checks) |
+| PLAN (XS/S/M) | `/ralph:plan --auto` | `NNN [--research-doc PATH]` |
+| PLAN (L/XL epic) | `/ralph:plan --auto --mode epic` | `NNN [--research-doc PATH]` |
+| REVIEW (plan) | `/ralph:review --mode plan` | `NNN [--plan-doc PATH]` |
+| IMPLEMENT | `/ralph:impl --auto` | `NNN [--plan-doc PATH]` |
+| PR | `/ralph:impl --mode pr` | `NNN` |
+| INTEGRATE | `/ralph:review` | `NNN` |
+
+All targets are skills in the same `ralph` plugin → unqualified names work in `Skill()` calls.
+
+## Skill() vs Agent()
+
+| Phase | Dispatch | Why |
+|---|---|---|
+| SPLIT, RESEARCH, PLAN, REVIEW (plan), INTEGRATE | `Skill("ralph:<verb>", args="NNN ...")` | Inline — these read/write durable state via MCP and need to share hero's context for resumability |
+| IMPLEMENT | `Skill("ralph:impl", args="NNN --auto --plan-doc PATH")` | The slim plugin uses `--auto` mode (one phase per invocation in an isolated worktree, enforced by `impl-worktree-gate.sh`). The runtime gates worktree isolation; hero does not need a separate Agent() session for this. |
+| PR (within IMPLEMENT) | `Skill("ralph:impl", args="NNN --mode pr")` | PR creation is `/ralph:impl --mode pr` — preserves the loop-runner sentinel `Queue empty.` and the queue-pick semantics from the source `ralph-pr` skill. |
+
+> Agent-based dispatch with `subagent_type=ralph-hero:impl-agent` still works against the old plugin's agent definitions in `plugin/ralph-hero/agents/` during the parallel period. The slim plugin prefers Skill() dispatch because it keeps the hero session in control of the resumability protocol. Plan 10 sunset will decide whether to relocate agent definitions into `ralph/agents/` or drop them in favor of pure Skill() dispatch.
+
+## Model selection (IMPLEMENT phase)
+
+Read `${RALPH_IMPL_MODEL:-sonnet}`. Default is sonnet; override via env or shell:
+
+```bash
+impl_model="${RALPH_IMPL_MODEL:-sonnet}"
+```
+
+Pass the resolved model explicitly to dispatched verbs that respect it. See [`docs/model-tier-policy.md`](../../../plugin/ralph-hero/docs/model-tier-policy.md) for the complexity-driven tier policy.
+
+## BLOCKED escalation
+
+After `/ralph:impl --auto` returns, inspect the terminal verdict. If it contains the prefix `IMPL BLOCKED ` (full format: `IMPL BLOCKED model=<x> needs=opus reason=<short>` — match on the prefix, not the full string, so detection cannot drift from the emitted format):
+
+1. If this dispatch's model was NOT opus AND no prior opus retry has occurred for this issue:
+   re-dispatch the same issue with `RALPH_IMPL_MODEL=opus`:
+   ```
+   Skill("ralph:impl", args="NNN --auto --plan-doc PATH (retry after BLOCKED)")
+   ```
+   Track a per-issue retry counter in TaskList metadata so a second BLOCKED at opus does not loop.
+2. If this dispatch's model was opus, OR the retry counter is already 1:
+   escalate via `save_issue(workflowState="__ESCALATE__", command="ralph_impl")` to Human Needed. Fire a best-effort push notification:
+   ```
+   PushNotification(title="Failed #NNN", body="<blocked-reason> — <issue-url>")
+   ```
+   STOP the hero loop and report the BLOCKED reason.
+
+Contract: at most ONE re-dispatch at the higher tier. A double-BLOCKED is a real escalation, not a model-tier issue.
+
+## Plan review gate
+
+After all plans complete, read `$RALPH_REVIEW_PLAN` (default `auto`):
+
+**`auto`:**
+
+Dispatch `Skill("ralph:review", args="NNN --mode plan --plan-doc PATH")` for each plan. Route on verdict:
+
+- **ALL APPROVED** → batch update all issues in the group to "In Progress", report plan locations, continue
+- **NEEDS_ITERATION** → return critique to `/ralph:plan`, re-dispatch, re-review. Max 2 iterations before escalating
+- **ESCALATE** → move issues to Human Needed, STOP with the critique
+
+**`interactive`:**
+
+Report planned groups with plan URLs and current state. All issues are in "Plan in Review".
+
+Use `AskUserQuestion`:
+- "Approve and implement" → batch update to "In Progress", continue
+- "Open plan in editor" → `open` / `xdg-open` the plan file, then re-present the picker
+- "Stop here" → mark gate task completed and STOP with plan URL + resume command
+
+## Merge gate
+
+After all PRs created, read `$RALPH_REVIEW_MODE` (default `interactive`):
+
+**`interactive`:** report PR URLs, STOP. Human must re-run `/ralph:hero NNN` or `/ralph:review NNN`.
+
+**`auto`:** dispatch `Skill("ralph:review", args="NNN")` per primary issue. `/ralph:review` owns code-review + merge mechanics (it's Plan 6's verb).
+
+## Error handling
+
+| Error | Action |
+|-------|--------|
+| Split failure | Report which issue failed, preserve other results, STOP |
+| Research failure | Report failure, other parallel research continues, STOP at convergence |
+| Implementation failure | STOP immediately, preserve worktree, do NOT continue |
+| Circular dependencies | Report the cycle, suggest manual cleanup, STOP |
+
+## Resumability
+
+Hero is resumable across context windows:
+
+1. `get_issue(includePipeline=true)` determines the current phase from GitHub state
+2. `TaskList()` restores progress from the session task list
+3. If TaskList is empty (new session): rebuild upfront task list from the current phase
+4. If TaskList has tasks: resume from the first pending unblocked task
+
+Re-run with `/ralph:hero <ROOT-NUMBER>`.
+
+## Cross-repo expansion
+
+When the root issue spans repos (detected during research or from issue body):
+
+1. **Check for matching pattern:** look up the issue's repos against `.ralph-repos.yml` patterns.
+2. **Invoke `decompose_feature` directly** (hero has the MCP tool):
+   ```
+   ralph_hero__decompose_feature({
+     title: <root issue title>,
+     description: <root body + research summary>,
+     pattern: <matched pattern name>,
+     dryRun: true
+   })
+   ```
+3. **Review proposal**, then re-call with `dryRun: false`. The tool wires sub-issues + dependencies on the project board.
+4. **Update task list:** add created sub-issues as tasks with `blockedBy` chains matching the pattern's `dependency-flow`. Independent repos get no `blockedBy` — they run in parallel.
+
+### Evidence-based dependency detection
+
+During tree expansion, if research found imports between repos not declared in the registry (e.g., `import { X } from 'ralph-hero'` in landcrawler-ai):
+
+- Treat repos as dependent (add `blockedBy` to the downstream sub-issue)
+- Surface to the human: "I found imports from ralph-hero in landcrawler-ai. Your registry doesn't declare this dependency — want me to add it?"
+- If human confirms, suggest adding a `dependency-flow` edge to the pattern
+
+Default for unknown relationships: if no evidence of dependency is found and no `dependency-flow` edge exists, treat repos as independent and run in parallel.

--- a/ralph/skills/hero/event-classes.md
+++ b/ralph/skills/hero/event-classes.md
@@ -1,0 +1,95 @@
+# Director Event Classification Taxonomy
+
+This file is the **canonical schema** for Director's event classifier. The classifier performs a lookup against this table to determine which team handles a given issue. Entries are evaluated in the order listed — `trigger:*` labels take highest priority, automation labels come next, and `workflow_state` matches are the fallback.
+
+**Extending this taxonomy**: Features D and F will add new rows here via PR. Each row is independent; adding a new event class requires only appending a row to the appropriate section and updating the notes column to identify the producer. No changes to Director's classifier logic are required — the lookup is table-driven.
+
+---
+
+## Priority 1 — Explicit trigger labels (highest priority)
+
+These labels are placed manually (by human or iOS remote-control shortcut) or by external event shims. A `trigger:<team>` label on any issue causes Director to dispatch that team regardless of workflow state. The label is consumed (removed) after dispatch.
+
+| workflow_state | labels | team | notes |
+|----------------|--------|------|-------|
+| any | `trigger:builders` | builders | Manual override: force builder dispatch. Hero handles the issue. |
+| any | `trigger:watch` | watchers | Manual override: force watcher dispatch. Feature C ships `ralph:hero --mode watch`. |
+| any | `trigger:scouts` | scouts | Manual override: force scout dispatch. Routes to `/ralph-hero:scouts --issue NNN`. |
+| any | `trigger:caretake` | caretakers | Manual override: force caretaker dispatch. Feature G ships `ralph:caretake`. |
+| any | `trigger:memorykeepers` | memorykeepers | Manual override: force memorykeeper dispatch. No skill yet; Director emits `needs input:` marker. |
+
+## Priority 2 — Automation labels (label exists, producer pending until noted)
+
+These labels are written by automated producers (event shims, dream-loop classifier, monitoring bridges). They signal that a specific team should handle the issue without requiring a manual trigger.
+
+| workflow_state | labels | team | notes |
+|----------------|--------|------|-------|
+| any | `watcher-auto` | watchers | Label written by Cloud Monitoring → board bridge (`plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py`). Feature C ships the `ralph:hero --mode watch` entrypoint. |
+| any | `debug-auto` | watchers | Label written by `ralph-debug-collate` (invoked from Watcher heartbeat). Observability follow-ups are owned by watchers. |
+| any | `scout-auto` | scouts | Label written by `.github/workflows/playwright-auto.yml` (per-PR) and `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` (nightly batch). Routes to `/ralph-hero:scouts`. |
+| any | `process-improvement` | caretakers | Label written by dream-loop cluster classifier (`scripts/dream/reflect.py::emit_process_improvement_issue`). Feature G ships `ralph:caretake`. |
+
+## Priority 3 — Workflow state (fallback routing)
+
+When no trigger or automation labels are present, Director routes by workflow state.
+
+| workflow_state | labels | team | notes |
+|----------------|--------|------|-------|
+| `Backlog` | none | caretakers | New issues need triage. Caretakers handle intake and routing. Feature G ships `ralph:caretake`; until then Director emits `needs input:` marker. |
+| `Research Needed` | none | builders | Issue is queued for research. Hero handles the full analyst → builder pipeline. |
+| `Research in Progress` | none | builders | Research is underway. Hero manages continuation. |
+| `Ready for Plan` | none | builders | Research complete; issue needs a plan. Hero handles planning. |
+| `Plan in Progress` | none | builders | Planning is underway. Hero manages continuation. |
+| `Plan in Review` | none | builders | Plan needs review. Hero handles the review gate. |
+| `In Progress` | none | builders | Active implementation. Hero orchestrates impl-agent. |
+| `In Review` | none | builders | PR open, awaiting review. Hero manages the merge gate. |
+| `Human Needed` | none | caretakers | Issue is blocked and needs human attention. Caretakers handle the unblock flow. Feature G ships `ralph:caretake`; until then Director emits `needs input:` marker. |
+| `Done` | none | — | Terminal state. Director skips — no dispatch needed. |
+| `Canceled` | none | — | Terminal state. Director skips — no dispatch needed. |
+
+---
+
+## Team → entrypoint mapping
+
+| team | skill entrypoint | status |
+|------|-----------------|--------|
+| builders | `ralph:hero` | live |
+| watchers | `ralph:hero --mode watch` | pending Feature C (GH-1270) |
+| scouts | `ralph-hero:scouts` | live |
+| memorykeepers | manual `dream-now` | no skill yet; Director emits `needs input:` |
+| caretakers | `ralph:caretake` | pending Feature G (GH-1274) |
+
+---
+
+## Classification algorithm (for implementors)
+
+Director evaluates in this order:
+
+1. Fetch the candidate issue's labels array.
+2. Check for any `trigger:*` label (Priority 1). First match wins.
+3. Check for any automation label: `watcher-auto`, `debug-auto`, `scout-auto`, `process-improvement` (Priority 2). First match wins.
+4. Fall through to `workflow_state` lookup (Priority 3).
+5. If the resolved team's entrypoint does not yet exist, emit `needs input: team <name> not yet implemented (Feature <X>); skipping dispatch` and continue to the next event.
+
+---
+
+## iOS-mode sentinel (Feature H contract)
+
+Director writes the sentinel file `${TMPDIR:-/tmp}/ralph-ios-mode` immediately before `Skill()` dispatch when `DISPATCH_REASON` matches `trigger:*` or `RemoteTrigger`. Downstream producers (`ralph-pr`, `ralph-postmortem`, scout-nightly, `ralph-merge`) test for this file to decide whether `--push-drive` and ntfy completion hooks default ON.
+
+The legacy `RALPH_IOS_MODE=1` env var is also honored as a manual operator override (e.g., for desk-mode forced pushes during testing). If either the sentinel file OR `RALPH_IOS_MODE=1` is set, producers treat iOS-mode as active.
+
+Priority 3 (workflow_state-driven) dispatches do NOT write the sentinel — only Priority 1 (`trigger:*`) and `RemoteTrigger` paths do. The sentinel persists until `$TMPDIR` rotation or session end; no explicit cleanup is required.
+
+---
+
+## Producers
+
+This table is the canonical inventory of automated label producers as of Feature D (GH-1271). New producers should add a row here when they land.
+
+| Label | Producer file | Trigger condition |
+|-------|---------------|-------------------|
+| `watcher-auto` | `plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py` | GCP Cloud Monitoring alert delivered to the configured Pub/Sub subscription |
+| `debug-auto` | `plugin/ralph-hero/skills/ralph-debug-collate/SKILL.md` (invoked from Watcher heartbeat) | Langfuse error grouping with ≥ N occurrences in window (default: 3) |
+| `process-improvement` | `scripts/dream/reflect.py::emit_process_improvement_issue` | Dream-loop cluster of size ≥ threshold (default: 5) with ≥ N% `tool_use_error` or `verdict: BLOCKED` signals (default: 30%) |
+| `scout-auto` | `.github/workflows/playwright-auto.yml` (per-PR) and `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` (nightly batch) | PR opened/synchronized/reopened with UI-touching changes; nightly schedule |

--- a/ralph/skills/hero/pr-drain.md
+++ b/ralph/skills/hero/pr-drain.md
@@ -1,0 +1,225 @@
+# PR-Drain Mode
+
+> Consulted by `/ralph:hero --mode pr-drain`. Defines PR classification rules, per-class actions, audit trail, and synth-issue threading.
+
+## Classification (in priority order)
+
+Date math is portable across macOS and Linux via Python 3 (no `date -d`, which is GNU-only):
+
+```bash
+DAYS_OLD=$(python3 -c "from datetime import datetime, timezone; print(int((datetime.now(timezone.utc) - datetime.fromisoformat('$updatedAt'.replace('Z','+00:00'))).total_seconds() / 86400))")
+```
+
+### Pre-classification guard — CI still running
+
+Before classifying, check `PR_JSON.statusCheckRollup`. If any element has `conclusion` (or `state`) in `[PENDING, IN_PROGRESS, QUEUED]` AND no element is `FAILURE`/`ERROR`/`CANCELLED`, CI is still running. Exit the mode immediately without creating a synth issue, posting a comment, or applying the `pr-drained` label — the next routine fire will reclassify when CI reaches a terminal state. Emit:
+
+```
+result: PR #<N> CI still pending — will reclassify on next fire.
+```
+
+This is the only path that leaves the PR unlabeled on purpose. All terminal classifications below either apply `pr-drained` (success) or skip it intentionally (`needs-human`, `merge-failed`).
+
+### Classification (CI is terminal — all checks have a non-pending conclusion)
+
+1. **`dependabot-auto-merge` candidate** — all of:
+   - `PR_JSON.author.login == "app/dependabot"`
+   - Title parses as a patch or minor version bump. The Dependabot convention is `Bump <pkg> from X.Y.Z to A.B.C`. Compute the bump type:
+     - `X != A` → major
+     - `Y != B` → minor
+     - otherwise → patch
+     - Match only patch or minor.
+   - Every `statusCheckRollup` element has `conclusion`/`state` in `[SUCCESS, SKIPPED, NEUTRAL]`. Any `FAILURE`/`ERROR`/`CANCELLED` → fall through to `dependabot-needs-review`.
+2. **`dependabot-needs-review`** — `author == "app/dependabot"` AND any of: bump is major, title doesn't parse as a version bump, or any CI check failed/errored/cancelled. (PENDING is handled by the pre-classification guard.)
+3. **`stale-close`** — `DAYS_OLD > 30`.
+4. **`stale-ping`** — `DAYS_OLD > 14`.
+5. **`needs-human`** — default.
+
+## Per-class actions
+
+### dependabot-auto-merge candidate
+
+Run code review as the merge gate:
+
+```
+Skill("code-review:code-review", "<N>")
+```
+
+The code-review skill does NOT return a verdict directly — it posts a comment. Fetch the most recent code-review comment:
+
+```bash
+COMMENT=$(gh pr view <N> --comments --json comments --jq '.comments | map(select(.body | startswith("### Code review"))) | last.body // ""')
+```
+
+Verdict classification:
+
+- Empty `COMMENT` → code-review opted out (Haiku eligibility agent treats Dependabot/automated PRs as not needing review). Trust signal → **GREEN**.
+- Contains `No issues found` → **GREEN**.
+- Contains `Found` and `issues:` → **MUST_FIX**.
+- Otherwise → **review-error** (unparseable shape).
+
+**If GREEN:**
+
+```bash
+gh pr merge <N> --squash --auto
+MERGE_RC=$?
+```
+
+Set `FINAL_CLASS=dependabot-auto-merge`, `REVIEW_VERDICT=GREEN`. Carry `MERGE_RC` to the audit trail step.
+
+**If MUST_FIX:**
+
+Single-quoted heredoc (body is fully static):
+
+```bash
+gh pr comment <N> --body-file - <<'BODY_EOF'
+## Code Review — MUST_FIX
+
+/ralph:hero --mode pr-drain ran code-review:code-review as the auto-merge gate. Review flagged issues; holding for human review. See the code-review comment posted above for findings.
+BODY_EOF
+```
+
+Set `FINAL_CLASS=dependabot-review-flagged`, `REVIEW_VERDICT=MUST_FIX`. Do NOT merge.
+
+**If review-error:**
+
+```bash
+gh pr comment <N> --body-file - <<'BODY_EOF'
+## Code Review — error
+
+/ralph:hero --mode pr-drain tried to run code-review:code-review as the auto-merge gate but the verdict shape was not parseable. Holding for human review.
+BODY_EOF
+```
+
+Set `FINAL_CLASS=review-error`, `REVIEW_VERDICT=n/a`. Do NOT merge.
+
+### dependabot-needs-review
+
+Run code review anyway (head start for the human), but do not merge:
+
+```
+Skill("code-review:code-review", "<N>")
+```
+
+Then post a routing comment pointing at the code-review findings:
+
+```bash
+gh pr comment <N> --body-file - <<'BODY_EOF'
+## Major version bump — needs human review
+
+/ralph:hero --mode pr-drain classified this as a Dependabot bump that needs human review (major bump, unparseable version, or non-passing CI). The code-review skill ran above; see its comment for findings.
+BODY_EOF
+```
+
+Set `FINAL_CLASS=dependabot-needs-review`. Parse the code-review comment with the same logic as the auto-merge branch to capture `REVIEW_VERDICT` (`GREEN` / `MUST_FIX` / `n/a`). Informational — we don't merge either way.
+
+### stale-close
+
+```bash
+gh pr close <N> --comment "Closing as stale: this PR has had no activity in 30+ days. Reopen if still relevant."
+```
+
+Set `FINAL_CLASS=stale-close`, `REVIEW_VERDICT=n/a`.
+
+### stale-ping
+
+Bind the author login first; use an unquoted heredoc so `${AUTHOR_LOGIN}` interpolates:
+
+```bash
+AUTHOR_LOGIN=$(printf '%s' "$PR_JSON" | jq -r '.author.login')
+gh pr comment <N> --body-file - <<BODY_EOF
+This PR has been open >14 days with no activity. @${AUTHOR_LOGIN} — is this still active? If not, /ralph:hero --mode pr-drain will close it in another ~16 days.
+BODY_EOF
+```
+
+Set `FINAL_CLASS=stale-ping`, `REVIEW_VERDICT=n/a`.
+
+### needs-human
+
+Emit:
+
+```
+needs input: PR #<N> shape unrecognized by /ralph:hero --mode pr-drain — manual triage required. Author: <author>, headRef: <headRefName>, title: <title>.
+```
+
+Do NOT post audit comment and do NOT add the `pr-drained` label. Skip the audit step, proceed directly to synth advance (advance to Human Needed).
+
+## Synthetic Ralph issue
+
+Reuse-or-create one per PR. Listing first:
+
+```
+ralph_hero__list_issues({ label: "kind:pr-drain", state: "OPEN", limit: 50 })
+```
+
+Scan titles for `PR #<N>`. If match, set `SYNTH_NUMBER` and advance to In Progress (skip create). Otherwise create:
+
+```
+ralph_hero__create_issue({
+  title: "Drain: PR #<N> — <PR title>",
+  labels: ["pr-drain", "kind:pr-drain"],
+  workflowState: "In Progress",
+  body: "Auto-created by /ralph:hero --mode pr-drain.\n\nClassification: <CLASS>\nPR: <URL>\nAuthor: <login>\nHead ref: <ref>"
+})
+```
+
+Threading invariant: synth issue created BEFORE PR mutation so a partial-completion failure leaves a queryable board artifact.
+
+## Audit trail (non-`needs-human` classes only)
+
+Determine success deterministically via the captured `MERGE_RC` (or equivalent for non-merge actions). If `MERGE_RC != 0` and stderr is not "already merged":
+
+```bash
+printf '## PR Drain — merge failed\n\n/ralph:hero --mode pr-drain attempted to act on this PR but the operation failed. Holding for human review.\n\nSynthetic issue: #%s\nClassification: %s\nError: %s\n' \
+  "$SYNTH_NUMBER" "$CLASS" "$STDERR" | gh pr comment <N> --body-file -
+```
+
+Set `FINAL_CLASS=merge-failed`, advance synth to Human Needed, do NOT label `pr-drained`.
+
+Otherwise, post success audit:
+
+```bash
+printf '## PR Drain\n\n/ralph:hero --mode pr-drain processed this PR.\n\n- Classification: %s\n- Synthetic issue: #%s\n- Review verdict: %s\n' \
+  "$FINAL_CLASS" "$SYNTH_NUMBER" "$REVIEW_VERDICT" | gh pr comment <N> --body-file -
+gh pr edit <N> --add-label pr-drained
+```
+
+## Synth advance + outcome record
+
+Terminal-success classes (`dependabot-auto-merge`, `dependabot-needs-review`, `dependabot-review-flagged`, `review-error`, `stale-close`, `stale-ping`):
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "Done" })
+```
+
+Terminal-handoff (`needs-human`, `merge-failed`):
+
+```
+ralph_hero__save_issue({ number: SYNTH_NUMBER, workflowState: "Human Needed" })
+```
+
+Record outcome:
+
+```
+knowledge_record_outcome({
+  event_type: "pr_drain",
+  issue_number: SYNTH_NUMBER,
+  verdict: FINAL_CLASS,
+  payload: { pr: <N>, review_verdict: REVIEW_VERDICT, author: <login> }
+})
+```
+
+## Result marker
+
+```
+result: Drained PR #<N> (class: <FINAL_CLASS>, synthetic issue: #<SYNTH_NUMBER>)
+```
+
+## Constraints (preserved verbatim from source)
+
+- MUST NOT add the `pr-drained` label until the Step-5 action has succeeded or been intentionally held (MUST_FIX / dependabot-needs-review). A failed merge MUST NOT be labeled drained — the next routine fire must retry.
+- MUST exit early without labeling, commenting, or creating a synth issue when CI is still pending (any check `PENDING`/`IN_PROGRESS`/`QUEUED` AND no terminal failure).
+- MUST create the synthetic issue BEFORE attempting any PR mutation.
+- Code review verdict is the merge gate — never bypass it for auto-merge candidates, even if CI is green.
+- Reuse the synthetic issue — do not create duplicates if the routine fires twice for the same PR before the first run completes.
+- Verdict detection is deterministic — parse the most recent `### Code review` comment. Empty comment (opt-out) is treated as GREEN.

--- a/ralph/skills/hero/state-machine.md
+++ b/ralph/skills/hero/state-machine.md
@@ -1,0 +1,80 @@
+# Hero State Machine
+
+> Consulted by `/ralph:hero` default mode. The skill body says *what phase to execute next*; this reference says *what each phase does* and *how convergence is detected*.
+
+## ASCII diagram
+
+```
++-------------------------------------------------------------------+
+|                     RALPH HERO STATE MACHINE                       |
++-------------------------------------------------------------------+
+|  START                                                             |
+|    |                                                               |
+|    v                                                               |
+|  ANALYZE ROOT                                                      |
+|    |                                                               |
+|    v                                                               |
+|  ANALYST PHASE                                                     |
+|    |- SPLIT (if M/L/XL) -- loop until all XS/S                    |
+|    |- RESEARCH (parallel) -- all "Research Needed" leaves          |
+|    | all "Ready for Plan"                                          |
+|    v                                                               |
+|  BUILDER PHASE                                                     |
+|    |- PLAN (per group) -- create implementation plans              |
+|    |- PLAN REVIEW GATE                                             |
+|    |   | plan review is "auto":                                    |
+|    |   |   /ralph:review --mode plan critiques plan                |
+|    |   |   APPROVED -> report plan location, advance, continue     |
+|    |   |   NEEDS_ITERATION -> return critique to /ralph:plan        |
+|    |   |   ESCALATE -> move to Human Needed, STOP                  |
+|    |   | plan review is "interactive":                              |
+|    |   |   report plan location, ask human for approval            |
+|    |   |   APPROVED -> advance, continue                           |
+|    |   |   REJECTED -> STOP                                        |
+|    |- IMPLEMENT (sequential) -- execute plan phases                |
+|    |- PR (per issue)                                               |
+|    v                                                               |
+|  MERGE GATE                                                        |
+|    | merge review is "interactive" (default):                      |
+|    |   report PR URLs, STOP -- human must request merge            |
+|    | merge review is "auto":                                       |
+|    |   proceed to /ralph:review (validate, merge, CI watch)        |
+|    v                                                               |
+|  INTEGRATOR PHASE                                                  |
+|    |- /ralph:review GH-[PRIMARY] (validate, merge, CI watch)       |
+|    v                                                               |
+|  COMPLETE                                                          |
++-------------------------------------------------------------------+
+```
+
+## Phases
+
+| Phase | MCP `phase` value | What it does |
+|---|---|---|
+| START | (none) | Entry point — call `get_issue(includePipeline=true)` and read `phase` |
+| SPLIT | `SPLIT` | One or more M/L/XL issues need decomposition. Dispatch `/ralph:caretake --mode split #NNN` per issue. After all complete, re-detect. |
+| RESEARCH | `RESEARCH` | All "Research Needed" leaves run in parallel via `/ralph:research --auto NNN` |
+| PLAN | `PLAN` | After research converges, plan per primary issue via `/ralph:plan --auto NNN [--research-doc PATH]` |
+| REVIEW | `REVIEW` | Plan-review gate. When `RALPH_REVIEW_PLAN=auto`, dispatch `/ralph:review --mode plan NNN`. When `interactive`, surface AskUserQuestion picker. |
+| HUMAN_GATE | `HUMAN_GATE` | Issue is in Human Needed. STOP and report blocker. Do not auto-dispatch unblock — that's caretake's job. |
+| IMPLEMENT | `IMPLEMENT` | Dispatch `/ralph:impl --auto NNN [--plan-doc PATH]` (one issue at a time, respecting `blockedBy` chains) |
+| INTEGRATE | `INTEGRATE` | PR + merge. PR via `/ralph:impl --mode pr NNN`; merge gate via `/ralph:review NNN` (default mode = code-review + merge). |
+| COMPLETE | `COMPLETE` | All issues in Done. Report final status. |
+| TERMINAL | `TERMINAL` | Issue is Canceled or otherwise dead. Skip. |
+
+## Convergence rules
+
+- **SPLIT → RESEARCH**: All issues in the group have `estimate ∈ {XS, S}`.
+- **RESEARCH → PLAN**: All issues have `workflowState == "Ready for Plan"`.
+- **PLAN → REVIEW**: All issues have `workflowState == "Plan in Review"` AND have a plan doc linked.
+- **REVIEW → IMPLEMENT**: All issues have `workflowState == "In Progress"` (review-agent approved).
+- **IMPLEMENT → INTEGRATE**: All issues have `workflowState == "In Review"` (PR open).
+- **INTEGRATE → COMPLETE**: All issues have `workflowState == "Done"` AND PRs merged AND CI green.
+
+Hero does NOT recompute these — it trusts the `phase` field from `get_issue(includePipeline=true)`.
+
+## Why this design
+
+- **GitHub IS the tree.** Convergence is detected from project field state, not a sidecar data structure.
+- **Single source of truth.** The MCP server owns the state machine; hero is a consumer.
+- **Phase-driven dispatch.** Each phase has one verb to call. No conditional verb selection beyond the `phase` field.

--- a/ralph/skills/hero/task-graph.md
+++ b/ralph/skills/hero/task-graph.md
@@ -1,0 +1,100 @@
+# Hero Task Graph
+
+> Consulted by `/ralph:hero` default mode Step 2. Defines the upfront `TaskCreate` + `addBlockedBy` shape per starting phase.
+
+## Resumability check (Step 1.5 in default mode)
+
+Before creating tasks, call `TaskList()`. If tasks already exist for this session and match the pipeline shape (subjects start with "Research GH-" / "Plan group GH-" / etc.), SKIP task creation and resume from the Execution Loop.
+
+## Task graph by starting phase
+
+**Starting from SPLIT:**
+
+```
+T-1..K: Split GH-NNN (for each M/L/XL issue)  → unblocked
+  After splits complete, re-detect pipeline position and rebuild task list for remaining phases.
+```
+
+**Starting from RESEARCH:**
+
+```
+T-1..N: Research GH-AAA … GH-ZZZ              → unblocked (parallel)
+T-N+1:  Plan group GH-[PRIMARY]               → blockedBy: [all research task IDs]
+T-N+2:  Review plan GH-[PRIMARY] (if auto)     → blockedBy: [plan task]
+    OR  Human gate (if interactive)            → blockedBy: [plan task]
+T-N+3..M: Implement GH-AAA … GH-ZZZ           → blockedBy: [review/gate task], each impl blockedBy prior impl
+T-M+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-M+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+**Starting from PLAN:**
+
+```
+T-1:  Plan group GH-[PRIMARY]                 → unblocked
+T-2:  Review plan GH-[PRIMARY] (if auto)       → blockedBy: [plan task]
+   OR Human gate (if interactive)              → blockedBy: [plan task]
+T-3..N: Implement GH-AAA … GH-ZZZ             → blockedBy: [review/gate task], each impl blockedBy prior impl
+T-N+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-N+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+**Starting from REVIEW/HUMAN_GATE:**
+
+```
+T-1:  Review plan / Human gate                → unblocked
+T-2..N: Implement GH-AAA … GH-ZZZ             → blockedBy: [review/gate task], each impl blockedBy prior impl
+T-N+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-N+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+**Starting from IMPLEMENT:**
+
+```
+T-1..N: Implement GH-AAA … GH-ZZZ             → each impl blockedBy prior impl (first is unblocked)
+T-N+1:  Create PR GH-[PRIMARY]                → blockedBy: [last impl task]
+T-N+2:  Finish GH-[PRIMARY]                   → blockedBy: [PR task]
+```
+
+## Implementation task ordering (dependency-graph-aware)
+
+After all plans are written, read each plan's `## Phase N:` headings and their `- **depends_on**:` annotations.
+
+1. For each phase in each plan, create an implementation task.
+2. Set `blockedBy` chains from the plan's dependency graph:
+   - Phase 2 `depends_on: [phase-1]` → Phase 2 impl task `blockedBy` Phase 1 impl task.
+   - Phase 3 `depends_on: null` → Phase 3 impl task has no `blockedBy`, can run in parallel with Phase 1.
+3. If a plan has NO `depends_on` annotations on any phase, fall back to sequential `blockedBy` chains (the per-phase shape above).
+
+This replaces default sequential ordering with a graph-driven ordering that enables parallel dispatch of independent phases.
+
+## Task creation pattern (two-step)
+
+```
+taskId = TaskCreate(subject="Research GH-NNN", description="...", activeForm="Researching GH-NNN")
+TaskUpdate(taskId, addBlockedBy=[dependency_task_ids])
+```
+
+Include `metadata.issue_number` in each task's description for traceability.
+
+## Cross-repo task metadata
+
+When an issue spans repos (detected during research or split), include in each task's metadata:
+
+- `repos`: list of repo keys involved
+- `localDirs`: mapping of repo key → local directory path
+- `dependencyFlow`: dependency edges (if any)
+
+This metadata flows to builder sub-agents so they know which directories to work in.
+
+## Execution loop
+
+Loop until pipeline is complete:
+
+1. `TaskList()` → filter to `status=pending` AND `blockedBy=[]`
+2. If no pending unblocked tasks: check for `in_progress` tasks; if all are `completed`, STOP (pipeline complete)
+3. Dispatch unblocked tasks:
+   - **Multiple unblocked impl tasks**: dispatch as parallel `Agent()` calls in a single message (no inter-task deps — that's why they're all unblocked)
+   - **Single unblocked task**: dispatch one agent
+   - **Non-impl tasks** (research, plan, PR): use phase-specific dispatch from [dispatch.md](dispatch.md)
+4. `TaskUpdate(status="completed")` for each completed task
+5. Repeat from step 1

--- a/ralph/skills/hero/watch-dispatch.md
+++ b/ralph/skills/hero/watch-dispatch.md
@@ -1,0 +1,82 @@
+# Watch Mode Dispatch
+
+> Consulted by `/ralph:hero --mode watch`. Defines the dispatch table for routing watcher events to gcp-incident-triage / debug-collate / log-reader / sre-fixit, the SOUL refusal preconditions, and the heartbeat fan-out shape.
+
+## SOUL refusal preconditions
+
+Before dispatching any sub-skill or subagent, verify the issue body contains at least one of:
+
+- A trace ID matching `projects/[^/]+/traces/[a-f0-9]+`
+- A literal `gcloud logging read ...` snippet
+- A `<!-- gcp-policy: ... -->` marker (which implies an upstream alert source that gcp-incident-triage will query)
+
+If none present, post a `needs input:` comment and escalate to Human Needed:
+
+```
+needs input: issue #NNN has no trace ID and no LQL snippet. Provide a trace ID (projects/<proj>/traces/<id>) or a gcloud logging read query before /ralph:hero --mode watch can proceed.
+```
+
+## Dispatch table
+
+Inspect the fetched issue and route to the first matching row:
+
+| Condition | Action |
+|-----------|--------|
+| Issue body contains `<!-- gcp-policy: ... -->` marker | `Skill("gcp-incident-triage", "--issue NNN")` |
+| Issue body contains a `langfuse-trace:` URL | `Skill("ralph:caretake", "--mode debug --issue NNN")` |
+| Issue has label `watcher-investigate` | `Agent(subagent_type="ralph-hero:log-reader", prompt="Investigate issue #NNN: <title>. <body>")` |
+| Issue has label `watcher-remediate` AND proposed action matches the sre-fixit allowlist | `Agent(subagent_type="ralph-hero:sre-fixit", prompt="Remediate issue #NNN: <title>. <body>")` |
+| No row matches | Escalate to `Human Needed` with a `needs input:` comment explaining which marker or label is missing |
+
+Dispatch rows must not overlap. A single issue should match at most one row. Priority is top-to-bottom: gcp-policy wins over langfuse-trace wins over labels.
+
+## sre-fixit pre-check
+
+Before dispatching `sre-fixit`, confirm the requested kubectl action from the issue body matches one of:
+
+- `kubectl scale deployment <name> --replicas=<N>`
+- `kubectl drain node <name>`
+- `kubectl rollout restart deployment/<name>`
+- `kubectl delete pod <name>`
+
+If the requested action is not in the list, do NOT dispatch sre-fixit. Escalate directly to Human Needed.
+
+## Heartbeat mode (no --issue arg)
+
+1. Call `list_issues({ labels: ["watcher-auto", "watcher-investigate", "watcher-remediate"], workflowState: "Backlog" })`.
+2. If empty, emit `result: heartbeat: 0 alerts dispatched` and stop.
+3. For each issue, dispatch per the table above (sequential — avoids race conditions on shared board state).
+4. **Langfuse error collation:**
+   - Preflight: check `RALPH_DEBUG=true`. If unset, log `debug-collate skipped: RALPH_DEBUG unset` and continue to step 5 without failing the heartbeat.
+   - If `RALPH_DEBUG=true`, invoke: `Skill("ralph:caretake", "--mode debug --auto-confirm --since 24h --min-occurrences 3")`. Capture the count of filed issues from the result line.
+5. Emit:
+   ```
+   result: heartbeat: N alerts dispatched, M debug-collate issues filed
+   ```
+
+The heartbeat loop is bounded — it processes only the issues returned by the initial `list_issues` call. New issues that arrive during the run are picked up on the next heartbeat invocation.
+
+## Terminal handlers
+
+After each sub-skill or subagent dispatch completes, emit a terminal result line + outcome-recorder stub:
+
+**On success (sub-skill/agent returned a result):**
+
+```
+result: #NNN dispatched to <sub-skill> — outcome: <summary>
+# outcome-recorder(decision=watch-dispatched, result=<outcome>, trace_id=<id-if-known>)
+```
+
+**On escalation (no dispatch row matched or sre-fixit pre-check failed):**
+
+```
+result: #NNN escalated to Human Needed — no matching dispatch condition
+# outcome-recorder(decision=watch-escalated, result=human-needed, trace_id=<id-if-known>)
+```
+
+**On SOUL refusal (no trace ID or LQL snippet):**
+
+```
+result: #NNN blocked — SOUL refusal: no trace ID or LQL snippet present
+# outcome-recorder(decision=watch-refused, result=missing-evidence, trace_id=none)
+```

--- a/thoughts/shared/plans/2026-05-23-GH-1390-ralph-plan-8-hero.md
+++ b/thoughts/shared/plans/2026-05-23-GH-1390-ralph-plan-8-hero.md
@@ -1,0 +1,518 @@
+---
+date: 2026-05-23
+github_issue: 1390
+status: ready
+type: plan
+tags: [ralph, plugin-restructure, plan-8, orchestrator]
+spec_reference: thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+---
+
+# Plan 8: `/ralph:hero` — fold hero/team/autopilot/director/pr-drain/watch
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold five source orchestrator skills (`hero`, `autopilot`, `director`, `watch`, `ralph-pr-drain` — plus the deprecated `team` shell) into a single `/ralph:hero` verb with five modes: default (one-shot orchestrator), `--mode auto` (autopilot drain), `--mode classify` (director-only), `--mode watch` (watcher heartbeat), `--mode pr-drain` (PR drain). Spec row 8 in the plan-of-plans.
+
+**Architecture:** Top-level `ralph/skills/hero/SKILL.md` (≤200 lines) owns arg parsing + mode dispatch only. Each mode body uses flat-sibling references for its opinion content. Hooks own state-transition enforcement, autopilot opt-in gate, and the inverse-Stop sentinel pattern from `autopilot-stop-gate.sh`. Cross-verb dispatch targets `/ralph:research|plan|impl|review|caretake` (all live).
+
+**Tech Stack:** Bash, Markdown, Claude Code skill loader + hooks, cross-plugin MCP (`mcp__plugin_ralph-hero_ralph-github__*`), `Skill()` / `Agent()` dispatch, `ScheduleWakeup` for `/loop` wakeup cadence.
+
+**Spec reference:** [`thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md`](../research/2026-05-22-ralph-slim-plugin-restructure.md)
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `ralph/skills/hero/SKILL.md` | Create (≤200 lines) | Top-level dispatcher: arg parsing, mode routing, terminal-token relay |
+| `ralph/skills/hero/state-machine.md` | Create (~100 lines) | ASCII state diagram + phase ordering + convergence rules (default mode) |
+| `ralph/skills/hero/task-graph.md` | Create (~120 lines) | Upfront task list shape per starting phase + parallel impl dispatch rules |
+| `ralph/skills/hero/dispatch.md` | Create (~120 lines) | Per-phase `Skill()` vs `Agent()` dispatch table + model selection + BLOCKED escalation |
+| `ralph/skills/hero/event-classes.md` | Port (~95 lines) | Director taxonomy table — verbatim port from `plugin/ralph-hero/skills/director/event-classes.md`, with team→entrypoint cells re-pointed at `/ralph:*` verbs |
+| `ralph/skills/hero/watch-dispatch.md` | Port + slim (~80 lines) | Watcher dispatch table + SOUL refusal preconditions + heartbeat fan-out |
+| `ralph/skills/hero/pr-drain.md` | Port + slim (~150 lines) | PR classification rules + per-class actions + audit trail + synth-issue threading |
+| `ralph/hooks/scripts/hero-state-gate.sh` | Create (~50 lines) | PreToolUse on `save_issue`/`advance_issue` — RALPH_COMMAND=hero scope guard + semantic-intent passthrough + valid state transition allowlist |
+| `ralph/hooks/scripts/hero-dispatch-log.sh` | Create (~40 lines) | PostToolUse on `Skill` — append one line per `/ralph:hero` → child-verb dispatch to `~/.ralph-hero/activity/...` for observability |
+| `ralph/hooks/scripts/autopilot-enable-gate.sh` | Port verbatim (~20 lines) | PreToolUse on `Skill` (matcher `loop`) — exit 2 if `RALPH_AUTOPILOT_ENABLE != true` |
+| `ralph/hooks/scripts/autopilot-stop-gate.sh` | Port verbatim (~30 lines) | Stop hook — block exit if `autopilot-pending-wakeup` sentinel exists |
+| `ralph/hooks/scripts/autopilot-wakeup-clear.sh` | Port verbatim (~20 lines) | PreToolUse on `ScheduleWakeup` — clear sentinel, reject 300s delay |
+| `ralph/hooks/scripts/autopilot-director-postcheck.sh` | Port + rename refs (~30 lines) | PostToolUse on `Skill` — write sentinel on non-`Queue empty.` results so the Stop gate can verify ScheduleWakeup followed |
+| `ralph/hooks/scripts/pr-drain-state-gate.sh` | Create (~40 lines) | PreToolUse on `save_issue` — allow synth-issue transitions only (kind:pr-drain label scope) |
+| `ralph/skills/hero/SKILL.md` (frontmatter) | — | `hooks:` block registers the 6 hero hooks above + reuses Plan 3's `branch-gate.sh` and Plan 6's `lock-release-on-failure.sh` |
+| `thoughts/shared/plans/2026-05-23-GH-1390-ralph-plan-8-hero.md` | (this plan) | Plan doc — frontmatter status: ready → in-progress on impl start |
+
+**Reference count:** 6 (matches Plan 4's ceiling for multi-mode verbs; justified by 3 modes having structurally distinct opinion content — orchestrator state machine vs. event-classes taxonomy vs. PR classification rules).
+
+**Hook count:** 6 new + 2 reuses = 8 total — under Plan 5's ceiling of 9.
+
+---
+
+## Phase 1: Skill scaffold + frontmatter + arg parser
+
+**Files:**
+- Create: `ralph/skills/hero/SKILL.md`
+
+- [ ] **Step 1: Write SKILL.md frontmatter** — see plan body for the full YAML block (model: opus, all 9 hooks wired, ~27 allowed-tools entries). Body of SKILL.md initially contains arg-parser Step 0 + a placeholder `Step 1: Dispatch (filled in by later phases)` and a `## Notes` footer. Phases 2-6 fill the actual mode bodies.
+
+- [ ] **Step 2: Verify the SKILL.md parses**
+
+```bash
+python3 -c "
+import yaml, sys, re
+src = open('ralph/skills/hero/SKILL.md').read()
+m = re.match(r'^---\n(.*?)\n---', src, re.DOTALL)
+assert m, 'no frontmatter'
+fm = yaml.safe_load(m.group(1))
+assert fm['description'].startswith('Autonomous orchestrator'), fm['description'][:80]
+assert 'opus' == fm['model'], fm['model']
+print('OK', len(fm['allowed-tools']), 'tools')
+"
+```
+
+Expected: `OK 27 tools` (or similar count).
+
+- [ ] **Step 3: Commit Phase 1**
+
+```bash
+git add ralph/skills/hero/SKILL.md
+git commit -m "feat(ralph): Plan 8 Phase 1 — /ralph:hero scaffold + frontmatter"
+```
+
+---
+
+## Phase 2: Default mode (orchestrator) — port from hero/
+
+**Files:**
+- Modify: `ralph/skills/hero/SKILL.md` (fill Step 1 default branch + add Step 2 default-mode body)
+- Create: `ralph/skills/hero/state-machine.md` (port ASCII state diagram + convergence rules from `plugin/ralph-hero/skills/hero/SKILL.md` lines 68-112)
+- Create: `ralph/skills/hero/task-graph.md` (per-phase task graph shape + dependency-graph-aware impl ordering + execution loop)
+- Create: `ralph/skills/hero/dispatch.md` (phase→verb mapping, Skill() vs Agent(), model selection via `${RALPH_IMPL_MODEL:-sonnet}`, BLOCKED escalation, plan review gate, merge gate, error handling, resumability)
+
+- [ ] **Step 1: Create state-machine.md** with the ASCII diagram, phase table (START/SPLIT/RESEARCH/PLAN/REVIEW/HUMAN_GATE/IMPLEMENT/INTEGRATE/COMPLETE/TERMINAL), convergence rules (SPLIT→RESEARCH: all XS/S; RESEARCH→PLAN: all Ready for Plan; etc.), and the design notes ("GitHub IS the tree", single source of truth in MCP).
+
+- [ ] **Step 2: Create task-graph.md** with the resumability check (`TaskList()` then skip if matches), per-starting-phase task graph (SPLIT/RESEARCH/PLAN/REVIEW/IMPLEMENT shapes), dependency-graph-aware impl ordering (read `- **depends_on**:` annotations from plan docs), task creation pattern (two-step: `TaskCreate` then `TaskUpdate(addBlockedBy=[...])`), task metadata (`issue_number`, `repos`, `localDirs`, `dependencyFlow`), and the execution loop.
+
+- [ ] **Step 3: Create dispatch.md** with:
+  - Phase → verb mapping table (SPLIT→`/ralph:caretake --mode split`, RESEARCH→`/ralph:research --auto`, PLAN→`/ralph:plan --auto`, REVIEW→`/ralph:review --mode plan`, IMPLEMENT→`/ralph:impl --auto`, PR→`/ralph:impl --mode pr`, INTEGRATE→`/ralph:review`)
+  - `Skill()` vs `Agent()` table (orchestrator phases inline via `Skill()`; IMPLEMENT via `Agent()` only when agent definitions exist — until Plan 10 sunset they live in old plugin)
+  - Model selection: read `${RALPH_IMPL_MODEL:-sonnet}` and pass explicitly
+  - BLOCKED escalation: match prefix `IMPL BLOCKED `, re-dispatch once with `model="opus"`, then escalate via `__ESCALATE__` + `PushNotification`
+  - Plan review gate per `$RALPH_REVIEW_PLAN` (auto / interactive)
+  - Merge gate per `$RALPH_REVIEW_MODE` (interactive default / auto)
+  - Error handling table
+  - Resumability protocol
+
+- [ ] **Step 4: Replace Step 1 placeholder in SKILL.md with the default-mode body** that references the three new docs. Body length target: ~30 lines (Step 1-4 of default mode), referring out to state-machine.md / task-graph.md / dispatch.md for the depth.
+
+- [ ] **Step 5: Verify**
+```bash
+wc -l ralph/skills/hero/SKILL.md ralph/skills/hero/state-machine.md ralph/skills/hero/task-graph.md ralph/skills/hero/dispatch.md
+```
+
+Expected: SKILL.md ≤200, refs ~100/120/120.
+
+- [ ] **Step 6: Commit Phase 2**
+```bash
+git add ralph/skills/hero/
+git commit -m "feat(ralph): Plan 8 Phase 2 — default mode + state/task/dispatch refs"
+```
+
+---
+
+## Phase 3: --mode classify (director fold)
+
+**Files:**
+- Modify: `ralph/skills/hero/SKILL.md` (append `## --mode classify` section)
+- Create: `ralph/skills/hero/event-classes.md` (port from `plugin/ralph-hero/skills/director/event-classes.md` then re-point team→entrypoint cells)
+
+- [ ] **Step 1: Port event-classes.md verbatim then re-point**
+```bash
+cp plugin/ralph-hero/skills/director/event-classes.md ralph/skills/hero/event-classes.md
+sed -i.bak '
+  s|`ralph-hero:hero`|`ralph:hero`|g
+  s|`ralph-hero:watch`|`ralph:hero --mode watch`|g
+  s|`ralph-hero:caretake`|`ralph:caretake`|g
+  s|/ralph-hero:hero|/ralph:hero|g
+  s|/ralph-hero:watch|/ralph:hero --mode watch|g
+  s|/ralph-hero:caretake|/ralph:caretake|g
+' ralph/skills/hero/event-classes.md
+rm ralph/skills/hero/event-classes.md.bak
+```
+
+> Note: `ralph-hero:scouts` lives in a separate plugin (`ralph-playwright`) — leave that reference untouched.
+
+- [ ] **Step 2: Append `## --mode classify` section to SKILL.md** with Steps 1-6 covering: parse `--issue NNN` / `RemoteTrigger` input, read `next_actions` (`Queue empty.` fast-path), `get_issue`, classify via [event-classes.md](event-classes.md) (priority: trigger labels → automation labels → workflow_state), iOS-mode sentinel write (`${TMPDIR:-/tmp}/ralph-ios-mode` on `trigger:*` / `RemoteTrigger`), Skill() dispatch (entrypoint exists → dispatch; missing memorykeepers → `needs input:`), trigger:* label consumption, emit `result:` marker.
+
+- [ ] **Step 3: Verify**
+```bash
+wc -l ralph/skills/hero/SKILL.md ralph/skills/hero/event-classes.md
+grep -c "/ralph:hero" ralph/skills/hero/event-classes.md
+grep -c "ralph-hero:hero" ralph/skills/hero/event-classes.md
+```
+
+Expected: SKILL.md ≤200, event-classes.md ~95 lines, ≥3 `/ralph:hero` hits, 0 `ralph-hero:hero` hits.
+
+- [ ] **Step 4: Commit Phase 3**
+```bash
+git add ralph/skills/hero/SKILL.md ralph/skills/hero/event-classes.md
+git commit -m "feat(ralph): Plan 8 Phase 3 — --mode classify + event-classes taxonomy"
+```
+
+---
+
+## Phase 4: --mode auto (autopilot fold)
+
+**Files:**
+- Modify: `ralph/skills/hero/SKILL.md` (append `## --mode auto` section)
+
+- [ ] **Step 1: Append `## --mode auto` section** with the `Skill("loop", args="…")` call body. Loop prompt uses `Run /ralph:hero --mode classify on the next-most-important event…` as the inner instruction. Document the continuation rule (Queue empty → end; other → `ScheduleWakeup` mandatory) and the cache-window guidance (60-270s for follow-on / 1200-1800s for stuck / NEVER 300s — enforced by `autopilot-wakeup-clear.sh`). Document `RALPH_AUTOPILOT_ENABLE` opt-in (enforced by `autopilot-enable-gate.sh` hook, not body), cancellation (`/tasks` + delete pending wakeup).
+
+- [ ] **Step 2: Verify**
+```bash
+wc -l ralph/skills/hero/SKILL.md
+grep "RALPH_AUTOPILOT_ENABLE" ralph/skills/hero/SKILL.md | wc -l
+```
+
+Expected: SKILL.md ≤200, ≥2 mentions of `RALPH_AUTOPILOT_ENABLE`.
+
+- [ ] **Step 3: Commit Phase 4**
+```bash
+git add ralph/skills/hero/SKILL.md
+git commit -m "feat(ralph): Plan 8 Phase 4 — --mode auto (autopilot fold)"
+```
+
+---
+
+## Phase 5: --mode watch (watch fold)
+
+**Files:**
+- Modify: `ralph/skills/hero/SKILL.md` (append `## --mode watch` section)
+- Create: `ralph/skills/hero/watch-dispatch.md`
+
+- [ ] **Step 1: Create watch-dispatch.md** with:
+  - SOUL refusal preconditions (trace ID regex `projects/[^/]+/traces/[a-f0-9]+`, or `gcloud logging read ...` snippet, or `<!-- gcp-policy: ... -->` marker; else `needs input:` + escalate)
+  - Dispatch table (first match wins): `gcp-policy` marker → `Skill("gcp-incident-triage", "--issue NNN")`; `langfuse-trace:` URL → `Skill("ralph:caretake", "--mode debug --issue NNN")`; `watcher-investigate` label → `Agent("ralph-hero:log-reader")`; `watcher-remediate` + kubectl allowlist match → `Agent("ralph-hero:sre-fixit")`; else escalate
+  - sre-fixit pre-check (four allowlisted kubectl shapes)
+  - Heartbeat mode (no-arg): `list_issues` once, loop sequentially, debug-collate if `RALPH_DEBUG=true`, emit `result: heartbeat: N alerts dispatched, M debug-collate issues filed`
+  - Terminal handlers (success / escalation / SOUL refusal) — outcome-recorder stub comments
+
+- [ ] **Step 2: Append `## --mode watch` section to SKILL.md** with argument parsing (`--issue NNN` → direct, else heartbeat), direct-mode dispatch (fetch, SOUL refusal preconditions, dispatch table, sre-fixit pre-check, emit terminal), heartbeat-mode dispatch (per watch-dispatch.md §Heartbeat mode).
+
+- [ ] **Step 3: Verify**
+```bash
+wc -l ralph/skills/hero/SKILL.md ralph/skills/hero/watch-dispatch.md
+```
+
+Expected: SKILL.md ≤200, watch-dispatch.md ~80 lines.
+
+- [ ] **Step 4: Commit Phase 5**
+```bash
+git add ralph/skills/hero/
+git commit -m "feat(ralph): Plan 8 Phase 5 — --mode watch (watch fold)"
+```
+
+---
+
+## Phase 6: --mode pr-drain (ralph-pr-drain fold)
+
+**Files:**
+- Modify: `ralph/skills/hero/SKILL.md` (append `## --mode pr-drain` section)
+- Create: `ralph/skills/hero/pr-drain.md`
+
+- [ ] **Step 1: Create pr-drain.md** with:
+  - Classification priority order (CI-pending guard → dependabot-auto-merge candidate → dependabot-needs-review → stale-close (>30d) → stale-ping (>14d) → needs-human). Python 3 one-liner for date math (portable across macOS/Linux).
+  - Per-class actions: `dependabot-auto-merge` runs `code-review:code-review` as merge gate, parses verdict (empty → GREEN opt-out; "No issues found" → GREEN; "Found ... issues:" → MUST_FIX; else review-error), then `gh pr merge <N> --squash --auto` or holding comment. `dependabot-needs-review` runs code-review for head start but never merges. `stale-close` closes with reason. `stale-ping` pings author with countdown. `needs-human` emits `needs input:` without commenting/labeling.
+  - Synthetic Ralph issue: `list_issues({label: "kind:pr-drain", state: "OPEN"})`, scan titles for `PR #<N>`, reuse if found, else create with `workflowState: "In Progress"` and labels `["pr-drain", "kind:pr-drain"]`. Threading invariant — synth created BEFORE PR mutation.
+  - Audit trail: success comment + `pr-drained` label (idempotency); failure → `merge-failed`, advance synth to Human Needed, do NOT label drained.
+  - Synth advance + `knowledge_record_outcome` (event_type: `pr_drain`, issue_number, verdict, payload).
+  - Result marker: `result: Drained PR #<N> (class: <FINAL_CLASS>, synthetic issue: #<SYNTH_NUMBER>)`.
+  - Constraints (preserved verbatim from source): never label until action succeeds; exit early without labeling/commenting/synth-creating when CI pending; synth created BEFORE PR mutation; code-review verdict is the merge gate; reuse synth (idempotency); verdict detection deterministic (parse `### Code review` comment).
+
+- [ ] **Step 2: Append `## --mode pr-drain` section to SKILL.md** with Steps 1-8 (parse + idempotency check; fetch PR; classify; create-or-reuse synth; act per class; audit trail; advance synth + record outcome; emit marker). Body content thin — defer to [pr-drain.md](pr-drain.md) for rules.
+
+- [ ] **Step 3: Verify**
+```bash
+wc -l ralph/skills/hero/SKILL.md ralph/skills/hero/pr-drain.md
+grep -c "/ralph:hero --mode pr-drain" ralph/skills/hero/pr-drain.md
+```
+
+Expected: SKILL.md ≤200, pr-drain.md ~150 lines, ≥2 mentions of the verb.
+
+- [ ] **Step 4: Commit Phase 6**
+```bash
+git add ralph/skills/hero/
+git commit -m "feat(ralph): Plan 8 Phase 6 — --mode pr-drain (ralph-pr-drain fold)"
+```
+
+---
+
+## Phase 7: Hooks
+
+**Files:**
+- Create: `ralph/hooks/scripts/hero-state-gate.sh`
+- Create: `ralph/hooks/scripts/hero-dispatch-log.sh`
+- Create: `ralph/hooks/scripts/pr-drain-state-gate.sh`
+- Port: `ralph/hooks/scripts/autopilot-enable-gate.sh`
+- Port: `ralph/hooks/scripts/autopilot-stop-gate.sh`
+- Port: `ralph/hooks/scripts/autopilot-wakeup-clear.sh`
+- Port: `ralph/hooks/scripts/autopilot-director-postcheck.sh`
+
+- [ ] **Step 1: Port the four autopilot hooks verbatim**
+```bash
+for hook in autopilot-enable-gate.sh autopilot-stop-gate.sh autopilot-wakeup-clear.sh autopilot-director-postcheck.sh; do
+  cp "plugin/ralph-hero/hooks/scripts/$hook" "ralph/hooks/scripts/$hook"
+  chmod +x "ralph/hooks/scripts/$hook"
+done
+```
+
+- [ ] **Step 2: Update autopilot-director-postcheck.sh** to recognize the new dispatch shape — source matcher recognizes `/ralph-hero:director`; slim plugin invokes `/ralph:hero --mode classify`. Inspect the matcher line, then patch via Edit so the sentinel is written for both legacy and slim dispatch shapes.
+
+- [ ] **Step 3: Create hero-state-gate.sh**
+
+```bash
+cat > ralph/hooks/scripts/hero-state-gate.sh <<'HOOK_EOF'
+#!/usr/bin/env bash
+# Plan 8: Validate state transitions issued by /ralph:hero.
+# Mirrors impl-state-gate.sh: RALPH_COMMAND scope guard + is_semantic_intent passthrough + valid state allowlist.
+
+set -euo pipefail
+
+source "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "hero" ]]; then
+  exit 0
+fi
+
+input=$(cat)
+target_state=$(printf '%s' "$input" | jq -r '.tool_input.workflowState // empty')
+
+if [[ -z "$target_state" ]]; then
+  exit 0
+fi
+
+if is_semantic_intent "$target_state"; then
+  exit 0
+fi
+
+valid_states=(
+  "Research Needed"
+  "Research in Progress"
+  "Ready for Plan"
+  "Plan in Progress"
+  "Plan in Review"
+  "In Progress"
+  "In Review"
+  "Done"
+  "Human Needed"
+)
+
+for s in "${valid_states[@]}"; do
+  if [[ "$target_state" == "$s" ]]; then
+    exit 0
+  fi
+done
+
+echo "[hero-state-gate] BLOCKED: workflowState='$target_state' not in valid transitions for /ralph:hero." >&2
+echo "[hero-state-gate] Valid states: ${valid_states[*]}" >&2
+exit 2
+HOOK_EOF
+chmod +x ralph/hooks/scripts/hero-state-gate.sh
+```
+
+- [ ] **Step 4: Create hero-dispatch-log.sh**
+
+```bash
+cat > ralph/hooks/scripts/hero-dispatch-log.sh <<'HOOK_EOF'
+#!/usr/bin/env bash
+# Plan 8: Append one line per /ralph:hero -> child-verb dispatch to the activity log
+# for observability. Mirrors record-activity.sh shape but scoped to Skill() dispatches
+# under RALPH_COMMAND=hero.
+
+set -euo pipefail
+
+if [[ "${RALPH_COMMAND:-}" != "hero" ]]; then
+  exit 0
+fi
+
+input=$(cat)
+skill_name=$(printf '%s' "$input" | jq -r '.tool_input.skill // empty')
+
+case "$skill_name" in
+  ralph:research|ralph:plan|ralph:impl|ralph:review|ralph:caretake|loop|code-review:code-review)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+today=$(date +%Y/%m/%d)
+log_dir="${RALPH_ACTIVITY_DIR:-$HOME/.ralph-hero/activity}/$today"
+mkdir -p "$log_dir"
+
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+sub="${RALPH_SUBCOMMAND:-default}"
+printf '{"ts":"%s","category":"work","kind":"hero-dispatch","subcommand":"%s","target":"%s"}\n' \
+  "$ts" "$sub" "$skill_name" >> "$log_dir/$(date +%H).jsonl"
+
+exit 0
+HOOK_EOF
+chmod +x ralph/hooks/scripts/hero-dispatch-log.sh
+```
+
+- [ ] **Step 5: Create pr-drain-state-gate.sh**
+
+```bash
+cat > ralph/hooks/scripts/pr-drain-state-gate.sh <<'HOOK_EOF'
+#!/usr/bin/env bash
+# Plan 8: Validate state transitions issued by /ralph:hero --mode pr-drain.
+# Synth issues (kind:pr-drain) only move to In Progress, Done, or Human Needed.
+
+set -euo pipefail
+
+source "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook-utils.sh"
+
+if [[ "${RALPH_COMMAND:-}" != "hero" || "${RALPH_SUBCOMMAND:-}" != "pr-drain" ]]; then
+  exit 0
+fi
+
+input=$(cat)
+target_state=$(printf '%s' "$input" | jq -r '.tool_input.workflowState // empty')
+
+if [[ -z "$target_state" ]]; then
+  exit 0
+fi
+
+case "$target_state" in
+  "In Progress"|"Done"|"Human Needed")
+    exit 0
+    ;;
+esac
+
+if is_semantic_intent "$target_state"; then
+  exit 0
+fi
+
+echo "[pr-drain-state-gate] BLOCKED: workflowState='$target_state' not allowed in pr-drain mode." >&2
+echo "[pr-drain-state-gate] Synth issues may only move to: In Progress, Done, Human Needed." >&2
+exit 2
+HOOK_EOF
+chmod +x ralph/hooks/scripts/pr-drain-state-gate.sh
+```
+
+- [ ] **Step 6: Verify hooks**
+```bash
+for h in ralph/hooks/scripts/{autopilot-enable-gate.sh,autopilot-stop-gate.sh,autopilot-wakeup-clear.sh,autopilot-director-postcheck.sh,hero-state-gate.sh,hero-dispatch-log.sh,pr-drain-state-gate.sh}; do
+  bash -n "$h" && echo "OK $h"
+done
+```
+
+Expected: every line prints `OK <path>`.
+
+- [ ] **Step 7: Commit Phase 7**
+```bash
+git add ralph/hooks/scripts/
+git commit -m "feat(ralph): Plan 8 Phase 7 — hero hooks (state-gate, dispatch-log, autopilot ports)"
+```
+
+---
+
+## Phase 8: Verification
+
+- [ ] **Step 1: SKILL.md size**
+```bash
+wc -l ralph/skills/hero/SKILL.md
+```
+Expected: ≤ 200.
+
+- [ ] **Step 2: All referenced files exist**
+```bash
+for ref in state-machine task-graph dispatch event-classes watch-dispatch pr-drain; do
+  test -f "ralph/skills/hero/${ref}.md" && echo "OK ${ref}.md" || echo "MISSING ${ref}.md"
+done
+```
+Expected: 6 lines, all `OK`.
+
+- [ ] **Step 3: Registered hooks match files on disk**
+```bash
+python3 - <<'CHECK_EOF'
+import yaml, re, os, sys
+src = open('ralph/skills/hero/SKILL.md').read()
+m = re.match(r'^---\n(.*?)\n---', src, re.DOTALL)
+fm = yaml.safe_load(m.group(1))
+referenced = set()
+for events in fm.get('hooks', {}).values():
+    for block in events:
+        for h in block.get('hooks', []):
+            cmd = h.get('command', '')
+            for part in cmd.split('/'):
+                if part.endswith('.sh'):
+                    referenced.add(part)
+on_disk = set(os.listdir('ralph/hooks/scripts'))
+missing = referenced - on_disk
+if missing:
+    print('MISSING:', missing)
+    sys.exit(1)
+print('OK — all', len(referenced), 'referenced hooks exist on disk')
+CHECK_EOF
+```
+Expected: `OK — all <N> referenced hooks exist on disk`.
+
+- [ ] **Step 4: Frontmatter sanity**
+```bash
+python3 -c "
+import yaml, re
+src = open('ralph/skills/hero/SKILL.md').read()
+m = re.match(r'^---\n(.*?)\n---', src, re.DOTALL)
+fm = yaml.safe_load(m.group(1))
+assert fm['model'] == 'opus', fm['model']
+assert 'argument-hint' in fm
+assert 'allowed-tools' in fm
+print('OK frontmatter')
+"
+```
+Expected: `OK frontmatter`.
+
+- [ ] **Step 5: Verb references**
+```bash
+grep -nE "/ralph(:|-hero:)" ralph/skills/hero/SKILL.md | head -30
+```
+Expected: every `/ralph-hero:*` reference is a sunset note or doc path (not a dispatched verb).
+
+---
+
+## Phase 9: Post-impl audit (per spec acceptance #6)
+
+- [ ] **Step 1: Run /review against the branch diff** via `Skill("review")`. Apply high-confidence findings inline; defer larger findings as friction-log inputs to Plan 9.
+
+- [ ] **Step 2: Run /skill-creator:skill-creator audit** via `Skill("skill-creator:skill-creator", args="audit ralph/skills/hero/")`. Apply trigger-gap / picker-ambiguity / missing-tool fixes inline.
+
+- [ ] **Step 3: Commit any audit fixes (skip if none)**
+```bash
+git add ralph/skills/hero/ ralph/hooks/scripts/
+git commit -m "feat(ralph): Plan 8 Phase 9 — apply /review + /skill-creator audit fixes"
+```
+
+---
+
+## Acceptance Criteria
+
+1. **Functional parity on 5 modes × real issues** — verified after merge by dogfooding (friction notes added to spec's Plan 8 entry).
+2. **`ralph/skills/hero/SKILL.md` ≤ 200 lines** — verified Phase 8 Step 1.
+3. **All enforcement in hooks** — verified by inspection: no "ensure that…" / "validate that…" prose in SKILL.md.
+4. **Local-dev edit-and-reload works** — verified Phase 8 (symlink resolves).
+5. **Old skills remain functional** — `plugin/ralph-hero/skills/{hero,autopilot,director,watch,ralph-pr-drain,team}/` untouched.
+6. **Per-phase audit applied** — Phase 9.
+
+---
+
+## Notes for the executor
+
+- **No SOUL.md.** Spec P10: substrate is the product. Source `hero/SOUL.md`, `director/SOUL.md`, `watch/SOUL.md` are deliberately not ported.
+- **No `references/` subfolder.** Spec convention: flat siblings.
+- **Don't delete anything in `plugin/ralph-hero/`.** Old plugin keeps running. Sunset is Plan 10.
+- **`--mode classify` is the ONLY mode that writes the iOS-mode sentinel.** Don't replicate in other modes.
+- **Autopilot opt-in gate lives at the hook layer** (`autopilot-enable-gate.sh`), not the skill body. Trust the hook.
+- **`ralph-pr-drain` keeps its synth-issue threading verbatim.** Synth uses `kind:pr-drain` label; classify mode never re-classifies pr-drain synths because Director filters them out upstream (`mcp-server/src/lib/directions.ts`).
+- **`--mode watch` heartbeat is bounded.** Processes only issues from the initial `list_issues` call. New issues mid-loop are deferred to the next heartbeat.
+- **BLOCKED escalation is one retry max.** Track per-issue retry count in TaskList metadata so a double-BLOCKED at opus escalates instead of looping.


### PR DESCRIPTION
## Summary

Plan 8 of the slim-plugin migration (closes #1390). Folds five source orchestrator skills (`hero`, `autopilot`, `director`, `watch`, `ralph-pr-drain` — plus the deprecated `team` shell) into a single `/ralph:hero` verb with five modes.

| Mode | Trigger | Role |
|---|---|---|
| **default** | `/ralph:hero NNN` | One-shot orchestrator: research → plan → review → impl → PR → merge |
| **`--mode auto`** | `/ralph:hero --mode auto` | Backlog drain via `/loop` dynamic mode (opt-in via `RALPH_AUTOPILOT_ENABLE=true`) |
| **`--mode classify`** | `/ralph:hero --mode classify [--issue NNN]` | Director-only event classify + dispatch |
| **`--mode watch`** | `/ralph:hero --mode watch [--issue NNN]` | Watcher heartbeat (gcp-incident-triage / debug-collate / log-reader / sre-fixit) |
| **`--mode pr-drain`** | `/ralph:hero --mode pr-drain --pr NNN` | PR drain (Dependabot/stale/unlinked) with code-review:code-review merge gate |

### Final shape

- `ralph/skills/hero/SKILL.md`: **194 lines** (under the 200 budget). Top-level dispatcher only — every mode body is 6-10 bullet-step lines pointing at flat-sibling references for opinion content.
- **Six flat-sibling references** — `state-machine.md` (80), `task-graph.md` (100), `dispatch.md` (133), `event-classes.md` (95), `watch-dispatch.md` (82), `pr-drain.md` (225). Total 715 lines of opinion content.
- **Combined: 909 lines** vs **1,523 lines** in source (`hero`/`autopilot`/`director`/`watch`/`ralph-pr-drain`) — **~40% LOC reduction**. The 5-source fold absorbs duplicate orchestration scaffolding from each source.
- **9 hook entries** registered in frontmatter (= the spec ceiling Plan 5 established):
  - **3 new:** `hero-state-gate.sh` (workflow-state allowlist + `is_semantic_intent` passthrough + `RALPH_COMMAND=hero` scope guard), `hero-dispatch-log.sh` (PostToolUse:Skill observability log), `pr-drain-state-gate.sh` (synth-issue transitions only)
  - **4 ports** with slim/legacy dual scope: `autopilot-enable-gate.sh`, `autopilot-stop-gate.sh`, `autopilot-wakeup-clear.sh`, `autopilot-director-postcheck.sh` — each updated to recognize both legacy `RALPH_COMMAND=autopilot` and slim `RALPH_COMMAND=hero` + `RALPH_SUBCOMMAND=auto`. The director-postcheck additionally accepts the new dispatch shape `skill_name=ralph:hero` with `--mode classify` in args
  - **2 reuses** from prior plans: `branch-gate.sh` (Plan 3), `lock-release-on-failure.sh` (Plan 3/6)

### Per-mode design notes

- **Default mode** body is six bullet-step lines pointing at `state-machine.md` / `task-graph.md` / `dispatch.md`. Resumability, dependency-graph-aware impl ordering, and BLOCKED escalation all live in those refs.
- **`--mode classify`** preserves the iOS-mode sentinel write contract (`${TMPDIR:-/tmp}/ralph-ios-mode` on `trigger:*` / `RemoteTrigger` only). Taxonomy in `event-classes.md` has every team→entrypoint cell re-pointed at `/ralph:*` verbs (legacy `/ralph-hero:scouts` left untouched — it lives in a separate plugin).
- **`--mode auto`** is a thin `Skill("loop", …)` wrapper. The opt-in gate, continuation rule (Queue-empty → end vs. otherwise → mandatory `ScheduleWakeup`), and 300s anti-pattern rejection are all enforced by hooks, not the body.
- **`--mode watch`** preserves the SOUL refusal preconditions verbatim. Dispatch table first-match-wins (gcp-policy > langfuse-trace > watcher-investigate > watcher-remediate). Heartbeat fan-out is bounded.
- **`--mode pr-drain`** preserves the synth-issue threading invariant (synth created BEFORE PR mutation), the CI-pending guard (exits early without labeling), the code-review-as-merge-gate pattern, and the `pr-drained` label idempotency.

### Per Plan 6/7 friction-log inputs

- Used `RALPH_COMMAND`/`RALPH_SUBCOMMAND` scoping for hooks (no mid-flow env mutation per Plan 4 lesson).
- `hero-state-gate.sh` mirrors `impl-state-gate.sh` shape (scope guard + `is_semantic_intent` passthrough + allowlist).
- `__CLOSE__` (not `__DONE__`) is the Done transition intent — verified by relying on the `is_semantic_intent` helper that lives in `hook-utils.sh`.

### Scope

- Old `plugin/ralph-hero/skills/{hero,autopilot,director,watch,ralph-pr-drain,team}/` untouched. Sunset is Plan 10.
- Plan doc: `thoughts/shared/plans/2026-05-23-GH-1390-ralph-plan-8-hero.md`.
- Spec: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` row 8.

## Test plan

- [ ] `/ralph:hero --mode classify` against the live board — verify it picks the top `next_actions` event, classifies via taxonomy, dispatches the correct verb, consumes `trigger:*` labels, emits `result:` marker
- [ ] `/ralph:hero --mode classify --issue NNN` against an issue with `trigger:builders` — verify label consumption + iOS-mode sentinel write
- [ ] `/ralph:hero --mode auto` with `RALPH_AUTOPILOT_ENABLE` unset — verify `autopilot-enable-gate.sh` blocks deterministically
- [ ] `/ralph:hero --mode auto` with `RALPH_AUTOPILOT_ENABLE=true` — verify `/loop` drives, the Queue-empty → terminate path works, the omitted-`ScheduleWakeup` path is blocked by `autopilot-stop-gate.sh`, and the 300s anti-pattern is rejected by `autopilot-wakeup-clear.sh`
- [ ] `/ralph:hero --mode watch` heartbeat against a Backlog with `watcher-auto` issues — verify dispatch table + heartbeat fan-out
- [ ] `/ralph:hero --mode pr-drain --pr NNN` against a Dependabot patch bump — verify code-review:code-review runs as the merge gate, synth issue created before PR mutation, `pr-drained` label idempotency
- [ ] `/ralph:hero NNN` against a real Ready-for-Plan issue — verify default mode drives the full pipeline (or pauses interactively at the plan-review / merge gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
