### PR TITLE
feat(ralph): Plan 9 — /ralph:setup fold (GH-1392)

### DIFF
--- a/ralph/skills/setup/SKILL.md
+++ b/ralph/skills/setup/SKILL.md
@@ -1,0 +1,113 @@
+---
+description: |
+  One-time setup for Ralph in this repo and on this machine. Three modes — default / `--mode project` (GitHub Project V2 bootstrap; custom fields, env vars, install-scope settings), `--mode cli` (install global `ralph` command + shell completions), `--mode repos` (bootstrap .ralph-repos.yml multi-repo registry). Triggers on "set up ralph", "configure ralph", "install ralph CLI", "create the project board", "bootstrap repos.yml", "fix missing workflow states".
+argument-hint: "[<project-number> | --mode <project|cli|repos>] [path]"
+context: inline
+model: haiku
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=setup"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - AskUserQuestion
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__health_check
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_project
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__setup_project
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+---
+
+# /ralph:setup — One-time setup in one verb
+
+Interactive bootstrap. Three modes; pick by need:
+
+| Mode | Trigger | Role |
+|---|---|---|
+| **default** / `--mode project` | `/ralph:setup [project-number]` | GitHub Project V2 bootstrap: custom fields, env vars, install-scope settings |
+| **`--mode cli`** | `/ralph:setup --mode cli` | Install global `ralph` command + shell completions |
+| **`--mode repos`** | `/ralph:setup --mode repos [path]` | Bootstrap `.ralph-repos.yml` for multi-repo portfolio |
+
+References: [scope-detection.md](scope-detection.md), [project-fields.md](project-fields.md), [token-setup.md](token-setup.md), [cli-install.md](cli-install.md), [repos-registry.md](repos-registry.md).
+
+## Configuration (resolved at load time)
+
+- Owner: !`echo ${RALPH_GH_OWNER:-NOT_SET}`
+- Repo: !`echo ${RALPH_GH_REPO:-NOT_SET}`
+- Project: !`echo ${RALPH_GH_PROJECT_NUMBER:-NOT_SET}`
+- Shell: !`basename "${SHELL:-/bin/bash}"`
+
+## Step 0: Parse arguments + set subcommand scope
+
+```bash
+case "$ARGUMENTS" in
+  --mode\ project*)  export RALPH_SUBCOMMAND=project ;;
+  --mode\ cli*)      export RALPH_SUBCOMMAND=cli ;;
+  --mode\ repos*)    export RALPH_SUBCOMMAND=repos ;;
+  *)                 export RALPH_SUBCOMMAND=project ;;
+esac
+```
+
+## Step 1: Dispatch by `RALPH_SUBCOMMAND`
+
+Route to the matching mode section below. Each mode ends by emitting a `result:` line the harness extractor reads directly.
+
+## Default mode (--mode project)
+
+Interactive GitHub Project V2 bootstrap. Re-run with a project number to resume from an existing project (e.g., after an interrupted run).
+
+1. **Detect install scope** — read `~/.claude/plugins/installed_plugins.json`, find the `ralph` or `ralph-hero` entry, check `scope`. Sets target settings file path per [scope-detection.md](scope-detection.md).
+2. **Health check** — `health_check` MCP tool. Display auth / repo access / project access / required fields status. On auth failure, STOP with rotation guidance from [token-setup.md](token-setup.md).
+3. **Determine project owner** — if `projectAccess` failed/skipped, ask via `AskUserQuestion` ("under org" vs "under personal account"). If owners differ, enter split-owner mode — see [token-setup.md](token-setup.md) §dual-token.
+4. **Create-or-verify project** — if arg passed: treat as resume number; `get_project` to verify; `setup_project` in extend mode to add any missing custom fields. If no arg + no `RALPH_GH_PROJECT_NUMBER`: `setup_project` to create. Field schema in [project-fields.md](project-fields.md).
+5. **Create default views (manual)** — GitHub's GraphQL API does not support view creation. Print step-by-step instructions for Ralph Table + Ralph Kanban from [project-fields.md](project-fields.md).
+6. **Write env vars** — to the target settings file from Step 1. Required: `RALPH_GH_OWNER`, `RALPH_GH_REPO`, `RALPH_GH_PROJECT_NUMBER`. Split-owner adds `RALPH_GH_PROJECT_OWNER`. Token via `gh auth` (no settings entry unless dual-PAT — see [token-setup.md](token-setup.md)).
+7. **Print restart instructions** — MCP server reads env at startup. Restart Claude Code, then re-run `/ralph:setup` to verify.
+
+```
+result: Setup complete — project #NNN created/verified, env written to <path>. Restart Claude Code.
+```
+
+Or on STOP:
+
+```
+result: Setup paused at <step> — <reason>. Resume: /ralph:setup [NNN]
+```
+
+## --mode cli
+
+Install the global `ralph` command and shell completions. Detailed steps in [cli-install.md](cli-install.md).
+
+1. **Locate plugin** — try slim cache `~/.claude/plugins/cache/ralph/ralph/<version>/` first; fall back to legacy `~/.claude/plugins/cache/ralph-hero/ralph-hero/<version>/`. Latest version (`sort -V | tail -1`) wins.
+2. **Install binary** — copy `scripts/ralph-cli.sh` → `~/.local/bin/ralph`, `mkdir -p` + `chmod +x`.
+3. **Detect shell + install completions** — `basename "$SHELL"`. zsh → `ralph-completions.zsh`; bash → `ralph-completions.bash`; other shells skip.
+4. **Check environment** — record `PATH_OK` (is `~/.local/bin` in `$PATH`?), `COMPINIT_OK` (zsh only — `compinit` in `~/.zshrc`?), `JUST_OK` (`command -v just`).
+5. **Print per-shell summary** — conditional on the flags. End with `ralph doctor` + `/ralph:setup` as next steps.
+
+```
+result: CLI installed — ~/.local/bin/ralph. Restart shell or `source ~/.zshrc`.
+```
+
+## --mode repos
+
+Bootstrap `.ralph-repos.yml` from real project data. Detailed flow + YAML schema + pattern detection in [repos-registry.md](repos-registry.md).
+
+1. **Confirm target path** — default `.ralph-repos.yml`; accept custom via arg or `AskUserQuestion`. If file exists: ask overwrite / merge / cancel.
+2. **Discover repos** — `health_check` then `pipeline_dashboard` (or `list_issues` fallback). Also try `gh api graphql ... projectV2.repositories` (user query → organization fallback).
+3. **Per-repo Q&A** — domain (frontend/backend/data/infra/docs/other), tech stack, default labels, default assignees, default estimate. `AskUserQuestion` per repo.
+4. **Detect patterns** — same-domain pairs → optionally create `cross-repo-feature` decomposition patterns with `dependency-flow` edges.
+5. **Write file** — YAML output to target path. Merge mode preserves existing repos + appends new ones.
+
+```
+result: Registry written — <path>. <N> repos, <M> patterns.
+```
+
+## Notes
+
+`RALPH_SUBCOMMAND` is set once at Step 0. SessionStart only sets `RALPH_COMMAND=setup`. No state-gate hooks — setup is not in the workflow pipeline. Old `/ralph-hero:setup{,-cli,-repos}` skills remain functional until Plan 10 sunset.

