### PR TITLE
feat(ralph): estimate-aware plan-research gate + human override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
           # Glob both naming conventions used today (*.test.sh and test-*.sh).
           # Each file runs in its own subshell so a `set -e` exit in one test
           # cannot abort the suite. First non-zero rc propagates.
+          # Both the main plugin and the slim ralph/ plugin carry hook tests.
           find plugin/ralph-hero/hooks/scripts/__tests__ \
+               ralph/hooks/scripts/__tests__ \
             \( -name '*.test.sh' -o -name 'test-*.sh' \) \
             -type f -print0 \
             | sort -z \

--- a/ralph/README.md
+++ b/ralph/README.md
@@ -33,6 +33,13 @@ Headline shape:
 | 9 | `/ralph:setup` | shipped |
 | 10 | sunset `plugin/ralph-hero/` | Wave 1 shipped 2026-05-23 (P0/P1 fixes). Wave 2 selective shipped 2026-05-23 (5 fixes + 1 doc + 3 close-with-rationale; 3 issues deferred as `[Wave 2 deferred]`). Wave 3 (deletion) blocked on real-session dogfooding. |
 
+## Environment
+
+| Variable | Default | Effect |
+|---|---|---|
+| `RALPH_REQUIRES_RESEARCH` | `true` | Global off-switch for the plan-research gate (`plan-research-required.sh`). Set to anything other than `true` to disable the gate entirely — any plan Write is allowed. |
+| `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` | `M` | Estimate at/above which a linked research doc is required before a plan can be written. Estimates strictly below it are waived (`M` waives XS/S; `S` waives only XS; `XS` waives nothing). Lower it to require research for smaller work, or raise it to relax. A per-plan `research_waived:` frontmatter line is an explicit human override regardless of estimate. |
+
 ## Local development
 
 ```bash

--- a/ralph/hooks/scripts/__tests__/plan-research-required.test.sh
+++ b/ralph/hooks/scripts/__tests__/plan-research-required.test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# ralph/hooks/scripts/__tests__/plan-research-required.test.sh
+# Tests for the estimate-aware plan-research-required.sh gate.
+#
+# Strategy: invoke the hook with crafted PreToolUse:Write JSON on stdin inside a
+# TMPDIR sandbox (CLAUDE_PROJECT_DIR override) so get_project_root /
+# find_existing_artifact resolve deterministically, and assert exit codes:
+#   0 = allowed (early-allow, waiver, or research-exists)
+#   2 = blocked (research required)
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/plan-research-required.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; ((PASS++)) || true; }
+fail() { echo "  FAIL: $1"; ((FAIL++)) || true; }
+
+# Sandbox project root. research/ stays empty except for the one fixture below.
+SBX="$(mktemp -d)"
+trap 'rm -rf "$SBX"' EXIT
+mkdir -p "$SBX/thoughts/shared/research" "$SBX/thoughts/shared/plans" "$SBX/src"
+# Fixture research doc — matches ticket GH-1 only.
+touch "$SBX/thoughts/shared/research/2026-05-24-GH-1-research.md"
+
+# run_case <desc> <expected_exit> <file_path> <content> [ENV=val ...]
+run_case() {
+  local desc="$1" expected="$2" fp="$3" content="$4"; shift 4
+  local json actual
+  json=$(jq -n --arg fp "$fp" --arg c "$content" \
+    '{tool_input: {file_path: $fp, content: $c}}')
+  set +e
+  CLAUDE_PROJECT_DIR="$SBX" env "$@" bash "$HOOK" <<<"$json" >/dev/null 2>&1
+  actual=$?
+  set -e
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$desc (exit $actual)"
+  else
+    fail "$desc — expected exit $expected, got $actual"
+  fi
+}
+
+PLANS="$SBX/thoughts/shared/plans"
+
+echo "=== plan-research-required gate tests ==="
+echo ""
+
+# --- Early-allow paths ---------------------------------------------------------
+run_case "non-/plans/ path allows" 0 \
+  "$SBX/src/notes.md" $'---\nestimate: M\n---'
+run_case "/plans/ path with no GH token allows" 0 \
+  "$PLANS/2026-05-24-adhoc.md" $'---\nestimate: M\n---'
+run_case "research doc exists allows (even at M)" 0 \
+  "$PLANS/2026-05-24-GH-1-x.md" $'---\nestimate: M\n---'
+run_case "RALPH_REQUIRES_RESEARCH=false allows" 0 \
+  "$PLANS/2026-05-24-GH-2-x.md" $'---\nestimate: M\n---' RALPH_REQUIRES_RESEARCH=false
+
+# --- Estimate-threshold waiver (default threshold M) ---------------------------
+run_case "estimate S below default M allows" 0 \
+  "$PLANS/2026-05-24-GH-2-x.md" $'---\nestimate: S\n---'
+run_case "estimate M at default threshold blocks" 2 \
+  "$PLANS/2026-05-24-GH-2-x.md" $'---\nestimate: M\n---'
+
+# --- Human-override waiver -----------------------------------------------------
+run_case "research_waived present allows (even at M)" 0 \
+  "$PLANS/2026-05-24-GH-2-x.md" $'---\nestimate: M\nresearch_waived: human-approved\n---'
+
+# --- Threshold override --------------------------------------------------------
+run_case "MIN=S + estimate S blocks (threshold raised)" 2 \
+  "$PLANS/2026-05-24-GH-2-x.md" $'---\nestimate: S\n---' RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE=S
+run_case "MIN=S + estimate XS allows" 0 \
+  "$PLANS/2026-05-24-GH-2-x.md" $'---\nestimate: XS\n---' RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE=S
+
+# --- Safe-default block --------------------------------------------------------
+run_case "no estimate + no waiver + no research blocks" 2 \
+  "$PLANS/2026-05-24-GH-2-x.md" $'---\ndate: 2026-05-24\ntype: plan\n---'
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/ralph/hooks/scripts/plan-research-required.sh
+++ b/ralph/hooks/scripts/plan-research-required.sh
@@ -1,12 +1,33 @@
 #!/bin/bash
-# ralph-hero/hooks/scripts/plan-research-required.sh
-# PreToolUse (Write): Block plan creation if no research doc
+# ralph/hooks/scripts/plan-research-required.sh
+# PreToolUse (Write): Block plan creation if no research doc — estimate-aware.
+#
+# This is the slim-only copy. It is intentionally AHEAD of the byte-identical
+# plugin/ralph-hero/ twin: the estimate-threshold + human-override waiver paths
+# below exist only here until the main plugin catches up.
+#
+# Allow-paths, in order:
+#   1. Path not under /plans/                      -> allow
+#   2. RALPH_REQUIRES_RESEARCH != "true"           -> allow (global off-switch)
+#   3. No GH-NNNN token in the path                -> allow (no linked ticket)
+#   4. A matching research doc exists              -> allow
+#   5. Frontmatter carries research_waived: <text> -> allow (human override)
+#   6. Frontmatter estimate is below the threshold -> allow (sub-threshold waiver)
+# Otherwise -> block.
 #
 # Environment:
-#   RALPH_REQUIRES_RESEARCH - Whether research is required (default: true)
+#   RALPH_REQUIRES_RESEARCH               - Global toggle (default: true)
+#   RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE  - Estimate at/above which research is
+#                                           required (default: M). Estimates
+#                                           strictly below it are waived:
+#                                             XS -> waives nothing
+#                                             S  -> waives XS
+#                                             M  -> waives XS, S
+#                                             L  -> waives XS, S, M
+#                                             XL -> waives XS, S, M, L
 #
 # Exit codes:
-#   0 - Research exists or not required
+#   0 - Research exists, not required, or waived
 #   2 - Research missing, block
 
 set -euo pipefail
@@ -23,7 +44,7 @@ if [[ "${RALPH_REQUIRES_RESEARCH:-true}" != "true" ]]; then
   allow
 fi
 
-ticket_id=$(echo "$file_path" | grep -oE 'GH-[0-9]+' | head -1)
+ticket_id=$(echo "$file_path" | grep -oE 'GH-[0-9]+' | head -1 || true)
 if [[ -z "$ticket_id" ]]; then
   allow
 fi
@@ -31,15 +52,51 @@ fi
 research_dir="$(get_project_root)/thoughts/shared/research"
 research_doc=$(find_existing_artifact "$research_dir" "$ticket_id")
 
-if [[ -z "$research_doc" ]]; then
-  block "Research required before planning
+if [[ -n "$research_doc" ]]; then
+  allow
+fi
+
+# No research doc. Parse the plan frontmatter from the Write content for the
+# two new waiver paths. `|| true` keeps each pipeline alive under
+# `set -euo pipefail` when grep finds no matching line (mirrors the convention
+# in split-estimate-gate.sh).
+content=$(get_field '.tool_input.content')
+frontmatter=$(printf '%s\n' "$content" \
+  | awk 'NR==1 && $0=="---"{f=1; next} f && $0=="---"{exit} f{print}')
+estimate=$(printf '%s\n' "$frontmatter" | grep -iE '^estimate:' | head -1 \
+  | sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*$//' | tr -d '"'\''' || true)
+waived_reason=$(printf '%s\n' "$frontmatter" | grep -iE '^research_waived:' | head -1 \
+  | sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*$//' || true)
+
+# Human-override waiver.
+if [[ -n "$waived_reason" && "$waived_reason" != "null" ]]; then
+  allow_with_context "Research requirement waived (human override): $waived_reason"
+fi
+
+# Estimate-threshold waiver: waived set = estimates strictly below the threshold.
+min_estimate="${RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE:-M}"
+case "$min_estimate" in
+  XS) waived="" ;;
+  S)  waived="XS" ;;
+  M)  waived="XS,S" ;;
+  L)  waived="XS,S,M" ;;
+  XL) waived="XS,S,M,L" ;;
+  *)  waived="XS,S" ;;
+esac
+if [[ -n "$estimate" ]] && validate_state "$estimate" "$waived"; then
+  allow_with_context "Research waived: estimate=$estimate below threshold $min_estimate"
+fi
+
+block "Research required before planning
 
 Ticket: $ticket_id
 Expected: Research document in $research_dir
 Found: None
 
-The planning command requires a research document.
-Run /ralph-research $ticket_id first."
-fi
-
-allow
+This issue is at/above the research-required estimate threshold ($min_estimate)
+and has no research document. Three ways forward:
+  1. Run /ralph:research $ticket_id first (creates the research doc).
+  2. Set the plan frontmatter estimate below $min_estimate if the work is
+     genuinely sub-threshold (XS/S).
+  3. Add 'research_waived: <reason>' to the plan frontmatter to record an
+     explicit human override."

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -136,7 +136,7 @@ No env-flip is needed between modes: the hooks discriminate by the file path bei
 1. **Intake** — resolve `ARG` per `intake-routing.md` (issue / research-doc / plan-path / free-form / no-arg). Read mentioned files FULLY before any sub-agent dispatch. Run parent-plan reuse check — if it short-circuits, post `## Plan Reference` and STOP.
 2. **Research & discovery** — `knowledge_recall(role="planner", brief=true)` if available; dispatch codebase-locator / codebase-analyzer / thoughts-locator in parallel (one message, multiple `Agent()` calls). Wait for ALL, read identified files FULLY.
 3. **Plan structure development** — propose phase count + ownership + verification points. `AskUserQuestion` to confirm. Loop until approved. Consult `plan-shapes.md` § Phase-section anatomy.
