### PR TITLE
GH-1410: triage-postcondition rejects RALPH_TRIAGE_ACTION=KEEP outright

### DIFF
--- a/plugin/ralph-hero/hooks/scripts/triage-postcondition.sh
+++ b/plugin/ralph-hero/hooks/scripts/triage-postcondition.sh
@@ -9,7 +9,7 @@
 #   RALPH_TRIAGE_ACTION - Action taken (set by skill). Structured verdicts (#1417):
 #     CLOSE-done, CLOSE-canceled, SPLIT, PROMOTE-research, PROMOTE-plan,
 #     WAIT-pr[=NNN], WAIT-upstream[=URL], WAIT-decision.
-#     Legacy (retained until Phase 6 / #1410): RESEARCH, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE.
+#     Legacy (still accepted): RESEARCH, CLOSE, HUMAN, CANCEL, RE-ESTIMATE. Bare KEEP is REJECTED (Phase 6 / #1410).
 #   RALPH_FORCE_STOP - If "true", allow stop even if postconditions fail (escape hatch)
 #
 # Exit codes:
@@ -41,10 +41,14 @@ if [[ -n "$triage_action" ]]; then
       echo "Triage postcondition passed: $ticket_id -> $triage_action"
       allow
       ;;
-    # Legacy palette — retained until Phase 6 (#1410) removes KEEP outright.
-    RESEARCH|CLOSE|KEEP|HUMAN|CANCEL|RE-ESTIMATE)
+    # Legacy palette (KEEP removed in Phase 6 / #1410 — see explicit reject below).
+    RESEARCH|CLOSE|HUMAN|CANCEL|RE-ESTIMATE)
       echo "Triage postcondition passed: $ticket_id -> $triage_action (legacy)"
       allow
+      ;;
+    # Phase 6 (#1410): bare KEEP is the dead-end the structured verdicts replace — reject it (exit 2).
+    KEEP)
+      block "Bare KEEP is deprecated. Pick a structured verdict — CLOSE-done, CLOSE-canceled, SPLIT, PROMOTE-research, PROMOTE-plan, WAIT-pr=NNN, WAIT-upstream=URL, or WAIT-decision."
       ;;
     *)
       warn "Unknown triage action '$triage_action' for $ticket_id (allowing)"
@@ -59,7 +63,7 @@ Ticket: $ticket_id
 Expected: RALPH_TRIAGE_ACTION set to one of the structured verdicts —
   CLOSE-done, CLOSE-canceled, SPLIT, PROMOTE-research, PROMOTE-plan,
   WAIT-pr[=NNN], WAIT-upstream[=URL], WAIT-decision —
