### PR TITLE
GH-1404: Define 8-verdict triage schema + update RALPH_TRIAGE_ACTION validation

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/triage-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/triage-postcondition.sh
@@ -6,7 +6,10 @@
 #
 # Environment:
 #   RALPH_TICKET_ID - Ticket being triaged
-#   RALPH_TRIAGE_ACTION - Action taken (set by skill): RESEARCH, SPLIT, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE
+#   RALPH_TRIAGE_ACTION - Action taken (set by skill). Structured verdicts (#1417):
+#     CLOSE-done, CLOSE-canceled, SPLIT, PROMOTE-research, PROMOTE-plan,
+#     WAIT-pr[=NNN], WAIT-upstream[=URL], WAIT-decision.
+#     Legacy (retained until Phase 6 / #1410): RESEARCH, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE.
 #   RALPH_FORCE_STOP - If "true", allow stop even if postconditions fail (escape hatch)
 #
 # Exit codes:
@@ -33,8 +36,14 @@ triage_action="${RALPH_TRIAGE_ACTION:-}"
 
 if [[ -n "$triage_action" ]]; then
   case "$triage_action" in
-    RESEARCH|SPLIT|CLOSE|KEEP|HUMAN|CANCEL|RE-ESTIMATE)
+    # Structured verdicts (#1417). WAIT-pr/WAIT-upstream accept an optional =NNN/=URL suffix.
+    CLOSE-done|CLOSE-canceled|SPLIT|PROMOTE-research|PROMOTE-plan|WAIT-pr|WAIT-pr=*|WAIT-upstream|WAIT-upstream=*|WAIT-decision)
       echo "Triage postcondition passed: $ticket_id -> $triage_action"
+      allow
+      ;;
+    # Legacy palette — retained until Phase 6 (#1410) removes KEEP outright.
+    RESEARCH|CLOSE|KEEP|HUMAN|CANCEL|RE-ESTIMATE)
+      echo "Triage postcondition passed: $ticket_id -> $triage_action (legacy)"
       allow
       ;;
     *)
@@ -47,7 +56,10 @@ fi
 block "Triage postcondition failed: no action taken
 
 Ticket: $ticket_id