-4. **Write the plan** — per `plan-shapes.md` (default-column required sections). Filename `thoughts/shared/plans/YYYY-MM-DD-[GH-NNNN-]description.md`.
+4. **Write the plan** — per `plan-shapes.md` (default-column required sections). Filename `thoughts/shared/plans/YYYY-MM-DD-[GH-NNNN-]description.md`. Stamp `estimate:` into the frontmatter from the fetched issue. If the linked-research check (Step 1) ended in "plan anyway", also stamp `research_waived:`.
 4a. **UI Validation Phase (conditional)** — skip if `--no-playwright`. Else consult `ui-validation-phase.md`; append `## Phase N: UI Validation` if frontend-relevant + ralph-playwright installed.
 5. **User review picker** — `AskUserQuestion` over *Approve* / *Approve with edits* / *Restart* / *Iterate*. `review-plan-gate.sh` hook enforces this picker runs before any state-advancing `save_issue`.
 6. **GitHub integration** — if `LINKED_ISSUE`: post `## Implementation Plan` artifact comment with doc URL + 1-line summary; update issue body if scope clarified; `save_issue(workflowState: "Plan in Review", command: "plan")`. Human reviews the plan; a separate `--mode review` or manual approval advances to "In Progress".
@@ -146,17 +146,17 @@ No env-flip is needed between modes: the hooks discriminate by the file path bei
 Autonomous XS/S plan picker. No questions; one issue, locked, planned, advanced. Frontmatter `hooks:` gate the flow (tier-validator, state-gate, postcondition, doc-validator, research-required, lock-release). XS/S only, 15-minute budget.
 
 1. **Branch check** — `git branch --show-current` must be `main`.
