### PR TITLE
GH-1416: split-on-epic emits a parent plan-of-plans so split children are autonomously plannable

### DIFF
--- a/ralph/hooks/scripts/doc-structure-validator.sh
+++ b/ralph/hooks/scripts/doc-structure-validator.sh
@@ -56,10 +56,22 @@ case "$command" in
     grep -qE '`[^`]+`' "$doc" || errors+=("Missing: backtick-wrapped file paths (e.g., \`src/file.ts\`) — referenced findings should use code-spans")
     ;;
   plan)
-    # Section names match ralph/skills/plan/plan-shapes.md § Section order.
-    grep -qE "^## Phase [0-9]" "$doc" || errors+=("Missing: '## Phase N:' header pattern (e.g., '## Phase 1: ...')")
-    grep -qE "^#### (Automated|Manual) Verification" "$doc" || errors+=("Missing: '#### Automated Verification' or '#### Manual Verification' subsections")
-    grep -qE "^- \[ \]" "$doc" || errors+=("Missing: success-criteria checkboxes '- [ ] ...'")
+    # Plan-of-plans (epic shape) vs regular plan: self-discriminate by shape, the
+    # same way plan-tier-validator.sh does. Strip fenced code blocks first so a
+    # plan-of-plans that documents the sibling shape in an example does not
+    # false-positive on the '## Feature Decomposition' grep.
+    plan_body=$(awk '/^```/ { f = !f; next } !f { print }' "$doc")
+    if grep -qE "^type:[[:space:]]*plan-of-plans" "$doc" \
+       || printf '%s\n' "$plan_body" | grep -qE "^## Feature Decomposition([[:space:]]|$)"; then
+      # Plan-of-plans shape — sections per ralph/skills/plan/decomposition.md § Plan-of-plans shape.
+      printf '%s\n' "$plan_body" | grep -qE "^## Feature Decomposition([[:space:]]|$)" || errors+=("Missing: '## Feature Decomposition' section (plan-of-plans shape)")
+      printf '%s\n' "$plan_body" | grep -qE "^## Feature Sequencing([[:space:]]|$)" || errors+=("Missing: '## Feature Sequencing' section (plan-of-plans shape)")
+    else
+      # Regular plan shape. Section names match ralph/skills/plan/plan-shapes.md § Section order.
+      grep -qE "^## Phase [0-9]" "$doc" || errors+=("Missing: '## Phase N:' header pattern (e.g., '## Phase 1: ...')")
+      grep -qE "^#### (Automated|Manual) Verification" "$doc" || errors+=("Missing: '#### Automated Verification' or '#### Manual Verification' subsections")
+      grep -qE "^- \[ \]" "$doc" || errors+=("Missing: success-criteria checkboxes '- [ ] ...'")
+    fi
     ;;
   review)
     grep -qE "APPROVED|NEEDS_ITERATION" "$doc" || errors+=("Missing: Verdict (APPROVED or NEEDS_ITERATION)")

--- a/ralph/hooks/scripts/doc-structure-validator.sh
+++ b/ralph/hooks/scripts/doc-structure-validator.sh
@@ -58,10 +58,12 @@ case "$command" in
   plan)
     # Plan-of-plans (epic shape) vs regular plan: self-discriminate by shape, the
     # same way plan-tier-validator.sh does. Strip fenced code blocks first so a
-    # plan-of-plans that documents the sibling shape in an example does not
-    # false-positive on the '## Feature Decomposition' grep.
+    # doc that documents the sibling shape in a fenced example does not
+    # false-positive on EITHER discriminator — both the frontmatter `type:` grep
+    # and the '## Feature Decomposition' grep run on the fence-stripped body
+    # (real frontmatter lives above any fence, so it survives the strip).
     plan_body=$(awk '/^```/ { f = !f; next } !f { print }' "$doc")
-    if grep -qE "^type:[[:space:]]*plan-of-plans" "$doc" \
+    if printf '%s\n' "$plan_body" | grep -qE "^type:[[:space:]]*plan-of-plans" \
        || printf '%s\n' "$plan_body" | grep -qE "^## Feature Decomposition([[:space:]]|$)"; then
       # Plan-of-plans shape — sections per ralph/skills/plan/decomposition.md § Plan-of-plans shape.
       printf '%s\n' "$plan_body" | grep -qE "^## Feature Decomposition([[:space:]]|$)" || errors+=("Missing: '## Feature Decomposition' section (plan-of-plans shape)")

