### PR TITLE
GH-1407: Add /ralph:caretake --mode watch-upstream for blocked:upstream items

### DIFF
--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: All board maintenance, grooming, and reflection in one verb. Triggers on "triage backlog", "clean up board", "scan for stale", "status check", "post-mortem", "capture friction", "retro the session", "trend report", "snapshot metrics", "unblock issue", "answer unblock questions", "collate debug errors", "filer Langfuse errors", "split this issue", "decompose ticket". Default mode is event-driven (reads `--issue NNN` labels and fans out via Skill). Named modes (triage/hygiene/unblock/postmortem/retro/trends/debug/split/watch-pr) each route to a dedicated mode body under `modes/`.
-argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|watch-pr|all>] [#NNN] [--since <window>] [--auto-confirm] [--question] [--loop [duration]] [--auto]"
+description: All board maintenance, grooming, and reflection in one verb. Triggers on "triage backlog", "clean up board", "scan for stale", "status check", "post-mortem", "capture friction", "retro the session", "trend report", "snapshot metrics", "unblock issue", "answer unblock questions", "collate debug errors", "filer Langfuse errors", "split this issue", "decompose ticket". Default mode is event-driven (reads `--issue NNN` labels and fans out via Skill). Named modes (triage/hygiene/unblock/postmortem/retro/trends/debug/split/watch-pr/watch-upstream) each route to a dedicated mode body under `modes/`.
+argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|watch-pr|watch-upstream|all>] [#NNN] [--since <window>] [--auto-confirm] [--question] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:
@@ -86,7 +86,7 @@ allowed-tools:
 
 # /ralph:caretake — Board steward in one verb
 
-All board maintenance flows through this one entrypoint. Nine named modes plus a default event-driven dispatcher. Each mode is a separate body under `modes/`; this top-level SKILL.md only owns arg parsing, dispatch routing, and the heartbeat fan-out.
+All board maintenance flows through this one entrypoint. Ten named modes plus a default event-driven dispatcher. Each mode is a separate body under `modes/`; this top-level SKILL.md only owns arg parsing, dispatch routing, and the heartbeat fan-out.
 
 | Mode | Trigger | Role |
 |---|---|---|
@@ -101,6 +101,7 @@ All board maintenance flows through this one entrypoint. Nine named modes plus a
 | **debug** | `/ralph:caretake --mode debug [--since 24h] [--auto-confirm]` | Collate Langfuse errors → file `debug-auto` issues |
 | **split** | `/ralph:caretake --mode split [#NNN]` | Split M/L/XL → multiple XS/S sub-issues |
 | **watch-pr** | `/ralph:caretake --mode watch-pr` | Resolve `blocked:pr-NNN` items when their PR merges (advance) or closes-unmerged (escalate) |
+| **watch-upstream** | `/ralph:caretake --mode watch-upstream` | Resolve `blocked:upstream` items when their external condition resolves (advance) or URL is dead/unparseable (escalate) |
 
 References: [label-routing.md](label-routing.md) (default-mode dispatch table), [outcome-tokens.md](outcome-tokens.md) (per-mode terminal verdicts), [split-decomposition.md](split-decomposition.md) (split-mode strategy + hook contracts).
 
@@ -160,6 +161,7 @@ Each mode body ends by emitting its terminal token (see [outcome-tokens.md](outc
 - [modes/debug.md](modes/debug.md) — collate Langfuse errors
 - [modes/split.md](modes/split.md) — M/L/XL → XS/S sub-issues
 - [modes/watch-pr.md](modes/watch-pr.md) — resolve `blocked:pr-NNN` items on PR merge/close
+- [modes/watch-upstream.md](modes/watch-upstream.md) — resolve `blocked:upstream` items on external condition
 
 ## Per-mode terminal tokens
 
@@ -175,6 +177,7 @@ The harness reads these from the transcript; do not paraphrase. Full table in [o
 - debug: `DEBUG FILED <N>` | `DEBUG SKIPPED <reason>`
 - split: `SPLIT <N>` | `SPLIT SKIPPED <reason>`
 - watch-pr: `WATCH-PR ADVANCED <N>` | `WATCH-PR IDLE` | `WATCH-PR SKIPPED — branch <name> is not main`
+- watch-upstream: `WATCH-UPSTREAM ADVANCED <N>` | `WATCH-UPSTREAM IDLE` | `WATCH-UPSTREAM SKIPPED — branch <name> is not main`
 
 ## Notes
 

--- a/ralph/skills/caretake/modes/watch-upstream.md
+++ b/ralph/skills/caretake/modes/watch-upstream.md
@@ -53,14 +53,14 @@ Determine whether the condition is **confidently met**. Only a confident MET adv
 - **Package-registry URL** → fetch the registry JSON (`curl -fsS`); MET only if a `version`/`tag` field satisfies the named release condition.
 - **Plain HTTP resource** → MET only if the condition names an explicit, checkable signal (e.g. "200 OK at `<url>`") and the fetch confirms it.
 - **Anything else / ambiguous** → treat as **still blocked** (leave parked).
-- **Dead URL** (404 / persistent fetch error) → **escalate** branch.
+- **Dead URL — HTTP 404/410 only** → **escalate** branch. Any *other* fetch failure (5xx, timeout, DNS) is **transient** → treat as **still blocked** (note it in the summary; retry next sweep). Never escalate on a one-off error — a flaky upstream must not prematurely push an item to Human Needed (matches watch-pr's "all fetch errors leave untouched" posture, but allows a definitive 404/410 to escalate).
 
 ## §Step 5: Act
 
 **Advance (condition confidently met).** Strip the `blocked:upstream` label and apply the deferred verdict:
 
 1. Determine the deferred verdict. **Default `PROMOTE-plan`** (the common case). If the issue carries an explicit `## Deferred Verdict: <verdict>` comment, honor it instead. (Phase 1 / #1404 writes a `## Triage Decision` comment, not a `## Deferred Verdict` comment, so the default applies unless a later phase adds the explicit comment.)
-2. Map the verdict to its target workflow state (same mapping as triage's 8-verdict schema): `PROMOTE-plan`→`"Ready for Plan"`, `PROMOTE-research`→`"Research Needed"`, `CLOSE-done`→`"Done"`, `CLOSE-canceled`→`"Canceled"`. Default `PROMOTE-plan`→Ready for Plan. If an honored `## Deferred Verdict` is itself a `WAIT-*` verdict, leave the item parked and note it.
+2. Map the verdict to its target. watch-upstream **only auto-applies the promote family**: `PROMOTE-plan`→`"Ready for Plan"`, `PROMOTE-research`→`"Research Needed"`. Default `PROMOTE-plan`→Ready for Plan. A `CLOSE-*` or `WAIT-*` deferred verdict is **NOT** auto-applied here — this watcher never closes issues (see §Constraints), and shouldn't auto-close on a speculative comment — so route those via the **escalate** branch instead (post a `## Escalation` noting the deferred verdict needs human confirmation before close/re-wait).
 3. Read the issue's current labels; `save_issue(number: NNN, workflowState: <verdict target>, command: "ralph_triage", labels: <current labels minus blocked:upstream, also dropping ralph-triage so the item is re-pickable in its new state>)`. The explicit `labels` array is required (save_issue replaces the full set; omitting it leaves `blocked:upstream` attached). Note: `command: "ralph_triage"` is passed for semantic parity, but `triage-state-gate.sh` does **not** gate this mode (it scopes to `RALPH_SUBCOMMAND=triage`; watch-upstream's is `watch-upstream`) — its transitions are unguarded, so pass only valid target states.
 4. Post a `## Watch-Upstream Resolution` comment: condition `<condition>` met at `<url>` → label stripped, verdict `<verdict>` applied.
 

--- a/ralph/skills/caretake/modes/watch-upstream.md
+++ b/ralph/skills/caretake/modes/watch-upstream.md
@@ -1,0 +1,88 @@
+# `--mode watch-upstream`
+
+Resolve Backlog items parked by the `WAIT-upstream` triage verdict. Scan issues carrying a `blocked:upstream` label, read the upstream URL + condition from the item's `## Triage Decision` comment, check whether the condition is met, and act: on **condition met** advance the item (default `PROMOTE-plan` → Ready for Plan); on **still blocked / can't confirm** leave it waiting; on **dead URL or unparseable condition** escalate (`WAIT-decision` → Human Needed). Autonomous — no human prompts. Emits one terminal token per invocation (see [outcome-tokens.md](../outcome-tokens.md)).
+
+```bash
+export RALPH_SUBCOMMAND=watch-upstream
+```
+
+This is the downstream consumer that makes the `WAIT-upstream` verdict non-dead-ending: an item waits on a *named, watched external condition* and advances when it resolves. Phase 1 (#1404) produces the `blocked:upstream` label + records the URL in a `## Triage Decision` comment; this mode resolves it.
+
+No `Stop` hook gates this mode (parity with `--mode watch-pr`/`hygiene`/`trends`) — it mutates only the `blocked:upstream`-parked items it owns. The terminal token is emitted by convention, not hook-enforced.
+
+## §Step 1: Verify branch
+
+```bash
+git branch --show-current
+```
+
+If NOT on `main`, STOP and emit:
+
+```
+WATCH-UPSTREAM SKIPPED — branch <name> is not main
+```
+
+watch-upstream mutates workflow state, so it must run from `main`. (Distinct from `WATCH-UPSTREAM IDLE`, which means "ran cleanly, found nothing to do".)
+
+## §Step 2: Find parked items
+
+`list_issues(profile: "analyst-triage", workflowState: "Backlog", label: "blocked:upstream", limit: 250)`. Unlike watch-pr's `blocked:pr-*` family, `blocked:upstream` is a single fixed label, so the server-side `label:` filter returns exactly the parked set.
+
+If no Backlog issue carries `blocked:upstream`, emit:
+
+```
+WATCH-UPSTREAM IDLE
+```
+
+and STOP.
+
+## §Step 3: Read the blocker condition
+
+For each parked item, read its **`## Triage Decision`** comment (this is where #1404's `WAIT-upstream` records the URL + condition — NOT a `## Blocker` comment, which does not exist). Extract:
+
+- the **upstream URL** (e.g. a GitHub issue/PR URL, a package-registry URL, or a plain HTTP resource), and
+- the **condition** that resolves the block (e.g. "external issue closed", "package `foo` ≥ 2.0 released").
+
+If no URL/condition is parseable from the comment, take the **escalate** branch (§Step 5) — the wait premise is unrecoverable.
+
+## §Step 4: Check the condition (conservative)
+
+Determine whether the condition is **confidently met**. Only a confident MET advances the item; anything uncertain leaves it parked (never false-advance):
+
+- **GitHub issue/PR URL** (`github.com/<owner>/<repo>/issues/N` or `/pull/N`) → `gh issue view <url> --json state` / `gh pr view <url> --json state,mergedAt`. MET = issue `CLOSED` / PR `MERGED`.
+- **Package-registry URL** → fetch the registry JSON (`curl -fsS`); MET only if a `version`/`tag` field satisfies the named release condition.
+- **Plain HTTP resource** → MET only if the condition names an explicit, checkable signal (e.g. "200 OK at `<url>`") and the fetch confirms it.
+- **Anything else / ambiguous** → treat as **still blocked** (leave parked).
+- **Dead URL** (404 / persistent fetch error) → **escalate** branch.
+
+## §Step 5: Act
+
+**Advance (condition confidently met).** Strip the `blocked:upstream` label and apply the deferred verdict:
+
+1. Determine the deferred verdict. **Default `PROMOTE-plan`** (the common case). If the issue carries an explicit `## Deferred Verdict: <verdict>` comment, honor it instead. (Phase 1 / #1404 writes a `## Triage Decision` comment, not a `## Deferred Verdict` comment, so the default applies unless a later phase adds the explicit comment.)
+2. Map the verdict to its target workflow state (same mapping as triage's 8-verdict schema): `PROMOTE-plan`→`"Ready for Plan"`, `PROMOTE-research`→`"Research Needed"`, `CLOSE-done`→`"Done"`, `CLOSE-canceled`→`"Canceled"`. Default `PROMOTE-plan`→Ready for Plan. If an honored `## Deferred Verdict` is itself a `WAIT-*` verdict, leave the item parked and note it.
+3. Read the issue's current labels; `save_issue(number: NNN, workflowState: <verdict target>, command: "ralph_triage", labels: <current labels minus blocked:upstream, also dropping ralph-triage so the item is re-pickable in its new state>)`. The explicit `labels` array is required (save_issue replaces the full set; omitting it leaves `blocked:upstream` attached). Note: `command: "ralph_triage"` is passed for semantic parity, but `triage-state-gate.sh` does **not** gate this mode (it scopes to `RALPH_SUBCOMMAND=triage`; watch-upstream's is `watch-upstream`) — its transitions are unguarded, so pass only valid target states.
+4. Post a `## Watch-Upstream Resolution` comment: condition `<condition>` met at `<url>` → label stripped, verdict `<verdict>` applied.
+
+**Leave (still blocked / can't confirm).** No mutation. The item keeps its `blocked:upstream` + `ralph-triage` labels and waits for the next sweep. (Per the plan's scoping choice, an item whose condition is live-but-unconfirmable parks indefinitely — no age/sweep escalation in this phase; a human or manual label removal is the escape.)
+
+**Escalate (dead URL or unparseable condition).** The watched condition can no longer be evaluated:
+
+1. Read the issue's current labels, then `save_issue(number: NNN, workflowState: "Human Needed", command: "ralph_triage", labels: <current labels minus blocked:upstream, keeping ralph-triage>)`. The explicit `labels` array is **required** — `save_issue` only mutates labels when the arg is provided (replace-set semantics), so omitting it would leave the stale `blocked:upstream` label attached and the next sweep would re-find and re-escalate the same dead item (inflating `WATCH-UPSTREAM ADVANCED <N>` every tick).
+2. Post a `## Escalation` comment: "Upstream blocker URL `<url>` is dead/unparseable; the deferred `<verdict>` can no longer auto-apply — needs a human decision (re-route, re-block on a new condition, or close)."
+
+## §Step 6: Emit terminal token
+
+Emit exactly one (see [outcome-tokens.md](../outcome-tokens.md)):
+
+- `WATCH-UPSTREAM ADVANCED <N>` — `<N>` items **resolved this sweep**: condition-met→promoted PLUS dead/unparseable→escalated. Still-blocked / can't-confirm items are NOT counted.
+- `WATCH-UPSTREAM IDLE` — no `blocked:upstream` items found (emitted at §Step 2).
+- `WATCH-UPSTREAM SKIPPED — branch <name> is not main` — §Step 1 branch-gate short-circuit.
+
+## §Constraints
+
+- One sweep per invocation; process only the `blocked:upstream`-labelled Backlog items found by the initial `list_issues` call.
+- **Conservative advance** — never false-advance. When the condition can't be confidently confirmed met, leave the item parked.
+- Mutates only parked items — never creates or closes issues, never touches items without a `blocked:upstream` label.
+- No code changes.
+- Heartbeat / `--loop` fan-out is wired in Phase 4 (#1408); until then this mode runs only via explicit `--mode watch-upstream` dispatch.

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -97,6 +97,14 @@ Trends is read-only — the markdown report printed to stdout is the deliverable
 
 watch-pr has no `Stop` postcondition hook (parity with hygiene/trends) — it mutates only the `blocked:pr-*`-parked items it owns. The token is reported for harness/loop consumption; no automated verification is performed against it.
 
+## Watch-Upstream terminal tokens
+
+- `WATCH-UPSTREAM ADVANCED <N>` — `<N>` items **resolved this sweep**: condition-met items promoted (default `PROMOTE-plan` → Ready for Plan) PLUS dead-URL/unparseable items escalated (`WAIT-decision` → Human Needed). Still-blocked / can't-confirm items are NOT counted (conservative — never false-advance).
+- `WATCH-UPSTREAM IDLE` — scan ran cleanly; no Backlog items carry a `blocked:upstream` label.
+- `WATCH-UPSTREAM SKIPPED — branch <name> is not main` — §Step 1 branch-gate short-circuit (parity with `TRIAGED skipped …`).
+
+watch-upstream has no `Stop` postcondition hook (parity with watch-pr/hygiene/trends) — it mutates only the `blocked:upstream`-parked items it owns. The token is reported for harness/loop consumption; no automated verification is performed against it.
+
 ## Loop continuation
 
 When a caretake mode is wrapped via `--loop` (see `ralph/skills/shared/loop-wrapper.md` for the canonical continuation-rules manifest), the `/loop` runtime reads each invocation's terminal token to decide whether to re-fire or stop.


### PR DESCRIPTION
## Summary

Phase 3b of epic #1417 — add `/ralph:caretake --mode watch-upstream`, the sibling of the merged `watch-pr` (#1406). It resolves the `WAIT-upstream` verdict shipped in Phase 1 (#1404): scans `blocked:upstream` items, reads the upstream URL + condition from the **`## Triage Decision`** comment, checks the condition, and acts:

- **condition confidently met** (GitHub URL closed/merged, package version match, or explicit HTTP signal) → strip `blocked:upstream` + apply deferred verdict (default `PROMOTE-plan` → Ready for Plan); post `## Watch-Upstream Resolution`.
- **still blocked / can't confirm** → leave parked (conservative — never false-advance).
- **dead URL / unparseable condition** → escalate (`WAIT-decision` → Human Needed).

### Design notes (issue premise drifted from Phase 1 reality)
- The issue references reading a `## Blocker` comment AND a `## Deferred Verdict` comment — **neither exists**. #1404's WAIT-upstream records the URL in the `## Triage Decision` comment (verified on main). This mode reads from there and defaults the verdict to `PROMOTE-plan`.
- **Conservative advance**: only a confidently-confirmed condition advances; ambiguous cases park. Trade-off (documented in the plan): a live-but-unconfirmable condition parks indefinitely (no age/sweep escape this phase) — a future phase could add sweep-count escalation.

Folds in the #1406 code-review lessons up front (explicit `labels=` strip on both advance + escalate to avoid re-escalation loops; dedicated `SKIPPED` token; `ADVANCED <N>` = resolved-this-sweep; verdict→state mapping; ungated-transition note).

## Changes
**Phase 1** (`ea424358`): new `ralph/skills/caretake/modes/watch-upstream.md`.
**Phase 2** (`b2546c6f`): wire into `ralph/skills/caretake/SKILL.md` (mode table, mode-bodies, argument-hint, description frontmatter, per-mode token quick-ref, `Nine`→`Ten`) + `ralph/skills/caretake/outcome-tokens.md` (`## Watch-Upstream terminal tokens`).

## Plan
[`thoughts/shared/plans/2026-05-25-GH-1407-caretake-watch-upstream-mode.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-25-GH-1407-caretake-watch-upstream-mode.md) · review APPROVED ([critique](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-25-GH-1407-critique.md))

## Test plan
- [x] `test -f modes/watch-upstream.md`; declares `RALPH_SUBCOMMAND=watch-upstream`; reads `## Triage Decision`; documents all 3 outcome branches
- [x] both label-strip `save_issue` calls pass an explicit `labels=` (no re-escalation loop)
- [x] all 3 tokens (`WATCH-UPSTREAM ADVANCED <N>` / `IDLE` / `SKIPPED`) in mode body + outcome-tokens.md; SKILL.md references watch-upstream in 5 surfaces; mode count → Ten
- [x] referenced tools (gh via Bash, list_issues, save_issue, create_comment, curl) all available
- Markdown-only; no TS — MCP suite unaffected (CI verifies)
- **Manual** (post-merge follow-up): run `--mode watch-upstream` against a `blocked:upstream` item whose `## Triage Decision` names a now-closed GitHub URL; confirm label stripped + advanced + `WATCH-UPSTREAM ADVANCED 1`

## Out of scope (later epic phases)
- Heartbeat/`--loop` fan-out (#1408), director `blocked:*` routing (#1409), age/sweep-count escalation for stuck items.

Closes #1407