-2. **Select issue** — `ARG=#NNN` → `get_issue`; else `list_issues(profile: "analyst-plan", limit: 50)`, filter XS/S Ready-for-Plan + unblocked + has-linked-research, pick highest priority. None eligible → exit cleanly.
-3. **Lock + research lookup** — `save_issue(workflowState: "__LOCK__", command: "plan")`. Find linked research per `intake-routing.md` § Linked-research check. If none → escalate to "Human Needed".
+2. **Select issue** — `ARG=#NNN` → `get_issue`; else `list_issues(profile: "analyst-plan", limit: 50)`, filter XS/S Ready-for-Plan + unblocked, pick highest priority. None eligible → exit cleanly. (XS/S no longer require linked research — the gate waives sub-threshold work.)
+3. **Lock + research lookup** — `save_issue(workflowState: "__LOCK__", command: "plan")`. Find linked research per `intake-routing.md` § Linked-research check. If none AND the issue's estimate is ≥ `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` (default `M`) → escalate to "Human Needed". Otherwise (sub-threshold XS/S) proceed; the `estimate:` stamp in Step 6 lets the gate waive research.
 4. **Parent-plan reuse** — per `intake-routing.md` § Parent-plan reuse. If short-circuit: post `## Plan Reference`, advance child to "In Progress", report, STOP.
 5. **Knowledge graph + sub-agent research** — same dispatch as default Steps 2-3, no AskUserQuestion. Wait for ALL, synthesize.
 5a. **UI Validation Phase (conditional)** — per `ui-validation-phase.md`. No user prompt; heuristic-only.
