### PR TITLE
GH-1402: Add --loop flag to ralph slim-plugin skills

### DIFF
--- a/ralph/CLAUDE.md
+++ b/ralph/CLAUDE.md
@@ -23,3 +23,56 @@ The symlink at `~/.claude/plugins/cache/ralph/HEAD` points here. Edits are picke
 ## What's still in `plugin/ralph-hero/`
 
 Everything not yet migrated. The old plugin keeps working until each verb has a counterpart in `ralph` that's been dogfooded for two weeks.
+
+## Loop and --auto suitability matrix
+
+Sources of truth: [`ralph/skills/shared/loop-wrapper.md`](skills/shared/loop-wrapper.md) (continuation-rules manifest) and [`ralph/skills/shared/auto-alias.md`](skills/shared/auto-alias.md) (per-verb `--auto` alias table). The table below is a summary; when there is any conflict, the source files win.
+
+| Skill / Mode | `--loop` Suitable? | `--auto` resolves to | Default interval | Terminal sentinels | Notes |
+|---|---|---|---|---|---|
+| `research --mode auto` | Yes | (this IS the auto mode) | dynamic | `Queue empty.` | drain Research Needed queue |
+| `research --mode prove` | No | — | — | — | single-claim investigation; interactive |
+| `research` default | No | `--mode auto` | — | — | interactive question intake |
+| `plan --mode auto` | Yes | (this IS the auto mode) | dynamic | `Queue empty.` | drain Ready for Plan queue |
+| `plan --mode review` | Yes | — | dynamic | `Queue empty.` | drain Plan in Review queue |
+| `plan --mode iterate` | No | — | — | — | single-plan surgical edit; interactive |
+| `plan --mode epic` | No | — | — | — | single-epic decomposition |
+| `plan` default | No | `--mode auto` | — | — | interactive phased plan creation |
+| `impl --mode auto` | Yes | (this IS the auto mode) | dynamic | `IMPL BLOCKED …` / `Queue empty.` | drain unlocked impl phases |
+| `impl --mode pr` | Yes | — | dynamic | `Queue empty.` | drain ready-for-PR queue |
+| `impl --mode address` | No | — | — | — | single PR feedback cycle |
+| `impl` default | No | `--mode auto` | — | — | interactive; pauses between phases |
+| `review` default | Yes | (no change; already autonomous) | dynamic | `Queue empty.` | drain In Review queue |
+| `review --mode val` | Yes | — | dynamic | `Queue empty.` | drain validation queue |
+| `review --mode code` | Yes | — | dynamic | `Queue empty.` | drain code-review queue |
+| `review --mode merge` | Yes | — | dynamic | `Queue empty.` | drain mergeable queue |
+| `caretake --mode triage` | Yes | (this IS the auto mode) | dynamic | `Queue empty.` | drain Backlog |
+| `caretake --mode hygiene` | Yes | — | `1h` | heartbeat (no `Queue empty.`) | periodic scan |
+| `caretake --mode unblock` | Yes | — | dynamic | `Queue empty.` | autonomous path only (no `--question`) |
+| `caretake --mode trends` | Yes | — | `6h` | heartbeat (no `Queue empty.`) | periodic snapshot |
+| `caretake --mode debug` | Yes | — | dynamic | `Queue empty.` | drain Langfuse errors |
+| `caretake --mode split` | Yes | — | dynamic | `Queue empty.` | drain M/L/XL queue |
+| `caretake --mode all` | Yes | — | `1h` | heartbeat (no `Queue empty.`) | periodic fan-out |
+| `caretake` default (event) | Yes | `--mode triage` | dynamic | `Queue empty.` | drain `trigger:*` labels |
+| `caretake --mode postmortem` | No | — | — | — | single artifact per session |
+| `caretake --mode retro` | No | — | — | — | single artifact per session |
+| `caretake --mode unblock --question` | No | — | — | — | interactive answer collection |
+| `catch-up --mode report` | Yes | — | `1d` | heartbeat (no `Queue empty.`) | periodic status post; `--dry-run` by default in loop |
+| `catch-up` default | No | — | — | — | interactive orientation |
+| `catch-up --mode narrative` | No | — | — | — | pure stdout; interactive |
+| `catch-up --mode dashboard` | No | — | — | — | pure stdout; interactive |
+| `hero` default | Yes | `--mode auto` | dynamic | `result: Queue empty.` | drain top-ranked issues |
+| `hero --mode auto` | Already wrapped | (this IS the auto mode) | dynamic | `result: Queue empty.` | uses `RALPH_AUTOPILOT_ENABLE=true` gate |
+| `hero --mode watch` | Yes | — | `15m` | heartbeat (no `Queue empty.`) | polling heartbeat |
+| `hero --mode classify` | No | — | — | — | redundant with `hero --mode auto` |
+| `hero --mode pr-drain` | No | — | — | — | single-PR action; loop would re-process same PR |
+| `form` all modes | No | — | — | — | interactive picker |
+| `setup` all modes | No | — | — | — | one-shot bootstrap |
+
+**Refusal message for unsuitable modes**: `--loop is not supported for this mode. Looping is meaningful only for autonomous queue-drainers; this surface is interactive. See ralph/CLAUDE.md § Loop suitability.`
+
+**`--auto` refusal for unsuitable verbs** (`form`, `catch-up`, `setup`): `--auto is not supported for this verb (interactive / single-artifact / one-shot). See ralph/CLAUDE.md § Loop and --auto suitability matrix for the canonical table.`
+
+## ScheduleWakeup rules for --loop-wrapped skills
+
+Skills wrapped via `--loop` must not call `ScheduleWakeup` themselves; `/loop` owns wakeup management. The one exception is `hero --mode auto`, where `autopilot-wakeup-clear.sh` + `autopilot-stop-gate.sh` enforce the contract deterministically. Adding a new direct `ScheduleWakeup` call from inside any other loop-suitable skill body is a bug — if you need to influence the wakeup cadence, do it via the continuation prompt in `loop-wrapper.md` instead.