--- a/ralph/skills/setup/cli-install.md
+++ b/ralph/skills/setup/cli-install.md
@@ -1,0 +1,109 @@
+# CLI install — global `ralph` command + completions
+
+> Consulted by `/ralph:setup --mode cli`. Step-by-step install with conditional summary.
+
+## Step 1: Locate plugin
+
+Try the slim cache first, fall back to legacy. The CLI binary + completion files live in `scripts/` of whichever resolves. Latest version wins:
+
+```bash
+# Try slim cache first
+LATEST_SLIM=$(ls "$HOME/.claude/plugins/cache/ralph/ralph/" 2>/dev/null | sort -V | tail -1)
+if [ -n "$LATEST_SLIM" ] && [ -f "$HOME/.claude/plugins/cache/ralph/ralph/$LATEST_SLIM/scripts/ralph-cli.sh" ]; then
+  PLUGIN_DIR="$HOME/.claude/plugins/cache/ralph/ralph/$LATEST_SLIM"
+else
+  # Fall back to legacy ralph-hero cache (authoritative until Plan 10 sunset)
+  LATEST_LEGACY=$(ls "$HOME/.claude/plugins/cache/ralph-hero/ralph-hero/" 2>/dev/null | sort -V | tail -1)
+  if [ -z "$LATEST_LEGACY" ]; then
+    echo "Error: neither ralph nor ralph-hero plugin cache found."
+    echo "Install via: claude plugin install https://github.com/cdubiel08/ralph-hero"
+    exit 1
+  fi
+  PLUGIN_DIR="$HOME/.claude/plugins/cache/ralph-hero/ralph-hero/$LATEST_LEGACY"
+fi
+echo "Plugin found: $PLUGIN_DIR"
+```
+
+If `scripts/ralph-cli.sh` is not present in the resolved dir, report the error and exit — the install is incomplete.
+
+## Step 2: Install binary
+
+```bash
+mkdir -p "$HOME/.local/bin"
+cp "$PLUGIN_DIR/scripts/ralph-cli.sh" "$HOME/.local/bin/ralph"
+chmod +x "$HOME/.local/bin/ralph"
+```
+
+Print: `Installed: ~/.local/bin/ralph`
+
+## Step 3: Detect shell + install completions
+
+Detect via `basename "$SHELL"`. Install completions only for zsh and bash; skip for any other shell.
+
+```bash
+# zsh
+cp "$PLUGIN_DIR/scripts/ralph-completions.zsh" "$HOME/.local/share/ralph/ralph-completions.zsh"
+# bash
+cp "$PLUGIN_DIR/scripts/ralph-completions.bash" "$HOME/.local/share/ralph/ralph-completions.bash"
+```
+
+Use `mkdir -p "$HOME/.local/share/ralph"` before copying. Skip the copy (with a warning) if the source file is not in the plugin.
+
+## Step 4: Environment checks
+
+Record these flags for the Step 5 summary:
+
+```bash
+echo "$PATH" | tr ':' '\n' | grep -qx "$HOME/.local/bin" && PATH_OK=true || PATH_OK=false
+# zsh only
+grep -q "compinit" "$HOME/.zshrc" 2>/dev/null && COMPINIT_OK=true || COMPINIT_OK=false
+command -v just >/dev/null 2>&1 && JUST_OK=true || JUST_OK=false
+```
+
+## Step 5: Per-shell summary
+
+Conditional content:
+
+- Omit the `export PATH` line if `PATH_OK=true`.
+- Omit the `autoload -Uz compinit` line if `COMPINIT_OK=true` (zsh only) or completions were skipped.
+- Omit the `source <completions>` line if completions were skipped.
+- Append the `just` warning if `JUST_OK=false`.
+
+### zsh template
+
+```
+Done! Ralph CLI installed.
+
+Next steps:
+1. Add to ~/.zshrc, then restart your shell (or run: source ~/.zshrc):
+   export PATH="$HOME/.local/bin:$PATH"               # omit if PATH_OK
+   autoload -Uz compinit && compinit                   # omit if COMPINIT_OK or completions skipped
+   source ~/.local/share/ralph/ralph-completions.zsh   # omit if completions skipped
+
+2. Verify: ralph doctor
+3. Set up your GitHub project: /ralph:setup
+
+Warning: 'just' is not installed — ralph won't work until it is.  # omit if JUST_OK
+Install: brew install just  (or see https://just.systems)
+```
+
+### bash template
+
+```
+Done! Ralph CLI installed.
+
+Next steps:
+1. Add to ~/.bashrc, then restart your shell (or run: source ~/.bashrc):
+   export PATH="$HOME/.local/bin:$PATH"               # omit if PATH_OK
+   source ~/.local/share/ralph/ralph-completions.bash  # omit if completions skipped
+
+2. Verify: ralph doctor
+3. Set up your GitHub project: /ralph:setup
+
+Warning: 'just' is not installed — ralph won't work until it is.  # omit if JUST_OK
+Install: brew install just  (or see https://just.systems)
+```
+
+### Other shells
+
+Skip completions entirely. Print the PATH export (omit if `PATH_OK=true`), `ralph doctor`, `/ralph:setup`, and the optional `just` warning.