-6. **Write plan doc** — per `plan-shapes.md` (auto-column required sections, including Files Affected). The `plan-research-required.sh` hook blocks Write if no linked research; `doc-structure-validator.sh` blocks Stop if required sections missing.
+6. **Write plan doc** — per `plan-shapes.md` (auto-column required sections, including Files Affected). Stamp `estimate:` into the frontmatter from the fetched issue. The `plan-research-required.sh` hook blocks Write if no linked research AND the estimate is ≥ threshold (the `estimate:` stamp waives sub-threshold XS/S); `doc-structure-validator.sh` blocks Stop if required sections missing.
 7. **Commit + push** — `git add ... && git commit -m "docs(plan): GH-NNN implementation plan" && git push origin main`.
 8. **Post artifact + advance + outcome** — `create_comment(## Implementation Plan ...)` → `save_issue(workflowState: "__COMPLETE__", command: "plan")` (advances to "Plan in Review") → `knowledge_record_outcome(event_type: "plan_completed", ...)` if available.
 9. **Report** — single block: *Plan complete for #NNN: [Title] / Plan: [path] / Status: Plan in Review*.
 
-**Escalation triggers (auto only):** advance to "Human Needed" when (a) no linked research exists, (b) issue is M/L/XL on research (suggest `--mode epic`), or (c) sub-agents surface conflicting implementations.
+**Escalation triggers (auto only):** advance to "Human Needed" when (a) no linked research exists AND the estimate is ≥ `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` (default `M`; sub-threshold XS/S proceed without research), (b) issue is M/L/XL on research (suggest `--mode epic`), or (c) sub-agents surface conflicting implementations.
 
 ## --mode epic
 

--- a/ralph/skills/plan/intake-routing.md
+++ b/ralph/skills/plan/intake-routing.md
@@ -34,8 +34,8 @@ When `ARG` resolves to a path, or when the user mentions specific files in a fre
 
 If `LINKED_ISSUE` is set and the issue has no linked research doc:
 
-- **Interactive mode** — surface to the user: *"This issue has no linked research. Plan anyway, or research first via `/ralph:research #NNN`?"* If the user chooses "research first", invoke that command and exit.
-- **Auto mode** — `plan-research-required.sh` is the hook-level enforcement. If no research doc is found, the Write of the plan doc will be blocked. Auto mode should detect this upfront in Step 3 and escalate to "Human Needed" rather than failing at the hook.
+- **Interactive mode** — surface to the user: *"This issue has no linked research. Plan anyway, or research first via `/ralph:research #NNN`?"* If the user chooses "research first", invoke that command and exit. If the user chooses "plan anyway", stamp `research_waived: human-approved — <one-line reason>` into the plan frontmatter so the gate's human-override path allows the Write and the waiver is auditable.
+- **Auto mode** — `plan-research-required.sh` is the hook-level enforcement, and it is estimate-aware: research is required only at/above `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` (default `M`). If no research doc is found AND the issue's estimate is ≥ that threshold, detect this upfront in Step 3 and escalate to "Human Needed". Otherwise (sub-threshold XS/S), stamp `estimate:` into the frontmatter and proceed — the gate waives the research requirement for sub-threshold work. Auto mode never sets `research_waived:`.
 - **Epic mode** — skipped (epics rarely have per-primary linked research; the plan-of-plans IS the research).
 - **Iterate / review modes** — skipped (these consume an existing plan; research is upstream).
 

--- a/ralph/skills/plan/plan-shapes.md
+++ b/ralph/skills/plan/plan-shapes.md
@@ -29,8 +29,16 @@ github_issues: [NNN, NNN, ...]   # for multi-issue groups
 github_urls:
   - https://github.com/OWNER/REPO/issues/NNN
 primary_issue: NNN
