### PR TITLE
GH-1399: tighten next_actions PR-search radius to open-item repos only

### DIFF
--- a/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
+++ b/plugin/ralph-hero/mcp-server/src/__tests__/directions-tools.test.ts
@@ -38,6 +38,13 @@ interface RawIssueFixture {
   closedAt?: string | null;
   parentNumber?: number | null;
   parentState?: string | null;
+  /**
+   * Override the `nameWithOwner` carried in the project item. Defaults to
+   * `owner/repo`. Tests that exercise multi-repo behavior (e.g. the GH-1399
+   * foreign-repo PR-leak regression) override this so item fixtures can map
+   * to distinct repos.
+   */
+  repository?: string;
 }
 
 /**
@@ -93,7 +100,13 @@ function rawIssue(fix: RawIssueFixture): unknown {
       updatedAt: fix.updatedAt ?? new Date().toISOString(),
       closedAt: fix.closedAt ?? null,
       assignees: { nodes: [] },
-      repository: { nameWithOwner: "owner/repo", name: "repo" },
+      repository: (() => {
+        const nameWithOwner = fix.repository ?? "owner/repo";
+        const name = nameWithOwner.includes("/")
+          ? nameWithOwner.split("/")[1]
+          : nameWithOwner;
+        return { nameWithOwner, name };
+      })(),
       subIssues: { totalCount: 0 },
       trackedIssues: { nodes: [] },
       trackedInIssues,
@@ -242,10 +255,21 @@ function createMockClient(
 
   // `client.query` is the repo-scoped surface. The tool calls it for the
   // internal PR search (`fetchOpenPRs`). Route by the query body so
-  // unrelated repo queries fall through to a clear error.
-  const query = vi.fn(async (q: string) => {
+  // unrelated repo queries fall through to a clear error. PRs are filtered
+  // by the `q` variable's `repo:<owner>/<repo>` clause so a per-repo search
+  // returns only that repo's fixtures — required for the GH-1399 regression
+  // to observe radius tightening rather than a global PR dump.
+  const query = vi.fn(async (q: string, vars?: { q?: string }) => {
     if (isOpenPRsSearchQuery(q)) {
-      return { search: { nodes: options.openPRs ?? [] } };
+      const searchExpr = vars?.q ?? "";
+      const repoMatch = searchExpr.match(/repo:([^\s]+)/);
+      const queriedRepo = repoMatch?.[1] ?? null;
+      const all = options.openPRs ?? [];
+      const filtered =
+        queriedRepo === null
+          ? all
+          : all.filter((pr) => pr.url.includes(queriedRepo));
+      return { search: { nodes: filtered } };
     }
     throw new Error(`Unmocked query: ${q.slice(0, 80)}`);
   });
@@ -317,6 +341,95 @@ describe("ralph_hero__next_actions", () => {
   beforeEach(() => {
     server = new McpServer({ name: "test", version: "0.0.0" });
     fieldCache = new FieldOptionCache();
+  });
+
+  // -------------------------------------------------------------------------
+  // GH-1399 regression: closed cross-repo items must not expand the PR-search
+  // radius. A stale closed item from a foreign repo on the board would
+  // otherwise pull every open PR from that repo into the directions ranking.
+  // -------------------------------------------------------------------------
+
+  it("does not search PRs from foreign repos whose only board items are closed", async () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const twoWeeksAgo = new Date(
+      Date.now() - 14 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    // Project mix mirrors the GH-1399 repro: one open item from the
+    // "primary" repo, one closed item from a foreign repo. The foreign
+    // repo should NOT trigger an `is:pr is:open repo:owner/foreign-repo`
+    // search, regardless of whether open PRs exist there.
+    const fixtures = [
+      rawIssue({
+        number: 904,
+        title: "Primary repo open issue",
+        workflowState: "Ready for Plan",
+        priority: "P1",
+        updatedAt: oneHourAgo,
+        repository: "owner/primary-repo",
+      }),
+      rawIssue({
+        number: 731,
+        title: "Foreign repo stale closed issue",
+        workflowState: "Done",
+        priority: "P2",
+        updatedAt: twoWeeksAgo,
+        closedAt: twoWeeksAgo,
+        repository: "owner/foreign-repo",
+      }),
+    ];
+
+    const { client, query } = createMockClient(
+      { projectNumber: 3 },
+      {
+        itemsByProject: { 3: fixtures },
+        // Open PR exists in the foreign repo — would have leaked before GH-1399.
+        // Returned for any PR search; assertion below checks no foreign-repo
+        // search was issued at all.
+        openPRs: [
+          {
+            number: 1355,
+            title: "Foreign repo open PR",
+            url: "https://github.com/owner/foreign-repo/pull/1355",
+            isDraft: false,
+            reviewDecision: "REVIEW_REQUIRED",
+            headRefName: "feature/GH-1301",
+            createdAt: twoWeeksAgo,
+          },
+        ],
+      },
+    );
+
+    registerDirectionsTools(server, client, fieldCache);
+    const tool = getTool(server, "ralph_hero__next_actions");
+
+    const result = await tool.handler(
+      buildArgs({ limit: 5, audience: "agent" }),
+      {},
+    );
+    const payload = parsePayload(result) as {
+      directions: Array<{ kind: string; pr: { url: string } | null }>;
+    };
+
+    expect(result.isError).toBeUndefined();
+
+    // Observable 1: no PR direction surfaces for the foreign repo.
+    const foreignPrDirections = payload.directions.filter(
+      (d) => d.kind === "pr" && d.pr?.url.includes("owner/foreign-repo"),
+    );
+    expect(foreignPrDirections).toHaveLength(0);
+
+    // Observable 2 (load-bearing): no GraphQL search was issued against the
+    // foreign repo. Asserts the radius tightened — not just the output filter.
+    const prSearchCalls = query.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" &&
+        (call[0] as string).includes("... on PullRequest"),
+    );
+    for (const call of prSearchCalls) {
+      const vars = call[1] as { q?: string } | undefined;
+      expect(vars?.q ?? "").not.toContain("owner/foreign-repo");
+    }
   });
 
   it("registers under the new name and accepts audience param", async () => {

--- a/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
+++ b/plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts
@@ -247,13 +247,19 @@ interface RawOpenPR {
 /**
  * Derive the unique `owner/repo` set from the project items so the PR search
  * mirrors the project's repo scope. Items lacking a `repository` field (e.g.
- * draft items) are skipped. Returns deterministic order (sorted) so the
- * downstream search query is stable.
+ * draft items) are skipped. Closed items (GitHub `closedAt` set, or workflow
+ * state Done/Canceled) also do NOT expand the radius — a stale closed
+ * cross-repo item on the board would otherwise pull every open PR from that
+ * foreign repo into `next_actions` (see GH-1399). Returns deterministic order
+ * (sorted) so the downstream search query is stable.
  */
 function uniqueRepos(items: DashboardItem[]): string[] {
   const seen = new Set<string>();
   for (const item of items) {
-    if (item.repository) seen.add(item.repository);
+    if (!item.repository) continue;
+    if (item.closedAt !== null) continue;
+    if (item.workflowState === "Done" || item.workflowState === "Canceled") continue;
+    seen.add(item.repository);
   }
   return Array.from(seen).sort();
 }

