### PR TITLE
fix(ralph): correct plan-review dispatch verb + scope plan-state-gate (GH-1413)

### DIFF
--- a/ralph/hooks/scripts/plan-state-gate.sh
+++ b/ralph/hooks/scripts/plan-state-gate.sh
@@ -12,11 +12,28 @@
 set -euo pipefail
 source "$(dirname "$0")/hook-utils.sh"
 
+# Slim-plugin scope: only activate for /ralph:plan. Without this guard the hook
+# stays registered after /ralph:plan hands off (e.g. under /ralph:hero) and fires
+# on every subsequent save_issue — including impl/merge transitions it has no
+# business adjudicating (GH-1413). Mirrors impl/merge/triage-state-gate.
+if [[ "${RALPH_COMMAND:-}" != "plan" ]]; then
+  allow
+fi
+
 read_input > /dev/null
 
 new_state=$(get_field '.tool_input.workflowState')
 if [[ -z "$new_state" ]]; then
   allow  # Not a state update
+fi
+
+# Semantic-intent transitions (__LOCK__, __COMPLETE__, __ESCALATE__, etc.) are
+# resolved by the MCP save_issue tool to concrete workflow states; the gate must
+# not block them at the intent layer. --mode auto/epic lock via __LOCK__ and
+# advance via __COMPLETE__, so without this passthrough those legitimate plan
+# transitions false-block (GH-1413).
+if is_semantic_intent "$new_state"; then
+  allow_with_context "Semantic intent '$new_state' is resolved server-side; plan-state-gate defers to MCP."
 fi
 
 # Slim-plugin /ralph:plan covers 5 modes (default + auto + epic + iterate + review).

--- a/ralph/skills/hero/dispatch.md
+++ b/ralph/skills/hero/dispatch.md
@@ -10,7 +10,7 @@
 | RESEARCH | `/ralph:research --auto` | `NNN` (or `NNN --mode prove` for claim-checks) |
 | PLAN (XS/S/M) | `/ralph:plan --auto` | `NNN [--research-doc PATH]` |
 | PLAN (L/XL epic) | `/ralph:plan --auto --mode epic` | `NNN [--research-doc PATH]` |
-| REVIEW (plan) | `/ralph:review --mode plan` | `NNN [--plan-doc PATH]` |
+| REVIEW (plan) | `/ralph:plan --mode review` | `NNN [--plan-doc PATH]` |
 | IMPLEMENT | `/ralph:impl --auto` | `NNN [--plan-doc PATH]` |
 | PR | `/ralph:impl --mode pr` | `NNN` |
 | INTEGRATE | `/ralph:review` | `NNN` |
@@ -62,7 +62,7 @@ After all plans complete, read `$RALPH_REVIEW_PLAN` (default `auto`):
 
 **`auto`:**
 
-Dispatch `Skill("ralph:review", args="NNN --mode plan --plan-doc PATH")` for each plan. Route on verdict:
+Dispatch `Skill("ralph:plan", args="NNN --mode review --plan-doc PATH")` for each plan. Route on verdict:
 
 - **ALL APPROVED** → batch update all issues in the group to "In Progress", report plan locations, continue
 - **NEEDS_ITERATION** → return critique to `/ralph:plan`, re-dispatch, re-review. Max 2 iterations before escalating

--- a/ralph/skills/hero/state-machine.md
+++ b/ralph/skills/hero/state-machine.md
@@ -23,7 +23,7 @@
 |    |- PLAN (per group) -- create implementation plans              |
 |    |- PLAN REVIEW GATE                                             |
 |    |   | plan review is "auto":                                    |
-|    |   |   /ralph:review --mode plan critiques plan                |
+|    |   |   /ralph:plan --mode review critiques plan                |
 |    |   |   APPROVED -> report plan location, advance, continue     |
 |    |   |   NEEDS_ITERATION -> return critique to /ralph:plan        |
 |    |   |   ESCALATE -> move to Human Needed, STOP                  |