-  or a legacy value (RESEARCH, CLOSE, KEEP, HUMAN, CANCEL, RE-ESTIMATE; removed in Phase 6 / #1410).
+  or a still-accepted legacy value (RESEARCH, CLOSE, HUMAN, CANCEL, RE-ESTIMATE). Bare KEEP is rejected (Phase 6 / #1410).
 Found: RALPH_TRIAGE_ACTION not set
 
 The triage skill must take an action (route to research, split, close, etc.) before completing.

--- a/plugin/ralph-hero/skills/ralph-triage/SKILL.md
+++ b/plugin/ralph-hero/skills/ralph-triage/SKILL.md
@@ -131,7 +131,7 @@ Choose ONE of the **8 structured verdicts** (#1417). Each verdict names its succ
 
 `RE-ESTIMATE` remains an orthogonal field-fix (correct the estimate; issue stays in Backlog for re-triage). It composes with a verdict on a later tick rather than replacing one.
 
-> The legacy `KEEP` verdict is **retired** by this change — it was the dead-end the structured set exists to remove (it left items in Backlog with no successor). The postcondition hook still accepts `KEEP` until Phase 6 (#1410), but new triage runs MUST pick a structured verdict. This skill is the legacy parallel surface; the active path is `/ralph:caretake --mode triage`.
+> The legacy `KEEP` verdict is **removed** — it was the dead-end the structured set exists to replace (it left items in Backlog with no successor). As of Phase 6 (#1410) the postcondition hook **rejects** bare `KEEP` (exit 2); triage runs MUST pick a structured verdict. This skill is the legacy parallel surface; the active path is `/ralph:caretake --mode triage`.
 
 ### Step 5: Take Action
 
@@ -182,7 +182,7 @@ Add a comment naming the exact condition being waited on.
 export RALPH_TRIAGE_ACTION=PROMOTE-plan   # or CLOSE-done, CLOSE-canceled, SPLIT, PROMOTE-research, WAIT-pr, WAIT-upstream, WAIT-decision
 ```
 
-Valid values: `CLOSE-done`, `CLOSE-canceled`, `SPLIT`, `PROMOTE-research`, `PROMOTE-plan`, `WAIT-pr[=NNN]`, `WAIT-upstream[=URL]`, `WAIT-decision` (the 8 structured verdicts), plus the orthogonal `RE-ESTIMATE` and the legacy set `RESEARCH`, `CLOSE`, `KEEP`, `HUMAN`, `CANCEL` (retained until Phase 6 / #1410). The postcondition hook will block completion if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
+Valid values: `CLOSE-done`, `CLOSE-canceled`, `SPLIT`, `PROMOTE-research`, `PROMOTE-plan`, `WAIT-pr[=NNN]`, `WAIT-upstream[=URL]`, `WAIT-decision` (the 8 structured verdicts), plus the orthogonal `RE-ESTIMATE` and the still-accepted legacy set `RESEARCH`, `CLOSE`, `HUMAN`, `CANCEL`. Bare `KEEP` is **rejected** (exit 2) as of Phase 6 (#1410). The postcondition hook will block completion if `RALPH_TRIAGE_ACTION` is unset or holds an unrecognized value.
 
 ### Step 6: Mark Issue as Triaged
 
@@ -253,7 +253,7 @@ When running as a team worker, mark your assigned task complete via TaskUpdate. 
 ```
 Triage done for #NNN: [Title]
 
-Action: [CLOSE/SPLIT/RE-ESTIMATE/RESEARCH/KEEP]
+Action: [one of the 8 structured verdicts (CLOSE-done/CLOSE-canceled/SPLIT/PROMOTE-research/PROMOTE-plan/WAIT-pr/WAIT-upstream/WAIT-decision), or RE-ESTIMATE]
 Reason: [Brief explanation]
 Label: ralph-triage applied
 
@@ -279,12 +279,12 @@ Rationale: [Why grouped]
 - Issue seems outdated but not certain
 - Scope seems large but could be done in phases
 
-**Low confidence (KEEP and comment):**
+**Low confidence (PROMOTE-research and comment):**
 - Ambiguous requirements
 - Can't determine if feature exists
 - Unclear if still relevant
 
-When uncertain, prefer KEEP with a detailed comment over closing valid work.
+When uncertain, prefer `PROMOTE-research` (route for investigation) with a detailed comment over closing valid work. (Bare `KEEP` — the old "leave in Backlog, no successor" dead-end — is removed as of Phase 6 / #1410.)
 
 ## Escalation Protocol
 

--- a/ralph/skills/caretake/modes/triage.md
+++ b/ralph/skills/caretake/modes/triage.md
@@ -121,11 +121,12 @@ export RALPH_TRIAGE_ACTION=SPLIT               # children created; stays Backlog
 export RALPH_TRIAGE_ACTION=WAIT-pr             # blocked:pr-NNN; stays Backlog
 export RALPH_TRIAGE_ACTION=WAIT-upstream       # blocked:upstream; stays Backlog
 export RALPH_TRIAGE_ACTION=WAIT-decision       # → Human Needed
-# Legacy values (still accepted by the postcondition allowlist; Phase 6 / #1410 removes them):
-# ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE | KEEP
+# Legacy values still accepted by the postcondition allowlist:
+# ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE
+# (bare KEEP is REJECTED as of Phase 6 / #1410 — the legacy plugin hook exits 2 on it.)
 ```
 
-Valid values: `CLOSE-done | CLOSE-canceled | SPLIT | PROMOTE-research | PROMOTE-plan | WAIT-pr | WAIT-upstream | WAIT-decision` (the 8 structured verdicts), plus the legacy set `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE | KEEP` retained until Phase 6 (#1410). `RALPH_TRIAGE_ACTION` is a self-discipline marker for the model — the **slim** postcondition hook (`ralph/hooks/scripts/triage-postcondition.sh`) does NOT read it; it greps the transcript for a valid **terminal token** (`TRIAGED …` / `Queue empty.`). The **legacy plugin** hook (`plugin/ralph-hero/hooks/scripts/triage-postcondition.sh`) does validate this env var against its allowlist.
+Valid values: `CLOSE-done | CLOSE-canceled | SPLIT | PROMOTE-research | PROMOTE-plan | WAIT-pr | WAIT-upstream | WAIT-decision` (the 8 structured verdicts), plus the legacy set `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE` (bare `KEEP` is **rejected** as of Phase 6 / #1410 — the legacy plugin hook exits 2 on it). `RALPH_TRIAGE_ACTION` is a self-discipline marker for the model — the **slim** postcondition hook (`ralph/hooks/scripts/triage-postcondition.sh`) does NOT read it; it greps the transcript for a valid **terminal token** (`TRIAGED …` / `Queue empty.`). The **legacy plugin** hook (`plugin/ralph-hero/hooks/scripts/triage-postcondition.sh`) does validate this env var against its allowlist.
 
 ## §Step 6: Mark issue as triaged
 

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -18,7 +18,7 @@ The **8 structured verdicts** (#1417) each emit a verbatim `TRIAGED <verdict>` t
 - `TRIAGED WAIT-decision` — escalated to Human Needed with a `## Escalation` comment naming the decision required; `ralph-triage` applied.
 - `Queue empty.` — no untriaged Backlog issues remain.
 
-**Legacy tokens (still accepted by the postcondition for back-compat; new runs should not emit them):** Phase 6 (#1410) prunes the legacy `RALPH_TRIAGE_ACTION=KEEP` path, but these terminal tokens stay valid so older transcripts and the parallel plugin surface don't regress.
+**Legacy tokens (still accepted by the postcondition for back-compat; new runs should not emit them):** Phase 6 (#1410) **removed** the legacy `RALPH_TRIAGE_ACTION=KEEP` path — the plugin hook now exits 2 on bare `KEEP`. These terminal *tokens* stay valid so older transcripts and the parallel plugin surface don't regress (none of them is `KEEP`, which was never a terminal token).
 
 - `TRIAGED routed → Research Needed` / `→ Ready for Plan` / `→ In Progress` — superseded by `PROMOTE-research` / `PROMOTE-plan` (the direct-to-In-Progress route is folded into `PROMOTE-plan`).
 - `TRIAGED duplicate` — superseded by `CLOSE-done`.
@@ -28,7 +28,7 @@ The **8 structured verdicts** (#1417) each emit a verbatim `TRIAGED <verdict>` t
 - `TRIAGED re-estimated` — emitted by the orthogonal `RE-ESTIMATE` action; issue stays in Backlog with `ralph-triage`.
 - `TRIAGED skipped — branch <name> is not main` — §Step 1 short-circuit; triage refuses to run on a feature branch.
 
-`triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens (8 verdict tokens + legacy set + `Queue empty.`). The `RALPH_TRIAGE_ACTION` allowlist (checked by the legacy plugin hook's §Step 5; the slim hook ignores the env var) is: `CLOSE-done | CLOSE-canceled | SPLIT | PROMOTE-research | PROMOTE-plan | WAIT-pr | WAIT-upstream | WAIT-decision` plus legacy `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE | KEEP`.
+`triage-postcondition.sh` (Stop hook) greps the transcript for one of these tokens (8 verdict tokens + legacy set + `Queue empty.`). The `RALPH_TRIAGE_ACTION` allowlist (checked by the legacy plugin hook's §Step 5; the slim hook ignores the env var) is: `CLOSE-done | CLOSE-canceled | SPLIT | PROMOTE-research | PROMOTE-plan | WAIT-pr | WAIT-upstream | WAIT-decision` plus legacy `ROUTE_TO_RESEARCH | ROUTE_TO_PLAN | ROUTE_TO_IMPL | CLOSE | HUMAN | CANCEL | RE-ESTIMATE` (bare `KEEP` is rejected as of Phase 6 / #1410).
 ## Hygiene terminal tokens
 
 - `HYGIENE COMPLETE <N archived>` — scan ran cleanly; `N` is the archive count (0 if dry-run or threshold not exceeded).

--- a/specs/issue-lifecycle.md
+++ b/specs/issue-lifecycle.md
@@ -134,8 +134,9 @@ Abstract intents resolve to concrete states based on the executing skill.
 | RESEARCH | Research Needed |
 | PLAN | Ready for Plan |
 | CLOSE | Done |
-| KEEP | *(no state change)* |
 | SPLIT | *(delegates to ralph_split)* |
+
+> **`KEEP` removed (Phase 6 / #1410):** bare `KEEP` was a dead-end (`no state change`) and is now rejected by `triage-postcondition.sh` (exit 2). A "park without advancing" outcome is now expressed by the structured `WAIT-pr` / `WAIT-upstream` (stay Backlog with a `blocked:*` label) or `WAIT-decision` (Human Needed) verdicts — see the 8-verdict triage schema (#1404).
 
 | Requirement | Enablement |
 |-------------|------------|


### PR DESCRIPTION
## Summary

Phase 6 (final) of epic #1417 — make the legacy plugin `triage-postcondition.sh` **reject** `RALPH_TRIAGE_ACTION=KEEP` with exit 2 + a deprecation message, and purge stale KEEP-as-usable references from the triage docs. **Merging this closes epic #1417** (all six children Done).

### Key implementation nuance
The hook's `*)` catch-all *warns-and-allows* (exit 0), so simply removing `KEEP` from the allowlist would leave it **allowed-with-warning**, not rejected. The fix adds an **explicit `KEEP)` → `block`** branch (exit 2) before `*)`, with a message listing the 8 structured verdicts. The slim hook needs no change (`KEEP` was never a slim terminal token — the palette test already asserts that).

### Scope
Per the title + ACs, **only `KEEP` is rejected**; the other legacy values (`RESEARCH`/`CLOSE`/`HUMAN`/`CANCEL`/`RE-ESTIMATE`) remain accepted (they have successors / `RE-ESTIMATE` is orthogonal; the issue's "only the 8" behavior-line is broader than its ACs — flagged in the plan, broader removal deferred).

## Changes
**Phase 1 — enforcement** (`ba2b0edd`): `plugin/ralph-hero/hooks/scripts/triage-postcondition.sh` — explicit `KEEP)`→block(exit 2); KEEP dropped from the legacy allow arm; comment + block-message updated.
**Phase 2 — doc purge** (`09dab779`): reframe KEEP as removed/rejected in `ralph/skills/caretake/modes/triage.md`, `plugin/ralph-hero/skills/ralph-triage/SKILL.md` (incl. report template + confidence-levels → `PROMOTE-research`), `ralph/skills/caretake/outcome-tokens.md`, and `specs/issue-lifecycle.md` (dropped the `| KEEP | no state change |` row — surfaced by plan review as a 4th stale ref).

## Plan
[`thoughts/shared/plans/2026-05-25-GH-1410-triage-reject-keep.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-25-GH-1410-triage-reject-keep.md) · review APPROVED (with edits) ([critique](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/reviews/2026-05-25-GH-1410-critique.md))

## Test plan
- [x] `RALPH_TRIAGE_ACTION=KEEP` → exit **2** + deprecation message (was exit 0)
- [x] `PROMOTE-plan` / `WAIT-pr=1338` / `RESEARCH` (remaining legacy) → exit 0
- [x] KEEP removed from the allow arm; explicit reject branch present
- [x] No doc presents KEEP as a usable action (4 files); spec `| KEEP |` row removed
- [x] slim palette test still green (KEEP was never a slim token)
- Bash + markdown only; no TS — MCP suite unaffected (CI verifies)

## Out of scope
- Migrating existing KEEP-labeled issues (per consuming-project, must land before enforcement bites their pipelines); broader legacy-value removal.

Closes #1410