--- a/ralph/skills/caretake/modes/split.md
+++ b/ralph/skills/caretake/modes/split.md
@@ -126,6 +126,18 @@ Sub-issue body template:
 
 For each dependency pair, `add_dependency`: the dependent issue is blocked by the earlier-phase issue. See [split-decomposition.md](../split-decomposition.md) §Dependency wiring for rules.
 
+## §Step 7.5: Write parent plan-of-plans
+
+When the split produced **2+ children** (the normal `SPLIT <N>` path — skip on the re-estimate / `SPLIT SKIPPED` path, which creates no children), write a parent plan-of-plans so the children are autonomously plannable. Without it, `/ralph:plan --mode auto` has neither a per-child research doc nor a parent plan to consume, so each child stalls and the cluster escalates to **Human Needed** (GH-1416).
+
+Write to `thoughts/shared/plans/YYYY-MM-DD-GH-<parent>-plan-of-plans.md` — the `<parent>` number is what the parent-plan-reuse glob `*GH-NNNN-*.md` keys on. Shape: [../../plan/decomposition.md](../../plan/decomposition.md) § Plan-of-plans shape — frontmatter `type: plan-of-plans`; sections `## Strategic Context`, `## Shared Constraints`, `## Feature Decomposition`, `## Integration Strategy`, `## Feature Sequencing`, `## What We're NOT Doing`. Model the wording on `/ralph:plan --mode epic` Step 3 (`ralph/skills/plan/SKILL.md`).
+
+One `### Feature` subsection per child under `## Feature Decomposition`, each embedding the child's **real issue number AND title** verbatim, plus its scope + acceptance from the body authored in §Step 6. The parent-plan-reuse short-circuit (`ralph/skills/plan/intake-routing.md`) matches a child to its section **by number or title**, so both must appear.
+
+Keep `## Feature Sequencing` **identical** to the `## Issue Split` dependency chain posted in §Step 8 — same edges, same order; the two artifacts must not diverge.
+
+This write happens in **caretake** context, where the plan skill's `plan-research-required.sh` Write gate is not armed — that is why split can emit a `plans/` doc with no research doc. The doc passes `doc-structure-validator.sh` because that hook recognizes the plan-of-plans shape (GH-1416).
+
 ## §Step 8: Update original issue
 
 Add a split-summary comment on the parent:

--- a/ralph/skills/caretake/split-decomposition.md
+++ b/ralph/skills/caretake/split-decomposition.md
@@ -65,6 +65,22 @@ Rules:
 
 Dependencies are orthogonal to workflow state. A child blocked by a sibling still gets `Ready for Plan` set in §Step 10 — `blockedBy` enforces ordering, not state.
 
+## §Plan-of-plans emission
+
+A multi-child split (`SPLIT <N>`, N ≥ 2) writes a **parent plan-of-plans** in [modes/split.md](modes/split.md) §Step 7.5. This is what makes split children autonomously plannable — closes GH-1416.
+
+**When it fires:** every split that creates ≥ 2 children. It does **not** fire on the re-estimate / `SPLIT SKIPPED` path (no children created, nothing to plan).
+
+**Filename:** `thoughts/shared/plans/YYYY-MM-DD-GH-<parent>-plan-of-plans.md`. The `<parent>` (the issue being split) is deliberate — the parent-plan-reuse short-circuit in `ralph/skills/plan/intake-routing.md` looks up the parent plan by glob `thoughts/shared/plans/*GH-<parent>-*.md`.
+
+**Shape:** the plan-of-plans shape in [../plan/decomposition.md](../plan/decomposition.md) § Plan-of-plans shape (`type: plan-of-plans` frontmatter; `## Feature Decomposition` + `## Feature Sequencing` are the load-bearing sections). `doc-structure-validator.sh` validates this shape (it self-discriminates plan-of-plans from regular plans by `type:`/`## Feature Decomposition`, fence-stripped).
+
+**Match contract:** one `### Feature` per child, each carrying the child's **real issue number AND title** — parent-plan reuse matches a child to its section *by number or title*. Without both, the reuse short-circuit can't bind the child and it falls back to the research-required path (the deadlock GH-1416 fixes).
+
+**Consistency:** `## Feature Sequencing` must equal the `## Issue Split` comment's dependency chain (§Step 8) — same edges, same order.
+
+**Why split (not plan) writes it:** split runs in **caretake** context, where the plan skill's `plan-research-required.sh` Write gate is not armed, so it can write a `plans/` doc with no research doc. The plan skill itself cannot (its own gate blocks the write).
+
 ## §Hook contracts
 
 Four `split-*` hooks gate this mode. Each scopes on `RALPH_SUBCOMMAND=split` (or legacy `RALPH_COMMAND=split` for the parallel period).