@@ -55,7 +55,7 @@
 | SPLIT | `SPLIT` | One or more M/L/XL issues need decomposition. Dispatch `/ralph:caretake --mode split #NNN` per issue. After all complete, re-detect. |
 | RESEARCH | `RESEARCH` | All "Research Needed" leaves run in parallel via `/ralph:research --auto NNN` |
 | PLAN | `PLAN` | After research converges, plan per primary issue via `/ralph:plan --auto NNN [--research-doc PATH]` |
-| REVIEW | `REVIEW` | Plan-review gate. When `RALPH_REVIEW_PLAN=auto`, dispatch `/ralph:review --mode plan NNN`. When `interactive`, surface AskUserQuestion picker. |
+| REVIEW | `REVIEW` | Plan-review gate. When `RALPH_REVIEW_PLAN=auto`, dispatch `/ralph:plan --mode review NNN`. When `interactive`, surface AskUserQuestion picker. |
 | HUMAN_GATE | `HUMAN_GATE` | Issue is in Human Needed. STOP and report blocker. Do not auto-dispatch unblock — that's caretake's job. |
 | IMPLEMENT | `IMPLEMENT` | Dispatch `/ralph:impl --auto NNN [--plan-doc PATH]` (one issue at a time, respecting `blockedBy` chains) |
 | INTEGRATE | `INTEGRATE` | PR + merge. PR via `/ralph:impl --mode pr NNN`; merge gate via `/ralph:review NNN` (default mode = code-review + merge). |

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -36,11 +36,11 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-plan-gate.sh"
-  PostToolUse:
     - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-state-gate.sh"
+  PostToolUse:
     - matcher: "Write"
       hooks:
         - type: command


### PR DESCRIPTION
Closes #1413.

Both defects from the bug report were confirmed to **persist in v0.1.11** source under `ralph/`. Fix is scoped to exactly the two reported defects.

## Pain point 1 — plan-review dispatched to a nonexistent verb
`ralph:hero` routed the REVIEW phase to `/ralph:review --mode plan`, but `ralph:review` has no `plan` mode (only `default`/`val`/`code`/`merge`). A literal dispatch falls through to `MODE=default` and `STOP`s with `FINISH BLOCKED — wrong state`. The actual plan-review verb is **`/ralph:plan --mode review`**.

Updated all 4 references:
- `ralph/skills/hero/dispatch.md` — phase→verb table + §Plan review gate `Skill()` call
- `ralph/skills/hero/state-machine.md` — ASCII diagram + phase table

## Pain point 2 — `plan-state-gate.sh` leaks across skills + false-blocks
Compared to its sibling gates (`impl-state-gate.sh`, `merge-state-gate.sh`, `triage-state-gate.sh`), `plan-state-gate.sh` was missing **two** guards:

1. **Scope-guard** `if [[ "${RALPH_COMMAND:-}" != "plan" ]]; then allow`. Without it the gate stays active after `/ralph:plan` hands off (e.g. under `/ralph:hero`) and fires on every later `save_issue` — including impl/merge transitions → the cross-skill leak.
2. **Semantic-intent passthrough** (`is_semantic_intent`). `__LOCK__`/`__COMPLETE__`/etc. resolve server-side; without the passthrough they false-block (also fixes latent cosmetic noise in plan's own auto/epic modes).

Plus the registration in `plan/SKILL.md` was **PostToolUse** — so the "block" was cosmetic (mutation already committed) and alarming. Moved it to **PreToolUse**, which the script header and its `allow_with_context` PreToolUse JSON already assumed, and which `set-skill-env.sh`'s comment already documents (it lists `plan-state-gate` among the `RALPH_COMMAND`-scoped gates).

## Verification
10 hook cases exercised — all pass:

| RALPH_COMMAND | state | result |
|---|---|---|
| _(unset)_ | In Review | allow (scope-guard) |
| impl | In Review | **allow** — leak scenario fixed |
| review | Done | **allow** — leak scenario fixed |
| plan | `__LOCK__` / `__COMPLETE__` | allow (semantic intent) |
| plan | In Review / Done | block (illegal plan transition) |
| plan | Plan in Review / In Progress | allow (legal) |
| plan | _(empty)_ | allow (label-only save) |

`allow_with_context` JSON validated; zero remaining `--mode plan` refs; bash + YAML lint clean. No MCP-server source touched → no npm release triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)