--- a/ralph/hooks/scripts/__tests__/triage-no-skill-dispatch.test.sh
+++ b/ralph/hooks/scripts/__tests__/triage-no-skill-dispatch.test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# ralph/hooks/scripts/__tests__/triage-no-skill-dispatch.test.sh
+# Tests for triage-no-skill-dispatch.sh
+#
+# Exercises:
+#   1. RALPH_SUBCOMMAND=triage + Skill tool → exit 2 (blocked)
+#   2. RALPH_SUBCOMMAND=hygiene + Skill tool → exit 0 (pass through)
+#   3. RALPH_SUBCOMMAND=triage + Agent tool → exit 0 (pass through)
+#   4. RALPH_SUBCOMMAND=triage + MCP tool → exit 0 (pass through)
+#   5. RALPH_SUBCOMMAND unset → exit 0 (pass through)
+
+set -euo pipefail
+
+HOOK="$(dirname "$0")/../triage-no-skill-dispatch.sh"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  ((PASS++)) || true
+}
+
+fail() {
+  echo "  FAIL: $1"
+  ((FAIL++)) || true
+}
+
+# Helper: invoke the hook with given env + JSON input, return exit code
+run_hook() {
+  local subcommand="${1:-}"
+  local tool_name="${2:-Skill}"
+  local input
+  input=$(printf '{"tool_name":"%s","tool_input":{}}' "$tool_name")
+
+  local exit_code=0
+  if [[ -n "$subcommand" ]]; then
+    RALPH_SUBCOMMAND="$subcommand" \
+    RALPH_COMMAND="caretake" \
+    RALPH_HOOK_INPUT="$input" \
+      bash "$HOOK" <<< "$input" 2>/dev/null
+    exit_code=$?
+  else
+    RALPH_COMMAND="caretake" \
+    RALPH_HOOK_INPUT="$input" \
+      bash "$HOOK" <<< "$input" 2>/dev/null
+    exit_code=$?
+  fi
+  echo "$exit_code"
+}
+
+echo "=== triage-no-skill-dispatch hook tests ==="
+echo ""
+
+echo "--- Should BLOCK (exit 2) ---"
+
+# Test 1: triage + Skill → blocked
+code=$(RALPH_SUBCOMMAND=triage RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"Skill","tool_input":{}}' \
+  bash "$HOOK" <<< '{"tool_name":"Skill","tool_input":{}}' 2>/dev/null; echo $?)
+if [[ "$code" == "2" ]]; then
+  pass "RALPH_SUBCOMMAND=triage + Skill tool → exit 2"
+else
+  fail "RALPH_SUBCOMMAND=triage + Skill tool → expected exit 2, got $code"
+fi
+
+echo ""
+echo "--- Should PASS THROUGH (exit 0) ---"
+
+# Test 2: hygiene + Skill → pass through (different subcommand)
+code=$(RALPH_SUBCOMMAND=hygiene RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"Skill","tool_input":{}}' \
+  bash "$HOOK" <<< '{"tool_name":"Skill","tool_input":{}}' 2>/dev/null; echo $?)
+if [[ "$code" == "0" ]]; then
+  pass "RALPH_SUBCOMMAND=hygiene + Skill tool → exit 0"
+else
+  fail "RALPH_SUBCOMMAND=hygiene + Skill tool → expected exit 0, got $code"
+fi
+
+# Test 3: triage + Agent → pass through (non-Skill tool)
+code=$(RALPH_SUBCOMMAND=triage RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"Agent","tool_input":{}}' \
+  bash "$HOOK" <<< '{"tool_name":"Agent","tool_input":{}}' 2>/dev/null; echo $?)
+if [[ "$code" == "0" ]]; then
+  pass "RALPH_SUBCOMMAND=triage + Agent tool → exit 0"
+else
+  fail "RALPH_SUBCOMMAND=triage + Agent tool → expected exit 0, got $code"
+fi
+
+# Test 4: triage + MCP tool → pass through
+code=$(RALPH_SUBCOMMAND=triage RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue","tool_input":{}}' \
+  bash "$HOOK" <<< '{"tool_name":"mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue","tool_input":{}}' 2>/dev/null; echo $?)
+if [[ "$code" == "0" ]]; then
+  pass "RALPH_SUBCOMMAND=triage + MCP get_issue tool → exit 0"
+else
+  fail "RALPH_SUBCOMMAND=triage + MCP get_issue tool → expected exit 0, got $code"
+fi
+
+# Test 5: RALPH_SUBCOMMAND unset → pass through
+code=$(RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"Skill","tool_input":{}}' \
+  bash "$HOOK" <<< '{"tool_name":"Skill","tool_input":{}}' 2>/dev/null; echo $?)
+if [[ "$code" == "0" ]]; then
+  pass "RALPH_SUBCOMMAND unset + Skill tool → exit 0"
+else
+  fail "RALPH_SUBCOMMAND unset + Skill tool → expected exit 0, got $code"
+fi
+
+# Test 6: all caretake mode passes Skill (e.g., fan-out)
+code=$(RALPH_SUBCOMMAND=all RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"Skill","tool_input":{}}' \
+  bash "$HOOK" <<< '{"tool_name":"Skill","tool_input":{}}' 2>/dev/null; echo $?)
+if [[ "$code" == "0" ]]; then
+  pass "RALPH_SUBCOMMAND=all + Skill tool → exit 0 (fan-out allowed)"
+else
+  fail "RALPH_SUBCOMMAND=all + Skill tool → expected exit 0, got $code"
+fi
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
+++ b/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
+# Tests for the triage-postcondition.sh terminal-token grep pattern.
+#
+# Strategy: test the grep alternation directly against sample transcript lines
+# rather than invoking the full hook (which requires a JSONL transcript file
+# and a live Stop hook environment). This exercises the exact regex at line ~48.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+PATTERN='^TRIAGED (routed → .+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.'
+
+pass() {
+  echo "  PASS: $1"
+  ((PASS++)) || true
+}
+
+fail() {
+  echo "  FAIL: $1"
+  ((FAIL++)) || true
+}
+
+assert_matches() {
+  local desc="$1"
+  local line="$2"
+  if echo "$line" | grep -qE "$PATTERN"; then
+    pass "$desc"
+  else
+    fail "$desc — expected match, got no match for: '$line'"
+  fi
+}
+
+assert_no_match() {
+  local desc="$1"
+  local line="$2"
+  if echo "$line" | grep -qE "$PATTERN"; then
+    fail "$desc — expected no match, but matched: '$line'"
+  else
+    pass "$desc"
+  fi
+}
+
+echo "=== triage-postcondition palette tests ==="
+echo ""
+echo "--- Valid tokens (should match) ---"
+
+assert_matches "TRIAGED routed → Research Needed" "TRIAGED routed → Research Needed"
+assert_matches "TRIAGED routed → Ready for Plan" "TRIAGED routed → Ready for Plan"
+assert_matches "TRIAGED routed → In Progress" "TRIAGED routed → In Progress"
+assert_matches "TRIAGED duplicate" "TRIAGED duplicate"
+assert_matches "TRIAGED canceled" "TRIAGED canceled"
+assert_matches "TRIAGED needs-split" "TRIAGED needs-split"
+assert_matches "TRIAGED escalated" "TRIAGED escalated"
+assert_matches "TRIAGED re-estimated" "TRIAGED re-estimated"
+assert_matches "TRIAGED skipped — branch feature/foo is not main" "TRIAGED skipped — branch feature/foo is not main"
+assert_matches "Queue empty." "Queue empty."
+
+echo ""
+echo "--- Retired/invalid tokens (should NOT match) ---"
+
+assert_no_match "TRIAGED valid (retired)" "TRIAGED valid"
+assert_no_match "KEEP (never a terminal token)" "KEEP"
+assert_no_match "Unknown token TRIAGED unknown" "TRIAGED unknown"
+assert_no_match "Bare TRIAGED with no verdict" "TRIAGED"
+assert_matches "Queue empty. with trailing text still matches (starts with sentinel)" "Queue empty. some extra text"
+assert_no_match "Lowercase queue empty." "queue empty."
+assert_no_match "Prose description of routing (not the literal token)" "Issue was routed to Research Needed"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
+++ b/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
-PATTERN='^TRIAGED (routed → .+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.'
+PATTERN='^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.'
 
 pass() {
   echo "  PASS: $1"

--- a/ralph/hooks/scripts/triage-no-skill-dispatch.sh
+++ b/ralph/hooks/scripts/triage-no-skill-dispatch.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# ralph/hooks/scripts/triage-no-skill-dispatch.sh
+# PreToolUse:Skill — Block Skill() dispatch when RALPH_SUBCOMMAND=triage.
+#
+# Triage is self-contained: it assesses ONE Backlog issue and routes it via
+# state transition. Downstream work happens when the next loop tick picks up
+# the routed issue via the appropriate verb's --auto (e.g., /ralph:plan --auto
+# picks up issues routed to "Ready for Plan"). Triage delegating into other
+# verbs via Skill() would cascade scope, break loop discipline, and undermine
+# the per-verb --auto contract.
+#
+# This hook does NOT block Agent() calls (triage legitimately uses sub-agents
+# like codebase-locator for assessment) or MCP tool calls (triage's core work
+# is get_issue / save_issue / add_dependency / create_comment). It is narrowly
+# scoped to Skill dispatches only.
+#
+# Scope guard: passes through silently when RALPH_SUBCOMMAND != triage.
+#
+# Exit codes:
+#   0 - Pass through (not in triage scope, or not a Skill call)
+#   2 - Blocked: Skill() dispatch from within triage
+
+set -euo pipefail
+source "$(dirname "$0")/hook-utils.sh"
+
+# Scope: only fires when caretake --mode triage is active.
+if [[ "${RALPH_SUBCOMMAND:-}" != "triage" ]]; then
+  allow
+fi
+
+read_input > /dev/null
+
+# We only block Skill tool calls. Agent() and MCP tools pass through.
+tool_name=$(get_field '.tool_name')
+if [[ "$tool_name" != "Skill" ]]; then
+  allow
+fi
+
+cat >&2 <<'EOF'
+═══════════════════════════════════════════════════════════════
+ Triage Skill() dispatch blocked
+═══════════════════════════════════════════════════════════════
+caretake --mode triage is self-contained — it assesses ONE
+issue and routes it via state transition. Downstream work
+happens when the next loop tick picks up the routed issue via
+the appropriate verb's --auto.
+
+If you need to delegate work, route the issue (ROUTE-TO-...)
+and let the loop handle it. If you genuinely need to invoke
+another skill from triage, that's a design change — propose
+it as a plan iteration, not a runtime override.
+═══════════════════════════════════════════════════════════════
+EOF
+exit 2

--- a/ralph/hooks/scripts/triage-postcondition.sh
+++ b/ralph/hooks/scripts/triage-postcondition.sh
@@ -45,7 +45,7 @@ fi
 transcript_text=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text' "$transcript_path" 2>/dev/null || true)
 
 # Match any of the documented terminal tokens.
-if echo "$transcript_text" | grep -qE '^TRIAGED (routed → .+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.' ; then
+if echo "$transcript_text" | grep -qE '^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.' ; then
   echo "Triage postcondition passed: terminal token found in transcript"
   allow
 fi

--- a/ralph/hooks/scripts/triage-postcondition.sh
+++ b/ralph/hooks/scripts/triage-postcondition.sh
@@ -45,7 +45,7 @@ fi
 transcript_text=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text' "$transcript_path" 2>/dev/null || true)
 
 # Match any of the documented terminal tokens.
-if echo "$transcript_text" | grep -qE '^TRIAGED (valid|duplicate|canceled|needs-split|skipped)|^Queue empty\.' ; then
+if echo "$transcript_text" | grep -qE '^TRIAGED (routed → .+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.' ; then
   echo "Triage postcondition passed: terminal token found in transcript"
   allow
 fi
@@ -53,12 +53,16 @@ fi
 block "Triage postcondition failed: no terminal token emitted
 
 Expected one of:
-  TRIAGED valid         (issue routed to Research Needed / Ready for Plan)
-  TRIAGED duplicate     (closed as duplicate)
-  TRIAGED canceled      (closed not_planned)
-  TRIAGED needs-split   (routed to split queue)
-  TRIAGED skipped …     (branch-gate short-circuit; non-main branch)
-  Queue empty.          (no untriaged Backlog issues)
+  TRIAGED routed → Research Needed   (issue routed to Research Needed)
+  TRIAGED routed → Ready for Plan    (issue routed to Ready for Plan)
+  TRIAGED routed → In Progress       (trivial fix; routed directly to In Progress)
+  TRIAGED duplicate                  (closed as duplicate)
+  TRIAGED canceled                   (closed not_planned)
+  TRIAGED needs-split                (routed to split queue)
+  TRIAGED escalated                  (escalated to Human Needed)
+  TRIAGED re-estimated               (estimate updated; stays in Backlog)
+  TRIAGED skipped …                  (branch-gate short-circuit; non-main branch)
+  Queue empty.                       (no untriaged Backlog issues)
 
 The /ralph:caretake --mode triage body must end by emitting one of these tokens.
 See ralph/skills/caretake/outcome-tokens.md for the full contract.

--- a/ralph/scripts/lint-loop-snippet.sh
+++ b/ralph/scripts/lint-loop-snippet.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# lint-loop-snippet.sh — Extract and syntax-check the bash arg-parsing snippet
+# from ralph/skills/shared/loop-wrapper.md.
+#
+# Usage: bash ralph/scripts/lint-loop-snippet.sh
+# Exits 0 on success, non-zero if the snippet has a syntax error or cannot be found.
+
+set -euo pipefail
+
+WRAPPER_MD="$(dirname "$0")/../skills/shared/loop-wrapper.md"
+
+if [[ ! -f "$WRAPPER_MD" ]]; then
+  echo "ERROR: loop-wrapper.md not found at: $WRAPPER_MD" >&2
+  exit 1
+fi
+
+# Extract the bash block immediately following "## Arg-parsing snippet".
+# Strategy: find the heading line, skip to the opening ```bash fence,
+# collect lines until the closing ``` fence, write to a temp file.
+
+TMPFILE="$(mktemp /tmp/lint-loop-snippet.XXXXXX.sh)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+in_target_section=0
+in_code_block=0
+
+while IFS= read -r line; do
+  if [[ "$line" == "## Arg-parsing snippet" ]]; then
+    in_target_section=1
+    continue
+  fi
+
+  # Stop scanning if we hit the next top-level section.
+  if [[ "$in_target_section" -eq 1 && "$line" =~ ^##[[:space:]] && "$line" != "## Arg-parsing snippet" ]]; then
+    break
+  fi
+
+  if [[ "$in_target_section" -eq 1 ]]; then
+    if [[ "$in_code_block" -eq 0 && "$line" == '```bash' ]]; then
+      in_code_block=1
+      continue
+    fi
+    if [[ "$in_code_block" -eq 1 && "$line" == '```' ]]; then
+      break
+    fi
+    if [[ "$in_code_block" -eq 1 ]]; then
+      echo "$line" >> "$TMPFILE"
+    fi
+  fi
+done < "$WRAPPER_MD"
+
+if [[ ! -s "$TMPFILE" ]]; then
+  echo "ERROR: could not extract bash snippet from ## Arg-parsing snippet section." >&2
+  exit 1
+fi
+
+echo "Extracted snippet ($(wc -l < "$TMPFILE") lines). Running bash -n syntax check..."
+
+if bash -n "$TMPFILE"; then
+  echo "OK: snippet passed bash -n syntax check."
+  exit 0
+else
+  echo "FAIL: snippet has a bash syntax error. See above for details." >&2
+  exit 1
+fi

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -21,6 +21,10 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-size-gate.sh"
+    - matcher: "Skill"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/triage-no-skill-dispatch.sh"
   PostToolUse:
     - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
       hooks:

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -107,6 +107,10 @@ References: [label-routing.md](label-routing.md) (default-mode dispatch table), 
 
 ## Step 0: Parse arguments + set subcommand scope
 
+**`--auto` alias** — resolve BEFORE `--loop` detection. See `ralph/skills/shared/auto-alias.md`:
+- If `--auto` in `$ARGUMENTS` AND `--mode` also present → emit `--auto cannot be combined with explicit --mode; pick one.` and STOP.
+- If `--auto` in `$ARGUMENTS` → strip `--auto` token, prepend `--mode triage` to `$ARGUMENTS` (verb=caretake alias row). Continue to `--loop` detection with the rewritten args.
+
 **`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set, route by mode (all use continuation-prompt template from `loop-wrapper.md`):
 - `--mode triage` → `caretake:triage` row; `--mode hygiene` → `caretake:hygiene` row; `--mode unblock` (no `--question`) → `caretake:unblock` row; `--mode debug` → `caretake:debug` row; `--mode split` → `caretake:split` row. Emit `Skill("loop", …)` then STOP.
 - No args (no `--issue`) → `caretake:default-event` row. Emit `Skill("loop", …)` then STOP.

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -111,7 +111,8 @@ References: [label-routing.md](label-routing.md) (default-mode dispatch table), 
 - `--mode triage` → `caretake:triage` row; `--mode hygiene` → `caretake:hygiene` row; `--mode unblock` (no `--question`) → `caretake:unblock` row; `--mode debug` → `caretake:debug` row; `--mode split` → `caretake:split` row. Emit `Skill("loop", …)` then STOP.
 - No args (no `--issue`) → `caretake:default-event` row. Emit `Skill("loop", …)` then STOP.
 - `--issue NNN` present, `--mode postmortem`, `--mode retro`, or `--mode unblock --question` → emit refusal from `loop-wrapper.md` § Refusal message, then STOP.
-- (`--mode all` and `--mode trends` are wired in Phase 3.)
+- **`--mode all`** → heartbeat; default interval `1h`. Use `caretake:all` manifest row — no `Queue empty.` terminal; re-fires on clock. Emit `Skill("loop", args="${LOOP_INTERVAL:-1h} /ralph:caretake --mode all ${STRIPPED_ARGS}\n\n<continuation from loop-wrapper.md manifest>")` then STOP.
+- **`--mode trends`** → periodic snapshot heartbeat; default interval `6h`. Use `caretake:trends` manifest row — no `Queue empty.` terminal; re-fires on clock. Emit `Skill("loop", args="${LOOP_INTERVAL:-6h} /ralph:caretake --mode trends ${STRIPPED_ARGS}\n\n<continuation from loop-wrapper.md manifest>")` then STOP.
 
 ```bash
 # Parse $ARGUMENTS into mode + flags. Each mode body sets RALPH_SUBCOMMAND itself

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: All board maintenance, grooming, and reflection in one verb. Triggers on "triage backlog", "clean up board", "scan for stale", "status check", "post-mortem", "capture friction", "retro the session", "trend report", "snapshot metrics", "unblock issue", "answer unblock questions", "collate debug errors", "filer Langfuse errors", "split this issue", "decompose ticket". Default mode is event-driven (reads `--issue NNN` labels and fans out via Skill). Named modes (triage/hygiene/unblock/postmortem/retro/trends/debug/split) each route to a dedicated mode body under `modes/`.
-argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|all>] [#NNN] [--since <window>] [--auto-confirm] [--question]"
+argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|all>] [#NNN] [--since <window>] [--auto-confirm] [--question] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -107,6 +107,12 @@ References: [label-routing.md](label-routing.md) (default-mode dispatch table), 
 
 ## Step 0: Parse arguments + set subcommand scope
 
+**`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set, route by mode (all use continuation-prompt template from `loop-wrapper.md`):
+- `--mode triage` → `caretake:triage` row; `--mode hygiene` → `caretake:hygiene` row; `--mode unblock` (no `--question`) → `caretake:unblock` row; `--mode debug` → `caretake:debug` row; `--mode split` → `caretake:split` row. Emit `Skill("loop", …)` then STOP.
+- No args (no `--issue`) → `caretake:default-event` row. Emit `Skill("loop", …)` then STOP.
+- `--issue NNN` present, `--mode postmortem`, `--mode retro`, or `--mode unblock --question` → emit refusal from `loop-wrapper.md` § Refusal message, then STOP.
+- (`--mode all` and `--mode trends` are wired in Phase 3.)
+
 ```bash
 # Parse $ARGUMENTS into mode + flags. Each mode body sets RALPH_SUBCOMMAND itself
 # (so per-mode hook scope picks up the right subcommand even when the caller

--- a/ralph/skills/caretake/modes/triage.md
+++ b/ralph/skills/caretake/modes/triage.md
@@ -102,13 +102,15 @@ export RALPH_TRIAGE_ACTION=ROUTE_TO_IMPL       # routed to In Progress
 # export RALPH_TRIAGE_ACTION=SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE
 ```
 
-Valid values: `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE`. The postcondition hook blocks exit if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
+Note: `CANCEL` is the close-not-planned sub-case of CLOSE (sets `issueState: CLOSED_NOT_PLANNED`, emits `TRIAGED canceled`) — a model picking `CANCEL` routes through the CLOSE action body above.
+
+Valid values: `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE`. `RALPH_TRIAGE_ACTION` is a self-discipline marker for the model — it is NOT validated by the postcondition hook. The postcondition hook (`triage-postcondition.sh`) enforces that a valid **terminal token** was emitted (it greps the transcript for `TRIAGED …` or `Queue empty.`); it does not read `RALPH_TRIAGE_ACTION` at all.
 
 ## §Step 6: Mark issue as triaged
 
-Apply the `ralph-triage` label only on `HUMAN` and `SPLIT` outcomes — the two that leave the issue in Backlog. Read current labels first, then include them all plus `ralph-triage` in the `save_issue` call.
+Apply the `ralph-triage` label on `HUMAN`, `SPLIT`, and `RE-ESTIMATE` outcomes — every outcome that leaves the issue in Backlog. Read current labels first, then include them all plus `ralph-triage` in the `save_issue` call.
 
-`ROUTE-TO` outcomes move the issue out of Backlog; the issue is naturally invisible to triage's Backlog query after routing, so no label is needed.
+Rationale: `ROUTE-TO` outcomes move the issue OUT of Backlog (the issue becomes invisible to §Step 2's Backlog query after routing, so no label is needed). `HUMAN`, `SPLIT`, and `RE-ESTIMATE` all leave the issue in Backlog — without the `ralph-triage` label, §Step 2's untriaged-Backlog picker would re-select the issue on the next triage tick, causing an infinite re-pick loop under `--loop`.
 
 ## §Step 7: Find and Link Related Issues
 

--- a/ralph/skills/caretake/modes/triage.md
+++ b/ralph/skills/caretake/modes/triage.md
@@ -63,10 +63,11 @@ Choose ONE:
 - **CLOSE** — feature already implemented, bug already fixed, duplicate, or no longer applicable.
 - **SPLIT** — issue is too large or covers multiple distinct items. Recommend XS/S sub-issues.
 - **RE-ESTIMATE** — current estimate missing or wrong; propose new value with reasoning.
-- **RESEARCH** — issue is valid but needs investigation; move to "Research Needed".
-- **KEEP** — issue is valid as-is; leave in Backlog with a clarifying comment if helpful.
+- **ROUTE-TO-Research Needed** — issue is valid but needs investigation before planning; move to "Research Needed".
+- **ROUTE-TO-Ready for Plan** — issue is well-specified; skip research and queue directly for planning.
+- **ROUTE-TO-In Progress** — trivial fix; assign and start immediately.
 
-When uncertain, prefer KEEP with a detailed comment over closing valid work.
+When uncertain, prefer `ROUTE-TO-Research Needed` (route for investigation) or `HUMAN` (escalate) over closing valid work.
 
 ## §Step 5: Take action
 
@@ -89,21 +90,25 @@ Add a comment on the parent listing sub-issues (reused and/or created). **Do NOT
 
 **RE-ESTIMATE.** Update the issue with the new estimate (XS/S/M/L/XL). Add a comment explaining the reasoning. Workflow state remains Backlog.
 
-**RESEARCH.** Set `workflowState: "Research Needed"` (`command: "ralph_triage"`). Add a comment: "Moved to Research Needed for investigation." Briefly note what needs research so downstream `/ralph:research` has actionable context.
-
-**KEEP.** Add a comment with any clarifications or context discovered. Leave workflow state as Backlog.
+**ROUTE-TO.** Set `workflowState: <target>` via `save_issue(command: "ralph_triage")` where `<target>` is one of `"Research Needed"`, `"Ready for Plan"`, or `"In Progress"`. Add a `## Triage Decision` comment explaining the routing choice and what downstream work is expected (e.g., what to investigate, what the plan should cover, or what the trivial fix is).
 
 **Before completing (REQUIRED for all branches):** export `RALPH_TRIAGE_ACTION` so `triage-postcondition.sh` can verify the action was taken:
 
 ```bash
-export RALPH_TRIAGE_ACTION=RESEARCH   # or SPLIT, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE
+# Pick the value that matches your action:
+export RALPH_TRIAGE_ACTION=ROUTE_TO_RESEARCH   # routed to Research Needed
+export RALPH_TRIAGE_ACTION=ROUTE_TO_PLAN       # routed to Ready for Plan
+export RALPH_TRIAGE_ACTION=ROUTE_TO_IMPL       # routed to In Progress
+# export RALPH_TRIAGE_ACTION=SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE
 ```
 
-Valid values: `RESEARCH`, `SPLIT`, `CLOSE`, `KEEP`, `HUMAN`, `CANCEL`, `RE-ESTIMATE`. The postcondition hook blocks exit if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
+Valid values: `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE`. The postcondition hook blocks exit if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
 
 ## §Step 6: Mark issue as triaged
 
-After completing any action, update labels to include `ralph-triage` while preserving existing labels. Read current labels first, then include them all plus `ralph-triage` in the `save_issue` call.
+Apply the `ralph-triage` label only on `HUMAN` and `SPLIT` outcomes — the two that leave the issue in Backlog. Read current labels first, then include them all plus `ralph-triage` in the `save_issue` call.
+
+`ROUTE-TO` outcomes move the issue out of Backlog; the issue is naturally invisible to triage's Backlog query after routing, so no label is needed.
 
 ## §Step 7: Find and Link Related Issues
 
@@ -154,12 +159,16 @@ After triage action is complete, scan for related issues in Backlog or Research 
 
 ## §Step 8: Emit terminal token
 
-Emit exactly one of the five tokens defined in [outcome-tokens.md](../outcome-tokens.md):
+Emit exactly one of the tokens defined in [outcome-tokens.md](../outcome-tokens.md):
 
-- `TRIAGED valid` — moved to Research Needed or Ready for Plan.
+- `TRIAGED routed → Research Needed` — issue routed to Research Needed for investigation.
+- `TRIAGED routed → Ready for Plan` — issue routed to Ready for Plan (well-specified, skip research).
+- `TRIAGED routed → In Progress` — trivial fix; issue routed directly to In Progress.
 - `TRIAGED duplicate` — closed as duplicate; references `## Duplicate Of` comment.
 - `TRIAGED canceled` — closed not-planned.
 - `TRIAGED needs-split` — left in Backlog with `needs-split` label so `--mode split` picks it up.
+- `TRIAGED escalated` — escalated to Human Needed; `ralph-triage` label applied.
+- `TRIAGED re-estimated` — estimate updated; issue stays in Backlog.
 - `Queue empty.` — no untriaged Backlog issues (emitted at §Step 2).
 
 `triage-postcondition.sh` greps the transcript for one of these tokens. Anything else fails the Stop hook with exit 2.
@@ -168,9 +177,9 @@ Emit exactly one of the five tokens defined in [outcome-tokens.md](../outcome-to
 
 - **High** (take action automatically): feature exists in codebase (CLOSE), exact duplicate found (CLOSE), issue explicitly marked "done" in comments (CLOSE).
 - **Medium** (act + note uncertainty): similar-but-not-identical feature, possibly-outdated issue, scope seems large but doable in phases.
-- **Low** (KEEP + comment): ambiguous requirements, can't determine if feature exists, unclear relevance.
+- **Low** (ROUTE-TO-Research Needed + comment): ambiguous requirements, can't determine if feature exists, unclear relevance.
 
-When uncertain, prefer KEEP over closing.
+When uncertain, prefer `ROUTE-TO-Research Needed` over closing, or `HUMAN` when you cannot make even a routing call.
 
 ## §Escalation
 
@@ -194,3 +203,7 @@ After escalating, apply the `ralph-triage` label so the issue is not re-picked.
 - No code changes.
 - Complete within 10 minutes.
 - The `triage-state-gate.sh` hook validates state transitions; `triage-postcondition.sh` validates the terminal token.
+
+## §Migration note
+
+Existing issues carrying the `ralph-triage` label from verdicts made under the prior palette continue to be excluded from re-pick by §Step 2's query (which filters out `ralph-triage`-labeled issues). To re-evaluate a dormant issue, manually remove the `ralph-triage` label and re-run triage. No automated batch cleanup ships with this phase.

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -15,7 +15,7 @@ Routing convention: the state name appears verbatim after the `→` token, case-
 - `TRIAGED canceled` — closed not-planned (tech changed, product direction shifted, etc.).
 - `TRIAGED needs-split` — left in Backlog with the `needs-split` label so `--mode split` picks it up on the next sweep. `ralph-triage` label applied.
 - `TRIAGED escalated` — escalated to Human Needed; `ralph-triage` label applied so the issue is not re-picked.
-- `TRIAGED re-estimated` — estimate updated; issue stays in Backlog.
+- `TRIAGED re-estimated` — estimate updated; issue stays in Backlog with the `ralph-triage` label applied (prevents re-pick under `--loop`).
 - `TRIAGED skipped — branch <name> is not main` — §Step 1 short-circuit; triage refuses to run on a feature branch.
 - `Queue empty.` — no untriaged Backlog issues remain.
 

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -6,14 +6,20 @@ Sections are filled across Plans 7 phases 3-8. Trends mode is read-only and emit
 
 ## Triage terminal tokens
 
-- `TRIAGED valid` — issue moved to `Research Needed` or `Ready for Plan` (the agent decided the issue is actionable).
+Routing convention: the state name appears verbatim after the `→` token, case-preserving (e.g., `TRIAGED routed → Research Needed` not `research needed`). `triage-postcondition.sh` uses `^TRIAGED routed → .+` to match the full routing family.
+
+- `TRIAGED routed → Research Needed` — issue routed to Research Needed for investigation.
+- `TRIAGED routed → Ready for Plan` — issue well-specified; routed directly to Ready for Plan (research skipped).
+- `TRIAGED routed → In Progress` — trivial fix; routed directly to In Progress.
 - `TRIAGED duplicate` — closed as duplicate; references a `## Duplicate Of` comment naming the surviving issue.
 - `TRIAGED canceled` — closed not-planned (tech changed, product direction shifted, etc.).
-- `TRIAGED needs-split` — left in Backlog with the `needs-split` label so `--mode split` picks it up on the next sweep.
+- `TRIAGED needs-split` — left in Backlog with the `needs-split` label so `--mode split` picks it up on the next sweep. `ralph-triage` label applied.
+- `TRIAGED escalated` — escalated to Human Needed; `ralph-triage` label applied so the issue is not re-picked.
+- `TRIAGED re-estimated` — estimate updated; issue stays in Backlog.
 - `TRIAGED skipped — branch <name> is not main` — §Step 1 short-circuit; triage refuses to run on a feature branch.
 - `Queue empty.` — no untriaged Backlog issues remain.
 
-`triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens. The hook also verifies `RALPH_TRIAGE_ACTION` is set to one of `RESEARCH | SPLIT | CLOSE | KEEP | HUMAN | CANCEL | RE-ESTIMATE`.
+`triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens. The `RALPH_TRIAGE_ACTION` allowlist (checked by the skill body's §Step 5) is: `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE`.
 ## Hygiene terminal tokens
 
 - `HYGIENE COMPLETE <N archived>` — scan ran cleanly; `N` is the archive count (0 if dry-run or threshold not exceeded).

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -79,3 +79,13 @@ Trends is read-only — the markdown report printed to stdout is the deliverable
 - `Queue empty.` — no M/L/XL issues exist in Backlog or Research Needed.
 
 `split-postcondition.sh` (Stop hook) greps the transcript for one of these tokens AND verifies via `list_sub_issues` that the parent has ≥ 2 children when `SPLIT <N>` is emitted.
+
+## Loop continuation
+
+When a caretake mode is wrapped via `--loop` (see `ralph/skills/shared/loop-wrapper.md` for the canonical continuation-rules manifest), the `/loop` runtime reads each invocation's terminal token to decide whether to re-fire or stop.
+
+**Drain modes** (triage, unblock, debug, split, caretake:default-event): `Queue empty.` is the sole termination signal. Every other terminal token (including progress tokens and `BLOCKED` variants) causes `/loop` to schedule the next tick at the appropriate delay bucket and re-fire.
+
+**Heartbeat modes** (hygiene, trends, all): these modes have no `Queue empty.` termination signal. `/loop` re-fires on a clock regardless of the token emitted — even when the invocation did nothing. The user cancels by deleting the pending wakeup via `/tasks`.
+
+**Non-loop invocations** are unaffected: all token semantics above apply to standalone caretake calls; the loop-continuation layer only activates when `--loop` was passed to the outermost invocation.

--- a/ralph/skills/catch-up/SKILL.md
+++ b/ralph/skills/catch-up/SKILL.md
@@ -24,6 +24,15 @@ allowed-tools:
 The unified orientation verb. Default flow is narrative + picker (matches the old
 `/ralph-hero:hello`). The `--mode` flag selects a single-surface alternative.
 
+## Step 0: `--loop` gate
+
+Use the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
+
+- **`--mode report`** → allowed. Default interval `1d`. Use `catch-up:report` manifest row — heartbeat, no `Queue empty.` terminal; re-fires on clock.
+  - Dry-run default: unless `--post` is in `$ARGUMENTS` OR `RALPH_CATCH_UP_HEARTBEAT_POST=true`, append `--dry-run` to `STRIPPED_ARGS` before wrapping (compose + print only; do NOT call `create_status_update`).
+  - Emit `Skill("loop", args="${LOOP_INTERVAL:-1d} /ralph:catch-up --mode report ${STRIPPED_ARGS}\n\n<continuation from loop-wrapper.md manifest>")` then STOP.
+- **Any other mode** (default/narrative/dashboard) → emit refusal from `loop-wrapper.md` § Refusal message, then STOP.
+
 ## Mode dispatch
 
 | Mode | Behavior | Equivalent to |
@@ -125,6 +134,8 @@ Compose per `report-composition.md`:
 3. Compose the markdown body using the template in `report-composition.md`.
 4. If `--with-trends`, call `ralph_hero__metrics_trends` with `format="markdown"` and append under `## Trends` only when ≥2 snapshots exist.
 5. Determine final status: `--status` override > `metrics.status` > fallback.
+
+**Heartbeat dry-run default**: when invoked via `--loop` without an explicit `--post` flag and `RALPH_CATCH_UP_HEARTBEAT_POST` is unset, `--dry-run` is implicitly active. The skill composes the report, writes the markdown body to stdout, appends the literal hint line `> hint: to actually post this status update, re-run with --post (or set RALPH_CATCH_UP_HEARTBEAT_POST=true).`, and exits WITHOUT calling `create_status_update`. Non-loop invocations preserve post-by-default behavior. Opt-in to heartbeat-posting: explicit `--post` OR `RALPH_CATCH_UP_HEARTBEAT_POST=true`.
 
 If `--dry-run`: display the composed body + determined status + `Dry run complete. No status update posted.` Stop.
 

--- a/ralph/skills/catch-up/SKILL.md
+++ b/ralph/skills/catch-up/SKILL.md
@@ -5,7 +5,7 @@ description: Orientation companion — catches you up on what changed since you 
   user asks "what's going on", "what should I work on", "catch me up", "show me
   the board", "post a status update", or starts a session wanting orientation.
   --mode flag selects narrative / dashboard / report sub-surfaces.
-argument-hint: "[--mode {narrative,dashboard,report}] [--dry-run] [--window N] [--status ON_TRACK|AT_RISK|OFF_TRACK] [--with-trends]"
+argument-hint: "[--mode {narrative,dashboard,report}] [--dry-run] [--window N] [--status ON_TRACK|AT_RISK|OFF_TRACK] [--with-trends] [--loop [duration]]"
 context: inline
 allowed-tools:
   - Read

--- a/ralph/skills/catch-up/SKILL.md
+++ b/ralph/skills/catch-up/SKILL.md
@@ -24,9 +24,15 @@ allowed-tools:
 The unified orientation verb. Default flow is narrative + picker (matches the old
 `/ralph-hero:hello`). The `--mode` flag selects a single-surface alternative.
 
-## Step 0: `--loop` gate
+## Step 0: Flag guards
 
-Use the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
+**`--auto` refusal** — if `--auto` appears in `$ARGUMENTS`, emit the following and STOP (see `ralph/skills/shared/auto-alias.md` § Refusal targets):
+
+```
+--auto is not supported for this verb (interactive / single-artifact / one-shot). See ralph/CLAUDE.md § Loop and --auto suitability matrix for the canonical table.
+```
+
+**`--loop` gate** — use the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
 
 - **`--mode report`** → allowed. Default interval `1d`. Use `catch-up:report` manifest row — heartbeat, no `Queue empty.` terminal; re-fires on clock.
   - Dry-run default: unless `--post` is in `$ARGUMENTS` OR `RALPH_CATCH_UP_HEARTBEAT_POST=true`, append `--dry-run` to `STRIPPED_ARGS` before wrapping (compose + print only; do NOT call `create_status_update`).

--- a/ralph/skills/form/SKILL.md
+++ b/ralph/skills/form/SKILL.md
@@ -43,6 +43,14 @@ inline descriptions into structured GitHub artifacts via an interactive picker.
 | `--mode draft` | Quick capture: ask 2-3 questions → write to `thoughts/shared/ideas/` | `/ralph-hero:draft` |
 | `--help` / `-h` | Print this table and exit | — |
 
+## Step 0: Flag guard
+
+**`--auto` refusal** — if `--auto` appears in `$ARGUMENTS`, emit the following and STOP (see `ralph/skills/shared/auto-alias.md` § Refusal targets):
+
+```
+--auto is not supported for this verb (interactive / single-artifact / one-shot). See ralph/CLAUDE.md § Loop and --auto suitability matrix for the canonical table.
+```
+
 ## Step 1: Intake routing
 
 Read `intake-shapes.md` to set `INPUT_TYPE` (`"idea"` | `"research"`) and (if applicable) capture `LINKED_ISSUE`. If no argument and not `--mode draft`, follow the no-args fallback in `intake-shapes.md` to list recent ideas.

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -106,6 +106,10 @@ References: [state-machine.md](state-machine.md), [task-graph.md](task-graph.md)
 
 ## Step 0: Parse arguments + set subcommand scope
 
+**`--auto` alias** — resolve BEFORE mode dispatch. See `ralph/skills/shared/auto-alias.md`:
+- If `--auto` in `$ARGUMENTS` AND `--mode` also present → emit `--auto cannot be combined with explicit --mode; pick one.` and STOP.
+- If `--auto` in `$ARGUMENTS` → strip `--auto` token, prepend `--mode auto` to `$ARGUMENTS` (verb=hero alias row). The `RALPH_AUTOPILOT_ENABLE` gate still applies — `--mode auto` dispatches via `/loop` which is guarded by `autopilot-enable-gate.sh`.
+
 ```bash
 case "$ARGUMENTS" in
   --mode\ auto*)        export RALPH_SUBCOMMAND=auto ;;

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -165,6 +165,8 @@ Do not maintain your own iteration counter or termination gate — `/loop` and `
 
 Watcher team entrypoint. Full dispatch table + SOUL refusal preconditions + heartbeat shape in [watch-dispatch.md](watch-dispatch.md).
 
+**`--loop` gate** — detect `--loop [interval]` (snippet from `loop-wrapper.md` § Arg-parsing snippet). If present: default interval `15m` (see `RALPH_WATCH_HEARTBEAT_MIN`). Use `hero:watch` manifest row — heartbeat, no `Queue empty.` terminal sentinel; re-fires unless `RALPH_WATCH_DISABLE=true` or user cancels via `/tasks`. Emit `Skill("loop", args="${LOOP_INTERVAL:-15m} /ralph:hero --mode watch ${STRIPPED_ARGS}\n\n<continuation from loop-wrapper.md manifest>")` then STOP.
+
 ```bash
 # Argument parse: --issue NNN or bare NNN → direct mode; no arg → heartbeat mode
 case "$ARGUMENTS" in

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -148,22 +148,7 @@ Director-only mode: classify one event, dispatch the correct verb, stop. Full ta
 
 Autonomous backlog drain via `/loop` dynamic mode. Opt-in enforced by `autopilot-enable-gate.sh` — if `RALPH_AUTOPILOT_ENABLE != true`, the `Skill("loop", …)` call exits 2 with a deterministic message.
 
-```
-Skill("loop", args="Run /ralph:hero --mode classify on the next-most-important event on the project queue. Classify reads next_actions, picks the top-ranked event, handles trigger:<team> label consumption, and dispatches the right team.
-
-Continuation rule (LOAD-BEARING — enforced by autopilot-stop-gate.sh):
-  • classify emits 'result: Queue empty'  → end the loop, do NOT call ScheduleWakeup.
-  • classify emits ANY OTHER result line  → you MUST call ScheduleWakeup before returning.
-
-Pick delays:
-  • 60-270s when classify made forward progress (stays in prompt cache)
-  • 1200-1800s when the queue has only stuck or in-review items
-  • NEVER 300s (rejected by autopilot-wakeup-clear.sh — cache-window anti-pattern)
-
-Trust classify's decisions. Human Needed issues are filtered out automatically — run /ralph:caretake --mode unblock in a separate loop to drain them.")
-```
-
-Do not maintain your own iteration counter or termination gate — `/loop` and `--mode classify` own that. Cancel via `/tasks` → delete pending wakeup.
+Emit `Skill("loop", args="Run /ralph:hero --mode classify …\n\n<continuation prompt from loop-wrapper.md § Continuation-prompt template, hero:default manifest row>")`. Fill `{INNER_COMMAND}` = `Run /ralph:hero --mode classify on the next-most-important event on the project queue`, `{TERMINAL_SENTINELS}` = `result: Queue empty.`, delay buckets from the manifest. Do not maintain an iteration counter — `/loop` and `--mode classify` own that. Cancel via `/tasks` → delete pending wakeup.
 
 ## --mode watch
 

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Autonomous orchestrator for the ralph slim plugin. Drives a GitHub issue through the full lifecycle (research → plan → impl → review → merge) with a human plan-approval gate by default. Five modes:default(one-shot), --mode auto (autopilot drain via /loop), --mode classify (director-only dispatch), --mode watch (watcher heartbeat), --mode pr-drain (PR triage). Triggers on "run the hero", "drain the backlog", "classify this issue", "dispatch this", "watch the alerts", "drain this PR", "auto mode", "ship this ticket".
-argument-hint: "[<issue-number> | --mode <auto|classify|watch|pr-drain>] [--issue NNN] [--pr NNN] [--since <window>]"
+argument-hint: "[<issue-number> | --mode <auto|classify|watch|pr-drain>] [--issue NNN] [--pr NNN] [--since <window>] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:

--- a/ralph/skills/impl/SKILL.md
+++ b/ralph/skills/impl/SKILL.md
@@ -92,6 +92,10 @@ References: [worktree-setup.md](worktree-setup.md) (worktree lifecycle, cross-re
 
 ## Step 0: Parse arguments
 
+**`--auto` alias** — resolve BEFORE `--loop` detection. See `ralph/skills/shared/auto-alias.md`:
+- If `--auto` in `$ARGUMENTS` AND `--mode` also present → emit `--auto cannot be combined with explicit --mode; pick one.` and STOP.
+- If `--auto` in `$ARGUMENTS` → strip `--auto` token, prepend `--mode auto` to `$ARGUMENTS` (verb=impl alias row). Continue to `--loop` detection with the rewritten args.
+
 **`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
 - MODE `auto` → `Skill("loop", …)` using the `impl:auto` manifest row + continuation-prompt template from `loop-wrapper.md`, then STOP.
 - MODE `pr` → `Skill("loop", …)` using the `impl:pr` row, then STOP.

--- a/ralph/skills/impl/SKILL.md
+++ b/ralph/skills/impl/SKILL.md
@@ -92,6 +92,11 @@ References: [worktree-setup.md](worktree-setup.md) (worktree lifecycle, cross-re
 
 ## Step 0: Parse arguments
 
+**`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
+- MODE `auto` → `Skill("loop", …)` using the `impl:auto` manifest row + continuation-prompt template from `loop-wrapper.md`, then STOP.
+- MODE `pr` → `Skill("loop", …)` using the `impl:pr` row, then STOP.
+- MODE `default` or `address` → emit the refusal from `loop-wrapper.md` § Refusal message, then STOP.
+
 Resolve `MODE`, `TARGET`, optional flags from args:
 
 - no args → `MODE=default`, prompt for TARGET

--- a/ralph/skills/impl/SKILL.md
+++ b/ralph/skills/impl/SKILL.md
@@ -9,7 +9,7 @@ description: Implement an approved plan, address PR review feedback, or create a
   --mode auto runs ONE phase autonomously per invocation, hook-gated. --mode
   address handles PR review feedback. --mode pr creates a pull request for a
   completed implementation.
-argument-hint: "[--mode auto|address|pr] [<issue-number|plan-path>] [--plan-doc <path>] [--push-drive|--no-push-drive]"
+argument-hint: "[--mode auto|address|pr] [<issue-number|plan-path>] [--plan-doc <path>] [--push-drive|--no-push-drive] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -120,6 +120,10 @@ critique-with-verdict.
 
 Set `MODE` ∈ `{default, auto, epic, iterate, review}` from `--mode` flag (default if absent). Capture `ARG` (remaining positional). Capture `--playwright` / `--no-playwright`. Bail with the mode table on `--help`.
 
+**`--auto` alias** — resolve BEFORE `--loop` detection. See `ralph/skills/shared/auto-alias.md`:
+- If `--auto` in `$ARGUMENTS` AND `--mode` also present → emit `--auto cannot be combined with explicit --mode; pick one.` and STOP.
+- If `--auto` in `$ARGUMENTS` → strip `--auto` token, prepend `--mode auto` to `$ARGUMENTS` (verb=plan alias row). Continue to `--loop` detection with the rewritten args.
+
 **`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
 - MODE `auto` → `Skill("loop", …)` using the `plan:auto` manifest row + continuation-prompt template from `loop-wrapper.md`, then STOP.
 - MODE `review` → `Skill("loop", …)` using the `plan:review` row, then STOP.

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -11,7 +11,7 @@ description: Create, iterate on, or review an implementation plan. Use whenever 
   autonomous XS/S picker. --mode epic is multi-tier strategic decomposition that
   creates feature children. --mode iterate makes surgical updates to an existing
   plan. --mode review produces an APPROVED/NEEDS_ITERATION verdict.
-argument-hint: "[--mode auto|epic|iterate|review] [<issue-number|plan-path|description>] [--playwright|--no-playwright]"
+argument-hint: "[--mode auto|epic|iterate|review] [<issue-number|plan-path|description>] [--playwright|--no-playwright] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -120,6 +120,11 @@ critique-with-verdict.
 
 Set `MODE` ∈ `{default, auto, epic, iterate, review}` from `--mode` flag (default if absent). Capture `ARG` (remaining positional). Capture `--playwright` / `--no-playwright`. Bail with the mode table on `--help`.
 
+**`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
+- MODE `auto` → `Skill("loop", …)` using the `plan:auto` manifest row + continuation-prompt template from `loop-wrapper.md`, then STOP.
+- MODE `review` → `Skill("loop", …)` using the `plan:review` row, then STOP.
+- MODE `default`, `iterate`, or `epic` → emit the refusal from `loop-wrapper.md` § Refusal message, then STOP.
+
 No env-flip is needed between modes: the hooks discriminate by the file path being written (review-no-dup / review-verify-doc no-op outside `thoughts/shared/reviews/`; doc-structure-validator picks its branch by which artifact dir has the most recent today-prefixed doc; plan-state-gate accepts the union of legitimate transitions across all modes).
 
 ## Default flow

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -88,6 +88,10 @@ Set `MODE` ∈ `{default, auto, prove}` from `--mode` flag (default if absent).
 Capture `ARG` as the remaining positional. Capture `--playwright` /
 `--no-playwright` overrides. Bail with the mode table on `--help` / `-h`.
 
+**`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
+- MODE `auto` → `Skill("loop", …)` using the `research:auto` manifest row + continuation-prompt template from `loop-wrapper.md`, then STOP.
+- MODE `default` or `prove` → emit the refusal from `loop-wrapper.md` § Refusal message, then STOP.
+
 ## Default flow
 
 ### Step 1: Intake

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -8,7 +8,7 @@ description: Investigate a codebase question, a GitHub issue, or a claim. Use wh
   lets you review findings before writing the doc). --mode auto runs the
   autonomous Research-Needed picker. --mode prove runs a 5-step knowledge-graph
   claim investigation that produces a verdict + confidence + evidence chains.
-argument-hint: "[--mode auto|prove] [<question|#NNN|claim>] [--playwright|--no-playwright]"
+argument-hint: "[--mode auto|prove] [<question|#NNN|claim>] [--playwright|--no-playwright] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -88,6 +88,10 @@ Set `MODE` ∈ `{default, auto, prove}` from `--mode` flag (default if absent).
 Capture `ARG` as the remaining positional. Capture `--playwright` /
 `--no-playwright` overrides. Bail with the mode table on `--help` / `-h`.
 
+**`--auto` alias** — resolve BEFORE `--loop` detection. See `ralph/skills/shared/auto-alias.md`:
+- If `--auto` in `$ARGUMENTS` AND `--mode` also present → emit `--auto cannot be combined with explicit --mode; pick one.` and STOP.
+- If `--auto` in `$ARGUMENTS` → strip `--auto` token, prepend `--mode auto` to `$ARGUMENTS` (verb=research alias row). Continue to `--loop` detection with the rewritten args.
+
 **`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). If `LOOP_RAW` is set:
 - MODE `auto` → `Skill("loop", …)` using the `research:auto` manifest row + continuation-prompt template from `loop-wrapper.md`, then STOP.
 - MODE `default` or `prove` → emit the refusal from `loop-wrapper.md` § Refusal message, then STOP.

--- a/ralph/skills/review/SKILL.md
+++ b/ralph/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Validate an implementation against its plan, run code review, merge an approved PR, or do the full close-out (val → code-review → merge → CI watch). Use whenever the user says "review this", "validate the impl", "run code review", "merge the PR", "close the loop", "ship it", "finish #NNN", "is this ready to merge", "did the plan get fulfilled". Default mode runs the full close-out and owns the depth-0 fan-out for `code-review:code-review`. --mode val validates impl vs. plan with citation gate + drift log. --mode code runs the code-review-and-fix loop (up to 3 rounds). --mode merge is merge-only mechanics (refuses unreviewed PRs).
-argument-hint: "[--mode val|code|merge] [<issue-number>] [--pr-url <url>] [--plan-doc <path>]"
+argument-hint: "[--mode val|code|merge] [<issue-number>] [--pr-url <url>] [--plan-doc <path>] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:

--- a/ralph/skills/review/SKILL.md
+++ b/ralph/skills/review/SKILL.md
@@ -61,6 +61,10 @@ References: [plan-vs-impl-rubric.md](plan-vs-impl-rubric.md) (val rubric: citati
 
 ## Step 0: Parse arguments
 
+**`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). All review modes are queue-drainers — `--loop` is accepted for all. If `LOOP_RAW` is set:
+- MODE `default` → `Skill("loop", …)` via `review:default` row + continuation-prompt template from `loop-wrapper.md`, then STOP.
+- MODE `val` → `review:val` row; `code` → `review:code` row; `merge` → `review:merge` row. In each case: STOP after emitting `Skill("loop", …)`.
+
 Resolve `MODE`, `TARGET`, optional flags from args:
 
 - no args → `MODE=default`, prompt for `TARGET`

--- a/ralph/skills/review/SKILL.md
+++ b/ralph/skills/review/SKILL.md
@@ -61,6 +61,10 @@ References: [plan-vs-impl-rubric.md](plan-vs-impl-rubric.md) (val rubric: citati
 
 ## Step 0: Parse arguments
 
+**`--auto` alias** — resolve BEFORE `--loop` detection. See `ralph/skills/shared/auto-alias.md`:
+- If `--auto` in `$ARGUMENTS` AND `--mode` also present → emit `--auto cannot be combined with explicit --mode; pick one.` and STOP.
+- If `--auto` in `$ARGUMENTS` → strip `--auto` token from `$ARGUMENTS` only (verb=review: default mode is already autonomous; no mode flag prepended). Continue to `--loop` detection with the rewritten args.
+
 **`--loop` gate** — run the arg-parsing snippet from `ralph/skills/shared/loop-wrapper.md` § Arg-parsing snippet (sets `LOOP_RAW`, `LOOP_INTERVAL`, `STRIPPED_ARGS`). All review modes are queue-drainers — `--loop` is accepted for all. If `LOOP_RAW` is set:
 - MODE `default` → `Skill("loop", …)` via `review:default` row + continuation-prompt template from `loop-wrapper.md`, then STOP.
 - MODE `val` → `review:val` row; `code` → `review:code` row; `merge` → `review:merge` row. In each case: STOP after emitting `Skill("loop", …)`.

--- a/ralph/skills/setup/SKILL.md
+++ b/ralph/skills/setup/SKILL.md
@@ -45,6 +45,12 @@ References: [scope-detection.md](scope-detection.md), [project-fields.md](projec
 
 ## Step 0: Parse arguments + set subcommand scope
 
+**`--auto` refusal** — if `--auto` appears in `$ARGUMENTS`, emit the following and STOP (see `ralph/skills/shared/auto-alias.md` § Refusal targets):
+
+```
+--auto is not supported for this verb (interactive / single-artifact / one-shot). See ralph/CLAUDE.md § Loop and --auto suitability matrix for the canonical table.
+```
+
 ```bash
 case "$ARGUMENTS" in
   --mode\ project*)  export RALPH_SUBCOMMAND=project ;;

--- a/ralph/skills/shared/__tests__/auto-alias.test.sh
+++ b/ralph/skills/shared/__tests__/auto-alias.test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# auto-alias.test.sh — Verify --auto arg-rewrite logic for ralph slim plugin skills
+# Usage: bash ralph/skills/shared/__tests__/auto-alias.test.sh
+# Exit 0 = all pass; exit 1 = at least one failure.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; echo "      expected: $2"; echo "      got:      $3"; FAIL=$((FAIL + 1)); }
+
+# Embed the same rewrite logic the Step-0 stanzas use.
+# $1 = verb (research|plan|impl|review|caretake|hero|form|catch-up|setup)
+# $2 = raw ARGUMENTS string
+# Outputs two lines: "ARGUMENTS=<result>" and "MSG=<conflict/refusal msg, empty if none>"
+resolve_auto() {
+  local verb="$1"
+  local ARGUMENTS="$2"
+  local MSG=""
+
+  # Refusal targets
+  case "$verb" in
+    form|catch-up|setup)
+      if [[ "$ARGUMENTS" =~ (^|[[:space:]])--auto([[:space:]]|$) ]]; then
+        MSG="--auto is not supported for this verb (interactive / single-artifact / one-shot). See ralph/CLAUDE.md § Loop and --auto suitability matrix for the canonical table."
+        printf 'ARGUMENTS=%s\nMSG=%s\n' "$ARGUMENTS" "$MSG"
+        return
+      fi
+      ;;
+  esac
+
+  # Alias-table verbs
+  if [[ "$ARGUMENTS" =~ (^|[[:space:]])--auto([[:space:]]|$) ]]; then
+    # Conflict: --auto + explicit --mode
+    if [[ "$ARGUMENTS" =~ (^|[[:space:]])--mode[[:space:]] ]]; then
+      MSG="--auto cannot be combined with explicit --mode; pick one."
+      printf 'ARGUMENTS=%s\nMSG=%s\n' "$ARGUMENTS" "$MSG"
+      return
+    fi
+
+    # Strip --auto token
+    local stripped
+    stripped="$(printf '%s' "$ARGUMENTS" | sed -E 's/(^|[[:space:]])--auto([[:space:]]|$)/\1/g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+    # Prepend resolved mode per alias table
+    case "$verb" in
+      research|plan|impl|hero)
+        ARGUMENTS="--mode auto${stripped:+ ${stripped}}"
+        ;;
+      caretake)
+        ARGUMENTS="--mode triage${stripped:+ ${stripped}}"
+        ;;
+      review)
+        # No mode prepend; default is already autonomous
+        ARGUMENTS="${stripped}"
+        ;;
+    esac
+  fi
+
+  printf 'ARGUMENTS=%s\nMSG=%s\n' "$ARGUMENTS" "$MSG"
+}
+
+# Helper: extract field from resolve_auto output
+get_field() {
+  local field="$1"
+  local output="$2"
+  printf '%s' "$output" | grep "^${field}=" | cut -d= -f2-
+}
+
+# ── fixtures ────────────────────────────────────────────────────────────────────
+
+# 1. --auto bare (research verb) → --mode auto
+out=$(resolve_auto research "--auto")
+args=$(get_field ARGUMENTS "$out"); msg=$(get_field MSG "$out")
+if [[ "$args" == "--mode auto" && -z "$msg" ]]; then
+  ok "--auto bare → --mode auto (research)"
+else
+  fail "--auto bare" "--mode auto / no msg" "args='$args' msg='$msg'"
+fi
+
+# 2. --auto --loop → mode resolved first, --loop preserved in STRIPPED_ARGS
+out=$(resolve_auto impl "--auto --loop")
+args=$(get_field ARGUMENTS "$out"); msg=$(get_field MSG "$out")
+if [[ "$args" == "--mode auto --loop" && -z "$msg" ]]; then
+  ok "--auto --loop → --mode auto --loop (impl)"
+else
+  fail "--auto --loop" "--mode auto --loop / no msg" "args='$args' msg='$msg'"
+fi
+
+# 3. --loop --auto (token order reversed) → same result
+out=$(resolve_auto plan "--loop --auto")
+args=$(get_field ARGUMENTS "$out"); msg=$(get_field MSG "$out")
+if [[ "$args" == "--mode auto --loop" && -z "$msg" ]]; then
+  ok "--loop --auto → --mode auto --loop (plan)"
+else
+  fail "--loop --auto" "--mode auto --loop / no msg" "args='$args' msg='$msg'"
+fi
+
+# 4. --auto #1234 → mode prepended, issue number preserved
+out=$(resolve_auto research "--auto #1234")
+args=$(get_field ARGUMENTS "$out"); msg=$(get_field MSG "$out")
+if [[ "$args" == "--mode auto #1234" && -z "$msg" ]]; then
+  ok "--auto #1234 → --mode auto #1234 (research)"
+else
+  fail "--auto #1234" "--mode auto #1234 / no msg" "args='$args' msg='$msg'"
+fi
+
+# 5. --auto --mode auto (conflict) → conflict message
+out=$(resolve_auto research "--auto --mode auto")
+msg=$(get_field MSG "$out")
+if [[ "$msg" == "--auto cannot be combined with explicit --mode; pick one." ]]; then
+  ok "--auto --mode auto → conflict message"
+else
+  fail "--auto --mode auto conflict" "conflict msg" "msg='$msg'"
+fi
+
+# 6. --auto --mode prove (conflict) → conflict message
+out=$(resolve_auto research "--auto --mode prove")
+msg=$(get_field MSG "$out")
+if [[ "$msg" == "--auto cannot be combined with explicit --mode; pick one." ]]; then
+  ok "--auto --mode prove → conflict message"
+else
+  fail "--auto --mode prove conflict" "conflict msg" "msg='$msg'"
+fi
+
+# 7. No --auto (baseline) → ARGUMENTS unchanged
+out=$(resolve_auto impl "--mode auto #5")
+args=$(get_field ARGUMENTS "$out"); msg=$(get_field MSG "$out")
+if [[ "$args" == "--mode auto #5" && -z "$msg" ]]; then
+  ok "no --auto baseline → ARGUMENTS unchanged"
+else
+  fail "no --auto baseline" "--mode auto #5 / no msg" "args='$args' msg='$msg'"
+fi
+
+# 8. caretake --auto → --mode triage
+out=$(resolve_auto caretake "--auto")
+args=$(get_field ARGUMENTS "$out"); msg=$(get_field MSG "$out")
+if [[ "$args" == "--mode triage" && -z "$msg" ]]; then
+  ok "--auto (caretake) → --mode triage"
+else
+  fail "--auto caretake" "--mode triage / no msg" "args='$args' msg='$msg'"
+fi
+
+# 9. review --auto → no mode flag added (default is already autonomous)
+out=$(resolve_auto review "--auto")
+args=$(get_field ARGUMENTS "$out"); msg=$(get_field MSG "$out")
+if [[ -z "$args" && -z "$msg" ]]; then
+  ok "--auto (review) → no mode flag added (default is autonomous)"
+else
+  fail "--auto review" "empty args / no msg" "args='$args' msg='$msg'"
+fi
+
+# 10. form --auto → refusal
+out=$(resolve_auto form "--auto")
+msg=$(get_field MSG "$out")
+if [[ "$msg" == *"--auto is not supported for this verb"* ]]; then
+  ok "--auto (form) → refusal message"
+else
+  fail "--auto form" "refusal msg" "msg='$msg'"
+fi
+
+# 11. catch-up --auto → refusal
+out=$(resolve_auto catch-up "--auto")
+msg=$(get_field MSG "$out")
+if [[ "$msg" == *"--auto is not supported for this verb"* ]]; then
+  ok "--auto (catch-up) → refusal message"
+else
+  fail "--auto catch-up" "refusal msg" "msg='$msg'"
+fi
+
+# 12. setup --auto → refusal
+out=$(resolve_auto setup "--auto")
+msg=$(get_field MSG "$out")
+if [[ "$msg" == *"--auto is not supported for this verb"* ]]; then
+  ok "--auto (setup) → refusal message"
+else
+  fail "--auto setup" "refusal msg" "msg='$msg'"
+fi
+
+# ── summary ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/ralph/skills/shared/__tests__/loop-arg-strip.test.sh
+++ b/ralph/skills/shared/__tests__/loop-arg-strip.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# loop-arg-strip.test.sh — Verify arg-parsing snippet from loop-wrapper.md § Arg-parsing snippet
+# Usage: bash ralph/skills/shared/__tests__/loop-arg-strip.test.sh
+# Exit 0 = all pass; exit 1 = at least one failure.
+#
+# Embeds an identical copy of the snippet (per loop-wrapper.md guidance: copy-paste,
+# not sourced, so each consumer is self-contained). Tests document REAL snippet behavior
+# including the --loop dynamic case (dynamic is not a numeric duration so it stays in
+# STRIPPED_ARGS).
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; echo "      expected: $2"; echo "      got:      $3"; FAIL=$((FAIL + 1)); }
+
+# Run the Phase-1 arg-parsing snippet for the given ARGUMENTS string.
+# Outputs three lines: LOOP_RAW=<val>  LOOP_INTERVAL=<val>  STRIPPED_ARGS=<val>
+run_snippet() {
+  local ARGUMENTS="$1"
+  local LOOP_RAW=""
+  local LOOP_INTERVAL=""
+  local STRIPPED_ARGS="$ARGUMENTS"
+  if [[ "$ARGUMENTS" =~ (^|[[:space:]])--loop([[:space:]]+([0-9]+[smhd][0-9smhd]*))?([[:space:]]|$) ]]; then
+    LOOP_RAW="1"
+    LOOP_INTERVAL="${BASH_REMATCH[3]}"
+    STRIPPED_ARGS="$(printf '%s' "$ARGUMENTS" | sed -E 's/(^|[[:space:]])--loop([[:space:]]+[0-9]+[smhd][0-9smhd]*)?([[:space:]]|$)/\1/g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  fi
+  printf 'LOOP_RAW=%s\nLOOP_INTERVAL=%s\nSTRIPPED_ARGS=%s\n' \
+    "$LOOP_RAW" "$LOOP_INTERVAL" "$STRIPPED_ARGS"
+}
+
+# Extract field from run_snippet output
+get_field() {
+  local field="$1"
+  local output="$2"
+  printf '%s' "$output" | grep "^${field}=" | cut -d= -f2-
+}
+
+# ── fixtures ────────────────────────────────────────────────────────────────────
+
+# 1. --loop (bare, no duration, no other args)
+out=$(run_snippet "--loop")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && -z "$interval" && -z "$stripped" ]]; then
+  ok "fixture 1: --loop → LOOP_RAW=1, LOOP_INTERVAL='', STRIPPED_ARGS=''"
+else
+  fail "fixture 1: --loop" "raw=1 interval='' stripped=''" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 2. --loop 5m (duration captured, stripped)
+out=$(run_snippet "--loop 5m")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && "$interval" == "5m" && -z "$stripped" ]]; then
+  ok "fixture 2: --loop 5m → LOOP_RAW=1, LOOP_INTERVAL='5m', STRIPPED_ARGS=''"
+else
+  fail "fixture 2: --loop 5m" "raw=1 interval='5m' stripped=''" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 3. --loop dynamic (dynamic is not a numeric duration; documents real behavior)
+# Snippet: --loop matches but duration pattern [0-9]+[smhd]* does not match "dynamic"
+# → LOOP_RAW=1, LOOP_INTERVAL='', STRIPPED_ARGS='dynamic' (word left behind by sed)
+out=$(run_snippet "--loop dynamic")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && -z "$interval" && "$stripped" == "dynamic" ]]; then
+  ok "fixture 3: --loop dynamic → LOOP_RAW=1, LOOP_INTERVAL='', STRIPPED_ARGS='dynamic'"
+else
+  fail "fixture 3: --loop dynamic" "raw=1 interval='' stripped='dynamic'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 4. --mode auto --loop (flag at end of args)
+out=$(run_snippet "--mode auto --loop")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && -z "$interval" && "$stripped" == "--mode auto" ]]; then
+  ok "fixture 4: --mode auto --loop → LOOP_RAW=1, LOOP_INTERVAL='', STRIPPED_ARGS='--mode auto'"
+else
+  fail "fixture 4: --mode auto --loop" "raw=1 interval='' stripped='--mode auto'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 5. --mode auto --loop 1h (flag with duration at end)
+out=$(run_snippet "--mode auto --loop 1h")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && "$interval" == "1h" && "$stripped" == "--mode auto" ]]; then
+  ok "fixture 5: --mode auto --loop 1h → LOOP_RAW=1, LOOP_INTERVAL='1h', STRIPPED_ARGS='--mode auto'"
+else
+  fail "fixture 5: --mode auto --loop 1h" "raw=1 interval='1h' stripped='--mode auto'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 6. --loop --mode auto (flag at beginning, other args follow)
+out=$(run_snippet "--loop --mode auto")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && -z "$interval" && "$stripped" == "--mode auto" ]]; then
+  ok "fixture 6: --loop --mode auto → LOOP_RAW=1, LOOP_INTERVAL='', STRIPPED_ARGS='--mode auto'"
+else
+  fail "fixture 6: --loop --mode auto" "raw=1 interval='' stripped='--mode auto'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 7. --mode auto --loop 5m #1234 (flag with duration, issue number preserved)
+out=$(run_snippet "--mode auto --loop 5m #1234")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && "$interval" == "5m" && "$stripped" == "--mode auto #1234" ]]; then
+  ok "fixture 7: --mode auto --loop 5m #1234 → LOOP_RAW=1, LOOP_INTERVAL='5m', STRIPPED_ARGS='--mode auto #1234'"
+else
+  fail "fixture 7: --mode auto --loop 5m #1234" "raw=1 interval='5m' stripped='--mode auto #1234'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 8. --loop --pr 99 (flag before other flag)
+out=$(run_snippet "--loop --pr 99")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && -z "$interval" && "$stripped" == "--pr 99" ]]; then
+  ok "fixture 8: --loop --pr 99 → LOOP_RAW=1, LOOP_INTERVAL='', STRIPPED_ARGS='--pr 99'"
+else
+  fail "fixture 8: --loop --pr 99" "raw=1 interval='' stripped='--pr 99'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 9. not-a-loop-flag --loop something (flag in mid-position; documents real behavior)
+# Snippet matches --loop; "something" is left in STRIPPED_ARGS (not a numeric duration)
+out=$(run_snippet "not-a-loop-flag --loop something")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ "$raw" == "1" && -z "$interval" && "$stripped" == "not-a-loop-flag something" ]]; then
+  ok "fixture 9: not-a-loop-flag --loop something → LOOP_RAW=1, LOOP_INTERVAL='', STRIPPED_ARGS='not-a-loop-flag something'"
+else
+  fail "fixture 9: not-a-loop-flag --loop something" "raw=1 interval='' stripped='not-a-loop-flag something'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# 10. Baseline: no --loop flag present
+out=$(run_snippet "--mode auto #5")
+raw=$(get_field LOOP_RAW "$out"); interval=$(get_field LOOP_INTERVAL "$out"); stripped=$(get_field STRIPPED_ARGS "$out")
+if [[ -z "$raw" && -z "$interval" && "$stripped" == "--mode auto #5" ]]; then
+  ok "fixture 10: baseline (no --loop) → LOOP_RAW='', LOOP_INTERVAL='', STRIPPED_ARGS='--mode auto #5'"
+else
+  fail "fixture 10: baseline" "raw='' interval='' stripped='--mode auto #5'" "raw='$raw' interval='$interval' stripped='$stripped'"
+fi
+
+# ── summary ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/ralph/skills/shared/__tests__/loop-continuation.test.sh
+++ b/ralph/skills/shared/__tests__/loop-continuation.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# loop-continuation.test.sh — Verify heartbeat-vs-drain distinction in loop-wrapper.md manifest
+# Usage: bash ralph/skills/shared/__tests__/loop-continuation.test.sh
+# Exit 0 = all pass; exit 1 = at least one failure.
+#
+# Parses loop-wrapper.md § Continuation-rules manifest.
+# Asserts:
+#   heartbeat-mode rows do NOT list "Queue empty." as a terminal sentinel.
+#   drain-mode rows DO list "Queue empty." as a terminal sentinel.
+# Catches manifest drift if someone wires a new skill with the wrong continuation shape.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+# Locate repo root from this script's location (ralph/skills/shared/__tests__)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LOOP_WRAPPER="${REPO_ROOT}/ralph/skills/shared/loop-wrapper.md"
+
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; echo "      expected: $2"; echo "      got:      $3"; FAIL=$((FAIL + 1)); }
+
+if [[ ! -f "$LOOP_WRAPPER" ]]; then
+  echo "FATAL: loop-wrapper.md not found at ${LOOP_WRAPPER}"
+  exit 1
+fi
+
+# Extract the manifest table: lines between ## Continuation-rules manifest and the next ---
+# Table rows start with "| " (pipe-space)
+manifest=$(awk '/^## Continuation-rules manifest/,/^---/' "$LOOP_WRAPPER" | grep '^|')
+
+if [[ -z "$manifest" ]]; then
+  echo "FATAL: No manifest table rows found in loop-wrapper.md § Continuation-rules manifest"
+  exit 1
+fi
+
+# Helper: get the row for a given skill:mode key (exact match on first column)
+get_row() {
+  local key="$1"
+  printf '%s\n' "$manifest" | grep "^| ${key} "
+}
+
+# Helper: check terminal-sentinel column (column 4) of a row for "Queue empty."
+row_has_queue_empty() {
+  local row="$1"
+  # Table cols: | skill:mode | progress sentinels | terminal sentinels | delay buckets | notes |
+  # Extract col 4 (terminal sentinels) by splitting on |
+  local terminal_col
+  terminal_col=$(printf '%s' "$row" | awk -F'|' '{print $4}')
+  printf '%s' "$terminal_col" | grep -q 'Queue empty\.'
+}
+
+# ── Heartbeat modes: must NOT have Queue empty. as terminal sentinel ───────────
+
+HEARTBEAT_MODES=(
+  "caretake:hygiene"
+  "caretake:trends"
+  "caretake:all"
+  "catch-up:report"
+  "hero:watch"
+)
+
+for mode in "${HEARTBEAT_MODES[@]}"; do
+  row=$(get_row "$mode")
+  if [[ -z "$row" ]]; then
+    fail "manifest row exists for ${mode}" "row present" "not found"
+    continue
+  fi
+  if row_has_queue_empty "$row"; then
+    fail "${mode} is heartbeat → no Queue empty. in terminal sentinels" \
+      "Queue empty. NOT present" \
+      "Queue empty. IS present in: $(printf '%s' "$row" | awk -F'|' '{print $4}')"
+  else
+    ok "${mode} (heartbeat) does not list Queue empty. as terminal sentinel"
+  fi
+done
+
+# ── Drain modes: must have Queue empty. as terminal sentinel ──────────────────
+
+DRAIN_MODES=(
+  "research:auto"
+  "plan:auto"
+  "plan:review"
+  "impl:auto"
+  "impl:pr"
+  "review:default"
+  "review:val"
+  "review:code"
+  "review:merge"
+  "caretake:triage"
+  "caretake:unblock"
+  "caretake:debug"
+  "caretake:split"
+  "caretake:default-event"
+  "hero:default"
+)
+
+for mode in "${DRAIN_MODES[@]}"; do
+  row=$(get_row "$mode")
+  if [[ -z "$row" ]]; then
+    fail "manifest row exists for ${mode}" "row present" "not found"
+    continue
+  fi
+  if row_has_queue_empty "$row"; then
+    ok "${mode} (drain) lists Queue empty. as terminal sentinel"
+  else
+    fail "${mode} is drain → Queue empty. in terminal sentinels" \
+      "Queue empty. present" \
+      "not found in: $(printf '%s' "$row" | awk -F'|' '{print $4}')"
+  fi
+done
+
+# ── Summary note from manifest ─────────────────────────────────────────────────
+# Verify the explanatory note about heartbeat vs drain is present in the file.
+if grep -q 'Heartbeat vs. drain continuation rule' "$LOOP_WRAPPER"; then
+  ok "manifest contains heartbeat-vs-drain continuation rule summary"
+else
+  fail "heartbeat-vs-drain summary" "summary present" "not found in loop-wrapper.md"
+fi
+
+# ── summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/ralph/skills/shared/__tests__/loop-refusal.test.sh
+++ b/ralph/skills/shared/__tests__/loop-refusal.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# loop-refusal.test.sh — Verify refusal-message template and unsuitable-mode coverage
+# Usage: bash ralph/skills/shared/__tests__/loop-refusal.test.sh
+# Exit 0 = all pass; exit 1 = at least one failure.
+#
+# Does NOT invoke skills — parses loop-wrapper.md, auto-alias.md, and ralph/CLAUDE.md.
+# Validates:
+#   1. The --loop refusal message in loop-wrapper.md renders as a single line.
+#   2. The unsuitable-mode list in ralph/CLAUDE.md covers every entry in the
+#      plan's Current-State unsuitable table:
+#        form, plan (default/iterate/epic), impl (default/address),
+#        research (default/prove), catch-up (default/narrative/dashboard),
+#        setup, hero (pr-drain), caretake (postmortem/retro), caretake (unblock --question)
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+# Locate repo root from this script's location (ralph/skills/shared/__tests__)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LOOP_WRAPPER="${REPO_ROOT}/ralph/skills/shared/loop-wrapper.md"
+AUTO_ALIAS="${REPO_ROOT}/ralph/skills/shared/auto-alias.md"
+RALPH_CLAUDE="${REPO_ROOT}/ralph/CLAUDE.md"
+
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; echo "      expected: $2"; echo "      got:      $3"; FAIL=$((FAIL + 1)); }
+
+# ── 1. loop-wrapper.md exists and has ## Refusal message section ────────────────
+
+if [[ -f "$LOOP_WRAPPER" ]]; then
+  ok "loop-wrapper.md exists"
+else
+  fail "loop-wrapper.md exists" "file present" "not found at ${LOOP_WRAPPER}"
+fi
+
+refusal_section=$(grep -c '^## Refusal message' "$LOOP_WRAPPER" 2>/dev/null || echo 0)
+if [[ "$refusal_section" -ge 1 ]]; then
+  ok "loop-wrapper.md has ## Refusal message section"
+else
+  fail "## Refusal message section" "≥1 match" "0 matches"
+fi
+
+# ── 2. Refusal message is a single contiguous line (no embedded newlines) ──────
+
+# Extract the canonical refusal string by searching for the identifying substring
+# Use -e flag to prevent grep from interpreting --loop as an option
+canonical_prefix="loop is not supported for this mode"
+matching_line=$(grep -e "$canonical_prefix" "$LOOP_WRAPPER" | head -1)
+
+if [[ -n "$matching_line" ]]; then
+  ok "canonical refusal text found in loop-wrapper.md"
+  # Verify it is a single line (no embedded newlines — the grep output is one line by definition)
+  ok "canonical refusal text is a single line (grep returns one line)"
+else
+  fail "canonical refusal text" "line containing '${canonical_prefix}'" "not found in loop-wrapper.md"
+fi
+
+# Verify the full canonical text appears verbatim on one line (use -e to avoid -- misparse)
+full_canonical="loop is not supported for this mode. Looping is meaningful only for autonomous queue-drainers; this surface is interactive. See ralph/CLAUDE.md"
+if grep -qe "$full_canonical" "$LOOP_WRAPPER"; then
+  ok "full canonical refusal text present verbatim (including CLAUDE.md reference)"
+else
+  fail "full canonical refusal text" "verbatim match" "not found in loop-wrapper.md"
+fi
+
+# ── 3. auto-alias.md exists and has ## Refusal targets section ─────────────────
+
+if [[ -f "$AUTO_ALIAS" ]]; then
+  ok "auto-alias.md exists"
+else
+  fail "auto-alias.md exists" "file present" "not found at ${AUTO_ALIAS}"
+fi
+
+refusal_targets_section=$(grep -c '^## Refusal targets' "$AUTO_ALIAS" 2>/dev/null || echo 0)
+if [[ "$refusal_targets_section" -ge 1 ]]; then
+  ok "auto-alias.md has ## Refusal targets section"
+else
+  fail "## Refusal targets section in auto-alias.md" "≥1 match" "0 matches"
+fi
+
+# ── 4. ralph/CLAUDE.md has the full unsuitable-mode matrix ─────────────────────
+# The canonical source for the loop suitability matrix is ralph/CLAUDE.md
+# (written in Phase 4). Parse it to confirm every unsuitable surface from the plan is covered.
+
+if [[ -f "$RALPH_CLAUDE" ]]; then
+  ok "ralph/CLAUDE.md exists"
+else
+  fail "ralph/CLAUDE.md exists" "file present" "not found at ${RALPH_CLAUDE}"
+fi
+
+# Each entry: label | grep pattern to search in ralph/CLAUDE.md
+check_unsuitable() {
+  local label="$1"
+  local pattern="$2"
+  if grep -qE "$pattern" "$RALPH_CLAUDE"; then
+    ok "unsuitable surface documented in ralph/CLAUDE.md: ${label}"
+  else
+    fail "unsuitable surface in ralph/CLAUDE.md: ${label}" \
+      "pattern '${pattern}' found" \
+      "not found"
+  fi
+}
+
+# Plan's Current-State unsuitable table (§ Where looping is meaningless):
+check_unsuitable "form"                         "form.*No|No.*form"
+check_unsuitable "plan iterate"                 "plan.*iterate|iterate"
+check_unsuitable "plan epic"                    "plan.*epic|epic"
+check_unsuitable "impl default/address"         "impl.*address|address"
+check_unsuitable "research default/prove"       "research.*prove|prove"
+check_unsuitable "catch-up default/narrative"   "catch-up.*No|narrative.*No"
+check_unsuitable "setup"                        "setup.*No|No.*setup"
+check_unsuitable "hero pr-drain"                "pr-drain.*No|No.*pr-drain"
+check_unsuitable "caretake postmortem"          "postmortem.*No|No.*postmortem"
+check_unsuitable "caretake retro"               "retro.*No|No.*retro"
+check_unsuitable "caretake unblock --question"  "unblock.*question|--question"
+
+# ── 5. Refusal targets in auto-alias.md cover form, catch-up, setup ────────────
+
+for verb in form catch-up setup; do
+  if grep -q "$verb" "$AUTO_ALIAS"; then
+    ok "auto-alias.md refusal targets include: ${verb}"
+  else
+    fail "auto-alias.md refusal targets include: ${verb}" "found" "not found"
+  fi
+done
+
+# ── summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/ralph/skills/shared/auto-alias.md
+++ b/ralph/skills/shared/auto-alias.md
@@ -1,0 +1,65 @@
+# auto-alias.md — Per-verb `--auto` alias for ralph slim plugin skills
+
+Reference fragment. SKILL.md bodies copy the logic below; they do not source this file.
+
+---
+
+## Alias table
+
+`--auto` rewrites `$ARGUMENTS` to the verb's most autonomous mode before `--loop` detection runs.
+`review` is already autonomous by default; no mode flag is added.
+
+| Verb | `--auto` rewrites to |
+|---|---|
+| research | `--mode auto` |
+| plan | `--mode auto` |
+| impl | `--mode auto` |
+| review | (no change; default mode is already an autonomous queue-drainer) |
+| caretake | `--mode triage` |
+| hero | `--mode auto` |
+
+---
+
+## Refusal targets
+
+Verbs that refuse `--auto` entirely (interactive / single-artifact / one-shot):
+
+- `form` — interactive picker with 3-5 AskUserQuestion calls
+- `catch-up` — interactive orientation (default/narrative/dashboard modes)
+- `setup` — one-shot bootstrap; no queue to drain
+
+Refusal text (emit verbatim, then STOP):
+
+```
+--auto is not supported for this verb (interactive / single-artifact / one-shot). See ralph/CLAUDE.md § Loop and --auto suitability matrix for the canonical table.
+```
+
+---
+
+## Conflict detection
+
+If `$ARGUMENTS` contains BOTH `--auto` AND an explicit `--mode <x>`, emit the following and STOP:
+
+```
+--auto cannot be combined with explicit --mode; pick one.
+```
+
+---
+
+## Step-0 stanza (copy into each alias-table verb's Step 0, ahead of `--loop` detection)
+
+```bash
+# --auto alias resolution (run BEFORE --loop detection)
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])--auto([[:space:]]|$) ]]; then
+  if [[ "$ARGUMENTS" =~ (^|[[:space:]])--mode[[:space:]] ]]; then
+    printf '%s\n' "--auto cannot be combined with explicit --mode; pick one."
+    exit 0
+  fi
+  # Rewrite: remove --auto token, prepend resolved mode (verb-specific)
+  ARGUMENTS="$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])--auto([[:space:]]|$)/\1/g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  ARGUMENTS="--mode <RESOLVED_MODE> ${ARGUMENTS}"
+fi
+```
+
+Replace `<RESOLVED_MODE>` per the alias table row for the verb being edited.
+`review` skips the `--mode` prepend (default is already autonomous); just strip `--auto`.

--- a/ralph/skills/shared/loop-wrapper.md
+++ b/ralph/skills/shared/loop-wrapper.md
@@ -1,0 +1,113 @@
+# loop-wrapper.md — Shared `--loop` substrate for ralph slim plugin skills
+
+Reference fragment. SKILL.md bodies copy the snippets below; they do not source this file.
+
+---
+
+## Arg-parsing snippet
+
+Copy into Step 0 of each loop-suitable SKILL.md body. Detects `--loop [optional duration]`
+anywhere in `$ARGUMENTS`, sets three variables, and leaves the rest of the args in `STRIPPED_ARGS`.
+
+```bash
+LOOP_RAW=""
+LOOP_INTERVAL=""
+STRIPPED_ARGS="$ARGUMENTS"
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])--loop([[:space:]]+([0-9]+[smhd][0-9smhd]*))?([[:space:]]|$) ]]; then
+  LOOP_RAW="1"
+  LOOP_INTERVAL="${BASH_REMATCH[3]}"
+  STRIPPED_ARGS="$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])--loop([[:space:]]+[0-9]+[smhd][0-9smhd]*)?([[:space:]]|$)/\1/g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+fi
+```
+
+Usage after the snippet:
+- `[[ -n "${LOOP_RAW:-}" ]]` — true when `--loop` was present.
+- `LOOP_INTERVAL` — the duration token (e.g. `5m`, `1h`); empty string for dynamic mode.
+- `STRIPPED_ARGS` — `$ARGUMENTS` with `--loop [duration]` removed; pass this to the wrapped invocation.
+
+---
+
+## Continuation-rules manifest
+
+One row per loop-suitable `skill:mode`. Heartbeat modes re-fire on a clock; drain modes stop on `Queue empty.`
+
+| skill:mode | progress sentinels | terminal sentinels | delay buckets | notes |
+|---|---|---|---|---|
+| research:auto | `Research complete for #NNN` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain Research Needed queue |
+| plan:auto | `Plan complete for #NNN` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain Ready for Plan queue |
+| plan:review | `Plan reviewed for #NNN` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain Plan in Review queue |
+| impl:auto | `Phase N/M complete.` / `Implementation complete for #NNN` | `IMPL BLOCKED …` / `Queue empty.` | 60-270s on progress; 1200s on no-op | drain unlocked impl phases |
+| impl:pr | `PR CREATED / …` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain ready-for-PR queue |
+| review:default | `FINISHED / …` / `FINISH BLOCKED — …` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain In Review queue |
+| review:val | `VALIDATION PASS / FIX / FAIL` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain validation queue |
+| review:code | `CODE REVIEW PASSED / ESCALATED` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain code-review queue |
+| review:merge | `MERGED / …` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain mergeable queue |
+| caretake:triage | `TRIAGED <verdict>` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain Backlog |
+| caretake:hygiene | `HYGIENE COMPLETE <N>` / `HYGIENE BLOCKED <reason>` | (none — heartbeat; re-fire always) | default interval 1h; 60-270s if changes made | periodic scan |
+| caretake:unblock | `UNBLOCK REQUEST POSTED` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain Human Needed queue |
+| caretake:trends | (markdown stdout is the deliverable) | (none — heartbeat; re-fire always) | default interval 6h; schedule accordingly | periodic snapshot |
+| caretake:debug | `DEBUG FILED <N>` / `DEBUG SKIPPED <reason>` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain Langfuse errors |
+| caretake:split | `SPLIT <N>` / `SPLIT SKIPPED <reason>` | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain M/L/XL queue |
+| caretake:all | (fan-out, no aggregated sentinel) | (none — heartbeat; re-fire always) | default interval 1h; schedule accordingly | periodic fan-out heartbeat |
+| caretake:default-event | per dispatched mode | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain trigger:* labels |
+| catch-up:report | `Status update posted successfully.` | (none — heartbeat; re-fire always) | default interval 1d; schedule accordingly | periodic status post |
+| hero:default | `result: Hero complete — …` / `result: Hero paused at …` | `result: Queue empty.` | 60-270s on progress; 1200-1800s idle | drain top-ranked issues |
+| hero:watch | `result: Watch complete — …` | (none — heartbeat; re-fire always) | default interval 15m; schedule accordingly | polling heartbeat |
+
+**Heartbeat vs. drain continuation rule**: heartbeat modes (caretake:hygiene, caretake:trends, caretake:all, catch-up:report, hero:watch) do NOT list `Queue empty.` as a terminal sentinel — they re-fire on a clock regardless of whether any work was found. Drain modes DO list `Queue empty.` as the signal to end the loop.
+
+---
+
+## Continuation-prompt template
+
+Paste this template into the `Skill("loop", args="…")` call in each SKILL.md's Step 0.
+Replace `{INNER_COMMAND}`, `{PROGRESS_SENTINELS}`, `{TERMINAL_SENTINELS}`, and `{DELAY_BUCKETS}`
+from the manifest row for the skill:mode being wrapped.
+
+```
+Skill("loop", args="${LOOP_INTERVAL:+${LOOP_INTERVAL} }{INNER_COMMAND}
+
+Continuation rules (LOAD-BEARING):
+  Progress sentinels  — re-fire: {PROGRESS_SENTINELS}
+  Terminal sentinels  — end loop, do NOT call ScheduleWakeup: {TERMINAL_SENTINELS}
+
+Pick delays:
+{DELAY_BUCKETS}
+  NEVER 300s (cache-window anti-pattern — 5 min lands exactly at the prompt-cache
+  expiry boundary; a new cache miss doubles token cost on every tick).
+
+Trust the inner command's decisions. It handles queue selection, locking, and all
+state transitions. Do not second-guess its result line or attempt to re-run work
+it declared complete. Cancel the loop via /tasks → delete pending wakeup.")
+```
+
+**Worked example (impl:auto):**
+
+```
+Skill("loop", args="Run /ralph:impl --mode auto ${STRIPPED_ARGS}
+
+Continuation rules (LOAD-BEARING):
+  Progress sentinels  — re-fire: Phase N/M complete. / Implementation complete for #NNN
+  Terminal sentinels  — end loop, do NOT call ScheduleWakeup: IMPL BLOCKED … / Queue empty.
+
+Pick delays:
+  60-270s when impl made forward progress (stays in prompt cache)
+  1200s when the queue has no unlocked phases (idle)
+  NEVER 300s (cache-window anti-pattern — 5 min lands exactly at the prompt-cache
+  expiry boundary; a new cache miss doubles token cost on every tick).
+
+Trust the inner command's decisions. It handles queue selection, locking, and all
+state transitions. Do not second-guess its result line or attempt to re-run work
+it declared complete. Cancel the loop via /tasks → delete pending wakeup.")
+```
+
+---
+
+## Refusal message
+
+Copy into the unsuitable-mode branch of any SKILL.md that receives `--loop` on an
+interactive or single-shot surface.
+
+```bash
+printf '%s\n' "--loop is not supported for this mode. Looping is meaningful only for autonomous queue-drainers; this surface is interactive. See ralph/CLAUDE.md § Loop suitability."
+```