--- a/thoughts/shared/plans/2026-05-24-GH-1399-next-actions-foreign-repo-pr-leak-fix.md
+++ b/thoughts/shared/plans/2026-05-24-GH-1399-next-actions-foreign-repo-pr-leak-fix.md
@@ -59,11 +59,11 @@ const rawOpenPRs = await fetchOpenPRs(client, repos);
 
 ### Verification
 
-- [ ] `npx vitest run src/__tests__/directions-tools.test.ts` — passes including new closed-only-foreign-repo test.
-- [ ] `npx vitest run src/__tests__/directions.test.ts` — passes (no changes expected; pure ranker untouched).
-- [ ] `npm run build` exits 0 (TypeScript strict mode).
-- [ ] `npm test` — full suite green.
-- [ ] Manual: simulate the GH-1399 repro by mocking 1 open landcrawler-ai item + 1 closed ralph-hero item with an open ralph-hero PR in fixtures; assert PR direction does NOT appear in output.
+- [x] `npx vitest run src/__tests__/directions-tools.test.ts` — passes including new closed-only-foreign-repo test.
+- [x] `npx vitest run src/__tests__/directions.test.ts` — passes (no changes expected; pure ranker untouched).
+- [x] `npm run build` exits 0 (TypeScript strict mode).
+- [x] `npm test` — full suite green (1626 passed, 1 skipped).
+- [x] Manual: simulate the GH-1399 repro by mocking 1 open landcrawler-ai item + 1 closed ralph-hero item with an open ralph-hero PR in fixtures; assert PR direction does NOT appear in output. (See new integration test.)
 
 ## What We're NOT Doing
 