--- a/ralph/skills/setup/project-fields.md
+++ b/ralph/skills/setup/project-fields.md
@@ -1,0 +1,50 @@
+# Project V2 fields + default views
+
+> Consulted by `/ralph:setup` default mode Step 4 (custom fields) and Step 5 (views).
+
+## Required custom fields
+
+`setup_project` creates three single-select fields with the canonical option set:
+
+| Field | Options | Notes |
+|---|---|---|
+| **Workflow State** | Backlog, Research Needed, Research in Progress, Ready for Plan, Plan in Progress, Plan in Review, In Progress, In Review, Done, Human Needed, Canceled | 11 states; drives every Ralph verb |
+| **Priority** | P0 (Critical), P1 (High), P2 (Medium), P3 (Low) | 4 options; used by `next_actions` ranking |
+| **Estimate** | XS(1), S(2), M(3), L(4), XL(5) | 5 options; split-gate uses M/L/XL to trigger decomposition |
+
+The tool seeds each field with the right colors. If colors drift later, update via `gh api graphql` (`updateProjectV2FieldOptionValue` mutation) or the GitHub UI.
+
+## Resume / extend semantics
+
+When called with a project number that already exists:
+
+- `get_project` first to confirm access.
+- `setup_project` runs in extend mode — it adds any missing fields, never destroys existing ones.
+- If a field exists but with mismatched options (e.g., someone added/removed states), report the diff and stop. Do not silently mutate user configuration.
+
+## Default views (created manually)
+
+**GitHub's GraphQL API does not support creating views programmatically.** Print these step-by-step instructions for the user to follow in the GitHub Projects UI:
+
+### Ralph Table
+
+1. **New view** → Table
+2. Name: `Ralph Table`
+3. Group by → **Priority**
+4. Kebab (⋯) → enable **Sub-issues**
+5. Filter: `-has:parent-issue`
+6. Save
+
+### Ralph Kanban
+
+1. **New view** → Board
+2. Name: `Ralph Kanban`
+3. Column field → **Workflow State**
+4. Filter: `-workflow-state:Canceled,Done,"Research in Progress","Plan in Progress","Plan in Review"`
+5. Save
+
+## Result
+
+Two complementary views:
+- **Ralph Table** — priority-grouped hierarchy of top-level issues with expandable sub-issues.
+- **Ralph Kanban** — board with only the actionable workflow columns (Backlog, Research Needed, Ready for Plan, In Progress, In Review, Human Needed).

--- a/ralph/skills/setup/repos-registry.md
+++ b/ralph/skills/setup/repos-registry.md
@@ -1,0 +1,113 @@
+# `.ralph-repos.yml` registry
+
+> Consulted by `/ralph:setup --mode repos`. Defines discovery flow, per-repo Q&A, pattern detection, and the YAML schema.
+
+## What it is
+
+`.ralph-repos.yml` is a per-repo opt-in registry that tells Ralph how to:
+
+- Apply per-repo default labels / assignees / estimates when creating issues
+- Group pipeline dashboard views by repo domain
+- Decompose features across repos via named patterns (`decompose_feature` MCP tool)
+
+Without this file, Ralph falls back to single-repo mode and treats all issues as belonging to `$RALPH_GH_REPO`.
+
+## Step 1: Confirm target path
+
+Default: `.ralph-repos.yml` in CWD. Accept a custom path via `$ARGUMENTS` or `AskUserQuestion`. If the file already exists, ask:
+
+- Overwrite (regenerate from scratch)
+- Merge (keep existing entries; append new ones)
+- Cancel
+
+## Step 2: Discover linked repos
+
+Combine two data sources:
+
+1. `health_check` then `pipeline_dashboard` (or `list_issues` fallback) — enumerates repos that already have issues in the project.
+2. `gh api graphql` — enumerates *linked* repos even if they don't have issues yet:
+
+```graphql
+query($owner: String!, $number: Int!) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      repositories(first: 50) {
+        nodes { nameWithOwner name owner { login } primaryLanguage { name } description }
+      }
+    }
+  }
+}
+```
+
+If the `user` query fails (org-owned project), retry with `organization(login: $owner)`. Tolerate the dual-query pattern silently.
+
+## Step 3: Per-repo Q&A
+
+For each discovered repo, ask the user via `AskUserQuestion`:
+
+- **Domain** — pick from: frontend, backend, data, infra, docs, mobile, other (or custom)
+- **Tech stack** — pre-fill from `primaryLanguage`; allow override
+- **Default labels** — comma-separated (e.g., `team:platform,area:auth`)
+- **Default assignees** — comma-separated GitHub logins
+- **Default estimate** — XS / S / M / L / XL (default: S)
+
+## Step 4: Detect decomposition patterns
+
+Heuristic: if two or more repos share a domain (e.g., `landcrawler-ai` + `landcrawler-toolkit` are both `data`), offer to create a `cross-repo-feature` pattern. Each pattern carries a list of repos and an optional `dependency-flow` edge.
+
+Pattern shape:
+
+```yaml
+patterns:
+  cross-repo-feature:
+    description: Feature that spans the data platform
+    decomposition:
+      - repo: landcrawler-ai
+        role: implementation
+      - repo: landcrawler-toolkit
+        role: consumer
+    dependency-flow:
+      - from: landcrawler-ai
+        to: landcrawler-toolkit
+```
+
+The pattern is consumed by `decompose_feature` (proposes sub-issues with the right blocking relationships).
+
+## Step 5: Write file
+
+YAML output. Merge mode: read the existing file, deep-merge new repos into the `repos:` map, append new patterns to `patterns:`. **Preserve any keys the user added by hand** (custom fields, hooks, notes — don't blow them away even if they're outside the documented schema).
+
+### Schema
+
+```yaml
+repos:
+  ralph-hero:
+    localDir: /Users/dubiel/projects/ralph-hero
+    domain: infra
+    tech: TypeScript
+    defaultLabels: [team:platform]
+    defaultAssignees: [cdubiel08]
+    defaultEstimate: S
+  landcrawler-ai:
+    localDir: /Users/dubiel/projects/landcrawler-ai
+    domain: data
+    tech: Python
+    defaultLabels: [team:data]
+    defaultEstimate: M
+
+patterns:
+  cross-repo-feature:
+    description: Feature spans data platform
+    decomposition: [...]
+    dependency-flow: [...]
+```
+
+## Recovery
+
+The skill is safe to re-run at any point — no side effects until Step 5 (file write). If a previous run was interrupted before Step 5, re-run cleanly. If Step 5 wrote an unintended overwrite:
+
+```bash
+git restore .ralph-repos.yml
+```
+
+Or restore from a prior backup. If the file was never committed, recovery requires re-entering custom entries by hand — which is why the **merge mode is the default** for re-runs.