-Expected: RALPH_TRIAGE_ACTION set to one of: RESEARCH, SPLIT, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE
+Expected: RALPH_TRIAGE_ACTION set to one of the structured verdicts —
+  CLOSE-done, CLOSE-canceled, SPLIT, PROMOTE-research, PROMOTE-plan,
+  WAIT-pr[=NNN], WAIT-upstream[=URL], WAIT-decision —
+  or a legacy value (RESEARCH, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE; removed in Phase 6 / #1410).
 Found: RALPH_TRIAGE_ACTION not set
 
 The triage skill must take an action (route to research, split, close, etc.) before completing.

--- a/plugin/ralph-hero/skills/ralph-triage/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-triage/SKILL.md
@@ -116,38 +116,31 @@ Then STOP.
 
 ### Step 4: Determine Recommendation
 
-Choose ONE action:
+Choose ONE of the **8 structured verdicts** (#1417). Each verdict names its successor — items advance now (`PROMOTE-*`), wait on a *named, watched condition* (`WAIT-*`), close (`CLOSE-*`), or decompose (`SPLIT`). There is no bare "keep" dead-end.
 
-**CLOSE** - Issue is done, duplicate, or no longer relevant
-- Feature already implemented
-- Bug already fixed
-- Duplicate of another issue
-- No longer applicable (tech/product changed)
+| Verdict | Workflow target | Downstream consumer |
+|---|---|---|
+| `CLOSE-done` | Done | — |
+| `CLOSE-canceled` | Canceled | — |
+| `SPLIT` | (stays Backlog, children created) | `--mode split` |
+| `PROMOTE-research` | Research Needed | `/ralph-research` |
+| `PROMOTE-plan` | Ready for Plan | `/ralph-plan` |
+| `WAIT-pr=NNN` | Backlog + `blocked:pr-NNN` label | watch-pr (Phase 3, #1406) |
+| `WAIT-upstream=URL` | Backlog + `blocked:upstream` label | watch-upstream (Phase 3, #1407) |
+| `WAIT-decision` | Human Needed + `## Escalation` comment | unblock workflow |
 
-**SPLIT** - Issue is too large or contains multiple distinct items
-- Recommend specific sub-issues to create
-- Each sub-issue should be XS or Small
+`RE-ESTIMATE` remains an orthogonal field-fix (correct the estimate; issue stays in Backlog for re-triage). It composes with a verdict on a later tick rather than replacing one.
 
-**RE-ESTIMATE** - Issue needs size adjustment
-- Current estimate missing or incorrect
-- Recommend new estimate with reasoning
-
-**RESEARCH** - Issue is valid but needs investigation
-- Move to "Research Needed" workflow state
-- Ready for `/ralph-research` to pick up
-
-**KEEP** - Issue is valid as-is
-- Leave in Backlog for prioritization
-- Add clarifying comment if helpful
+> The legacy `KEEP` verdict is **retired** by this change — it was the dead-end the structured set exists to remove (it left items in Backlog with no successor). The postcondition hook still accepts `KEEP` until Phase 6 (#1410), but new triage runs MUST pick a structured verdict. This skill is the legacy parallel surface; the active path is `/ralph:caretake --mode triage`.
 
 ### Step 5: Take Action
 
 **General error handling pattern (applies to all action branches below):**
 If `save_issue`, `create_issue`, `add_sub_issue`, or `add_dependency` returns an error, read the error message — it contains valid states/intents and a specific Recovery action. Retry with the corrected parameters. If the error indicates a permanent problem (invalid permissions, missing field, etc.), escalate per the Escalation Protocol below.
 
-**If CLOSE:** Choose the destination state based on closure reason:
-- **Done** — for issues that are already implemented, already fixed, or duplicates of completed work. Use `issueState: "CLOSED"` (reason: completed).
-- **Canceled** — for issues that are no longer relevant (tech changed, product direction shifted, no longer applicable). Use `issueState: "CLOSED_NOT_PLANNED"` (reason: not planned).
+**If CLOSE-done / CLOSE-canceled:** Choose the destination state based on closure reason:
+- **`CLOSE-done`** → Done — for issues that are already implemented, already fixed, or duplicates of completed work. Use `issueState: "CLOSED"` (reason: completed).
+- **`CLOSE-canceled`** → Canceled — for issues that are no longer relevant (tech changed, product direction shifted, no longer applicable). Use `issueState: "CLOSED_NOT_PLANNED"` (reason: not planned).
 
 Update the issue workflow state accordingly (command: "ralph_triage"). Add a comment explaining why it was closed and which destination state was chosen.
 
@@ -171,21 +164,29 @@ Add a comment to the original listing sub-issues (reused and/or created).
 
 **If RE-ESTIMATE:** Update the issue with the new estimate (XS/S/M/L/XL). Add a comment explaining the estimate reasoning. Workflow state remains Backlog.
 
-**If RESEARCH:** Update the issue workflow state to "Research Needed" (command: "ralph_triage"). Add a comment: "Moved to Research Needed for investigation." The comment should also briefly note what specifically needs to be researched (e.g., "Investigate whether feature X already exists in module Y" or "Clarify scope of integration with system Z") so the downstream `/ralph-research` agent has actionable context.
+**If PROMOTE-research:** Update the issue workflow state to "Research Needed" (command: "ralph_triage"). Add a comment: "Moved to Research Needed for investigation." The comment should also briefly note what specifically needs to be researched (e.g., "Investigate whether feature X already exists in module Y" or "Clarify scope of integration with system Z") so the downstream `/ralph-research` agent has actionable context.
 
-**If KEEP:** Add a comment with any clarifications or context discovered. Leave workflow state as Backlog.
+**If PROMOTE-plan:** The issue is well-specified and can skip research. Update the workflow state to "Ready for Plan" (command: "ralph_triage"). Add a comment noting what the plan should cover.
+
+**If WAIT-pr=NNN / WAIT-upstream=URL:** The issue is valid but blocked on a *named, watched condition*. Leave it in Backlog and apply the matching `blocked:*` label so the Phase 3 watcher (#1406/#1407) can resolve it when the condition clears:
+- **`WAIT-pr=NNN`** — blocked on PR #NNN merging. Apply `blocked:pr-NNN` (e.g. `blocked:pr-1338`) + `ralph-triage`.
+- **`WAIT-upstream=URL`** — blocked on an external/upstream condition. Apply `blocked:upstream` + `ralph-triage`; record the URL in the comment (the label carries no URL).
+
+Add a comment naming the exact condition being waited on.
+
+**If WAIT-decision:** Needs a human call before it can advance. Set workflow state to "Human Needed" (command: "ralph_triage"), post a `## Escalation` comment stating the specific decision required, and apply `ralph-triage`.
 
 **Before completing (REQUIRED for all action branches):** Set the `RALPH_TRIAGE_ACTION` environment variable so the postcondition hook (`triage-postcondition.sh`) can verify the action was taken. Use Bash to export the value:
 
 ```bash
-export RALPH_TRIAGE_ACTION=RESEARCH   # or SPLIT, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE
+export RALPH_TRIAGE_ACTION=PROMOTE-plan   # or CLOSE-done, CLOSE-canceled, SPLIT, PROMOTE-research, WAIT-pr, WAIT-upstream, WAIT-decision
 ```
 
-Valid values: `RESEARCH`, `SPLIT`, `CLOSE`, `KEEP`, `HUMAN` (when escalating), `CANCEL`, `RE-ESTIMATE`. The postcondition hook will block completion if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
+Valid values: `CLOSE-done`, `CLOSE-canceled`, `SPLIT`, `PROMOTE-research`, `PROMOTE-plan`, `WAIT-pr[=NNN]`, `WAIT-upstream[=URL]`, `WAIT-decision` (the 8 structured verdicts), plus the orthogonal `RE-ESTIMATE` and the legacy set `RESEARCH`, `CLOSE`, `KEEP`, `HUMAN`, `CANCEL` (retained until Phase 6 / #1410). The postcondition hook will block completion if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
 
 ### Step 6: Mark Issue as Triaged
 
-After completing any action (CLOSE/SPLIT/RE-ESTIMATE/RESEARCH/KEEP), update the issue labels to include "ralph-triage" while preserving existing labels.
+After any verdict that **leaves the issue in Backlog** (`SPLIT`, `WAIT-pr`, `WAIT-upstream`, `RE-ESTIMATE`, plus legacy `HUMAN`), update the issue labels to include "ralph-triage" (and any `blocked:*` label) while preserving existing labels. `PROMOTE-*`, `CLOSE-*`, and `WAIT-decision` move the issue out of Backlog, so re-pick suppression isn't needed there.
 
 **Important**: Preserve existing labels when adding `ralph-triage`. Read the issue's current labels first, then include them all plus `ralph-triage` in the update.
 

--- a/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
+++ b/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
-PATTERN='^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.'
+PATTERN='^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped|CLOSE-done|CLOSE-canceled|SPLIT|PROMOTE-research|PROMOTE-plan|WAIT-pr=.+|WAIT-upstream|WAIT-decision)|^Queue empty\.'
 
 pass() {
   echo "  PASS: $1"
@@ -59,12 +59,25 @@ assert_matches "TRIAGED skipped — branch feature/foo is not main" "TRIAGED ski
 assert_matches "Queue empty." "Queue empty."
 
 echo ""
+echo "--- 8 structured verdict tokens (#1417, should match) ---"
+
+assert_matches "TRIAGED CLOSE-done" "TRIAGED CLOSE-done"
+assert_matches "TRIAGED CLOSE-canceled" "TRIAGED CLOSE-canceled"
+assert_matches "TRIAGED SPLIT" "TRIAGED SPLIT"
+assert_matches "TRIAGED PROMOTE-research" "TRIAGED PROMOTE-research"
+assert_matches "TRIAGED PROMOTE-plan" "TRIAGED PROMOTE-plan"
+assert_matches "TRIAGED WAIT-pr=1338 (=NNN suffix kept)" "TRIAGED WAIT-pr=1338"
+assert_matches "TRIAGED WAIT-upstream (suffix dropped)" "TRIAGED WAIT-upstream"
+assert_matches "TRIAGED WAIT-decision" "TRIAGED WAIT-decision"
+
+echo ""
 echo "--- Retired/invalid tokens (should NOT match) ---"
 
 assert_no_match "TRIAGED valid (retired)" "TRIAGED valid"
 assert_no_match "KEEP (never a terminal token)" "KEEP"
 assert_no_match "Unknown token TRIAGED unknown" "TRIAGED unknown"
 assert_no_match "Bare TRIAGED with no verdict" "TRIAGED"
+assert_no_match "TRIAGED WAIT-pr without =NNN suffix (must name the PR)" "TRIAGED WAIT-pr"
 assert_matches "Queue empty. with trailing text still matches (starts with sentinel)" "Queue empty. some extra text"
 assert_no_match "Lowercase queue empty." "queue empty."
 assert_no_match "Prose description of routing (not the literal token)" "Issue was routed to Research Needed"

--- a/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
+++ b/ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
-PATTERN='^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped|CLOSE-done|CLOSE-canceled|SPLIT|PROMOTE-research|PROMOTE-plan|WAIT-pr=.+|WAIT-upstream|WAIT-decision)|^Queue empty\.'
+PATTERN='^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped|CLOSE-done|CLOSE-canceled|SPLIT|PROMOTE-research|PROMOTE-plan|WAIT-pr=[0-9]+|WAIT-upstream|WAIT-decision)|^Queue empty\.'
 
 pass() {
   echo "  PASS: $1"
@@ -78,6 +78,7 @@ assert_no_match "KEEP (never a terminal token)" "KEEP"
 assert_no_match "Unknown token TRIAGED unknown" "TRIAGED unknown"
 assert_no_match "Bare TRIAGED with no verdict" "TRIAGED"
 assert_no_match "TRIAGED WAIT-pr without =NNN suffix (must name the PR)" "TRIAGED WAIT-pr"
+assert_no_match "TRIAGED WAIT-pr=abc non-numeric suffix (PR numbers are integers)" "TRIAGED WAIT-pr=abc"
 assert_matches "Queue empty. with trailing text still matches (starts with sentinel)" "Queue empty. some extra text"
 assert_no_match "Lowercase queue empty." "queue empty."
 assert_no_match "Prose description of routing (not the literal token)" "Issue was routed to Research Needed"

--- a/ralph/hooks/scripts/triage-postcondition.sh
+++ b/ralph/hooks/scripts/triage-postcondition.sh
@@ -47,9 +47,9 @@ transcript_text=$(jq -r 'select(.type == "assistant") | .message.content[]? | se
 # Match any of the documented terminal tokens. The 8 structured verdicts (#1417)
 # are matched verbatim; the legacy alternations (routed/duplicate/canceled/…) are
 # retained for back-compat so older transcripts and the parallel plugin surface
-# don't regress. WAIT-pr requires the literal "=NNN" suffix so the branch can't
-# over-match prose.
-if echo "$transcript_text" | grep -qE '^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped|CLOSE-done|CLOSE-canceled|SPLIT|PROMOTE-research|PROMOTE-plan|WAIT-pr=.+|WAIT-upstream|WAIT-decision)|^Queue empty\.' ; then
+# don't regress. WAIT-pr requires a literal "=NNN" numeric suffix (PR numbers are
+# integers) so the branch can't over-match prose or a non-numeric suffix.
+if echo "$transcript_text" | grep -qE '^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped|CLOSE-done|CLOSE-canceled|SPLIT|PROMOTE-research|PROMOTE-plan|WAIT-pr=[0-9]+|WAIT-upstream|WAIT-decision)|^Queue empty\.' ; then
   echo "Triage postcondition passed: terminal token found in transcript"
   allow
 fi

--- a/ralph/hooks/scripts/triage-postcondition.sh
+++ b/ralph/hooks/scripts/triage-postcondition.sh
@@ -44,25 +44,31 @@ fi
 # pipeline-heavy under set -euo pipefail; append `|| true` per Plan 6 lesson.
 transcript_text=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text' "$transcript_path" 2>/dev/null || true)
 
-# Match any of the documented terminal tokens.
-if echo "$transcript_text" | grep -qE '^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped)|^Queue empty\.' ; then
+# Match any of the documented terminal tokens. The 8 structured verdicts (#1417)
+# are matched verbatim; the legacy alternations (routed/duplicate/canceled/…) are
+# retained for back-compat so older transcripts and the parallel plugin surface
+# don't regress. WAIT-pr requires the literal "=NNN" suffix so the branch can't
+# over-match prose.
+if echo "$transcript_text" | grep -qE '^TRIAGED (routed (→ )?.+|duplicate|canceled|needs-split|escalated|re-estimated|skipped|CLOSE-done|CLOSE-canceled|SPLIT|PROMOTE-research|PROMOTE-plan|WAIT-pr=.+|WAIT-upstream|WAIT-decision)|^Queue empty\.' ; then
   echo "Triage postcondition passed: terminal token found in transcript"
   allow
 fi
 
 block "Triage postcondition failed: no terminal token emitted
 
-Expected one of:
-  TRIAGED routed → Research Needed   (issue routed to Research Needed)
-  TRIAGED routed → Ready for Plan    (issue routed to Ready for Plan)
-  TRIAGED routed → In Progress       (trivial fix; routed directly to In Progress)
-  TRIAGED duplicate                  (closed as duplicate)
-  TRIAGED canceled                   (closed not_planned)
-  TRIAGED needs-split                (routed to split queue)
-  TRIAGED escalated                  (escalated to Human Needed)
-  TRIAGED re-estimated               (estimate updated; stays in Backlog)
-  TRIAGED skipped …                  (branch-gate short-circuit; non-main branch)
+Expected one of the 8 verdict tokens:
+  TRIAGED CLOSE-done                 (closed as done/implemented/duplicate)
+  TRIAGED CLOSE-canceled             (closed not_planned)
+  TRIAGED SPLIT                      (children created; stays in Backlog)
+  TRIAGED PROMOTE-research           (routed to Research Needed)
+  TRIAGED PROMOTE-plan               (routed to Ready for Plan)
+  TRIAGED WAIT-pr=NNN                (parked in Backlog; blocked:pr-NNN)
+  TRIAGED WAIT-upstream              (parked in Backlog; blocked:upstream)
+  TRIAGED WAIT-decision              (escalated to Human Needed)
   Queue empty.                       (no untriaged Backlog issues)
+
+Legacy tokens still accepted: TRIAGED routed → … / duplicate / canceled /
+  needs-split / escalated / re-estimated / skipped …
 
 The /ralph:caretake --mode triage body must end by emitting one of these tokens.
 See ralph/skills/caretake/outcome-tokens.md for the full contract.

--- a/ralph/skills/caretake/modes/triage.md
+++ b/ralph/skills/caretake/modes/triage.md
@@ -58,25 +58,33 @@ and STOP.
 
 ## §Step 4: Determine action
 
-Choose ONE:
+Choose ONE of the **8 structured verdicts**. Every verdict names its successor — items either advance now (`PROMOTE-*`), wait on a *named, watched condition* (`WAIT-*`), close (`CLOSE-*`), or decompose (`SPLIT`). There is no bare "keep" dead-end: a verdict that leaves an issue in Backlog must name what it waits on.
 
-- **CLOSE** — feature already implemented, bug already fixed, duplicate, or no longer applicable.
-- **SPLIT** — issue is too large or covers multiple distinct items. Recommend XS/S sub-issues.
-- **RE-ESTIMATE** — current estimate missing or wrong; propose new value with reasoning.
-- **ROUTE-TO-Research Needed** — issue is valid but needs investigation before planning; move to "Research Needed".
-- **ROUTE-TO-Ready for Plan** — issue is well-specified; skip research and queue directly for planning.
-- **ROUTE-TO-In Progress** — trivial fix; assign and start immediately.
+| Verdict | Workflow target | Downstream consumer |
+|---|---|---|
+| `CLOSE-done` | Done | — |
+| `CLOSE-canceled` | Canceled | — |
+| `SPLIT` | (stays Backlog, children created) | caretake `--mode split` |
+| `PROMOTE-research` | Research Needed | `/ralph:research --mode auto` |
+| `PROMOTE-plan` | Ready for Plan | `/ralph:plan --mode auto` |
+| `WAIT-pr=NNN` | Backlog + `blocked:pr-NNN` label | watch-pr (Phase 3, #1406) |
+| `WAIT-upstream=URL` | Backlog + `blocked:upstream` label | watch-upstream (Phase 3, #1407) |
+| `WAIT-decision` | Human Needed + `## Escalation` comment | unblock workflow |
 
-When uncertain, prefer `ROUTE-TO-Research Needed` (route for investigation) or `HUMAN` (escalate) over closing valid work.
+When uncertain, prefer `PROMOTE-research` (route for investigation) or `WAIT-decision` (escalate) over `CLOSE-*` on valid work.
+
+**Orthogonal action — `RE-ESTIMATE`**: if the estimate is missing or wrong, correct it (issue stays in Backlog for re-triage on the next sweep). This is a field fix, not a routing verdict, so it composes with — rather than replaces — one of the 8 verdicts on a later tick.
+
+> The `WAIT-*` verdicts only *park* the item against a labelled condition this phase (Phase 1, #1404). The watchers that strip the label and re-apply the deferred verdict ship in Phase 3 (#1406/#1407). Until then a `WAIT-*` item waits indefinitely with its `blocked:*` label.
 
 ## §Step 5: Take action
 
 If `save_issue`, `create_issue`, `add_sub_issue`, or `add_dependency` returns an error, read the error message — it contains valid states/intents and a specific recovery action. Retry with corrected parameters. If the error indicates a permanent problem (invalid permissions, missing field, etc.), escalate per §Escalation below.
 
-**CLOSE.** Choose the destination state by closure reason:
+**CLOSE-done / CLOSE-canceled.** Choose the destination state by closure reason:
 
-- **Done** — already implemented, already fixed, duplicate of completed work. Use `issueState: "CLOSED"` (reason: completed).
-- **Canceled** — no longer relevant (tech changed, product direction shifted). Use `issueState: "CLOSED_NOT_PLANNED"` (reason: not planned).
+- **`CLOSE-done`** → Done — already implemented, already fixed, duplicate of completed work. Use `issueState: "CLOSED"` (reason: completed).
+- **`CLOSE-canceled`** → Canceled — no longer relevant (tech changed, product direction shifted). Use `issueState: "CLOSED_NOT_PLANNED"` (reason: not planned).
 
 Update workflow state accordingly (`command: "ralph_triage"`). Add a comment explaining the closure reason and chosen destination state.
 
@@ -90,27 +98,40 @@ Add a comment on the parent listing sub-issues (reused and/or created). **Do NOT
 
 **RE-ESTIMATE.** Update the issue with the new estimate (XS/S/M/L/XL). Add a comment explaining the reasoning. Workflow state remains Backlog.
 
-**ROUTE-TO.** Set `workflowState: <target>` via `save_issue(command: "ralph_triage")` where `<target>` is one of `"Research Needed"`, `"Ready for Plan"`, or `"In Progress"`. Add a `## Triage Decision` comment explaining the routing choice and what downstream work is expected (e.g., what to investigate, what the plan should cover, or what the trivial fix is).
+**PROMOTE-research / PROMOTE-plan.** Set `workflowState: <target>` via `save_issue(command: "ralph_triage")` where `<target>` is `"Research Needed"` (`PROMOTE-research`) or `"Ready for Plan"` (`PROMOTE-plan`). Add a `## Triage Decision` comment explaining the routing choice and what downstream work is expected (what to investigate, or what the plan should cover).
+
+**WAIT-pr=NNN / WAIT-upstream=URL.** The issue is valid but blocked on a *named, watched condition*. Leave it in Backlog and apply the matching `blocked:*` label so the Phase 3 watcher can pick it up when the condition resolves:
+
+- **`WAIT-pr=NNN`** — blocked on PR #NNN merging. Apply `blocked:pr-NNN` (e.g. `blocked:pr-1338`) + `ralph-triage`.
+- **`WAIT-upstream=URL`** — blocked on an external/upstream condition. Apply `blocked:upstream` + `ralph-triage`. Record the URL in the `## Triage Decision` comment (the label carries no URL).
+
+Add a `## Triage Decision` comment naming the exact condition being waited on.
+
+**WAIT-decision.** Needs a human call before it can advance. Set `workflowState: "Human Needed"` (`command: "ralph_triage"`), post a `## Escalation` comment stating the specific decision required, and apply `ralph-triage`.
 
 **Before completing (REQUIRED for all branches):** export `RALPH_TRIAGE_ACTION` so `triage-postcondition.sh` can verify the action was taken:
 
 ```bash
-# Pick the value that matches your action:
-export RALPH_TRIAGE_ACTION=ROUTE_TO_RESEARCH   # routed to Research Needed
-export RALPH_TRIAGE_ACTION=ROUTE_TO_PLAN       # routed to Ready for Plan
-export RALPH_TRIAGE_ACTION=ROUTE_TO_IMPL       # routed to In Progress
-# export RALPH_TRIAGE_ACTION=SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE
+# Pick the value that matches your verdict:
+export RALPH_TRIAGE_ACTION=PROMOTE-research    # → Research Needed
+export RALPH_TRIAGE_ACTION=PROMOTE-plan        # → Ready for Plan
+export RALPH_TRIAGE_ACTION=CLOSE-done          # → Done
+export RALPH_TRIAGE_ACTION=CLOSE-canceled      # → Canceled
+export RALPH_TRIAGE_ACTION=SPLIT               # children created; stays Backlog
+export RALPH_TRIAGE_ACTION=WAIT-pr             # blocked:pr-NNN; stays Backlog
+export RALPH_TRIAGE_ACTION=WAIT-upstream       # blocked:upstream; stays Backlog
+export RALPH_TRIAGE_ACTION=WAIT-decision       # → Human Needed
+# Legacy values (still accepted by the postcondition allowlist; Phase 6 / #1410 removes them):
+# ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE | KEEP
 ```
 
-Note: `CANCEL` is the close-not-planned sub-case of CLOSE (sets `issueState: CLOSED_NOT_PLANNED`, emits `TRIAGED canceled`) — a model picking `CANCEL` routes through the CLOSE action body above.
-
-Valid values: `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE`. `RALPH_TRIAGE_ACTION` is a self-discipline marker for the model — it is NOT validated by the postcondition hook. The postcondition hook (`triage-postcondition.sh`) enforces that a valid **terminal token** was emitted (it greps the transcript for `TRIAGED …` or `Queue empty.`); it does not read `RALPH_TRIAGE_ACTION` at all.
+Valid values: `CLOSE-done | CLOSE-canceled | SPLIT | PROMOTE-research | PROMOTE-plan | WAIT-pr | WAIT-upstream | WAIT-decision` (the 8 structured verdicts), plus the legacy set `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE | KEEP` retained until Phase 6 (#1410). `RALPH_TRIAGE_ACTION` is a self-discipline marker for the model — the **slim** postcondition hook (`ralph/hooks/scripts/triage-postcondition.sh`) does NOT read it; it greps the transcript for a valid **terminal token** (`TRIAGED …` / `Queue empty.`). The **legacy plugin** hook (`plugin/ralph-hero/hooks/scripts/triage-postcondition.sh`) does validate this env var against its allowlist.
 
 ## §Step 6: Mark issue as triaged
 
-Apply the `ralph-triage` label on `HUMAN`, `SPLIT`, and `RE-ESTIMATE` outcomes — every outcome that leaves the issue in Backlog. Read current labels first, then include them all plus `ralph-triage` in the `save_issue` call.
+Apply the `ralph-triage` label on every verdict that **leaves the issue in Backlog**: `SPLIT`, `WAIT-pr`, `WAIT-upstream`, and the orthogonal `RE-ESTIMATE` (plus legacy `HUMAN`). Read current labels first, then include them all plus `ralph-triage` (and any `blocked:*` label from §Step 5) in the `save_issue` call.
 
-Rationale: `ROUTE-TO` outcomes move the issue OUT of Backlog (the issue becomes invisible to §Step 2's Backlog query after routing, so no label is needed). `HUMAN`, `SPLIT`, and `RE-ESTIMATE` all leave the issue in Backlog — without the `ralph-triage` label, §Step 2's untriaged-Backlog picker would re-select the issue on the next triage tick, causing an infinite re-pick loop under `--loop`.
+Rationale: `PROMOTE-*`, `CLOSE-*`, and `WAIT-decision` move the issue OUT of Backlog (it becomes invisible to §Step 2's Backlog query, so no `ralph-triage` is needed for re-pick suppression). `SPLIT`, `WAIT-pr`, `WAIT-upstream`, and `RE-ESTIMATE` all leave the issue in Backlog — without the `ralph-triage` label, §Step 2's untriaged-Backlog picker would re-select the issue on the next triage tick, causing an infinite re-pick loop under `--loop`. The `WAIT-*` items also carry a `blocked:*` label so the Phase 3 watcher (once shipped) can find and resolve them.
 
 ## §Step 7: Find and Link Related Issues
 
@@ -161,19 +182,19 @@ After triage action is complete, scan for related issues in Backlog or Research 
 
 ## §Step 8: Emit terminal token
 
-Emit exactly one of the tokens defined in [outcome-tokens.md](../outcome-tokens.md):
+Emit exactly one token, matching the verdict from §Step 4. One token per verdict (see [outcome-tokens.md](../outcome-tokens.md) for the full contract):
 
-- `TRIAGED routed → Research Needed` — issue routed to Research Needed for investigation.
-- `TRIAGED routed → Ready for Plan` — issue routed to Ready for Plan (well-specified, skip research).
-- `TRIAGED routed → In Progress` — trivial fix; issue routed directly to In Progress.
-- `TRIAGED duplicate` — closed as duplicate; references `## Duplicate Of` comment.
-- `TRIAGED canceled` — closed not-planned.
-- `TRIAGED needs-split` — left in Backlog with `needs-split` label so `--mode split` picks it up.
-- `TRIAGED escalated` — escalated to Human Needed; `ralph-triage` label applied.
-- `TRIAGED re-estimated` — estimate updated; issue stays in Backlog.
+- `TRIAGED CLOSE-done` — closed as done/implemented/duplicate (`## Duplicate Of` comment when a duplicate).
+- `TRIAGED CLOSE-canceled` — closed not-planned.
+- `TRIAGED SPLIT` — children created; issue stays in Backlog with `ralph-triage`.
+- `TRIAGED PROMOTE-research` — routed to Research Needed for investigation.
+- `TRIAGED PROMOTE-plan` — routed to Ready for Plan (well-specified, skip research).
+- `TRIAGED WAIT-pr=NNN` — parked in Backlog with `blocked:pr-NNN` (the `=NNN` is part of the token).
+- `TRIAGED WAIT-upstream` — parked in Backlog with `blocked:upstream` (URL recorded in the `## Triage Decision` comment, not the token).
+- `TRIAGED WAIT-decision` — escalated to Human Needed with a `## Escalation` comment.
 - `Queue empty.` — no untriaged Backlog issues (emitted at §Step 2).
 
-`triage-postcondition.sh` greps the transcript for one of these tokens. Anything else fails the Stop hook with exit 2.
+Legacy tokens (`TRIAGED routed → …`, `duplicate`, `canceled`, `needs-split`, `escalated`, `re-estimated`, `skipped …`) remain accepted by the postcondition for back-compat; new triage runs SHOULD emit the verdict-named tokens above. `triage-postcondition.sh` greps the transcript for one of these tokens — anything else fails the Stop hook with exit 2.
 
 ## §Confidence levels
 

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -6,20 +6,29 @@ Sections are filled across Plans 7 phases 3-8. Trends mode is read-only and emit
 
 ## Triage terminal tokens
 
-Routing convention: the state name appears verbatim after the `→` token, case-preserving (e.g., `TRIAGED routed → Research Needed` not `research needed`). `triage-postcondition.sh` uses `^TRIAGED routed → .+` to match the full routing family.
+The **8 structured verdicts** (#1417) each emit a verbatim `TRIAGED <verdict>` token — the verdict name appears after `TRIAGED `, case-preserving. These are the tokens new triage runs emit:
 
-- `TRIAGED routed → Research Needed` — issue routed to Research Needed for investigation.
-- `TRIAGED routed → Ready for Plan` — issue well-specified; routed directly to Ready for Plan (research skipped).
-- `TRIAGED routed → In Progress` — trivial fix; routed directly to In Progress.
-- `TRIAGED duplicate` — closed as duplicate; references a `## Duplicate Of` comment naming the surviving issue.
-- `TRIAGED canceled` — closed not-planned (tech changed, product direction shifted, etc.).
-- `TRIAGED needs-split` — left in Backlog with the `needs-split` label so `--mode split` picks it up on the next sweep. `ralph-triage` label applied.
-- `TRIAGED escalated` — escalated to Human Needed; `ralph-triage` label applied so the issue is not re-picked.
-- `TRIAGED re-estimated` — estimate updated; issue stays in Backlog with the `ralph-triage` label applied (prevents re-pick under `--loop`).
-- `TRIAGED skipped — branch <name> is not main` — §Step 1 short-circuit; triage refuses to run on a feature branch.
+- `TRIAGED CLOSE-done` — closed as done/implemented/duplicate; references a `## Duplicate Of` comment when a duplicate.
+- `TRIAGED CLOSE-canceled` — closed not-planned (tech changed, product direction shifted, etc.).
+- `TRIAGED SPLIT` — children created; issue stays in Backlog with the `ralph-triage` label so `--mode split` / the picker doesn't re-select it.
+- `TRIAGED PROMOTE-research` — routed to Research Needed for investigation.
+- `TRIAGED PROMOTE-plan` — issue well-specified; routed to Ready for Plan (research skipped).
+- `TRIAGED WAIT-pr=NNN` — parked in Backlog with `blocked:pr-NNN` + `ralph-triage`; the `=NNN` PR number is part of the token. Phase 3 (#1406) watch-pr strips the label when the PR merges.
+- `TRIAGED WAIT-upstream` — parked in Backlog with `blocked:upstream` + `ralph-triage`; the upstream URL is recorded in the `## Triage Decision` comment, not the token (URLs are unwieldy in a terminal token). Phase 3 (#1407) watch-upstream resolves it.
+- `TRIAGED WAIT-decision` — escalated to Human Needed with a `## Escalation` comment naming the decision required; `ralph-triage` applied.
 - `Queue empty.` — no untriaged Backlog issues remain.
 
-`triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens. The `RALPH_TRIAGE_ACTION` allowlist (checked by the skill body's §Step 5) is: `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | SPLIT | CLOSE | HUMAN | CANCEL | RE-ESTIMATE`.
+**Legacy tokens (still accepted by the postcondition for back-compat; new runs should not emit them):** Phase 6 (#1410) prunes the legacy `RALPH_TRIAGE_ACTION=KEEP` path, but these terminal tokens stay valid so older transcripts and the parallel plugin surface don't regress.
+
+- `TRIAGED routed → Research Needed` / `→ Ready for Plan` / `→ In Progress` — superseded by `PROMOTE-research` / `PROMOTE-plan` (the direct-to-In-Progress route is folded into `PROMOTE-plan`).
+- `TRIAGED duplicate` — superseded by `CLOSE-done`.
+- `TRIAGED canceled` — superseded by `CLOSE-canceled`.
+- `TRIAGED needs-split` — superseded by `SPLIT`.
+- `TRIAGED escalated` — superseded by `WAIT-decision`.
+- `TRIAGED re-estimated` — emitted by the orthogonal `RE-ESTIMATE` action; issue stays in Backlog with `ralph-triage`.
+- `TRIAGED skipped — branch <name> is not main` — §Step 1 short-circuit; triage refuses to run on a feature branch.
+
+`triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens (8 verdict tokens + legacy set + `Queue empty.`). The `RALPH_TRIAGE_ACTION` allowlist (checked by the legacy plugin hook's §Step 5; the slim hook ignores the env var) is: `CLOSE-done | CLOSE-canceled | SPLIT | PROMOTE-research | PROMOTE-plan | WAIT-pr | WAIT-upstream | WAIT-decision` plus legacy `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE | KEEP`.
 ## Hygiene terminal tokens
 
 - `HYGIENE COMPLETE <N archived>` — scan ran cleanly; `N` is the archive count (0 if dry-run or threshold not exceeded).


### PR DESCRIPTION
## Summary

Phase 1 of epic #1417 — replace the ad-hoc triage verdict vocabulary with the **8 structured verdicts**, each naming its downstream successor. The genuinely-new capability is the **`WAIT-*` deferred family** (`WAIT-pr=NNN`, `WAIT-upstream=URL`, `WAIT-decision`), which parks an item against a *named, watched condition* instead of dead-ending it in Backlog — the failure mode the epic exists to fix.

Verdict set: `CLOSE-done`, `CLOSE-canceled`, `SPLIT`, `PROMOTE-research`, `PROMOTE-plan`, `WAIT-pr=NNN`, `WAIT-upstream=URL`, `WAIT-decision`.

**Scope is schema + validation only.** No `WAIT-*` consumer is wired here (Phase 3 / #1406-#1407); a parked item just carries a `blocked:*` label. Legacy `KEEP` is **retained** in the validation allowlists (Phase 6 / #1410 removes it).

### Reconciliation note (issue premise had drifted from the code)
- The **active** slim `/ralph:caretake --mode triage` already moved past bare `KEEP` to `ROUTE-TO-*`, and enforces via a **terminal-token regex** — not `RALPH_TRIAGE_ACTION`. This PR covers the slim hook **and its palette test**, which the issue body omitted.
- The `RALPH_TRIAGE_ACTION` allowlist change applies to the **legacy plugin** hook (env-var model). Both surfaces now document the same vocabulary.
- Verdict→token design: **8 verbatim `TRIAGED <verdict>` tokens**, keeping all legacy alternations for no-regression. See plan Key Discoveries for the alternative considered.

## Changes
**Phase 1 — slim active path** (`658ae220`):
- `ralph/skills/caretake/modes/triage.md` — §Step 4 schema table, §Step 5 action bodies (incl. `WAIT-*`), §Step 6 label rationale, §Step 8 tokens
- `ralph/skills/caretake/outcome-tokens.md` — 8 verbatim tokens; legacy tokens retained as back-compat
- `ralph/hooks/scripts/triage-postcondition.sh` — regex matches the 8 new tokens + all legacy ones (`WAIT-pr=.+` requires the `=NNN` suffix)
- `ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh` — +8 match assertions, +1 no-match guard

**Phase 2 — legacy plugin sync** (`6150aaf4`):
- `plugin/ralph-hero/skills/ralph-triage/SKILL.md` — 8-verdict schema + `PROMOTE-*`/`WAIT-*` bodies; `KEEP` marked retired
- `plugin/ralph-hero/hooks/scripts/triage-postcondition.sh` — `RALPH_TRIAGE_ACTION` allowlist accepts 8 new values (+ `=NNN`/`=URL` suffix forms) plus retained legacy set incl. `KEEP`

## Plan
[`thoughts/shared/plans/2026-05-25-GH-1404-8-verdict-triage-schema.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-25-GH-1404-8-verdict-triage-schema.md) · review APPROVED ([critique](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-25-GH-1404-critique.md))

## Test plan
- [x] `bash ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh` → 26 passed, 0 failed
- [x] `bash -n` on both postcondition hooks → syntax OK
- [x] `RALPH_TRIAGE_ACTION=PROMOTE-plan` / `WAIT-pr=1338` / `KEEP` (legacy) all accepted by the plugin hook; bogus value warns-then-allows (pre-existing behavior)
- [x] 8 verbatim `TRIAGED <verdict>` token lines present in `outcome-tokens.md`
- Docs + bash only; no TS touched — MCP server suite verified by CI

Closes #1404
