### PR TITLE
fix(ralph): hero --mode auto loop sleeps ~30 min on every productive tick

### DIFF
--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -148,7 +148,9 @@ Director-only mode: classify one event, dispatch the correct verb, stop. Full ta
 
 Autonomous backlog drain via `/loop` dynamic mode. Opt-in enforced by `autopilot-enable-gate.sh` — if `RALPH_AUTOPILOT_ENABLE != true`, the `Skill("loop", …)` call exits 2 with a deterministic message.
 
-Emit `Skill("loop", args="Run /ralph:hero --mode classify …\n\n<continuation prompt from loop-wrapper.md § Continuation-prompt template, hero:default manifest row>")`. Fill `{INNER_COMMAND}` = `Run /ralph:hero --mode classify on the next-most-important event on the project queue`, `{TERMINAL_SENTINELS}` = `result: Queue empty.`, delay buckets from the manifest. Do not maintain an iteration counter — `/loop` and `--mode classify` own that. Cancel via `/tasks` → delete pending wakeup.
+Emit `Skill("loop", args="Run /ralph:hero --mode classify …\n\n<continuation prompt from loop-wrapper.md § Continuation-prompt template, hero:auto manifest row>")`. Fill `{INNER_COMMAND}` = `Run /ralph:hero --mode classify on the next-most-important event on the project queue`, `{PROGRESS_SENTINELS}` = `result: Dispatched #NNN to <team> via <entrypoint>` (the line `--mode classify` emits on every successful dispatch — see step 6 of `--mode classify` above), `{TERMINAL_SENTINELS}` = `result: Queue empty.`, delay buckets from the `hero:auto` row (60-270s on dispatch; 1200s idle). Do not maintain an iteration counter — `/loop` and `--mode classify` own that. Cancel via `/tasks` → delete pending wakeup.
+
+> **Use the `hero:auto` row, NOT `hero:default`.** `--mode auto` wraps `--mode classify`, whose success line is `result: Dispatched #NNN …` — not the `result: Hero complete …` / `result: Hero paused …` lines on the `hero:default` row. Keying the loop to `hero:default` made every successful dispatch match no progress sentinel, so the model fell through to the idle bucket (~30 min) on every productive tick. The `hero:auto` row makes a dispatch register as progress so the drain continues at 60-270s.
 
 ## --mode watch
 

--- a/ralph/skills/shared/__tests__/loop-continuation.test.sh
+++ b/ralph/skills/shared/__tests__/loop-continuation.test.sh
@@ -95,6 +95,7 @@ DRAIN_MODES=(
   "caretake:split"
   "caretake:default-event"
   "hero:default"
+  "hero:auto"
 )
 
 for mode in "${DRAIN_MODES[@]}"; do

--- a/ralph/skills/shared/loop-wrapper.md
+++ b/ralph/skills/shared/loop-wrapper.md
@@ -52,6 +52,7 @@ One row per loop-suitable `skill:mode`. Heartbeat modes re-fire on a clock; drai
 | caretake:default-event | per dispatched mode | `Queue empty.` | 60-270s on progress; 1200-1800s idle | drain trigger:* labels |
 | catch-up:report | `Status update posted successfully.` | (none — heartbeat; re-fire always) | default interval 1d; schedule accordingly | periodic status post |
 | hero:default | `result: Hero complete — …` / `result: Hero paused at …` | `result: Queue empty.` | 60-270s on progress; 1200-1800s idle | drain top-ranked issues |
+| hero:auto | `result: Dispatched #NNN to <team> via <entrypoint>` | `result: Queue empty.` | 60-270s on dispatch; 1200s when a tick dispatched nothing but queue non-terminal | classify-drain (the row `hero --mode auto` wraps — its inner command is `--mode classify`, whose success line is `Dispatched …`, NOT `Hero complete`). Pinned idle value mirrors impl:auto so a successful dispatch always registers as progress instead of falling through to idle |
 | hero:watch | `result: Watch complete — …` | (none — heartbeat; re-fire always) | default interval 15m; schedule accordingly | polling heartbeat |
 
 **Heartbeat vs. drain continuation rule**: heartbeat modes (caretake:hygiene, caretake:trends, caretake:all, catch-up:report, hero:watch) do NOT list `Queue empty.` as a terminal sentinel — they re-fire on a clock regardless of whether any work was found. Drain modes DO list `Queue empty.` as the signal to end the loop.


### PR DESCRIPTION
## Problem

`/ralph:hero --mode auto` (the slim plugin's north-star autopilot entry) tends to pick **~30 min** wakeup delays even while it's actively draining the queue, when it should continue at 60-270s to keep working.

## Root cause

`--mode auto` runs `--mode classify` as its inner command per tick, but its `/loop` continuation prompt borrowed the **`hero:default`** manifest row in `loop-wrapper.md`. That row's progress sentinels are `result: Hero complete …` / `result: Hero paused …` — strings `--mode classify` **never emits**. Classify's actual success line is:

```
result: Dispatched #NNN to <team> via <entrypoint>
```

So on the most common, most productive outcome (a successful dispatch), the loop's continuation logic matched **no** progress sentinel and **no** terminal sentinel (`Queue empty.`), and fell through to the **idle bucket (1200-1800s ≈ 30 min)** on every productive tick.

Two compounding smells:
- There was **no `classify`/`hero:auto` row** in the manifest at all — `--mode auto` was forced to reuse `hero:default`.
- `hero:default`'s idle bucket is a vague range (`1200-1800s idle`); the one row that gets this right is `impl:auto` (`1200s on no-op` — single value, concrete trigger).

## Fix

- Add a dedicated **`hero:auto`** manifest row in `loop-wrapper.md`, keyed to the `Dispatched` progress sentinel with a **pinned 1200s** idle value (mirroring `impl:auto`). A successful dispatch now registers as progress → drain continues at 60-270s.
- Repoint `hero/SKILL.md` `--mode auto` at the `hero:auto` row, fill `{PROGRESS_SENTINELS}` explicitly, and add an inline note explaining why `hero:default` is wrong here.
- Extend `loop-continuation.test.sh` to cover the new drain row.

## Test

```
$ bash ralph/skills/shared/__tests__/loop-continuation.test.sh
Results: 22 passed, 0 failed
```
(includes the new `hero:auto (drain) lists Queue empty. as terminal sentinel` assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)