+estimate: XS|S|M|L|XL             # optional; copied from the linked issue
+research_waived: <reason>         # optional; human override (interactive only)
 ---
 ```
+
+- `estimate:` — copied from the linked issue. Lets `plan-research-required.sh`
+  waive the research requirement for sub-threshold work (estimates below
+  `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE`, default `M`).
+- `research_waived:` — set **only** when a human explicitly approves planning
+  without research (interactive "plan anyway"). Auto mode never sets this.
 
 ## Section order (standard plan)
 

--- a/thoughts/shared/plans/2026-05-24-relax-plan-research-required-gate.md
+++ b/thoughts/shared/plans/2026-05-24-relax-plan-research-required-gate.md
@@ -1,0 +1,217 @@
+---
+date: 2026-05-24
+status: approved
+type: plan
+tags: [hooks, plan, research-gate, ralph-slim, estimate]
+---
+
+# Relax the plan-research-required gate — estimate-aware waiver + human override
+
+## Prior Work
+
+- `split-estimate-gate.sh` (`ralph/hooks/scripts/split-estimate-gate.sh`) is the canonical estimate-aware gate: `RALPH_MIN_ESTIMATE` → allowed-set via a `case` statement, `validate_state` helper, safe-default on missing estimate. This plan mirrors that shape, inverted (waive *below* a threshold instead of allow *at/above*).
+- `set-skill-env.sh` (`ralph/hooks/scripts/set-skill-env.sh`) documents why bare `export` in a hook is throwaway and only `CLAUDE_ENV_FILE` writes (SessionStart only) survive — the reason this plan avoids any runtime mode-env propagation.
+
+## Overview
+
+`plan-research-required.sh` hard-blocks the Write of any plan doc whose filename carries a `GH-NNNN` token when no `thoughts/shared/research/*GH-NNNN*` file exists. The only escape is the global, undocumented `RALPH_REQUIRES_RESEARCH=false`. This contradicts the rest of the pipeline: triage explicitly offers `ROUTE-TO-Ready for Plan` ("well-specified; skip research and queue directly for planning"), and `--mode auto` is the **XS/S picker** — yet a Ready-for-Plan XS/S issue with no research gets bounced to **Human Needed** (auto) or blocked at the hook (interactive). A 1-line fix is forced to carry a research document.
+
+This plan makes the gate *estimate-aware*: research is required only for issues at/above a configurable estimate threshold (default `M`), so XS/S work is waived. It also gives interactive planning a human-override path. The hook stays a pure content inspector — no GitHub call, no new persisted state, no runtime mode-env — and the waiver is auditable in the plan's own frontmatter.
+
+Decisions locked with the user: **(A) estimate-threshold policy**, **slim `ralph/` plugin only**, **(ii) soften interactive / keep auto strict** (delivered via an explicit frontmatter stamp rather than a mode-env-dependent warn).
+
+## Current State Analysis
+
+The hook (`ralph/hooks/scripts/plan-research-required.sh`) and its `plugin/ralph-hero/` twin are byte-identical. Flow: allow if path not under `/plans/`; allow if `RALPH_REQUIRES_RESEARCH != true`; extract `GH-NNNN` from the path, allow if none; else require a matching research doc via `find_existing_artifact`, block if absent.
+
+The hook is registered in `ralph/skills/plan/SKILL.md` frontmatter as `PreToolUse: Write`. SessionStart sets only `RALPH_COMMAND=plan` via `set-skill-env.sh`; the parsed `--mode` is **never** propagated to the hook environment.
+
+### Key Discoveries
+
+- The hook only sees `tool_input.file_path` and `tool_input.content` — it has no estimate, no workflow state, no labels. `tool_input.content` (the plan body, frontmatter included) is available at PreToolUse:Write. (`ralph/hooks/scripts/plan-research-required.sh:15-16`)
+- Plan frontmatter does **not** currently carry `estimate` — only `date/status/type/tags/github_issue(s)/primary_issue`. (`ralph/skills/plan/plan-shapes.md:24-37`)
+- `split-estimate-gate.sh` reads estimate from a `get_issue` *response* and computes an allowed-set from `RALPH_MIN_ESTIMATE` via a `case` statement + `validate_state`. (`ralph/hooks/scripts/split-estimate-gate.sh:36-47`)
+- Triage already routes around research: `ROUTE-TO-Ready for Plan` = "skip research and queue directly for planning". (`ralph/skills/caretake/modes/triage.md:59-68`)
+- `--mode auto` is the **XS/S picker** and today filters on `has-linked-research`, escalating to Human Needed when none exists. (`ralph/skills/plan/SKILL.md:146-159`; `ralph/skills/plan/intake-routing.md` § Linked-research check)
+- `set-skill-env.sh` persists env via `CLAUDE_ENV_FILE` **only in a SessionStart context** — mid-body Bash cannot reliably write hook-visible env, so a literal "warn-in-interactive / block-in-auto" mode switch is fragile. (`ralph/hooks/scripts/set-skill-env.sh`)
+- `plan-tier-validator.sh` blocks only when *both* epic and regular plan shapes appear; a regular `## Phase N:` plan is safe. (`ralph/hooks/scripts/plan-tier-validator.sh:30-37`)
+- CI's `test-hooks` job globs only `plugin/ralph-hero/hooks/scripts/__tests__` — `ralph/hooks/scripts/__tests__` has **zero CI coverage** today. (`.github/workflows/ci.yml:135-150`)
+- Slim hook tests are self-contained `*.test.sh` scripts (no bats). (`ralph/hooks/scripts/__tests__/`)
+
+## Desired End State
+
+1. `plan-research-required.sh` allows a plan Write when the plan frontmatter's `estimate:` is strictly below `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` (default `M`), even with no research doc.
+2. The hook allows a plan Write when frontmatter carries a non-empty `research_waived:` reason (human override).
+3. Existing behavior is preserved as the safe default: research-doc-exists → allow; missing/unparseable estimate AND no waiver AND estimate ≥ threshold → block; `RALPH_REQUIRES_RESEARCH=false` → allow.
+4. `--mode auto` (XS/S picker) no longer bounces research-less XS/S issues to Human Needed — it stamps `estimate:` and proceeds. M/L/XL paths (epic mode) are unchanged.
+5. Interactive mode, on "plan anyway", stamps `research_waived:` so the human override is explicit and auditable.
+6. `RALPH_REQUIRES_RESEARCH` and `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` are documented.
+7. The new hook test runs in CI alongside the two existing slim hook tests.
+
+### Verification
+
+- New `ralph/hooks/scripts/__tests__/plan-research-required.test.sh` passes for all branches (below-threshold allow, at/above-threshold block, waiver allow, research-exists allow, non-plans path allow, no-ticket allow, global-toggle allow, threshold override).
+- `bash ralph/hooks/scripts/__tests__/plan-research-required.test.sh` exits 0.
+- The `test-hooks` CI job discovers and runs the slim test (verify the `find` path includes `ralph/hooks/scripts/__tests__`).
+- Manual: craft a plan-doc Write JSON with `estimate: S` and no research doc → hook exits 0; same with `estimate: M` → exits 2; add `research_waived: human-approved` to the `M` case → exits 0.
+
+## What We're NOT Doing
+
+- **Not** touching `plugin/ralph-hero/hooks/scripts/plan-research-required.sh` (slim-only scope; the copies diverge until the main plugin catches up — note this in the doc header comment).
+- **Not** adding a GitHub/`gh` call inside the hook (keeps it fast and offline; estimate comes from the plan content the skill stamps).
+- **Not** introducing a runtime mode-env (`RALPH_PLAN_MODE`/sentinel file) — the human-override stamp delivers (ii)'s intent without it.
+- **Not** changing the workflow state machine or triage routing.
+- **Not** changing epic-mode behavior (it already skips the linked-research check).
+
+## Implementation Approach
+
+Three phases, each independently testable. Phase 1 is the gate logic (self-contained, fully unit-testable). Phase 2 wires the skill to stamp the frontmatter fields the gate now reads. Phase 3 documents the knobs and closes the CI coverage gap. The trust boundary (an LLM could stamp a false `estimate`/`research_waived`) is accepted and mitigated by safe-default-to-block + visible audit trail, consistent with the rest of the hook system.
+
+## Phase 1: Estimate-aware gate logic
+
+### Overview
+
+Rewrite `plan-research-required.sh` to add two allow-paths (estimate-threshold waiver, human-override waiver) parsed from the Write content's YAML frontmatter, keeping all existing early-allows and the terminal block.
+
+### Changes Required
+
+#### 1. Hook rewrite
+
+**File**: `ralph/hooks/scripts/plan-research-required.sh`
+**Changes**:
+- Update the header comment: document `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` (default `M`), the two new waiver paths, and a one-line note that this is the slim-only copy (intentionally ahead of the `plugin/ralph-hero/` twin).
+- Keep the existing early-allows in order: non-`/plans/` path; `RALPH_REQUIRES_RESEARCH != true`; no `GH-NNNN` in path; research-doc-exists (`find_existing_artifact`).
+- After those, before the terminal `block`, parse the frontmatter from `tool_input.content`:
+  ```bash
+  content=$(get_field '.tool_input.content')
+  frontmatter=$(printf '%s\n' "$content" \
+    | awk 'NR==1 && $0=="---"{f=1; next} f && $0=="---"{exit} f{print}')
+  estimate=$(printf '%s\n' "$frontmatter" | grep -iE '^estimate:' | head -1 \
+    | sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*$//' | tr -d '"'\''')
+  waived_reason=$(printf '%s\n' "$frontmatter" | grep -iE '^research_waived:' | head -1 \
+    | sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*$//')
+  ```
+- Human-override waiver:
+  ```bash
+  if [[ -n "$waived_reason" && "$waived_reason" != "null" ]]; then
+    allow_with_context "Research requirement waived (human override): $waived_reason"
+  fi
+  ```
+- Estimate-threshold waiver (waived set = estimates strictly below the threshold):
+  ```bash
+  min_estimate="${RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE:-M}"
+  case "$min_estimate" in
+    XS) waived="" ;;
+    S)  waived="XS" ;;
+    M)  waived="XS,S" ;;
+    L)  waived="XS,S,M" ;;
+    XL) waived="XS,S,M,L" ;;
+    *)  waived="XS,S" ;;
+  esac
+  if [[ -n "$estimate" ]] && validate_state "$estimate" "$waived"; then
+    allow_with_context "Research waived: estimate=$estimate below threshold $min_estimate"
+  fi
+  ```
+- Augment the terminal `block` message to list the two new escape paths (set an estimate below `$min_estimate`, or add `research_waived:`) alongside the existing `/ralph:research` suggestion.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `bash -n ralph/hooks/scripts/plan-research-required.sh` (syntax OK)
+- [x] Hand-run with `{"tool_input":{"file_path":".../plans/2026-05-24-GH-1-x.md","content":"---\nestimate: S\n---"}}` on stdin exits 0
+- [x] Same content with `estimate: M` exits 2
+- [x] Same `estimate: M` content plus `research_waived: human-approved` exits 0
+- [x] `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE=S` + `estimate: S` exits 2 (threshold raised)
+
+#### Manual Verification
+- [ ] Reading the block message, an operator understands all three ways forward (research, smaller estimate, explicit waiver)
+
+## Phase 2: Plan authoring wiring
+
+### Overview
+
+Teach the plan skill to stamp `estimate:` (all modes) and `research_waived:` (interactive override) so the gate's new allow-paths actually trigger, and relax the auto-mode research filter for waived estimates.
+
+### Changes Required
+
+#### 1. Frontmatter spec
+
+**File**: `ralph/skills/plan/plan-shapes.md`
+**Changes**: Add to the frontmatter block two optional fields with usage notes:
+- `estimate: XS|S|M|L|XL` — "copied from the linked issue; lets `plan-research-required.sh` waive the research requirement for sub-threshold work."
+- `research_waived: <reason>` — "set only when a human explicitly approves planning without research (interactive 'plan anyway'). Auto mode never sets this."
+
+#### 2. Intake / linked-research check
+
+**File**: `ralph/skills/plan/intake-routing.md`
+**Changes**: In § Linked-research check:
+- Interactive branch: when the user chooses "plan anyway", instruct the skill to stamp `research_waived: human-approved — <one-line reason>` into the plan frontmatter.
+- Auto branch: replace "no research doc → escalate to Human Needed" with "no research doc AND estimate ≥ `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` → escalate; otherwise stamp `estimate:` and proceed (the gate waives sub-threshold work)."
+
+#### 3. Skill body
+
+**File**: `ralph/skills/plan/SKILL.md`
+**Changes**:
+- Default + auto write steps: stamp `estimate:` into frontmatter from the fetched issue.
+- `--mode auto` Step 2: drop the hard `has-linked-research` filter (XS/S no longer require research); keep XS/S scoping.
+- `--mode auto` Step 3 escalation: gate the missing-research escalation on estimate ≥ threshold (a no-op for the XS/S picker today, but future-proofs against a raised threshold).
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `grep -n 'estimate:' ralph/skills/plan/plan-shapes.md` shows the new field documented
+- [x] `grep -n 'research_waived' ralph/skills/plan/intake-routing.md ralph/skills/plan/plan-shapes.md` shows the override documented
+
+#### Manual Verification
+- [ ] Dry read of SKILL.md auto flow confirms an XS/S Ready-for-Plan issue with no research now proceeds to a plan write rather than escalating
+- [ ] Interactive "plan anyway" path clearly results in a `research_waived:` stamp
+
+## Phase 3: Docs, tests, and CI coverage
+
+### Overview
+
+Document the two env knobs, add a self-contained hook test, and wire the slim hook-test directory into CI so the test (and the two pre-existing slim tests) actually run.
+
+### Changes Required
+
+#### 1. Env documentation
+
+**File**: `ralph/README.md` (and a one-line pointer in `ralph/CLAUDE.md` if an env table exists there)
+**Changes**: Document `RALPH_REQUIRES_RESEARCH` (global off-switch, default `true`) and `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` (research-required threshold, default `M`; estimates below it are waived).
+
+#### 2. Hook test
+
+**File**: `ralph/hooks/scripts/__tests__/plan-research-required.test.sh` (new)
+**Changes**: Self-contained `.test.sh` (mirror `triage-postcondition-palette.test.sh` structure) that invokes the hook with crafted JSON on stdin and asserts exit codes for: non-`/plans/` path (allow); no-ticket path (allow); research-doc-exists (allow — create a temp research file under a temp project root); `estimate: S` below default threshold (allow); `estimate: M` at threshold + no research (block); `research_waived:` present (allow); `RALPH_REQUIRES_RESEARCH=false` (allow); `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE=S` + `estimate: S` (block). Use a `TMPDIR` sandbox + `CLAUDE_PROJECT_DIR` override so `get_project_root`/`find_existing_artifact` resolve deterministically.
+
+#### 3. CI coverage
+
+**File**: `.github/workflows/ci.yml`
+**Changes**: In the `test-hooks` job, extend the `find` to also traverse `ralph/hooks/scripts/__tests__` (either add the path to the existing `find` arg list or add a second `find` invocation with the same glob/sort/xargs pipeline).
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `bash ralph/hooks/scripts/__tests__/plan-research-required.test.sh` exits 0 with all assertions passing
+- [x] `find ralph/hooks/scripts/__tests__ \( -name '*.test.sh' -o -name 'test-*.sh' \) -type f` lists the new test
+- [x] CI `test-hooks` job (per the edited `ci.yml`) includes the slim path — verify by reading the diff / a local dry-run of the find pipeline
+
+#### Manual Verification
+- [ ] README env section reads clearly for a user deciding whether to lower the threshold or disable the gate
+
+## Testing Strategy
+
+### Unit Tests
+- `plan-research-required.test.sh` exercises every hook branch via stdin JSON + exit-code assertions (Phase 3 #2). This is the primary safety net.
+
+### Integration Tests
+- None automated (the skill-side stamping is prose). Covered by manual dry-runs in Phase 2.
+
+### Manual Testing Steps
+1. In a scratch repo with the slim plugin, run `/ralph:plan` on an XS issue with no research doc → plan writes successfully (estimate waiver).
+2. Run on an M issue with no research → blocked; choose "plan anyway" → `research_waived:` stamped → write succeeds.
+3. `export RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE=S` and retry the XS case → still allowed; the S case → now blocked.
+
+## Performance Considerations
+
+The hook adds one `awk` + two `grep`/`sed` passes over the in-memory plan content — negligible, and strictly cheaper than the alternative (a `gh` call per plan write). No network, no disk state beyond the existing `find_existing_artifact` lookup.


### PR DESCRIPTION
## Summary

Relaxes the slim `ralph/` plugin's `plan-research-required.sh` gate so it is **estimate-aware**: a linked research doc is required only for plans at/above `RALPH_RESEARCH_REQUIRED_MIN_ESTIMATE` (default `M`). Sub-threshold XS/S work is waived, and a `research_waived:` frontmatter line provides an explicit, auditable human override. This resolves the contradiction where a Ready-for-Plan XS/S issue (which triage may route around research) was bounced to Human Needed or blocked at the hook.

The hook stays a pure content inspector — no GitHub call, no new persisted state, no runtime mode-env.

### Changes
- **Phase 1 — gate logic** (`plan-research-required.sh`): two new allow-paths (estimate-threshold + human-override) after the research-doc check, before the terminal block. Added `|| true` to the frontmatter/ticket greps so a non-match doesn't abort the gate under `set -euo pipefail` (the literal plan snippet had this latent bug; also fixed the pre-existing no-ticket abort). Slim-only — intentionally ahead of the `plugin/ralph-hero/` twin.
- **Phase 2 — plan-skill wiring**: `plan-shapes.md` documents `estimate:`/`research_waived:`; `intake-routing.md` + `SKILL.md` stamp them and estimate-gate the auto-mode escalation.
- **Phase 3 — docs, test, CI**: README env table; new 10-case `plan-research-required.test.sh`; `ci.yml` `test-hooks` now traverses `ralph/hooks/scripts/__tests__` (closing the zero-coverage gap for all three slim tests).

## Test plan
- `bash ralph/hooks/scripts/__tests__/plan-research-required.test.sh` → **10 passed, 0 failed**
- Full edited CI `test-hooks` pipeline across both plugin dirs → exit 0
- `bash -n` clean; `ci.yml` parses as valid YAML
- Branch-by-branch exit codes verified: below-threshold allow, at/above block, waiver allow, research-exists allow, non-plans/no-ticket/global-toggle allow, threshold override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