--- a/ralph/skills/setup/scope-detection.md
+++ b/ralph/skills/setup/scope-detection.md
@@ -1,0 +1,34 @@
+# Install scope detection
+
+> Consulted by `/ralph:setup` default mode Step 1. Decides which settings file to write env vars to.
+
+## Detect
+
+Read `~/.claude/plugins/installed_plugins.json`. Find the most recent entry for the ralph family — try both new and legacy names:
+
+- New (slim): `"ralph@ralph"`
+- Legacy: `"ralph-hero@ralph-hero"`
+
+Use the latest entry's `"scope"` field.
+
+## Decide target path
+
+| Scope | Settings file | Reason |
+|---|---|---|
+| `"user"` | `~/.claude/settings.json` | CLI works from any directory; one set of env vars covers all projects |
+| `"project"` | `<project>/.claude/settings.local.json` | CLI only works from this project; settings are gitignored |
+| undetermined / not found | `<project>/.claude/settings.local.json` | Conservative fallback — local-scoped is reversible without touching user settings |
+
+## User-facing message
+
+After detection, tell the user:
+
+- User-scoped: "Ralph is installed at user scope — config will be written to `~/.claude/settings.json` so the CLI works from any directory."
+- Project-scoped: "Ralph is installed at project scope — config will be written to `.claude/settings.local.json`. The CLI will only work from this project directory."
+- Undetermined: "Could not detect install scope. Writing to `.claude/settings.local.json` (project-scoped) — you can rerun with the user-scope install if you want global access."
+
+## Why this matters
+
+`gh auth` tokens live in the system keychain and don't need a settings entry. Non-token env vars (`RALPH_GH_OWNER`, `RALPH_GH_REPO`, `RALPH_GH_PROJECT_NUMBER`, optional split-owner overrides) MUST live in a settings file the MCP server reads at startup.
+
+If the user is on a user-scoped install but the setup writes to `settings.local.json`, the CLI will silently behave differently inside vs. outside the project root — a common source of "ralph doctor works here but not there" reports.

--- a/ralph/skills/setup/token-setup.md
+++ b/ralph/skills/setup/token-setup.md
@@ -1,0 +1,71 @@
+# Token setup
+
+> Consulted by `/ralph:setup` default mode for auth flow and rotation guidance.
+
+## Three auth modes
+
+### 1. `gh auth` keychain (default, recommended)
+
+```bash
+gh auth login -s repo,project,read:org
+```
+
+Stores a token in the system keychain. The MCP server reads it via `gh auth token` at startup. **No settings file entry needed for the token.**
+
+To rotate: `gh auth refresh -s repo,project,read:org`.
+To check: `gh auth status` (or `just doctor` if the CLI is installed).
+
+### 2. Single PAT in settings
+
+For systems where `gh` is unavailable or undesired:
+
+```json
+{
+  "env": {
+    "RALPH_HERO_GITHUB_TOKEN": "ghp_your_token_here"
+  }
+}
+```
+
+Resolution chain (highest wins): `RALPH_GH_REPO_TOKEN` → `RALPH_HERO_GITHUB_TOKEN` → `gh auth token`.
+
+### 3. Dual-token split-owner
+
+Required when the repo is under an org but the project is under your personal account (or vice versa). Two PATs:
+
+- **Repo token** — scopes: `repo`, `read:org`
+- **Project token** — scopes: `project`
+
+Settings file (paths depend on install scope — see [scope-detection.md](scope-detection.md)):
+
+```json
+{
+  "env": {
+    "RALPH_GH_REPO_TOKEN": "ghp_repo_only",
+    "RALPH_GH_PROJECT_TOKEN": "ghp_project_only",
+    "RALPH_GH_OWNER": "your-org",
+    "RALPH_GH_REPO": "your-repo",
+    "RALPH_GH_PROJECT_OWNER": "your-personal-username",
+    "RALPH_GH_PROJECT_NUMBER": "1"
+  }
+}
+```
+
+Explicit env vars **always take precedence over `gh auth`.** To rotate, regenerate the PAT at <https://github.com/settings/tokens> and update the settings file. `gh auth` does not manage these.
+
+## Required scopes
+
+- `repo` — read/write issues, PRs, comments
+- `project` — read/write Project V2 fields and items
+- `read:org` — list org repos linked to a project (skipped if working only with personal repos)
+
+## Where NOT to put tokens
+
+- **Not in `.mcp.json`** — that file has no `env` block; the MCP server inherits from Claude Code's process.
+- **Not in `~/.bashrc`/`.zshrc` below the interactive guard** — non-interactive Claude Code MCP child processes won't see them.
+- **Not in git** — `settings.local.json` is gitignored; never check it in.
+- **Not in `RALPH_HERO_GITHUB_TOKEN` for split-owner setups** — that single token will only have access to one side. Use the dual-token variables instead.
+
+## Recovery from a bad rotation
+
+If the new token doesn't work and the old one was invalidated, the MCP server logs `auth failed` at startup. Re-run `gh auth login -s repo,project,read:org` (mode 1) or update the settings file (modes 2/3), then **restart Claude Code** — the MCP server reads env at startup only.