### PR DESCRIPTION
## Summary

Generalizes the existing `hero --mode auto` `/loop` wrapping pattern into a uniform **`--loop [duration]`** flag across every loop-suitable skill+mode in `ralph/`, adds a complementary per-verb **`--auto`** alias, and overhauls the triage verdict palette to drive forward motion.

- **`--loop [duration]`** — short-circuits a skill's Step 0 to emit `Skill("loop", args="<interval> /ralph:<verb> <stripped-args>\n\n<continuation-rules>")` and return. The wrapped child re-enters the same skill with `--loop` stripped and runs its normal autonomous flow inside `/loop`'s runtime. Wired into drain modes (research/plan/impl/review/caretake) and heartbeat modes (hero watch=15m, caretake all=1h / trends=6h, catch-up report=1d).
- **`--auto`** — aliases each verb to its most autonomous mode (research/plan/impl/hero→`--mode auto`, caretake→`--mode triage`, review→default). Composes with `--loop`; conflicts with explicit `--mode`.
- **Shared substrate** — per-skill continuation rules + the arg-parsing snippet + refusal message live in one source of truth: `ralph/skills/shared/loop-wrapper.md` (manifest) and `ralph/skills/shared/auto-alias.md` (alias table). `hero --mode auto` was refactored to consume the shared template (−15 lines, no behavior change).
- **catch-up heartbeat dry-run** — `catch-up --mode report --loop` defaults to `--dry-run` (prints + hint line, no GitHub post) unless `--post` or `RALPH_CATCH_UP_HEARTBEAT_POST=true`, so cadenced loops don't spam status updates.
- **Triage palette overhaul** — replaces the dormant `KEEP` verdict with explicit `ROUTE-TO-<queue>` outcomes so every triage call produces forward motion or escalates; adds a `triage-no-skill-dispatch.sh` self-containment hook (triage routes via state transition; the next loop tick picks the issue up via the right verb's `--auto`).

Interactive / single-shot surfaces (form, setup, plan default/iterate/epic, impl default/address, research default/prove, catch-up default/narrative/dashboard, hero pr-drain, caretake postmortem/retro/unblock --question) explicitly **refuse** `--loop`/`--auto` with a one-line message.

## Plan

[`thoughts/shared/plans/2026-05-24-GH-1402-add-loop-flag-to-ralph-skills.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-24-GH-1402-add-loop-flag-to-ralph-skills.md) (7 phases, M-tier) · Review critique: [`thoughts/shared/reviews/2026-05-24-GH-1402-critique.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-24-GH-1402-critique.md)

## Test plan

- `ralph/skills/shared/__tests__/loop-arg-strip.test.sh` — 10 arg-stripping fixtures ✅
- `ralph/skills/shared/__tests__/loop-refusal.test.sh` — refusal message + unsuitable-mode list ✅
- `ralph/skills/shared/__tests__/loop-continuation.test.sh` — heartbeat rows omit `Queue empty.`, drain rows include it ✅
- `ralph/skills/shared/__tests__/auto-alias.test.sh` — 12 `--auto` rewrite/conflict/refusal fixtures ✅
- `ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh` — 17 token-palette assertions ✅
- `ralph/hooks/scripts/__tests__/triage-no-skill-dispatch.test.sh` — 6 self-containment-gate assertions ✅
- `ralph/scripts/lint-loop-snippet.sh` — arg-parsing snippet passes `bash -n` ✅
- MCP-server regression: `npm test` → 1624 passed, 3 skipped ✅

10 new files, 13 modified. No MCP-server source / schema changes; one existing hook edit (`triage-postcondition.sh`) + one new hook (`triage-no-skill-dispatch.sh`).

Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
