### PR TITLE
GH-1408: Add watch-pr + watch-upstream to /ralph:caretake heartbeat fan-out

### DIFF
--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -91,7 +91,7 @@ All board maintenance flows through this one entrypoint. Ten named modes plus a 
 | Mode | Trigger | Role |
 |---|---|---|
 | **default** | `/ralph:caretake --issue NNN` | Event-driven: read labels, dispatch the right mode via `Skill()` |
-| **all** | `/ralph:caretake` (no args) or `/ralph:caretake --mode all` | Heartbeat fan-out: hygiene + catch-up report + trends |
+| **all** | `/ralph:caretake` (no args) or `/ralph:caretake --mode all` | Heartbeat fan-out: hygiene + watch-pr + watch-upstream + catch-up report + trends |
 | **triage** | `/ralph:caretake --mode triage [#NNN]` | Pick oldest untriaged Backlog, assess, route |
 | **hygiene** | `/ralph:caretake --mode hygiene` | Scan for archive candidates, stale items, WIP violations |
 | **unblock** | `/ralph:caretake --mode unblock [#NNN] [--question]` | Interactive answer OR autonomous request post |
@@ -142,9 +142,11 @@ esac
 - **`--mode <name>`** → read `modes/<name>.md` and follow its body. The mode body sets `RALPH_SUBCOMMAND=<name>` and runs.
 - **No args** or **`--mode all`** → heartbeat fan-out. Invoke serially:
   1. `Skill("ralph:caretake", args="--mode hygiene")`
-  2. `Skill("ralph:catch-up", args="--mode report")`
-  3. `Skill("ralph:caretake", args="--mode trends")`
-  Report consolidated outcome (one line per child).
+  2. `Skill("ralph:caretake", args="--mode watch-pr")`
+  3. `Skill("ralph:caretake", args="--mode watch-upstream")`
+  4. `Skill("ralph:catch-up", args="--mode report")`
+  5. `Skill("ralph:caretake", args="--mode trends")`
+  Report consolidated outcome (one line per child — 5 total). The watch modes run before report/trends so the dashboards reflect post-watch board state; both no-op (`IDLE`) on an empty board, or `SKIPPED` when the heartbeat fires off `main`.
 
 ## Step 2: Emit result line
 


### PR DESCRIPTION
## Summary

Phase 4 of epic #1417 — wire the two merged watcher modes (`watch-pr` #1406, `watch-upstream` #1407) into the `/ralph:caretake` no-args (and `--mode all`) heartbeat fan-out, so each periodic tick drives forward progress (resolving PR/upstream-blocked items) instead of only printing dashboards.

Fan-out order: **hygiene → watch-pr → watch-upstream → catch-up report → trends** (watch modes run *before* report/trends so the dashboards reflect post-watch board state). Both watch modes no-op (`IDLE`) on an empty board, or `SKIPPED` when the heartbeat fires off `main` — no regression to the existing hygiene/report/trends behavior.

## Changes
Single file, single phase (`124e6364`): `ralph/skills/caretake/SKILL.md`
- Step 1 "No args" path: 3-mode → 5-mode serial list.
- `**all**` mode-table row updated to match (was stale "hygiene + catch-up report + trends").

## Plan
[`thoughts/shared/plans/2026-05-25-GH-1408-caretake-heartbeat-watch-fanout.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-25-GH-1408-caretake-heartbeat-watch-fanout.md) · review APPROVED ([critique](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-25-GH-1408-critique.md))

## Test plan
- [x] Step 1 fan-out lists 5 numbered invocations in order hygiene → watch-pr → watch-upstream → report → trends
- [x] `**all**` mode-table row updated to list all 5 (no stale row contradicting Step 1)
- [x] consolidated-outcome note says "one line per child — 5 total"
- Markdown-only; no TS — MCP suite unaffected (CI verifies)
- **Manual** (post-merge): run `/ralph:caretake` no-args on an empty board → 5 child lines incl. `WATCH-PR IDLE` / `WATCH-UPSTREAM IDLE` (no regression)

## Out of scope
- Director `blocked:*` routing (#1409), Phase 6 KEEP removal (#1410), heartbeat interval change (stays 1h).

Closes #1408