--- a/thoughts/shared/plans/2026-05-23-GH-1392-ralph-plan-9-setup.md
+++ b/thoughts/shared/plans/2026-05-23-GH-1392-ralph-plan-9-setup.md
@@ -1,0 +1,295 @@
+---
+date: 2026-05-23
+github_issue: 1392
+status: ready
+type: plan
+tags: [ralph, plugin-restructure, plan-9, setup]
+spec_reference: thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md
+---
+
+# Plan 9: `/ralph:setup` — fold setup/setup-cli/setup-repos
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold three source setup skills (`setup`, `setup-cli`, `setup-repos`) into one `/ralph:setup` verb with three modes: default (Project V2 bootstrap), `--mode cli` (install global CLI + completions), `--mode repos` (bootstrap `.ralph-repos.yml`). Spec row 9 in the plan-of-plans.
+
+**Architecture:** Top-level `ralph/skills/setup/SKILL.md` (≤200 lines) owns arg parsing + mode dispatch. Each mode body delegates opinion content to flat-sibling references. No state-gate hooks needed — setup is not in the workflow pipeline.
+
+**Tech Stack:** Bash, Markdown, Claude Code skill loader, cross-plugin MCP (`ralph_hero__setup_project`, `health_check`, `get_project`, `pipeline_dashboard`, `list_issues`, `decompose_feature`, `create_issue`), `gh` CLI for GraphQL queries.
+
+**Spec reference:** [`thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md`](../research/2026-05-22-ralph-slim-plugin-restructure.md)
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `ralph/skills/setup/SKILL.md` | Create (≤200 lines) | Top-level dispatcher: arg parsing, mode routing, terminal summary |
+| `ralph/skills/setup/scope-detection.md` | Create (~60 lines) | User-vs-project install scope detection + which settings file to write |
+| `ralph/skills/setup/project-fields.md` | Create (~80 lines) | Required custom fields (Workflow State / Priority / Estimate), default views, color/description guidance |
+| `ralph/skills/setup/token-setup.md` | Create (~80 lines) | Auth modes (`gh auth`, single PAT, dual-token split-owner), token rotation, scope requirements |
+| `ralph/skills/setup/cli-install.md` | Create (~70 lines) | `ralph` CLI install + per-shell completions (zsh/bash) + compinit/PATH checks |
+| `ralph/skills/setup/repos-registry.md` | Create (~100 lines) | `.ralph-repos.yml` discovery + YAML schema + decomposition pattern detection |
+| `ralph/skills/setup/SKILL.md` (frontmatter) | — | `hooks:` block: SessionStart only (set `RALPH_COMMAND=setup`). No state gates — setup is not a pipeline verb. |
+| `thoughts/shared/plans/2026-05-23-GH-1392-ralph-plan-9-setup.md` | (this plan) | Plan doc |
+
+**Reference count:** 5 (matches Plan 4's range). All justified by mode separation — each mode's deep prose lives in its own ref.
+
+**Hook count:** 0 new (only the inherited SessionStart `set-skill-env.sh`). Setup is not a workflow-state-mutating verb.
+
+---
+
+## Phase 1: Scaffold SKILL.md + frontmatter
+
+**Files:**
+- Create: `ralph/skills/setup/SKILL.md`
+
+Frontmatter:
+
+```yaml
+---
+description: One-time setup for Ralph in this repo and on this machine. Three modes — default/--mode project (GitHub Project V2 bootstrap: custom fields, env vars, install-scope settings), --mode cli (install global `ralph` command + shell completions), --mode repos (bootstrap .ralph-repos.yml multi-repo registry). Triggers on "set up ralph", "configure ralph", "install ralph CLI", "create the project board", "bootstrap repos.yml", "fix missing workflow states".
+argument-hint: "[<project-number> | --mode <project|cli|repos>] [path]"
+context: inline
+model: haiku
+hooks:
+  SessionStart:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=setup"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - AskUserQuestion
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__health_check
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_project
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__setup_project
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
+  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+---
+```
+
+Body shape (target ≤120 lines after frontmatter):
+
+- Title + mode table + refs list
+- Configuration block (Owner / Repo / Project / install scope)
+- Step 0: arg parser sets `RALPH_SUBCOMMAND` via case statement on `$ARGUMENTS`
+- Step 1: dispatch by `RALPH_SUBCOMMAND`
+- Default / `--mode project` body: 6-step list (Step 1 health check → Step 2 project owner → Step 3 create-or-verify → Step 4 views (manual) → Step 5 write env vars → Step 6 restart instructions). Each step ≤3 lines pointing at refs.
+- `--mode cli` body: 4-step list (Step 1 locate plugin → Step 2 install binary → Step 3 detect shell + install completions → Step 4 summary). Defer to [cli-install.md](cli-install.md).
+- `--mode repos` body: 5-step list (Step 1 confirm target → Step 2 discover repos → Step 3 per-repo Q&A → Step 4 detect patterns → Step 5 write file). Defer to [repos-registry.md](repos-registry.md).
+- Notes footer (≤4 lines)
+
+Acceptance:
+
+- [ ] Frontmatter parses, `model: haiku` (matches source), 11 allowed-tools
+- [ ] SKILL.md ≤ 200 lines
+- [ ] Commit: `feat(ralph): Plan 9 Phase 1 — /ralph:setup scaffold + frontmatter`
+
+---
+
+## Phase 2: Default mode (--mode project) + refs
+
+**Files:**
+- Create: `ralph/skills/setup/scope-detection.md` (~60 lines)
+- Create: `ralph/skills/setup/project-fields.md` (~80 lines)
+- Create: `ralph/skills/setup/token-setup.md` (~80 lines)
+- Modify: SKILL.md (fill default-mode body)
+
+### scope-detection.md content
+
+- How to detect user-vs-project install scope from `~/.claude/plugins/installed_plugins.json` (`"scope"` field of latest `ralph-hero@ralph-hero` entry — though note that slim plugin is `ralph@ralph`, may need to scan for either name during the parallel period).
+- Where to write env vars per scope (user → `~/.claude/settings.json`; project → `<project>/.claude/settings.local.json`).
+- Fallback behavior when scope is undetermined (use project-local; warn).
+- User-facing message templates.
+
+### project-fields.md content
+
+- Required custom fields: Workflow State (11 options), Priority (4 options), Estimate (5 options).
+- `setup_project` creates them with correct colors.
+- Default views (Ralph Table grouped by Priority with sub-issues + filter `-has:parent-issue`; Ralph Kanban filtered to active workflow states) — **created manually in GitHub UI**, not via GraphQL (the API doesn't support view creation).
+- Field-update GraphQL example for color/description tweaks.
+
+### token-setup.md content
+
+- Three auth modes:
+  1. **`gh auth` keychain** (default, recommended): `gh auth login -s repo,project,read:org`. The MCP server reads it automatically; no settings.json token needed.
+  2. **Single PAT**: `RALPH_HERO_GITHUB_TOKEN` in settings file. Override chain: `RALPH_GH_REPO_TOKEN` → `RALPH_HERO_GITHUB_TOKEN` → `gh auth token`.
+  3. **Dual-token split-owner** (org repo + personal project): `RALPH_GH_REPO_TOKEN` (repo, read:org), `RALPH_GH_PROJECT_TOKEN` (project), `RALPH_GH_PROJECT_OWNER`.
+- Rotation: regenerate at https://github.com/settings/tokens, update settings file (`gh auth` doesn't manage these). For `gh` keychain: `gh auth refresh -s repo,project,read:org`.
+- Where NOT to put tokens: not in `.mcp.json`, not in `.bashrc` after interactive guard, not in git.
+
+### Default-mode body in SKILL.md
+
+```markdown
+## Default mode (--mode project)
+
+Interactive GitHub Project V2 bootstrap. Run `/ralph:setup [project-number]` to resume from an existing project (e.g., after an interrupted run).
+
+1. **Detect install scope** — see [scope-detection.md](scope-detection.md). Sets target settings file path.
+2. **Health check** — `health_check` MCP tool. Display auth / repo access / project access / required fields status. Fast-fail on auth failure with rotation guidance ([token-setup.md](token-setup.md)).
+3. **Determine project owner** — if `projectAccess` failed/skipped, ask via `AskUserQuestion` ("under org" / "under personal account"). If owners differ, enter split-owner mode → see [token-setup.md](token-setup.md) §dual-token.
+4. **Create-or-verify project** — if arg passed, treat as resume number: `get_project` to verify, `setup_project` in extend mode to add any missing custom fields. If no arg and no `RALPH_GH_PROJECT_NUMBER`, `setup_project` to create. Field schema in [project-fields.md](project-fields.md).
+5. **Create default views (manual)** — GitHub's GraphQL API doesn't support view creation. Print step-by-step instructions for Ralph Table + Ralph Kanban from [project-fields.md](project-fields.md).
+6. **Write env vars** — to the target settings file from Step 1. Three required: `RALPH_GH_OWNER`, `RALPH_GH_REPO`, `RALPH_GH_PROJECT_NUMBER`. Split-owner: also `RALPH_GH_PROJECT_OWNER`. Token via `gh auth` (no settings.json entry unless dual-PAT — see [token-setup.md](token-setup.md)).
+7. **Print restart instructions** — MCP server reads env at startup. Restart Claude Code, then re-run `/ralph:setup` to verify.
+
+Terminal:
+```
+result: Setup complete — project #NNN created/verified, env written to <path>, restart Claude Code.
+```
+
+Or on STOP:
+```
+result: Setup paused at <step> — <reason>. Resume: /ralph:setup [NNN]
+```
+```
+
+Acceptance:
+
+- [ ] Three refs exist, each within line targets
+- [ ] SKILL.md default-mode body uses bullet-step shape (≤8 lines per step)
+- [ ] Commit: `feat(ralph): Plan 9 Phase 2 — --mode project + scope/fields/token refs`
+
+---
+
+## Phase 3: --mode cli + cli-install.md
+
+**Files:**
+- Create: `ralph/skills/setup/cli-install.md` (~70 lines)
+- Modify: SKILL.md (append `## --mode cli` section)
+
+### cli-install.md content
+
+- Locate plugin: try slim path `~/.claude/plugins/cache/ralph/ralph/` first, fall back to legacy `~/.claude/plugins/cache/ralph-hero/ralph-hero/`. The CLI binary + completion files live in `scripts/` of whichever resolves. Pick the latest version (`ls | sort -V | tail -1`).
+- Install binary: copy `scripts/ralph-cli.sh` → `~/.local/bin/ralph`, `chmod +x`.
+- Detect shell via `basename "$SHELL"`. Install completions:
+  - zsh: `scripts/ralph-completions.zsh` → `~/.local/share/ralph/ralph-completions.zsh`
+  - bash: `scripts/ralph-completions.bash` → `~/.local/share/ralph/ralph-completions.bash`
+  - else: skip completions
+- Check `compinit` is in `~/.zshrc` (zsh only); record `COMPINIT_OK`.
+- Check `~/.local/bin` is in `$PATH`; record `PATH_OK`.
+- Check `just` is installed; record `JUST_OK`.
+- Per-shell summary with conditional omissions (omit PATH export if `PATH_OK`, omit `autoload -Uz compinit` if `COMPINIT_OK` for zsh, omit `source <completions>` if completions skipped).
+
+### --mode cli body in SKILL.md
+
+```markdown
+## --mode cli
+
+Install the global `ralph` command and shell completions. Detailed steps in [cli-install.md](cli-install.md).
+
+1. **Locate plugin** — try slim cache (`~/.claude/plugins/cache/ralph/ralph/<version>/`) then legacy (`ralph-hero/ralph-hero/`). Latest version wins.
+2. **Install binary** — copy `scripts/ralph-cli.sh` → `~/.local/bin/ralph` (mkdir, chmod +x).
+3. **Detect shell + install completions** — zsh/bash only; other shells skip.
+4. **Check environment** — PATH contains `~/.local/bin`? `compinit` in `~/.zshrc` (zsh only)? `just` installed?
+5. **Print per-shell summary** — conditional on environment-check flags. End with `ralph doctor` + `/ralph:setup` as suggested next steps.
+
+Terminal:
+```
+result: CLI installed — ~/.local/bin/ralph. Restart shell or `source ~/.zshrc`.
+```
+```
+
+Acceptance:
+
+- [ ] cli-install.md exists and covers slim+legacy cache paths
+- [ ] SKILL.md body ≤10 lines for this mode
+- [ ] Commit: `feat(ralph): Plan 9 Phase 3 — --mode cli + cli-install ref`
+
+---
+
+## Phase 4: --mode repos + repos-registry.md
+
+**Files:**
+- Create: `ralph/skills/setup/repos-registry.md` (~100 lines)
+- Modify: SKILL.md (append `## --mode repos` section)
+
+### repos-registry.md content
+
+- File purpose: `.ralph-repos.yml` tells Ralph how to apply per-repo defaults, group dashboard views, decompose features across repos with named patterns.
+- Discovery: use `pipeline_dashboard` (or `list_issues` fallback) to enumerate repos with issues. Then query `gh api graphql` for `projectV2.repositories` (try `user{}` first, fall back to `organization{}`).
+- Per-repo Q&A: domain (frontend/backend/data/infra/docs/other), tech stack (Python/TypeScript/Go/etc.), default labels, default assignees, default estimate.
+- Pattern detection: if two repos share a domain (e.g., `landcrawler-ai` + `landcrawler-toolkit`) ask whether to create a `cross-repo-feature` decomposition pattern with a `dependency-flow` edge.
+- YAML schema example.
+- Merge semantics for re-run: preserve existing entries, add new ones; user can opt for overwrite or cancel.
+- Recovery: `git restore .ralph-repos.yml` if user committed it.
+
+### --mode repos body in SKILL.md
+
+```markdown
+## --mode repos
+
+Bootstrap `.ralph-repos.yml` from real project data. Detailed flow + YAML schema in [repos-registry.md](repos-registry.md).
+
+1. **Confirm target path** — default `.ralph-repos.yml`; accept custom via arg or `AskUserQuestion`. If exists: overwrite/merge/cancel.
+2. **Discover repos** — `health_check` then `pipeline_dashboard` (or `list_issues` fallback). Also try `gh api graphql ... projectV2.repositories` (user → org fallback).
+3. **Per-repo Q&A** — domain, tech, default labels, default assignees, default estimate. Use `AskUserQuestion` per repo.
+4. **Detect patterns** — same-domain pairs → optionally create decomposition patterns with `dependency-flow` edges.
+5. **Write file** — YAML output to target path. Merge mode preserves existing repos + appends new ones.
+
+Terminal:
+```
+result: Registry written — <path>. <N> repos, <M> patterns.
+```
+```
+
+Acceptance:
+
+- [ ] repos-registry.md exists with YAML schema + discovery + pattern detection
+- [ ] Commit: `feat(ralph): Plan 9 Phase 4 — --mode repos + repos-registry ref`
+
+---
+
+## Phase 5: Verification + final commit
+
+- [ ] **Acceptance checks**:
+  ```bash
+  wc -l ralph/skills/setup/SKILL.md
+  # Expect ≤ 200
+  for ref in scope-detection project-fields token-setup cli-install repos-registry; do
+    test -f "ralph/skills/setup/${ref}.md" && echo "OK ${ref}.md" || echo "MISSING"
+  done
+  # Expect 5 OK lines
+  python3 -c "
+  import yaml, re
+  src = open('ralph/skills/setup/SKILL.md').read()
+  m = re.match(r'^---\n(.*?)\n---', src, re.DOTALL)
+  fm = yaml.safe_load(m.group(1))
+  assert fm['model'] == 'haiku', fm['model']
+  assert 'allowed-tools' in fm
+  print('OK frontmatter, tools=', len(fm['allowed-tools']))
+  "
+  ```
+
+- [ ] **Commit plan doc**: `docs(plan): GH-1392 Plan 9 /ralph:setup implementation plan`
+
+- [ ] **Push + PR**: `git push -u origin worktree-ralph-plan-9-setup` then `gh pr create --title "feat(ralph): Plan 9 — /ralph:setup fold (GH-1392)"`
+
+---
+
+## Acceptance Criteria
+
+Per spec:
+1. **Functional parity on 3 modes** — verified post-merge by running each mode against a real setup target.
+2. **`ralph/skills/setup/SKILL.md` ≤ 200 lines** — verified Phase 5.
+3. **All enforcement in hooks** — setup has no enforcement (no workflow-state transitions), so the convention is satisfied trivially.
+4. **Local-dev edit-and-reload works** — verified by symlink resolution.
+5. **Old skills remain functional** — `plugin/ralph-hero/skills/{setup,setup-cli,setup-repos}/` untouched.
+6. **Per-phase audit applied** — Phase 5.
+
+---
+
+## Notes for the executor
+
+- **No new hooks.** Setup is not in the workflow pipeline; existing state-gate hooks (hero-state-gate.sh etc.) are not relevant. SessionStart only sets `RALPH_COMMAND=setup`.
+- **No SOUL.md.** Per spec P10.
+- **Slim cache path first.** When locating the plugin in `--mode cli`, try `~/.claude/plugins/cache/ralph/ralph/` (slim) before falling back to `~/.claude/plugins/cache/ralph-hero/ralph-hero/` (legacy). The slim plugin will eventually own the CLI scripts; until Plan 10 sunset, the legacy path is the authoritative location.
+- **Don't delete anything in `plugin/ralph-hero/`** in this plan. Sunset is Plan 10.
+- **Source's `context: fork` field** is dropped in the slim plugin; the slim convention is `context: inline` (matches every other slim verb).
+- **Model: haiku** matches the source setup skills. Setup is mechanical — no opus required.


### PR DESCRIPTION
## Summary

Plan 9 of the slim-plugin migration (closes #1392). Folds three setup skills (`setup`, `setup-cli`, `setup-repos`) into one `/ralph:setup` verb with three modes.

| Mode | Trigger | Role |
|---|---|---|
| **default** / `--mode project` | `/ralph:setup [project-number]` | GitHub Project V2 bootstrap — custom fields, env vars, install-scope settings |
| **`--mode cli`** | `/ralph:setup --mode cli` | Install global `ralph` command + shell completions |
| **`--mode repos`** | `/ralph:setup --mode repos [path]` | Bootstrap `.ralph-repos.yml` for multi-repo portfolio |

### Final shape

- `ralph/skills/setup/SKILL.md`: **113 lines** (well under the 200 budget). Top-level dispatcher with each mode body 6-8 bullet steps pointing at refs.
- **Five flat-sibling references** — `scope-detection.md` (34), `project-fields.md` (50), `token-setup.md` (71), `cli-install.md` (109), `repos-registry.md` (113). Total 377 lines of opinion content.
- **Combined: 490 lines** vs **1,501 lines** in source (`setup` + `setup-cli` + `setup-repos`) — **~67% LOC reduction**. Setup skills had heavy install-prose duplication that the fold absorbs.
- **0 new hooks** — setup is not a workflow-state-mutating verb. SessionStart only sets `RALPH_COMMAND=setup`.
- **`model: haiku`** — matches source. Setup is mechanical, no opus required.

### Per-mode design notes

- **Default mode** preserves the resume-from-project-number recovery path, the install-scope auto-detect, the split-owner dual-token flow (deferred to `token-setup.md`), and the manual-view-creation pattern (GraphQL doesn't support project view creation).
- **`--mode cli`** locator tries the slim cache `~/.claude/plugins/cache/ralph/ralph/` FIRST, falling back to legacy `ralph-hero/ralph-hero/`. The legacy path is the authoritative source of `scripts/ralph-cli.sh` until Plan 10 sunset.
- **`--mode repos`** preserves merge-as-default semantics (re-running doesn't blow away user-added keys), `gh api graphql user{} → organization{}` fallback chain, and the same-domain decomposition-pattern auto-suggestion.

### Scope

- Old `plugin/ralph-hero/skills/{setup,setup-cli,setup-repos}/` untouched. Sunset is Plan 10.
- Plan doc: `thoughts/shared/plans/2026-05-23-GH-1392-ralph-plan-9-setup.md`.
- Spec: `thoughts/shared/research/2026-05-22-ralph-slim-plugin-restructure.md` row 9.

## Test plan

- [ ] `/ralph:setup` (no args) on a fresh repo — verify health check → project owner picker → setup_project → views guidance → env vars written to the right settings file → restart prompt
- [ ] `/ralph:setup <existing-number>` — verify resume path skips `setup_project` create, runs `get_project` + extend-mode field-add
- [ ] `/ralph:setup --mode cli` on a system with slim cache present — verify slim cache is tried first
- [ ] `/ralph:setup --mode cli` with only legacy `ralph-hero/ralph-hero/` cache — verify fallback resolves the binary
- [ ] `/ralph:setup --mode repos` on a project with 2+ linked repos — verify per-repo Q&A, pattern auto-detection, YAML write
- [ ] `/ralph:setup --mode repos` re-run with existing file — verify merge mode preserves existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