@@ -127,11 +127,11 @@ function uniqueRepos(items: DashboardItem[]): string[] {
 
 #### Automated Verification
 
-- [ ] `npx vitest run src/__tests__/directions-tools.test.ts` passes including the new regression test.
-- [ ] `npx vitest run src/__tests__/directions.test.ts` passes unchanged.
-- [ ] `npm run build` exits 0 with no TypeScript errors.
-- [ ] `npm test` full suite green.
-- [ ] `grep -n "closedAt" plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts` shows the new filter wired into `uniqueRepos`.
+- [x] `npx vitest run src/__tests__/directions-tools.test.ts` passes including the new regression test.
+- [x] `npx vitest run src/__tests__/directions.test.ts` passes unchanged.
+- [x] `npm run build` exits 0 with no TypeScript errors.
+- [x] `npm test` full suite green (1626 passed).
+- [x] `grep -n "closedAt" plugin/ralph-hero/mcp-server/src/tools/directions-tools.ts` shows the new filter wired into `uniqueRepos`.
 
 #### Manual Verification
 


### PR DESCRIPTION
## Summary

Fixes [#1399](https://github.com/cdubiel08/ralph-hero/issues/1399). `uniqueRepos()` in `directions-tools.ts` previously derived the PR-search radius from every project item with a `repository` field, regardless of whether the item was open or closed. A single stale closed cross-repo item on the board was enough to pull every open PR from that foreign repo into the directions ranking — the observed 2026-05-24 repro had 5 closed `cdubiel08/ralph-hero` items on Project 8 leaking PR #1355.

The fix is a single open-item filter inside `uniqueRepos()`: skip items where `closedAt !== null` OR `workflowState ∈ {Done, Canceled}`. Pure ranker (`lib/directions.ts`) untouched.

## Plan

[`thoughts/shared/plans/2026-05-24-GH-1399-next-actions-foreign-repo-pr-leak-fix.md`](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1399/thoughts/shared/plans/2026-05-24-GH-1399-next-actions-foreign-repo-pr-leak-fix.md)

Backed by research at [`thoughts/shared/research/2026-05-24-GH-1399-next-actions-foreign-repo-pr-leak.md`](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1399/thoughts/shared/research/2026-05-24-GH-1399-next-actions-foreign-repo-pr-leak.md) and APPROVED critique at [`thoughts/shared/reviews/2026-05-24-GH-1399-critique.md`](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1399/thoughts/shared/reviews/2026-05-24-GH-1399-critique.md).

## Test plan

- [x] `npx vitest run src/__tests__/directions-tools.test.ts` — passes (9 tests, including new GH-1399 regression).
- [x] `npx vitest run src/__tests__/directions.test.ts` — passes unchanged.
- [x] `npm run build` exits 0.
- [x] `npm test` — 1626 passed / 1 skipped.

The new regression test mirrors the repro shape: 1 open primary-repo item + 1 closed foreign-repo item + 1 open foreign-repo PR. Asserts both:

1. No PR direction surfaces for the foreign repo in `directions[]`.
2. **(Load-bearing)** No GraphQL search was issued whose `q` variable contains the foreign repo — proves the radius tightened, not just the output filter.

Mock client was extended to route `openPRs` by the `q` variable's `repo:` clause so per-repo searches return only that repo's fixtures. `rawIssue` fixture gained an optional `repository` override (backwards-compatible).

## What's NOT in this PR

- Option 2 from the issue body (filter PR directions by `linkedIssueNumber ∈ board-item-set`). Deferred until evidence shows an open foreign item still leaks unrelated PRs.
- `RALPH_GH_REPO`-based filtering. Radius derives from project state, not env vars.
- Ranker changes (`lib/directions.ts`).

Closes #1399

🤖 Generated with [Claude Code](https://claude.com/claude-code)