--- a/thoughts/shared/plans/2026-05-24-GH-1416-split-plan-of-plans-emission.md
+++ b/thoughts/shared/plans/2026-05-24-GH-1416-split-plan-of-plans-emission.md
@@ -167,10 +167,10 @@ reuse depends on, and the consistency requirement with the `## Issue Split` comm
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `grep -nE "plan-of-plans" ralph/skills/caretake/modes/split.md` shows the new write step
-- [ ] `grep -nE "plan-of-plans" ralph/skills/caretake/split-decomposition.md` shows the documented contract
-- [ ] `grep -n "thoughts/shared/plans" ralph/skills/caretake/modes/split.md` confirms the write target path is present
-- [ ] No `^## Feature Decomposition` + `^## Phase` mixed-shape corruption introduced into any plan doc by the example text (review against `plan-tier-validator.sh`)
+- [x] `grep -nE "plan-of-plans" ralph/skills/caretake/modes/split.md` shows the new write step
+- [x] `grep -nE "plan-of-plans" ralph/skills/caretake/split-decomposition.md` shows the documented contract
+- [x] `grep -n "thoughts/shared/plans" ralph/skills/caretake/modes/split.md` confirms the write target path is present
+- [x] No `^## Feature Decomposition` + `^## Phase` mixed-shape corruption introduced (all such references in the edited files are inline backtick-wrapped, not line-start headings — `grep -nE '^## (Feature Decomposition|Phase [0-9])'` returns none)
 
 #### Manual Verification
 - [ ] Run `/ralph:caretake --mode split` on a real M/L/XL test issue: a plan-of-plans file is created, sections map 1:1 to children by number/title, and `## Feature Sequencing` matches the `## Issue Split` comment

--- a/thoughts/shared/plans/2026-05-24-GH-1416-split-plan-of-plans-emission.md
+++ b/thoughts/shared/plans/2026-05-24-GH-1416-split-plan-of-plans-emission.md
@@ -122,21 +122,21 @@ checks byte-for-byte unchanged.
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `bash -n ralph/hooks/scripts/doc-structure-validator.sh` (syntax OK); `shellcheck` if available reports no new errors
-- [ ] **plan-of-plans passes** — using an isolated project root so freshest-wins/path selection is unambiguous:
+- [x] `bash -n ralph/hooks/scripts/doc-structure-validator.sh` (syntax OK); `shellcheck` if available reports no new errors
+- [x] **plan-of-plans passes** — using an isolated project root so freshest-wins/path selection is unambiguous (note: fixture must `mkdir -p` all three artifact dirs — `plans/ reviews/ research/` — since the validator's `find` loop runs under `set -e`):
   ```
   tmp=$(mktemp -d); mkdir -p "$tmp/thoughts/shared/plans"
   printf '%s\n' '---' 'type: plan-of-plans' '---' '## Feature Decomposition' '### Feature A' '## Feature Sequencing' 'A -> B' \
     > "$tmp/thoughts/shared/plans/$(date +%F)-GH-9999-plan-of-plans.md"
   CLAUDE_PROJECT_DIR="$tmp" bash ralph/hooks/scripts/doc-structure-validator.sh <<< '{}'   # expect exit 0
   ```
-- [ ] **regular plan still gated** — same isolated-dir recipe, fixture missing `## Phase N`:
+- [x] **regular plan still gated** — same isolated-dir recipe, fixture missing `## Phase N`:
   ```
   tmp=$(mktemp -d); mkdir -p "$tmp/thoughts/shared/plans"
   printf '%s\n' '---' 'type: plan' '---' '## Overview' 'x' > "$tmp/thoughts/shared/plans/$(date +%F)-GH-9998-regular.md"
   CLAUDE_PROJECT_DIR="$tmp" bash ralph/hooks/scripts/doc-structure-validator.sh <<< '{}'   # expect exit 2
   ```
-- [ ] `npm test` in `plugin/ralph-hero/mcp-server/` still passes (no unintended breakage; hooks are out-of-tree but confirm the suite is green)
+- [x] `npm test` in `plugin/ralph-hero/mcp-server/` still passes (1626 passed, 1 skipped — no unintended breakage; hooks are out-of-tree bash)
 
 #### Manual Verification
 - [ ] Re-read the diff: the regular-plan path is byte-for-byte unchanged when no plan-of-plans signal is present


### PR DESCRIPTION
## Summary

Makes `/ralph:caretake --mode split` emit a parent **plan-of-plans** so freshly-split clusters are autonomously plannable. Today split leaves only a `## Issue Split` comment, so the autonomous planner — which consumes a per-child research doc *or* a parent plan-of-plans — has nothing to bind to, and every child escalates to **Human Needed** (the GH-1416 deadlock).

Two phases over disjoint files:

- **Phase 1 — `ralph/hooks/scripts/doc-structure-validator.sh`**: the `plan` branch now self-discriminates a plan-of-plans (frontmatter `type: plan-of-plans`, or a fence-stripped `## Feature Decomposition` heading) and validates it against `## Feature Decomposition` + `## Feature Sequencing` instead of the regular plan's `## Phase N` / Verification / checkbox rules. Mirrors the existing self-discrimination in `plan-tier-validator.sh`. **Required, not cosmetic**: without it the validator (path-based, fires on the next plan-skill Stop within 15 min) would reject the split-authored plan-of-plans and re-break the child's `plan --mode auto` run. Regular-plan path is byte-for-byte unchanged.
- **Phase 2 — `ralph/skills/caretake/modes/split.md` §Step 7.5 + `split-decomposition.md`**: after a multi-child split, write `thoughts/shared/plans/YYYY-MM-DD-GH-<parent>-plan-of-plans.md` — one `### Feature` per child carrying the child's real number + title (so the parent-plan-reuse short-circuit binds by number/title), with `## Feature Sequencing` kept identical to the `## Issue Split` chain. The writer lives in split because **caretake** context does not arm the plan skill's `plan-research-required.sh` gate.

Closes the gap with **no new gate logic** — it reuses the existing, tested parent-plan-reuse short-circuit (`ralph/skills/plan/intake-routing.md`).

## Plan

`thoughts/shared/plans/2026-05-24-GH-1416-split-plan-of-plans-emission.md`
Research: `thoughts/shared/research/2026-05-24-GH-1416-split-epic-autopilot-deadlock-handoff.md` (`## Follow-up Research`)
Review: `thoughts/shared/reviews/2026-05-24-GH-1416-critique.md` (APPROVED)

## Test plan

Automated (Phase 1, run against isolated `CLAUDE_PROJECT_DIR` fixtures — all artifact dirs present):
- `bash -n` syntax OK.
- plan-of-plans doc → validator exit 0.
- regular plan missing `## Phase N` → validator exit 2 (unchanged).
- regular plan with `## Phase N` → exit 0; plan-of-plans missing `## Feature Sequencing` → exit 2; fenced `## Feature Decomposition` example stays a regular plan → exit 0.
- `npm test` (mcp-server): 1626 passed, 1 skipped (out-of-tree change, no TS impact).

Automated (Phase 2): grep confirms the §Step 7.5 write step + `thoughts/shared/plans` target in `split.md` and the documented contract in `split-decomposition.md`; no line-start `## Feature Decomposition`/`## Phase` headings accidentally introduced.

Manual (left for reviewer — autonomous run can't exercise these):
- Run `/ralph:caretake --mode split` on a real M/L/XL issue → plan-of-plans created, 1:1 child mapping, sequencing matches the comment.
- `/ralph:plan --mode auto #<child>` → posts `## Plan Reference`, advances to In Progress, no child plan doc, no Stop block.
- End-to-end drain of a split cluster (e.g. #1417 → #1404–#1410) without Human-Needed escalation (one-time backfill for the already-split cluster).

Closes #1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
