### PR TITLE
Add using-html skill to ralph plugin

### DIFF
--- a/ralph/CLAUDE.md
+++ b/ralph/CLAUDE.md
@@ -7,7 +7,7 @@ The slim successor to `ralph-hero`. See `../thoughts/shared/research/2026-05-22-
 ## Conventions
 
 - **SKILL.md ≤ ~150 lines.** Opinion content goes in flat sibling .md files, not the skill body.
-- **No `references/` subfolder by default.** Reference files are siblings of SKILL.md. Only `caretake/` uses a `modes/` subfolder.
+- **No `references/` subfolder by default.** Reference files are siblings of SKILL.md. Two named exceptions: `caretake/` uses a `modes/` subfolder, and the vendored `using-html/` utility skill keeps its upstream `references/` + `assets/` subfolders. `using-html/` is preserved byte-identical from its source so it tracks upstream cleanly — do not flatten it to match this convention.
 - **No SOUL.md files.** Substrate is the product (principle P10).
 - **Enforcement lives in hooks/, not skill prose.** If you find yourself writing "make sure to validate X" in a SKILL.md, that's a hook.
 - **Artifact state lives in the MCP server.** Skills read/write via `mcp__plugin_ralph-hero_ralph-github__*` tools (cross-plugin during migration).

--- a/ralph/skills/using-html/SKILL.md
+++ b/ralph/skills/using-html/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: using-html
+description: Use when producing multi-option design comparisons, research synthesis docs, status/incident reports, implementation plans, PR reviews & writeups, module maps, design-system references, component-variant sheets, SVG figures & flowcharts, interaction/animation prototypes, or slide decks — anything that would otherwise be a long Markdown document. Reach for this skill whenever the user asks to "compare", "explore options", "research", "summarize findings", "write up", "synthesize", "explain how X works", "plan", "review this PR", "map this package", "show our design tokens", "draw/diagram", "flowchart", "prototype", "tune the easing", or "make a deck/slides" — and especially when the output will exceed ~100 lines, contain side-by-side options, be visual or interactive, or be shared with another person. HTML beats Markdown for these by a wide margin (visual hierarchy, tables, SVG diagrams, navigability, live interaction); default to invoking this skill even if the user doesn't explicitly ask for HTML.
+---
+
+# using-html
+
+You produce self-contained HTML artifacts in place of long Markdown when the output benefits from visual structure — side-by-side comparisons, sticky-nav navigability, callouts, diagrams, live interaction, or anything a reader will share with someone else.
+
+This SKILL.md is the **router**: it carries the rules that apply to *every* artifact (core principles, the JS budget, the file finisher). The per-workflow anatomy — page structure, worked-example fragments, anti-patterns — lives in `references/`. **Pick the workflow from the index below, then read that one reference file before writing.**
+
+Every artifact is one HTML file — no CDNs, no external assets, no `<script src>`. It must work offline, as an email attachment, and after being uploaded to a wiki.
+
+## Core principles
+
+- **One file, fully self-contained.** Inline CSS, inline SVG, inline vanilla JS. Zero CDNs, zero external assets, zero `fetch()`, zero `import` from a URL. If you find yourself reaching for a `<link rel>` or `<script src>`, stop — the artifact must keep working when uploaded or emailed. This is absolute and does not flex.
+- **Read the bundled assets every time.** Use the Read tool on `assets/skeleton.html` and `assets/theme.css` before writing. Inline `theme.css` into the skeleton's `<style>` block (replacing `{{THEME_CSS}}`) and fill `{{TITLE}}`. For an **Interactive-tier** workflow (see budget below), also Read `assets/interactive.css` and append it inside the same `<style>` block. Don't reconstruct the palette from memory — that's where visual drift comes from.
+- **Vanilla JS only, budgeted by workflow.** No frameworks, no build step, no `<script src>`. How much JS is allowed depends on the workflow:
+
+  | Budget class | Ceiling | Workflows | What the JS does |
+  |---|---|---|---|
+  | **None** | 0 lines | Planning, PR writeup, Design system | Pure layout. No JS. |
+  | **Micro** | ≤ ~15 lines | Specs, Research, Code review, SVG figures | Tab switch, collapse-toggle, copy-to-clipboard. |
+  | **Interactive** | ≤ ~60 lines | Decks, Component variants, Prototyping, Flowchart | Arrow-key nav, control→SVG/CSS mutation, drag-reorder, step-detail panels. Author as *data + a small render loop*, not a wall of imperative DOM building. |
+
+  If an interactive workflow's JS would blow past ~60 lines, that's the signal it belongs in a future "editor"-tier skill — not that the budget should stretch.
+- **Syntax highlighting.** Hand-code `<span class="kw|str|cm|fn">` inside `<pre>` blocks. The theme defines those four classes against the slate code-panel background. Don't invoke Prism, highlight.js, or any other library — they break self-containment and produce colors that fight the palette.
+- **Imperative voice in any prose.** This is an artifact, not a tutorial. Lead with what IS, not what the reader should do.
+
+## File location & finisher
+
+Resolve the output path before writing. Prefer a project-local `thoughts/shared/html-out/` when running inside a repo that has a `thoughts/` directory (this gets the artifact into the user's corpus for later retrieval); otherwise write to `~/claude-html-out/`.
+
+Run this bash snippet via the Bash tool (substituting `<topic-slug>` for a kebab-case short label of the artifact):
+
+```bash
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+  if [ -d "$git_root/thoughts" ]; then
+    out_dir="$git_root/thoughts/shared/html-out"
+  fi
+fi
+out_dir="${out_dir:-$HOME/claude-html-out}"
+mkdir -p "$out_dir"
+date_part=$(date +%Y-%m-%d)
+slug="<topic-slug>"
+out="$out_dir/$date_part-$slug.html"
+n=2
+while [ -e "$out" ]; do
+  out="$out_dir/$date_part-$slug-$n.html"
+  n=$((n + 1))
+done
+echo "$out"
+```
+
+The final `echo "$out"` gives you the resolved path. Use it as the Write target.
+
+After writing the file, finish the turn in this order:
+
+1. Run `open "$out"` via Bash — opens in the default browser.
+2. Restate the resolved path in chat on its own line so the user has it if they missed the `open` flash.
+
+Don't summarize the artifact's contents in chat after opening — the artifact speaks for itself, and the chat summary just duplicates work.
+
+## Workflow index
+
+Match the request to one row, then **Read that reference file** before writing. Each reference carries the page anatomy, a worked-example fragment, and anti-patterns.
+
+| If the user wants… | Trigger phrases | Read | Tier |
+|---|---|---|---|
+| To compare ≥2 candidate solutions to one decision | "compare", "tradeoffs", "N ways to…", "options for…", "side-by-side", "explore designs" | `references/specs.md` | Micro |
+| A synthesis of findings / how something works / a status or incident report | "research", "summarize findings", "explain how X works", "feature explainer", "status report", "postmortem" | `references/research.md` | Micro / Interactive |
+| A build plan handed to an implementer | "implementation plan", "milestones for…", "how would you build X", "hand-off doc" | `references/planning.md` | None |
+| To review a diff, write a PR description, or map an unfamiliar package | "review this PR/diff", "what's risky here", "write the PR description", "explain how X works in this repo", "map this package" | `references/code-review.md` | None / Micro |
+| To document design tokens or lay out every variant of a component | "design system", "show our tokens", "every variant of X", "all states of this component" | `references/design.md` | None / Interactive |
+| Vector figures for a doc, or a process drawn as a flowchart | "draw the figures", "illustrate X", "flowchart this", "show the failure paths" | `references/diagrams.md` | Micro / Interactive |
+| To feel a transition or click through an interaction | "prototype this", "tune the easing", "let me feel the reorder", "mock the click-through" | `references/prototyping.md` | Interactive |
+| A presentation to arrow-key through in a meeting | "make a deck", "slides for this", "present this", "turn this thread into a deck" | `references/decks.md` | Interactive |
+
+When two rows could fit, prefer the more specific one (e.g. "explain how auth works *in this repo*" → code-review module map, not a generic research report). If none fit cleanly but the output is still a long shareable document, default to `references/research.md`.
+
+> **Not yet covered:** drag-and-drop editors with export-back-to-agent (triage boards, feature-flag editors, prompt tuners). Those need 250–400 lines of stateful JS plus a serialize-to-clipboard contract and are deferred to a future editor-tier skill. If asked for one, build the closest covered shape (e.g. a prototype or a comparison) and say so.

--- a/ralph/skills/using-html/assets/interactive.css
+++ b/ralph/skills/using-html/assets/interactive.css
@@ -1,0 +1,116 @@
+/* ============================================================
+   INTERACTIVE-TIER CHROME (using-html v2)
+   Inline this AFTER theme.css, in the same <style> block, ONLY for
+   Interactive-tier workflows: decks, component variants, prototyping,
+   flowchart. Document-tier artifacts must not carry this weight.
+   Reuses the marine-ink palette vars defined at the top of theme.css.
+   ============================================================ */
+
+/* --- slide deck (09) --- */
+.deck { max-width: none; }
+.slide {
+  display: none;
+  min-height: calc(100vh - 152px);
+  flex-direction: column;
+  justify-content: center;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.slide.on { display: flex; }
+.slide-inner { width: 100%; }
+.title-slide h1 { font-size: 52px; }
+.title-slide .subtitle { font-size: 22px; color: var(--gray-500); font-family: var(--serif); margin-top: 8px; }
+.title-slide .byline { font-family: var(--mono); font-size: 12px; color: var(--gray-500); margin-top: 24px; }
+
+.ship-list { display: flex; flex-direction: column; gap: 14px; margin-top: 12px; }
+.ship-item { display: grid; grid-template-columns: 16px 1fr; gap: 14px; align-items: start; }
+.ship-item .ship-dot { width: 11px; height: 11px; border-radius: 50%; background: var(--moss); margin-top: 7px; }
+.ship-item .ship-title { font-family: var(--serif); font-size: 19px; color: var(--ink); }
+.ship-item .ship-desc { font-size: 14px; color: var(--gray-700); }
+.ship-item .ship-ref { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+
+.prog-list { display: flex; flex-direction: column; gap: 18px; margin-top: 12px; }
+.prog-item .prog-head { display: flex; justify-content: space-between; margin-bottom: 6px; }
+.prog-item .prog-title { font-size: 15px; color: var(--ink); }
+.prog-item .prog-pct { font-family: var(--mono); font-size: 13px; color: var(--accent); }
+.prog-track { height: 10px; background: var(--gray-150); border: 1.5px solid var(--gray-300); border-radius: 999px; overflow: hidden; }
+.prog-fill { height: 100%; background: var(--accent); }
+
+.metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 16px; margin-top: 12px; }
+.metric { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); padding: 18px; }
+.metric .metric-label { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); }
+.metric .metric-value { font-family: var(--serif); font-size: 34px; color: var(--ink); line-height: 1.1; margin: 4px 0; }
+.metric .metric-delta { font-family: var(--mono); font-size: 12px; color: var(--moss); }
+.metric .metric-delta.down { color: var(--rust); }
+.sparkline-wrap { margin-top: 8px; }
+
+.decision-card { border: 1.5px solid var(--gray-300); border-left: 4px solid var(--accent); border-radius: 0 12px 12px 0; background: var(--white); padding: 22px 26px; }
+.decision-card .decision-q { font-family: var(--serif); font-size: 22px; color: var(--ink); margin-bottom: 8px; }
+.decision-card .options { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 14px; }
+.decision-card .opt { font-family: var(--mono); font-size: 12px; border: 1.5px solid var(--gray-300); border-radius: 8px; padding: 6px 12px; }
+.decision-card .opt.lean { border-color: var(--accent); background: rgba(46,93,126,0.10); color: var(--accent); }
+
+.next-list { list-style: none; padding-left: 0; }
+.next-list li { padding: 8px 0; border-top: 1px solid var(--gray-150); font-size: 16px; }
+
+.deck-nav { position: fixed; bottom: 20px; right: 24px; font-family: var(--mono); font-size: 12px; color: var(--gray-500); background: var(--white); border: 1.5px solid var(--gray-300); border-radius: 999px; padding: 6px 14px; }
+
+/* --- toolbar / controls (component variants, prototyping) --- */
+.toolbar { display: flex; flex-wrap: wrap; gap: 18px; align-items: center; border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); padding: 14px 18px; margin: 16px 0 24px; }
+.control { display: flex; flex-direction: column; gap: 5px; }
+.control .control-label { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); }
+.control .control-value { font-family: var(--mono); font-size: 12px; color: var(--accent); }
+.radio-group { display: flex; gap: 0; border: 1.5px solid var(--gray-300); border-radius: 8px; overflow: hidden; }
+.radio-group .seg { font-family: var(--mono); font-size: 12px; padding: 6px 12px; background: var(--white); color: var(--gray-700); cursor: pointer; border: none; border-right: 1px solid var(--gray-300); }
+.radio-group .seg:last-child { border-right: none; }
+.radio-group .seg.on { background: var(--accent); color: var(--white); }
+input[type=range] { accent-color: var(--accent); }
+
+/* --- component variant matrix (06) --- */
+.variant-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 18px; }
+.variant-cell { display: flex; flex-direction: column; gap: 8px; }
+.variant-cell .variant-label { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+.variant-cell .card { padding: 16px; }
+.card.v-flat { box-shadow: none; border-color: var(--gray-150); }
+.card.v-outlined { border-width: 1.5px; }
+.card.v-elevated { border-color: transparent; box-shadow: 0 6px 20px rgba(27,35,41,0.12); }
+.card.v-stripe { border-left: 4px solid var(--accent); }
+.card.v-inset { background: var(--gray-150); border-color: var(--gray-150); }
+.card.v-horizontal { display: grid; grid-template-columns: 48px 1fr; gap: 12px; align-items: center; }
+.snippet-panel { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--slate); margin-top: 22px; overflow: hidden; }
+.snippet-panel .snippet-head { font-family: var(--mono); font-size: 11px; color: var(--gray-500); padding: 10px 16px; border-bottom: 1px solid rgba(255,255,255,0.08); }
+.snippet-panel pre { padding: 14px 16px; font-family: var(--mono); font-size: 12.5px; line-height: 1.6; color: #E8E6DE; overflow-x: auto; }
+
+/* --- prototyping bench (07, 08) --- */
+.bench { border: 1.5px solid var(--gray-300); border-radius: 16px; background: var(--white); padding: 40px; margin: 16px 0; display: flex; flex-direction: column; align-items: center; gap: 24px; }
+.stage { display: flex; align-items: center; justify-content: center; min-height: 160px; width: 100%; }
+
+/* animation sandbox (07) */
+.ease-row { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+.ease-btn { font-family: var(--mono); font-size: 12px; border: 1.5px solid var(--gray-300); border-radius: 8px; padding: 6px 14px; background: var(--white); color: var(--gray-700); cursor: pointer; }
+.ease-btn.active { background: var(--accent); color: var(--white); border-color: var(--accent); }
+.timeline { width: 100%; max-width: 420px; height: 4px; background: var(--gray-150); border-radius: 999px; position: relative; }
+.timeline .key { position: absolute; top: -4px; width: 12px; height: 12px; border-radius: 50%; background: var(--white); border: 2.5px solid var(--accent); transform: translateX(-50%); }
+
+/* drag-to-reorder (08) */
+.proto-list { width: 100%; max-width: 360px; display: flex; flex-direction: column; gap: 8px; }
+.proto-item { display: flex; align-items: center; gap: 12px; border: 1.5px solid var(--gray-300); border-radius: 10px; background: var(--white); padding: 12px 14px; cursor: grab; }
+.proto-item .grip { color: var(--gray-300); font-size: 16px; cursor: grab; user-select: none; }
+.proto-item .count { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+.proto-item.dragging { opacity: 0.4; border-color: var(--accent); }
+.proto-item.drop-target { border-top: 2px solid var(--accent); }
+
+/* --- annotated flowchart (13) --- */
+.flow-layout { display: grid; grid-template-columns: minmax(0, 1fr) 260px; gap: 24px; margin: 16px 0; }
+@media (max-width: 860px) { .flow-layout { grid-template-columns: 1fr; } }
+.flow-canvas { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); padding: 18px; overflow-x: auto; }
+.flow-canvas .node rect { fill: var(--white); stroke: var(--gray-300); stroke-width: 1.5; cursor: pointer; }
+.flow-canvas .node text { font-family: var(--sans); font-size: 12px; fill: var(--ink); }
+.flow-canvas .node.gate rect { fill: var(--gray-150); }
+.flow-canvas .node.ok rect { stroke: var(--moss); }
+.flow-canvas .node.bad rect { stroke: var(--rust); }
+.flow-canvas .node.sel rect { stroke: var(--accent); stroke-width: 2.5; }
+.flow-canvas .edge { stroke: var(--gray-500); stroke-width: 1.5; fill: none; marker-end: url(#arrow); }
+.flow-legend { font-size: 13px; }
+.flow-legend .flow-hint { border: 1.5px solid var(--gray-300); border-left: 3px solid var(--accent); border-radius: 0 10px 10px 0; background: var(--white); padding: 14px 16px; margin-top: 12px; }
+.flow-legend .flow-hint .where { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }

--- a/ralph/skills/using-html/assets/skeleton.html
+++ b/ralph/skills/using-html/assets/skeleton.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}}</title>
+<style>
+{{THEME_CSS}}
+</style>
+</head>
+<body>
+<!-- agent fills body content here -->
+</body>
+</html>

--- a/ralph/skills/using-html/assets/theme.css
+++ b/ralph/skills/using-html/assets/theme.css
@@ -1,0 +1,654 @@
+/* --- :root palette + type stacks (marine ink on cream) --- */
+:root {
+  --paper:    #f5f1e8;
+  --ink:      #1b2329;
+  --accent:   #2e5d7e;
+  --rust:     #b35a2c;
+  --moss:     #5a7847;
+  --sand:     #e6dcc4;
+  --slate:    #1f262b;
+  --gray-150: #ece7db;
+  --gray-300: #cdc6b7;
+  --gray-500: #847d6c;
+  --gray-700: #3a3a36;
+  --white:    #ffffff;
+
+  --serif: 'Iowan Old Style', Charter, ui-serif, Georgia, serif;
+  --sans:  system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --mono:  'JetBrains Mono', 'SF Mono', Menlo, ui-monospace, monospace;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  background: var(--paper);
+  color: var(--gray-700);
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  padding: 56px 32px 96px;
+}
+
+.page { max-width: 1360px; margin: 0 auto; }
+
+h1 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 38px;
+  line-height: 1.15;
+  color: var(--ink);
+  margin-bottom: 18px;
+  letter-spacing: -0.01em;
+}
+
+h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 22px;
+  color: var(--ink);
+  margin: 40px 0 14px;
+  scroll-margin-top: 24px;
+}
+
+p { margin-bottom: 12px; max-width: 680px; }
+code { font-family: var(--mono); font-size: 13px; }
+a { color: var(--accent); text-decoration: none; border-bottom: 1px solid currentColor; }
+ul { padding-left: 20px; max-width: 680px; }
+li { margin-bottom: 6px; }
+
+/* --- shared components used by both workflows --- */
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  margin-bottom: 10px;
+}
+
+.tldr {
+  border: 1.5px solid var(--gray-300);
+  border-left: 3px solid var(--accent);
+  border-radius: 10px;
+  background: var(--white);
+  padding: 16px 18px;
+  margin-bottom: 8px;
+  max-width: 760px;
+}
+.tldr b { color: var(--ink); }
+
+.callout {
+  display: flex;
+  gap: 12px;
+  border: 1.5px solid var(--sand);
+  background: rgba(230, 220, 196, 0.35);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin: 18px 0;
+  font-size: 14px;
+  max-width: 760px;
+}
+.callout .ico { color: var(--accent); font-weight: 600; }
+
+.card {
+  background: var(--white);
+  border: 1.5px solid var(--gray-300);
+  border-radius: 12px;
+  padding: 24px;
+}
+
+details {
+  border: 1.5px solid var(--gray-300);
+  border-radius: 10px;
+  background: var(--white);
+  margin: 14px 0;
+  overflow: hidden;
+  max-width: 760px;
+}
+details summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--ink);
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+details summary::-webkit-details-marker { display: none; }
+details summary::before {
+  content: "▸";
+  color: var(--accent);
+  font-family: var(--sans);
+  font-size: 12px;
+  transition: transform 120ms;
+}
+details[open] summary::before { transform: rotate(90deg); }
+details summary .where {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--gray-500);
+  margin-left: auto;
+}
+details .body { padding: 0 16px 16px; }
+details .body p { font-size: 14px; }
+
+.tabs {
+  border: 1.5px solid var(--gray-300);
+  border-radius: 10px;
+  background: var(--white);
+  margin: 16px 0 8px;
+  overflow: hidden;
+  max-width: 760px;
+}
+.tabs .tabbar {
+  display: flex;
+  border-bottom: 1px solid var(--gray-300);
+  background: var(--gray-150);
+}
+.tabs .tabbar button {
+  appearance: none;
+  border: none;
+  background: none;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--gray-500);
+  padding: 10px 16px;
+  cursor: pointer;
+  border-right: 1px solid var(--gray-300);
+}
+.tabs .tabbar button.on {
+  background: var(--white);
+  color: var(--ink);
+  border-bottom: 2px solid var(--accent);
+  margin-bottom: -1px;
+}
+.tabs pre {
+  display: none;
+  margin: 0;
+  padding: 16px 18px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--ink);
+  overflow-x: auto;
+}
+.tabs pre.on { display: block; }
+
+/* --- spec workflow: comparison cards --- */
+
+.prompt-box {
+  background: var(--gray-150);
+  border: 1.5px solid var(--gray-300);
+  border-radius: 12px;
+  padding: 16px 20px;
+  font-size: 14.5px;
+  color: var(--gray-700);
+  max-width: 760px;
+}
+.prompt-box .label {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--gray-500);
+  display: block;
+  margin-bottom: 6px;
+}
+
+.approaches {
+  display: grid;
+  gap: 28px;
+  margin-bottom: 56px;
+}
+.approaches[data-n="2"] { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.approaches[data-n="3"] { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.approaches[data-n="4"] { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+@media (max-width: 1100px) {
+  .approaches[data-n="2"],
+  .approaches[data-n="3"],
+  .approaches[data-n="4"] { grid-template-columns: 1fr; }
+}
+
+.approach {
+  background: var(--white);
+  border: 1.5px solid var(--gray-300);
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.approach-head h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 21px;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+.approach-head .num {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--sand);
+  color: var(--ink);
+  padding: 2px 8px;
+  border-radius: 8px;
+  margin-right: 8px;
+  vertical-align: 3px;
+}
+.approach-head p {
+  font-size: 14px;
+  color: var(--gray-500);
+}
+
+/* code panel inside an approach card */
+.code {
+  background: var(--slate);
+  border-radius: 12px;
+  padding: 18px 20px;
+  overflow-x: auto;
+}
+.code pre {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: #E8E6DE;
+  white-space: pre;
+}
+.code .kw  { color: var(--accent); }   /* keywords -> marine teal */
+.code .str { color: var(--moss); }     /* strings  -> moss        */
+.code .cm  { color: var(--gray-500); } /* comments -> warm gray   */
+.code .fn  { color: #c9b98a; }         /* identifiers, warm tan   */
+
+.tradeoffs {
+  border: 1.5px solid var(--gray-300);
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 13px;
+}
+.tradeoffs .row { display: grid; grid-template-columns: 1fr 1fr; }
+.tradeoffs .row + .row { border-top: 1.5px solid var(--gray-300); }
+.tradeoffs .cell { padding: 10px 14px; }
+.tradeoffs .cell:first-child { border-right: 1.5px solid var(--gray-300); }
+.tradeoffs .head {
+  background: var(--gray-150);
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.tradeoffs .pro::before,
+.tradeoffs .con::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 8px;
+  vertical-align: 2px;
+}
+.tradeoffs .pro::before { background: var(--moss); }
+.tradeoffs .con::before { background: var(--rust); }
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.chip {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  background: var(--gray-150);
+  border: 1.5px solid var(--gray-300);
+  color: var(--gray-700);
+  padding: 5px 10px;
+  border-radius: 8px;
+  white-space: nowrap;
+}
+.chip strong { color: var(--ink); font-weight: 600; }
+
+.reco {
+  border-left: 4px solid var(--accent);
+  background: var(--white);
+  border-radius: 0 12px 12px 0;
+  padding: 24px 28px;
+  max-width: 860px;
+}
+.reco h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 22px;
+  color: var(--ink);
+  margin-bottom: 10px;
+}
+.reco p { font-size: 15px; margin-bottom: 8px; }
+.reco code {
+  background: var(--gray-150);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+/* --- report workflow: sticky-nav editorial layout --- */
+
+.report {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr);
+  gap: 48px;
+}
+@media (max-width: 920px) {
+  .report { grid-template-columns: 1fr; }
+  .report nav { display: none; }
+}
+
+.report nav {
+  position: sticky;
+  top: 32px;
+  align-self: start;
+  font-size: 13px;
+}
+.report nav .label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  margin-bottom: 12px;
+}
+.report nav a {
+  display: block;
+  padding: 5px 0 5px 12px;
+  border-left: 2px solid var(--gray-300);
+  color: var(--gray-700);
+  text-decoration: none;
+  border-bottom: none;
+}
+.report nav a:hover { color: var(--ink); border-color: var(--ink); }
+.report nav a.l2 { padding-left: 24px; font-size: 12.5px; color: var(--gray-500); }
+.report nav .files {
+  margin-top: 28px;
+  border-top: 1px solid var(--gray-300);
+  padding-top: 16px;
+}
+.report nav .files code {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--gray-500);
+  padding: 3px 0;
+}
+
+dl.faq { margin-top: 8px; max-width: 680px; }
+dl.faq dt {
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--ink);
+  margin-top: 18px;
+}
+dl.faq dd { font-size: 14px; margin: 4px 0 0; }
+
+/* ============================================================
+   DOCUMENT-TIER COMPONENTS (added in v2)
+   Shared across planning, code-review, design-system, diagrams.
+   Interactive-tier chrome lives in interactive.css.
+   ============================================================ */
+
+.page-head { margin-bottom: 30px; }
+.page-head h1 { margin-bottom: 12px; }
+.lede { font-size: 16px; color: var(--gray-700); max-width: 720px; }
+
+/* severity pills — reused by planning risks + code-review risk tags */
+.sev {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 6px;
+  border: 1.5px solid var(--gray-300);
+  color: var(--gray-700);
+  white-space: nowrap;
+}
+.sev.high { background: rgba(179, 90, 44, 0.14); border-color: var(--rust); color: var(--rust); }
+.sev.med  { background: rgba(201, 153, 60, 0.16); border-color: #b8893a; color: #8a6420; }
+.sev.low  { background: rgba(90, 120, 71, 0.14); border-color: var(--moss); color: var(--moss); }
+
+/* compact inline table-of-contents row (PR writeup, planning) */
+.toc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 8px 0 28px;
+}
+.toc a {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--gray-700);
+  background: var(--gray-150);
+  border: 1.5px solid var(--gray-300);
+  border-radius: 999px;
+  padding: 4px 12px;
+  border-bottom: 1.5px solid var(--gray-300);
+}
+.toc a:hover { border-color: var(--accent); color: var(--accent); }
+
+/* --- annotated diff (code-review) --- */
+.diff {
+  border: 1.5px solid var(--gray-300);
+  border-radius: 10px;
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  background: var(--white);
+  margin: 12px 0;
+}
+.diff .hunk {
+  background: var(--gray-150);
+  color: var(--gray-500);
+  padding: 6px 14px;
+  border-bottom: 1px solid var(--gray-300);
+}
+.diff-row { display: grid; grid-template-columns: 44px 1fr; }
+.diff-row .ln {
+  text-align: right;
+  padding: 1px 10px;
+  color: var(--gray-500);
+  background: var(--gray-150);
+  border-right: 1px solid var(--gray-300);
+  user-select: none;
+}
+.diff-row .code { padding: 1px 14px; white-space: pre-wrap; color: var(--ink); }
+.diff-row.add .code { background: rgba(90, 120, 71, 0.13); }
+.diff-row.add .ln  { background: rgba(90, 120, 71, 0.10); }
+.diff-row.del .code { background: rgba(179, 90, 44, 0.12); }
+.diff-row.del .ln  { background: rgba(179, 90, 44, 0.10); }
+.diff-row .mark { background: rgba(46, 93, 126, 0.18); border-radius: 3px; padding: 0 2px; }
+
+/* inline review comments anchored to a diff */
+.comments { margin: 4px 0 0; display: flex; flex-direction: column; gap: 8px; }
+.bubble {
+  border: 1.5px solid var(--gray-300);
+  border-left: 3px solid var(--gray-500);
+  border-radius: 0 8px 8px 0;
+  background: var(--white);
+  padding: 10px 14px;
+  font-family: var(--sans);
+  font-size: 13px;
+}
+.bubble .label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-right: 8px;
+}
+.bubble.blocking { border-left-color: var(--rust); }
+.bubble.blocking .label { color: var(--rust); }
+.bubble.nit { border-left-color: #b8893a; }
+.bubble.nit .label { color: #8a6420; }
+.bubble.ctx { border-left-color: var(--accent); }
+.bubble.ctx .label { color: var(--accent); }
+
+/* --- PR head (review + writeup) --- */
+.pr-head { margin-bottom: 22px; }
+.pr-head .repo-line { font-family: var(--mono); font-size: 12px; color: var(--gray-500); margin-bottom: 8px; }
+.meta-row { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-top: 6px; }
+.branch { font-family: var(--mono); font-size: 12px; background: var(--gray-150); border: 1.5px solid var(--gray-300); border-radius: 6px; padding: 2px 8px; }
+.branch .arrow { color: var(--gray-500); margin: 0 4px; }
+.stat { font-family: var(--mono); font-size: 12px; }
+.stat.add { color: var(--moss); }
+.stat.del { color: var(--rust); }
+.avatar { width: 26px; height: 26px; border-radius: 50%; background: var(--accent); color: var(--white); display: inline-flex; align-items: center; justify-content: center; font-size: 11px; font-family: var(--mono); }
+
+/* risk map: per-file overview chips */
+.risk-map { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 14px 0 22px; }
+.file-chip { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono); font-size: 11.5px; background: var(--white); border: 1.5px solid var(--gray-300); border-radius: 8px; padding: 4px 10px; }
+.file-chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--gray-300); }
+.file-chip .dot.attention { background: var(--rust); }
+.file-chip .dot.medium { background: #b8893a; }
+.file-chip .dot.safe { background: var(--moss); }
+.legend { font-family: var(--mono); font-size: 10.5px; color: var(--gray-500); margin-left: auto; }
+
+/* file cards (review) */
+.file-card { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); margin: 16px 0; overflow: hidden; }
+.file-card .file-head { display: flex; align-items: center; gap: 12px; padding: 12px 16px; background: var(--gray-150); border-bottom: 1px solid var(--gray-300); }
+.file-card .file-path { font-family: var(--mono); font-size: 13px; color: var(--ink); }
+.file-card .file-delta { font-family: var(--mono); font-size: 11.5px; margin-left: auto; color: var(--gray-500); }
+.file-card .body { padding: 14px 16px; }
+
+.next-steps { border: 1.5px solid var(--gray-300); border-left: 3px solid var(--accent); border-radius: 0 12px 12px 0; background: var(--white); padding: 18px 22px; margin-top: 24px; max-width: 760px; }
+.checklist { list-style: none; padding-left: 0; }
+.checklist li { padding-left: 26px; position: relative; }
+.checklist li::before { content: "☐"; position: absolute; left: 0; color: var(--accent); }
+.checklist li.done::before { content: "☑"; color: var(--moss); }
+
+/* before/after panels (PR writeup) */
+.ba { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 14px 0; }
+@media (max-width: 760px) { .ba { grid-template-columns: 1fr; } }
+.panel { border: 1.5px solid var(--gray-300); border-radius: 10px; background: var(--white); padding: 14px 16px; }
+.panel .label { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); margin-bottom: 8px; }
+.panel.after { border-color: var(--accent); }
+
+/* file tour, focus, tests, rollout (PR writeup) */
+.why { color: var(--gray-700); font-size: 14px; margin-top: 6px; }
+.why b, .focus .item b { color: var(--ink); }
+.focus .item, .rollout .step { display: grid; grid-template-columns: 28px 1fr; gap: 12px; padding: 8px 0; border-top: 1px solid var(--gray-150); }
+.focus .item .n, .rollout .step .n { font-family: var(--mono); font-size: 12px; color: var(--accent); }
+.rollout .step .when { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+
+/* --- module map (code understanding) --- */
+.diagram-panel { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); padding: 22px; margin: 16px 0; overflow-x: auto; }
+.step { display: grid; grid-template-columns: 34px 1fr; gap: 14px; padding: 12px 0; border-top: 1px solid var(--gray-150); }
+.step .badge { font-family: var(--mono); font-size: 12px; background: var(--sand); color: var(--ink); border-radius: 8px; padding: 2px 0; text-align: center; height: fit-content; }
+.step .step-loc { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+.snippet { background: var(--slate); border-radius: 10px; padding: 14px 16px; overflow-x: auto; margin-top: 8px; }
+.snippet pre { font-family: var(--mono); font-size: 12px; line-height: 1.6; color: #E8E6DE; white-space: pre; }
+.snippet .dim { color: var(--gray-500); }
+.snippet .hot { background: rgba(46, 93, 126, 0.30); border-radius: 3px; }
+.key-files { border: 1.5px solid var(--gray-300); border-radius: 10px; background: var(--white); overflow: hidden; margin: 14px 0; }
+.key-files .kf { display: grid; grid-template-columns: 230px 1fr; gap: 14px; padding: 10px 16px; font-size: 13px; }
+.key-files .kf + .kf { border-top: 1px solid var(--gray-150); }
+.key-files .kf .path { font-family: var(--mono); font-size: 12px; color: var(--ink); }
+.gotchas li b { color: var(--ink); }
+
+/* --- implementation plan (planning) --- */
+.summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1px; background: var(--gray-300); border: 1.5px solid var(--gray-300); border-radius: 12px; overflow: hidden; margin: 18px 0 30px; }
+.summary .cell { background: var(--white); padding: 14px 16px; }
+.summary .cell .k { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); margin-bottom: 4px; }
+.summary .cell .v { font-size: 16px; color: var(--ink); font-family: var(--serif); }
+.summary .cell .v.accent { color: var(--accent); }
+
+.milestones { margin: 8px 0 30px; }
+.milestone { display: grid; grid-template-columns: 92px 28px 1fr; gap: 4px; }
+.milestone .when { font-family: var(--mono); font-size: 11.5px; color: var(--gray-500); padding-top: 2px; text-align: right; padding-right: 14px; }
+.milestone .rail { display: flex; flex-direction: column; align-items: center; }
+.milestone .rail .dot { width: 13px; height: 13px; border-radius: 50%; background: var(--white); border: 2.5px solid var(--accent); margin-top: 3px; }
+.milestone .rail .dot.done { background: var(--moss); border-color: var(--moss); }
+.milestone .rail .line { flex: 1; width: 2px; background: var(--gray-300); margin: 2px 0; }
+.milestone .ms-body { padding-bottom: 22px; }
+.milestone .ms-body h3 { font-family: var(--serif); font-weight: 500; font-size: 16px; color: var(--ink); margin-bottom: 4px; }
+.milestone .tags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
+.milestone .tag { font-family: var(--mono); font-size: 10.5px; background: var(--gray-150); border: 1px solid var(--gray-300); border-radius: 6px; padding: 2px 8px; color: var(--gray-700); }
+
+.diagram { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); padding: 22px; margin: 16px 0; text-align: center; overflow-x: auto; }
+.diagram .caption { font-size: 13px; color: var(--gray-500); margin-top: 12px; }
+
+.mocks { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin: 16px 0; }
+.mock { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); overflow: hidden; }
+.mock .mock-label { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); padding: 8px 14px; background: var(--gray-150); border-bottom: 1px solid var(--gray-300); }
+.mock .mock-body { padding: 16px; }
+
+.risks { border: 1.5px solid var(--gray-300); border-radius: 12px; overflow: hidden; margin: 14px 0; }
+.risks .risk-row { display: grid; grid-template-columns: 90px 1fr; gap: 14px; padding: 12px 16px; align-items: start; }
+.risks .risk-row + .risk-row { border-top: 1px solid var(--gray-150); }
+.risks .risk-row .what { font-size: 14px; }
+.risks .risk-row .what .mit { color: var(--gray-500); font-size: 13px; display: block; margin-top: 3px; }
+
+.open-q { border: 1.5px solid var(--gray-300); border-left: 3px solid #b8893a; border-radius: 0 12px 12px 0; background: var(--white); padding: 16px 20px; margin: 14px 0; max-width: 760px; }
+.open-q .oq { padding: 6px 0; }
+.open-q .oq .qt { color: var(--ink); font-weight: 600; }
+.open-q .oq .owner { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+
+/* --- design system reference --- */
+.swatch-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 12px; margin: 14px 0 28px; }
+.swatch { border: 1.5px solid var(--gray-300); border-radius: 10px; overflow: hidden; background: var(--white); }
+.swatch .sw-chip { height: 64px; }
+.swatch .sw-meta { padding: 8px 10px; }
+.swatch .sw-name { font-size: 12px; color: var(--ink); }
+.swatch .sw-hex { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+
+.type-scale { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); overflow: hidden; margin: 14px 0 28px; }
+.type-row { display: grid; grid-template-columns: 1fr 140px; gap: 16px; align-items: baseline; padding: 14px 18px; }
+.type-row + .type-row { border-top: 1px solid var(--gray-150); }
+.type-row .type-meta { font-family: var(--mono); font-size: 11px; color: var(--gray-500); text-align: right; }
+.t-display { font-family: var(--serif); font-size: 40px; color: var(--ink); line-height: 1; }
+.t-h1 { font-family: var(--serif); font-size: 30px; color: var(--ink); }
+.t-h2 { font-family: var(--serif); font-size: 22px; color: var(--ink); }
+.t-body { font-size: 15px; color: var(--gray-700); }
+.t-small { font-size: 13px; color: var(--gray-700); }
+.t-caption { font-size: 11px; color: var(--gray-500); }
+
+.spacing-ruler { margin: 14px 0 28px; }
+.space-row { display: grid; grid-template-columns: 70px 1fr; gap: 14px; align-items: center; padding: 5px 0; }
+.space-row .space-label { font-family: var(--mono); font-size: 11.5px; color: var(--gray-500); }
+.space-row .space-bar { height: 16px; background: var(--accent); border-radius: 3px; }
+
+.token-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); gap: 12px; margin: 14px 0 28px; }
+.radius-card, .shadow-card { background: var(--white); border: 1.5px solid var(--gray-300); padding: 16px; text-align: center; }
+.radius-card .demo { height: 48px; background: var(--accent); margin-bottom: 10px; }
+.radius-card .lbl, .shadow-card .lbl { font-family: var(--mono); font-size: 11px; color: var(--gray-500); }
+
+.component-sheet { display: grid; gap: 16px; margin: 14px 0; }
+.component { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); padding: 18px 20px; }
+.component .cmp-name { font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); margin-bottom: 14px; }
+.component-stage { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+
+/* live demo components (design system) */
+.btn { font-family: var(--sans); font-size: 13px; border-radius: 8px; padding: 8px 16px; border: 1.5px solid var(--accent); cursor: pointer; }
+.btn-primary { background: var(--accent); color: var(--white); }
+.btn-secondary { background: var(--white); color: var(--accent); }
+.btn-ghost { background: none; border-color: transparent; color: var(--accent); }
+.btn-danger { background: var(--rust); border-color: var(--rust); color: var(--white); }
+.demo-input { font-family: var(--sans); font-size: 13px; border: 1.5px solid var(--gray-300); border-radius: 8px; padding: 8px 12px; background: var(--white); }
+.badge { font-family: var(--mono); font-size: 11px; border-radius: 999px; padding: 2px 10px; border: 1.5px solid var(--gray-300); }
+.badge-neutral { background: var(--gray-150); color: var(--gray-700); }
+.badge-accent { background: rgba(46,93,126,0.14); border-color: var(--accent); color: var(--accent); }
+.badge-success { background: rgba(90,120,71,0.14); border-color: var(--moss); color: var(--moss); }
+.badge-warning { background: rgba(179,90,44,0.14); border-color: var(--rust); color: var(--rust); }
+
+/* --- SVG figure sheet (diagrams) --- */
+.fig-sheet { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin: 16px 0; }
+.figure { border: 1.5px solid var(--gray-300); border-radius: 12px; background: var(--white); overflow: hidden; }
+.fig-canvas { padding: 20px; text-align: center; background: var(--paper); }
+.fig-cap { padding: 14px 16px; }
+.fig-cap .fig-title { font-family: var(--serif); font-size: 16px; color: var(--ink); }
+.fig-cap .fig-sub { font-size: 13px; color: var(--gray-500); }
+.fig-palette { display: flex; gap: 6px; padding: 0 16px 14px; flex-wrap: wrap; }
+.fig-palette .sw-chip { width: 22px; height: 22px; border-radius: 5px; border: 1px solid var(--gray-300); }

--- a/ralph/skills/using-html/references/code-review.md
+++ b/ralph/skills/using-html/references/code-review.md
@@ -1,0 +1,118 @@
+# Reference: Code review & understanding
+
+Three sub-shapes share this reference — pick the one that matches the request.
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/03-code-review-pr.html> (annotated
+review) · <https://thariqs.github.io/html-effectiveness/17-pr-writeup.html> (PR writeup) ·
+<https://thariqs.github.io/html-effectiveness/04-code-understanding.html> (module map)
+**JS budget:** None (writeup) to Micro (≤ ~15 lines: file collapse, diagram-node click).
+
+---
+
+## (a) Annotated PR review — reviewer's side
+
+**Trigger:** "review this PR", "review this diff", "what's risky in this change". Renders a diff
+as something scannable — risk map up top, file cards with inline margin comments.
+
+**Anatomy:** `.pr-head` (`.repo-line`, an `<h1>`, a `.meta-row` with `.branch`→`.branch`,
+`.stat.add`/`.stat.del`, an `.avatar`) → **`.risk-map`** of `.file-chip`s (each a `.dot`
+`.attention/.medium/.safe` + path) with a `.legend` → one **`.file-card`** per file
+(`.file-head` with `.file-path` + `.sev` risk tag + `.file-delta`) whose `.body` holds a `.diff`
+(`.hunk` header, `.diff-row` rows — `.add`/`.del`, each with `.ln` + `.code`, `.mark` for inline
+highlights) and a `.comments` stack of `.bubble` (`.blocking` / `.nit` / `.ctx`, each with a mono
+`.label`) → a `.next-steps` block with a `.checklist`. Micro JS: click a `.file-head` to
+collapse its body.
+
+```html
+<div class="risk-map">
+  <span class="file-chip"><span class="dot attention"></span>auth/session.ts</span>
+  <span class="file-chip"><span class="dot safe"></span>README.md</span>
+  <span class="legend">● blocking ● review ● safe</span>
+</div>
+
+<div class="file-card">
+  <div class="file-head"><span class="file-path">auth/session.ts</span>
+    <span class="sev high">High</span><span class="file-delta">+38 −4</span></div>
+  <div class="body">
+    <div class="diff">
+      <div class="hunk">@@ rotateToken() @@</div>
+      <div class="diff-row del"><span class="ln">21</span><span class="code">  return sign(payload)</span></div>
+      <div class="diff-row add"><span class="ln">21</span><span class="code">  return sign(payload, { <span class="mark">expiresIn: '15m'</span> })</span></div>
+    </div>
+    <div class="comments">
+      <div class="bubble blocking"><span class="label">Blocking</span>No refresh path — a 15m
+        expiry logs everyone out mid-session.</div>
+    </div>
+  </div>
+</div>
+
+<div class="next-steps"><h2>Next steps</h2>
+  <ul class="checklist"><li>Add a refresh-token path</li><li class="done">Expiry is configurable</li></ul>
+</div>
+```
+
+---
+
+## (b) PR writeup — author's side
+
+**Trigger:** "write the PR description", "explain this change for reviewers", "write up this PR".
+No JS — native `<details>`.
+
+**Anatomy:** `.pr-head` + `.toc` chip row → `.tldr` + `.lede` → **`.ba`** before/after
+(`.panel` + `.panel.after`) → a **file tour** of `<details>` accordions, each summarizing a file
+with a `.why` paragraph (`<b>` the motivation) → **`.focus`** list of `.item` (`.n` + what + why)
+telling reviewers where to look → **`.tests`** `.checklist` → **`.rollout`** of `.step` rows
+(`.n` + `.when` + description).
+
+```html
+<div class="pr-head"><div class="repo-line">acme/api · PR #312</div>
+  <h1>Move notification delivery onto a queue</h1></div>
+<div class="toc"><a href="#why">Why</a><a href="#tour">File tour</a><a href="#focus">Where to look</a></div>
+<div class="tldr"><b>TL;DR</b> — delivery moves from inline to a worker so a slow provider can't
+  block the request path.</div>
+<div class="ba">
+  <div class="panel"><div class="label">Before</div>send happens inside the request</div>
+  <div class="panel after"><div class="label">After</div>request enqueues; a worker delivers</div>
+</div>
+<div class="focus"><div class="item"><span class="n">1</span><div><b>Retry semantics</b> in
+  worker.ts — confirm at-least-once is acceptable.</div></div></div>
+```
+
+---
+
+## (c) Module map — code understanding
+
+**Trigger:** "explain how X works in this repo", "map this package", "trace the auth flow".
+Centerpiece is an SVG boxes-and-arrows diagram with the **hot path** highlighted.
+
+**Anatomy:** `.repo-line` + a short summary → **`.diagram-panel`** holding the inline `<svg>`
+module map (boxes + arrows; mark the hot path) → numbered **`.step`** call-path entries (`.badge`
+number + body + `.step-loc` file:line) each with a `.snippet` (`.code` `<pre>`, `.dim` context
+lines, `.hot` highlighted lines) → **`.key-files`** list of `.kf` (`.path` + description) →
+**`.gotchas`** `<ul>` with `<b>` leading clauses. Micro JS: click a diagram box to scroll to its
+step.
+
+```html
+<div class="diagram-panel"><svg viewBox="0 0 640 160"><!-- boxes + arrows, hot path in accent --></svg></div>
+<div class="step"><span class="badge">1</span>
+  <div><div class="step-loc">middleware/auth.ts:18</div>
+    <p>Every request hits <code>requireUser()</code> first.</p>
+    <div class="snippet"><pre><span class="dim">app.use(</span><span class="hot">requireUser</span><span class="dim">)</span></pre></div>
+  </div></div>
+<div class="key-files">
+  <div class="kf"><span class="path">middleware/auth.ts</span><span>Entry gate; resolves the session.</span></div>
+</div>
+```
+
+## Anti-patterns (group, each with why)
+
+- **Don't render a diff as a plain `<pre>` block.** The margin comments, risk tags, and add/del
+  coloring are the entire reason to leave the terminal. A monochrome `<pre>` is just a worse
+  `git diff`.
+- **Don't bury "where to focus" in prose.** Reviewers triage by it — make it a `.focus` list so
+  they can jump straight to the parts that need judgment.
+- **For a module map, the SVG must show the hot path**, not just every box. An undifferentiated
+  box-and-line diagram carries no more meaning than a file listing; highlighting the path the code
+  actually takes is the value.
+- **Don't mix the reviewer view (a) and author view (b).** A review flags risk; a writeup sells
+  the change. Pick the one the user asked for.

--- a/ralph/skills/using-html/references/decks.md
+++ b/ralph/skills/using-html/references/decks.md
@@ -1,0 +1,81 @@
+# Reference: Slide deck
+
+**Interactive-tier** — read `assets/interactive.css` and inline it after `theme.css`.
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/09-slide-deck.html>
+**JS budget:** Interactive (≤ ~60 lines — really ~25 for arrow-key nav).
+
+A handful of `<section>` tags and ~20 lines of JS is a slide deck. Point it at a thread or a doc
+and get something to arrow-key through in a meeting — no Keynote, no export step.
+
+## Page anatomy
+
+Wrap everything in `<div class="deck">`. Each slide is a `<section class="slide">`; exactly one
+carries `.on` at a time (the JS toggles it). Inside each, use a `.slide-inner`.
+
+- **Title slide** → `.slide.title-slide` with `<h1>`, `.subtitle`, `.byline`.
+- **Shipped list** → `.ship-list` of `.ship-item` (`.ship-dot` + `.ship-title` + `.ship-desc` +
+  `.ship-ref`).
+- **Progress** → `.prog-list` of `.prog-item` (`.prog-head` with `.prog-title` + `.prog-pct`, then
+  a `.prog-track` > `.prog-fill` whose width is the percent).
+- **Metrics** → `.metrics` row of `.metric` (`.metric-label` + `.metric-value` + `.metric-delta`,
+  add `.down` for a negative delta); reuse a small inline `<svg>` sparkline in `.sparkline-wrap`.
+- **Decision** → `.decision-card` (`.decision-q` + `.options` of `.opt`, mark the recommended one
+  `.lean`).
+- **Next steps** → `.next-list`.
+
+Add a `.deck-nav` indicator and the arrow-key script at the end of the body:
+
+```html
+<div class="deck">
+  <section class="slide title-slide on"><div class="slide-inner">
+    <h1>Platform Eng</h1><div class="subtitle">Week of Mar 10</div>
+    <div class="byline">— infra team</div></div></section>
+
+  <section class="slide"><div class="slide-inner">
+    <div class="eyebrow">Shipped</div>
+    <div class="ship-list">
+      <div class="ship-item"><span class="ship-dot"></span>
+        <div><div class="ship-title">Queue-backed notifications</div>
+          <div class="ship-desc">Delivery moved off the request path.</div>
+          <div class="ship-ref">#312</div></div></div>
+    </div></div></section>
+
+  <section class="slide"><div class="slide-inner">
+    <div class="metrics">
+      <div class="metric"><div class="metric-label">p95 latency</div>
+        <div class="metric-value">180ms</div><div class="metric-delta">−40ms</div></div>
+      <div class="metric"><div class="metric-label">Error rate</div>
+        <div class="metric-value">0.4%</div><div class="metric-delta down">+0.1%</div></div>
+    </div></div></section>
+</div>
+<div class="deck-nav" id="nav">1 / 3</div>
+
+<script>
+const slides = [...document.querySelectorAll('.slide')];
+let i = 0;
+const nav = document.getElementById('nav');
+function show(n){
+  i = Math.max(0, Math.min(slides.length - 1, n));
+  slides.forEach((s, k) => s.classList.toggle('on', k === i));
+  nav.textContent = (i + 1) + ' / ' + slides.length;
+}
+addEventListener('keydown', e => {
+  if (e.key === 'ArrowRight' || e.key === ' ') show(i + 1);
+  if (e.key === 'ArrowLeft') show(i - 1);
+});
+addEventListener('click', () => show(i + 1));
+show(0);
+</script>
+```
+
+## Anti-patterns (each with why)
+
+- **Don't make slides scroll as one long page.** Arrow-key, one-at-a-time is what makes it a deck
+  rather than a report. If you want a scroll document, that's `references/research.md`.
+- **Don't overload a slide.** One idea per `<section>`. A slide that needs scrolling has become a
+  page; split it.
+- **Don't invent parallel chart classes.** Reuse the metric/sparkline vocabulary; a deck and a
+  status report should look like the same hand drew them.
+- **Don't add a build step or an export.** The whole appeal is one HTML file you arrow-key through
+  — keep it that way.

--- a/ralph/skills/using-html/references/design.md
+++ b/ralph/skills/using-html/references/design.md
@@ -1,0 +1,111 @@
+# Reference: Design system & component variants
+
+Two sub-shapes share this reference.
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/05-design-system.html> (token reference)
+· <https://thariqs.github.io/html-effectiveness/06-component-variants.html> (variant matrix)
+**JS budget:** None (token reference) to Interactive (≤ ~60 lines: variant-matrix toolbar).
+
+The point of both: render design *as design*. Tokens become swatches, components become real
+styled HTML you can copy from — not screenshots, not descriptions.
+
+---
+
+## (a) Living design system — token reference
+
+**Trigger:** "document our design tokens", "show the design system", "render these tokens".
+No JS — everything is static styled HTML.
+
+**Anatomy:**
+- **Colors** → `.swatch-grid` of `.swatch` (a colored `.sw-chip` block + `.sw-meta` with
+  `.sw-name` + `.sw-hex`).
+- **Type scale** → `.type-scale` of `.type-row`, each pairing a live specimen
+  (`.t-display`/`.t-h1`/`.t-h2`/`.t-body`/`.t-small`/`.t-caption`) with `.type-meta` (size /
+  weight / line-height).
+- **Spacing** → `.spacing-ruler` of `.space-row` (a `.space-bar` whose width *is* the token + a
+  `.space-label`).
+- **Radii / shadows** → `.token-cards` of `.radius-card` / `.shadow-card` (a `.demo` block + a
+  `.lbl`).
+- **Components** → `.component-sheet` of `.component` blocks (`.cmp-name` + `.component-stage`
+  rendering the real `.btn` variants, `.demo-input`, `.badge` variants).
+
+```html
+<div class="swatch-grid">
+  <div class="swatch"><div class="sw-chip" style="background:#2e5d7e"></div>
+    <div class="sw-meta"><div class="sw-name">accent</div><div class="sw-hex">#2e5d7e</div></div></div>
+</div>
+
+<div class="type-scale">
+  <div class="type-row"><div class="t-h1">The quick brown fox</div>
+    <div class="type-meta">30px · 500 · 1.15</div></div>
+</div>
+
+<div class="component"><div class="cmp-name">Button</div>
+  <div class="component-stage">
+    <button class="btn btn-primary">Primary</button>
+    <button class="btn btn-secondary">Secondary</button>
+    <button class="btn btn-ghost">Ghost</button>
+    <button class="btn btn-danger">Danger</button>
+  </div></div>
+```
+
+---
+
+## (b) Component variant matrix
+
+**Trigger:** "show every variant of X", "lay out all states of this component", "card variant
+matrix". Interactive: a toolbar drives the live cards.
+
+**Anatomy:** a **`.toolbar`** of `.control`s (`.control-label` + a `.radio-group` of `.seg`
+buttons, and/or one `input[type=range]` with a `.control-value`) → a **`.variant-grid`** of
+`.variant-cell` (a `.variant-label` + a `.card` in each variant: `.v-flat`/`.v-outlined`/
+`.v-elevated`/`.v-stripe`/`.v-inset`/`.v-horizontal`) → a **`.snippet-panel`** echoing the markup
+of the current selection. The toolbar must actually mutate the cards — a static grid is just a
+worse contact sheet.
+
+```html
+<div class="toolbar">
+  <div class="control"><span class="control-label">Density</span>
+    <div class="radio-group">
+      <button class="seg on" data-density="cozy">Cozy</button>
+      <button class="seg" data-density="compact">Compact</button>
+    </div></div>
+  <div class="control"><span class="control-label">Radius <span class="control-value" id="rv">10px</span></span>
+    <input type="range" min="0" max="20" value="10" id="radius"></div>
+</div>
+
+<div class="variant-grid">
+  <div class="variant-cell"><span class="variant-label">elevated</span>
+    <div class="card v-elevated">…</div></div>
+  <!-- one cell per variant -->
+</div>
+
+<div class="snippet-panel"><div class="snippet-head">selected markup</div>
+  <pre>&lt;div class="card v-elevated"&gt;…&lt;/div&gt;</pre></div>
+
+<script>
+const grid = document.querySelector('.variant-grid');
+const rv = document.getElementById('rv');
+document.getElementById('radius').addEventListener('input', e => {
+  rv.textContent = e.target.value + 'px';
+  grid.querySelectorAll('.card').forEach(c => c.style.borderRadius = e.target.value + 'px');
+});
+document.querySelectorAll('.radio-group .seg').forEach(seg => seg.addEventListener('click', () => {
+  const g = seg.closest('.radio-group');
+  g.querySelectorAll('.seg').forEach(s => s.classList.remove('on'));
+  seg.classList.add('on');
+  grid.dataset.density = seg.dataset.density;
+}));
+</script>
+```
+
+## Anti-patterns (group, each with why)
+
+- **Don't screenshot components.** Render them as real styled HTML so the tokens are inspectable
+  and the markup is copy-able — that round-trip back into the next prompt is the whole point.
+- **For the matrix, the toolbar must drive the cards.** If the controls don't mutate anything,
+  drop them and ship a static contact sheet; a fake toolbar is worse than none.
+- **Don't invent a parallel palette.** Pull swatches from the real `:root` vars; a design-system
+  doc that drifts from the tokens it documents is actively misleading.
+- **Keep the spacing bars literal.** A `.space-bar` whose width equals the token value teaches the
+  scale at a glance; a uniform bar with a number beside it doesn't.

--- a/ralph/skills/using-html/references/diagrams.md
+++ b/ralph/skills/using-html/references/diagrams.md
@@ -1,0 +1,99 @@
+# Reference: Illustrations & diagrams
+
+Two sub-shapes share this reference.
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/10-svg-illustrations.html> (figure
+sheet) · <https://thariqs.github.io/html-effectiveness/13-flowchart-diagram.html> (flowchart)
+**JS budget:** Micro (figure sheet: copy buttons) to Interactive (flowchart: ≤ ~60 lines, as
+*data + a render/click loop*, not imperative DOM building).
+
+Inline SVG gives you a real pen. Hand-author it; never emit a raster image or pull in Mermaid via
+`<script src>` — that breaks self-containment and you lose the ability to tweak by hand.
+
+---
+
+## (a) SVG figure sheet
+
+**Trigger:** "draw the figures for this post", "illustrate X", "make diagrams I can paste out".
+Multiple independent figures, each extractable on its own.
+
+**Anatomy:** a **`.fig-sheet`** grid of `.figure` cards, each with a `.fig-canvas` (one inline
+`<svg>`), a `.fig-cap` (`.fig-title` + `.fig-sub`), and an optional `.fig-palette` of `.sw-chip`
+swatches so the figure's colors are reusable. Micro JS (optional): a per-figure "copy SVG"
+button.
+
+```html
+<div class="fig-sheet">
+  <figure class="figure">
+    <div class="fig-canvas"><svg viewBox="0 0 200 120" width="200" height="120">
+      <rect x="20" y="30" width="160" height="60" rx="10" fill="#e6dcc4" stroke="#2e5d7e"/>
+      <text x="100" y="65" text-anchor="middle" font-size="13" fill="#1b2329">job queue</text>
+    </svg></div>
+    <figcaption class="fig-cap"><div class="fig-title">Work queue</div>
+      <div class="fig-sub">Producers enqueue; workers drain.</div></figcaption>
+    <div class="fig-palette"><span class="sw-chip" style="background:#2e5d7e"></span>
+      <span class="sw-chip" style="background:#e6dcc4"></span></div>
+  </figure>
+</div>
+```
+
+---
+
+## (b) Annotated flowchart
+
+**Trigger:** "draw the deploy pipeline", "flowchart this process", "show the failure paths".
+Clicking a node reveals its detail.
+
+**Anatomy:** `.page-head` → a **`.flow-layout`** (two columns) placing a `.flow-canvas` (one large
+inline `<svg>`) next to a `.flow-legend`. Nodes are `<g class="node">` (add `.gate`/`.ok`/`.bad`
+to encode state) each with a `<rect>` + `<text>`; edges are `<path class="edge">` (define one
+`<marker id="arrow">` for the arrowhead). Clicking a node toggles `.sel` and fills a `.flow-hint`
+panel in the legend (`.where` for the file/command).
+
+**Author the JS as data + a small loop**, not 96 lines of hand-built DOM:
+
+```html
+<div class="flow-layout">
+  <div class="flow-canvas"><svg viewBox="0 0 360 220">
+    <defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#847d6c"/></marker></defs>
+    <path class="edge" d="M80,50 L80,90"/>
+    <g class="node" data-id="build"><rect x="20" y="20" width="120" height="32" rx="8"/>
+      <text x="80" y="40" text-anchor="middle">build</text></g>
+    <g class="node gate" data-id="tests"><rect x="20" y="90" width="120" height="32" rx="8"/>
+      <text x="80" y="110" text-anchor="middle">tests pass?</text></g>
+    <g class="node bad" data-id="rollback"><rect x="200" y="90" width="120" height="32" rx="8"/>
+      <text x="260" y="110" text-anchor="middle">rollback</text></g>
+  </svg></div>
+  <div class="flow-legend"><div class="label">STEP DETAIL</div>
+    <div class="flow-hint" id="hint">Click a step to see what runs.</div></div>
+</div>
+
+<script>
+const detail = {
+  build:    { t: "Compile + bundle", w: "ci/build.sh" },
+  tests:    { t: "Gate: unit + e2e must pass", w: "ci/test.sh" },
+  rollback: { t: "Failure path: redeploy last green", w: "ci/rollback.sh" },
+};
+const hint = document.getElementById('hint');
+document.querySelectorAll('.node').forEach(n => n.addEventListener('click', () => {
+  document.querySelectorAll('.node').forEach(x => x.classList.remove('sel'));
+  n.classList.add('sel');
+  const d = detail[n.dataset.id];
+  hint.innerHTML = d.t + '<div class="where">' + d.w + '</div>';
+}));
+</script>
+```
+
+## Anti-patterns (group, each with why)
+
+- **Don't emit a raster image or a Mermaid `<script>`.** Inline hand-authored SVG is the point —
+  self-contained and tweakable by hand. A `<script src>` to a diagram CDN breaks the one-file
+  guarantee.
+- **Don't make flowchart nodes undifferentiated boxes.** Encode state in the class
+  (`.gate`/`.ok`/`.bad`) so the diagram carries meaning at a glance, not just topology.
+- **Don't build the flowchart with 90 lines of imperative DOM.** Author the SVG by hand and keep
+  the JS to a data table + a click loop — that's what keeps it inside the interactive budget and
+  legible.
+- **Keep figures independent.** Each `.figure` should stand alone so the reader can copy one SVG
+  out without dragging the others along.

--- a/ralph/skills/using-html/references/planning.md
+++ b/ralph/skills/using-html/references/planning.md
@@ -1,0 +1,88 @@
+# Reference: Implementation plan
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/16-implementation-plan.html>
+**JS budget:** None. Pure layout.
+
+**Trigger this workflow when** the user says "turn this into a plan", "implementation plan
+for…", "milestones for…", "how would you build X", "write the hand-off doc", or after a
+comparison has been decided and now needs sequencing. This is the doc you hand the implementer —
+plan-shaped, not comparison-shaped. (If the user wants to *compare* options, that's
+`references/specs.md`.)
+
+## Page anatomy
+
+Top → bottom:
+
+1. **`.page-head`** — `.eyebrow` (e.g. `Plan · acme/web-client`) + `<h1>` (what's being built) +
+   `.prompt-box` quoting the request.
+2. **`.summary` grid** — 3–5 `.cell` k/v pairs giving the at-a-glance frame: scope, estimate,
+   owner, risk level, dependencies. Use `.v.accent` on the one headline value.
+3. **`.milestones`** — a left-rail timeline of `.milestone` rows (`.when` date · `.rail` with
+   `.dot`/`.line` · `.ms-body`). Mark shipped/known-good milestones with `.dot.done`. Each
+   `.ms-body` has an `<h3>`, a sentence of detail, and `.tags` (`.tag` pills for the touched
+   areas).
+4. **`.diagram`** — one inline `<svg>` data-flow showing how the pieces connect, with a
+   `.caption`. Hand-draw it; don't paste a screenshot.
+5. **`.mocks`** (optional) — a grid of `.mock` cards, each a `.mock-label` + `.mock-body` inline
+   UI sketch of a screen the plan introduces.
+6. **`.risks`** — a table of `.risk-row` (a `.sev` `.high/.med/.low` pill + a `.what` description
+   whose `.mit` line states the mitigation). A plan with no called-out risks reads as naïve.
+7. **`.open-q`** — unresolved questions, each `.oq` with a `.qt` question and an `.owner` who
+   should answer it.
+
+## Worked example — header + summary + one milestone + a risk
+
+```html
+<header class="page-head">
+  <div class="eyebrow">Plan · acme/web-client</div>
+  <h1>Comment threads on task cards</h1>
+  <div class="prompt-box"><span class="label">PROMPT</span>
+    Turn the threaded-comments comparison into an implementation plan.</div>
+</header>
+
+<div class="summary">
+  <div class="cell"><div class="k">Scope</div><div class="v accent">4 milestones</div></div>
+  <div class="cell"><div class="k">Estimate</div><div class="v">~1.5 weeks</div></div>
+  <div class="cell"><div class="k">Risk</div><div class="v">Medium</div></div>
+  <div class="cell"><div class="k">Owner</div><div class="v">web team</div></div>
+</div>
+
+<div class="milestones">
+  <div class="milestone">
+    <div class="when">May 26</div>
+    <div class="rail"><div class="dot done"></div><div class="line"></div></div>
+    <div class="ms-body">
+      <h3>1 · Comment data model + API</h3>
+      <p>Add the <code>comments</code> table and the read/write endpoints.</p>
+      <div class="tags"><span class="tag">db</span><span class="tag">api</span></div>
+    </div>
+  </div>
+  <!-- more milestones; last one drops the .line -->
+</div>
+
+<svg class="..." viewBox="0 0 600 140"><!-- inline data-flow diagram --></svg>
+
+<div class="risks">
+  <div class="risk-row">
+    <span class="sev high">High</span>
+    <div class="what">Realtime fan-out could swamp the socket server.
+      <span class="mit">Mitigation: batch deliveries on a 250ms window; cap thread depth.</span></div>
+  </div>
+</div>
+
+<div class="open-q">
+  <div class="oq"><span class="qt">Soft-delete or hard-delete comments?</span>
+    <span class="owner">— needs product</span></div>
+</div>
+```
+
+## Anti-patterns (each with why)
+
+- **Don't write the plan as a flat numbered list.** The timeline + risk table are what make it
+  scannable and hand-off-able; a numbered list is Markdown with extra steps.
+- **Don't omit the risk table.** A plan that names no risks reads as either naïve or
+  over-confident. The `.sev` pills let a reviewer triage what to push back on in seconds.
+- **Don't screenshot the architecture.** Hand-draw the data-flow as inline SVG so it stays
+  self-contained and tweakable.
+- **Don't bury open questions in prose.** Surface them as `.open-q` with an owner, so the reader
+  knows exactly what's still undecided and who unblocks it.

--- a/ralph/skills/using-html/references/prototyping.md
+++ b/ralph/skills/using-html/references/prototyping.md
@@ -1,0 +1,101 @@
+# Reference: Prototyping
+
+Two sub-shapes share this reference. Both are **Interactive-tier** — read
+`assets/interactive.css` and inline it after `theme.css`.
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/07-prototype-animation.html> (animation
+sandbox) · <https://thariqs.github.io/html-effectiveness/08-prototype-interaction.html>
+(clickable / drag flow)
+**JS budget:** Interactive (≤ ~60 lines).
+
+Motion and interaction can't be described, only felt. The artifact runs the real thing so the user
+reacts to it in five seconds instead of imagining it from a paragraph. Keep fidelity
+throwaway — polish is the implementer's job.
+
+---
+
+## (a) Animation sandbox
+
+**Trigger:** "prototype this transition", "tune the easing", "show the micro-interaction so I can
+feel it".
+
+**Anatomy:** a **`.bench`** wrapper containing a `.stage` (the real animated element runs here),
+an `.ease-row` of `.ease-btn` presets (one carries `.active`), an optional `.timeline` `.track`
+with keyframe `.key` markers, and a `.snippet` echoing the CSS/keyframes. JS swaps the easing/
+duration and replays.
+
+```html
+<div class="bench">
+  <div class="stage"><div id="card" class="card" style="padding:20px">Task done ✓</div></div>
+  <div class="ease-row">
+    <button class="ease-btn active" data-ease="cubic-bezier(.2,.8,.2,1)">Smooth</button>
+    <button class="ease-btn" data-ease="cubic-bezier(.34,1.56,.64,1)">Overshoot</button>
+    <button class="ease-btn" data-ease="linear">Linear</button>
+  </div>
+</div>
+<script>
+const card = document.getElementById('card');
+function play(ease){
+  card.style.transition = 'none'; card.style.transform = 'scale(.85)'; card.style.opacity = '.4';
+  requestAnimationFrame(() => {
+    card.style.transition = `transform 420ms ${ease}, opacity 420ms ${ease}`;
+    card.style.transform = 'scale(1)'; card.style.opacity = '1';
+  });
+}
+document.querySelectorAll('.ease-btn').forEach(b => b.addEventListener('click', () => {
+  document.querySelectorAll('.ease-btn').forEach(x => x.classList.remove('active'));
+  b.classList.add('active'); play(b.dataset.ease);
+}));
+play('cubic-bezier(.2,.8,.2,1)');
+</script>
+```
+
+---
+
+## (b) Clickable / drag-to-reorder flow
+
+**Trigger:** "prototype this interaction", "let me feel the reorder", "mock the click-through".
+
+**Anatomy:** a **`.bench`** holding a `.proto-list` of `.proto-item` rows (each a `.grip` handle +
+label + optional `.count`), using native `draggable="true"`. A dragged item gets `.dragging`; the
+row under the cursor gets `.drop-target`. Pair the bench with a short `.lede`/notes block stating
+what the prototype is testing.
+
+```html
+<div class="bench"><div class="proto-list" id="list">
+  <div class="proto-item" draggable="true"><span class="grip">⠿</span>Inbox<span class="count">12</span></div>
+  <div class="proto-item" draggable="true"><span class="grip">⠿</span>Starred<span class="count">3</span></div>
+  <div class="proto-item" draggable="true"><span class="grip">⠿</span>Archive<span class="count">88</span></div>
+</div></div>
+<script>
+const list = document.getElementById('list');
+let dragged = null;
+list.addEventListener('dragstart', e => { dragged = e.target.closest('.proto-item'); dragged.classList.add('dragging'); });
+list.addEventListener('dragend', () => { dragged.classList.remove('dragging'); list.querySelectorAll('.proto-item').forEach(i => i.classList.remove('drop-target')); });
+list.addEventListener('dragover', e => {
+  e.preventDefault();
+  const over = e.target.closest('.proto-item');
+  if (!over || over === dragged) return;
+  list.querySelectorAll('.proto-item').forEach(i => i.classList.remove('drop-target'));
+  over.classList.add('drop-target');
+  const rect = over.getBoundingClientRect();
+  const after = e.clientY > rect.top + rect.height / 2;
+  list.insertBefore(dragged, after ? over.nextSibling : over);
+});
+</script>
+```
+
+> This is at the top of the interactive budget. If you need a Save/export-to-markdown step,
+> persisted columns, or dependency logic, that's the deferred *editor* tier — build the prototype
+> shape here and say the export piece is out of scope.
+
+## Anti-patterns (group, each with why)
+
+- **Don't describe motion in prose.** The entire value is that it runs; a paragraph about easing
+  is exactly what the prototype replaces.
+- **Don't reach for a framework or a drag library.** Native `draggable` + a few listeners is
+  enough and keeps the file self-contained.
+- **Don't over-polish.** Throwaway fidelity is the point — the prototype answers "does this feel
+  right?", not "is this production-ready?".
+- **Don't add an export/save button.** That tips the artifact into editor territory (deferred).
+  Keep prototypes about *feel*, not state capture.

--- a/ralph/skills/using-html/references/research.md
+++ b/ralph/skills/using-html/references/research.md
@@ -1,0 +1,103 @@
+# Reference: Research reports
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/14-research-feature-explainer.html>
+(feature) · <https://thariqs.github.io/html-effectiveness/15-research-concept-explainer.html>
+(concept) · <https://thariqs.github.io/html-effectiveness/11-status-report.html> (status) ·
+<https://thariqs.github.io/html-effectiveness/12-incident-report.html> (incident)
+**JS budget:** Micro (≤ ~15 lines for the tab switcher) — except the concept-explainer variant,
+which is Interactive (≤ ~60 lines to wire its SVG demo).
+
+**Trigger this workflow when** the user says "research X and report back", "summarize what you
+found", "investigate Y", "write up your findings", "explain how Z works", "feature explainer
+for...", "incident timeline / postmortem of...", or asks for any synthesis of findings from
+multiple sources/files into one durable document.
+
+## Page anatomy
+
+Wrap the page in `<div class="report">` to activate the two-column grid layout:
+
+1. **Sidebar (`<nav>`)** — sticky 200px, hidden under 920px (the CSS already handles the breakpoint). Inside:
+   - `<div class="label">ON THIS PAGE</div>` + anchor `<a>` links for each H2. For nested step lists, add `class="l2"` to the child links so they indent.
+   - **"Files read" footer** at the bottom — `<div class="files">` containing `<div class="label">FILES READ</div>` and one `<code>` per file path. Include this whenever the report is grounded in a codebase; it lets the reader verify by grepping the same paths.
+2. **Main column (`<main>`)** in this order:
+   - `<header>` with `.eyebrow` (e.g. `Research · feature summary`) + `<h1>` (may contain `<code>` for module/path names).
+   - `.tldr` callout — one paragraph max, `<b>` on the most important claim.
+   - `<h2>` sections with `id="..."` for the anchor links. The CSS gives them `scroll-margin-top: 24px` so anchors land below any sticky chrome.
+3. **Inline content patterns** — use as fits:
+   - **Accordions** for step-by-step or optional drill-down. `<details><summary>1 · Identify the caller <span class="where">middleware/ratelimit.ts:21</span></summary><div class="body"><p>…</p></div></details>`. The mono `.where` slot on the right is for the file:line citation.
+   - **Tabs** for the same concept across config / call-site / response. Wrap in `<div class="tabs" data-tabs>` with a `.tabbar` of `<button data-t="0">` etc. and `<pre>` panes whose first carries `class="on"`. Then add this 10-line vanilla JS at the bottom of the body:
+
+     ```html
+     <script>
+     document.querySelectorAll("[data-tabs]").forEach(box => {
+       const btns = box.querySelectorAll("button");
+       const panes = box.querySelectorAll("pre");
+       btns.forEach(b => b.addEventListener("click", () => {
+         btns.forEach(x => x.classList.remove("on"));
+         panes.forEach(x => x.classList.remove("on"));
+         b.classList.add("on");
+         panes[+b.dataset.t].classList.add("on");
+       }));
+     });
+     </script>
+     ```
+   - **Callouts** for tips and gotchas — `<div class="callout"><span class="ico">★</span><div>…</div></div>`.
+   - **FAQ** — `<dl class="faq"><dt>Question?</dt><dd>Answer.</dd></dl>`. 3-6 entries max.
+   - **Gotchas** — a plain `<ul>` with `<b>` on the leading clause of each `<li>`.
+
+## Worked example — sidebar + header + TL;DR
+
+```html
+<div class="report">
+  <nav>
+    <div class="label">ON THIS PAGE</div>
+    <a href="#tldr">TL;DR</a>
+    <a href="#path">Request path</a>
+    <a href="#path" class="l2">1. Identify</a>
+    <a href="#path" class="l2">2. Bucket lookup</a>
+    <a href="#config">Configuring a route</a>
+    <div class="files">
+      <div class="label">FILES READ</div>
+      <code>middleware/ratelimit.ts</code>
+      <code>lib/tokenBucket.ts</code>
+      <code>config/limits.yaml</code>
+    </div>
+  </nav>
+
+  <main>
+    <header>
+      <div class="eyebrow">Research · feature summary</div>
+      <h1>How rate limiting works in <code>acme/api</code></h1>
+      <div class="tldr" id="tldr">
+        <b>TL;DR</b> — Every request runs <code>rateLimit()</code>, which resolves the caller to a bucket key and either consumes one token or returns <code>429</code>.
+      </div>
+    </header>
+
+    <h2 id="path">The request path</h2>
+    <details open>
+      <summary>1 · Identify the caller <span class="where">middleware/ratelimit.ts:21</span></summary>
+      <div class="body"><p>The middleware reduces the request to a <code>bucketKey</code>…</p></div>
+    </details>
+    <!-- more steps, more sections -->
+  </main>
+</div>
+```
+
+## Anti-patterns (each with why)
+
+- **Don't write a Markdown-style linear wall of `<p>` tags.** A report that's just paragraphs down a single column is Markdown with extra steps. Use the structural patterns — TOC, sections with anchors, callouts, accordions — so the reader has entry points and signposts. Navigability is the point of going to HTML.
+- **Don't put the sidebar nav in normal flow.** Without `position: sticky` (which `.report nav` already sets), it scrolls off and becomes useless on page two. The nav exists so the reader can jump between sections at any scroll position.
+- **Don't omit the "Files read" footer on code-grounded reports.** Naming the files makes the report verifiable — the reader can grep the same paths and check the claims. Without it, the report is "trust me." With it, it's "here's exactly what I looked at."
+- **Don't write a multi-paragraph TL;DR.** The TL;DR exists so a skimmer gets the headline claim in 10 seconds. If it takes two paragraphs, it isn't a TL;DR — it's the introduction, and you've defeated its purpose.
+- **Don't hide must-read content inside `<details>`.** Accordions are for optional drill-down (steps, sub-procedures, less-common cases). If the reader *must* see something to understand the report, put it inline.
+- **Don't end with a "Recommendation" aside.** Reports describe what IS — how a system works, what the data shows, what happened in an incident. Prescription belongs in the specs workflow, not here.
+
+## Permitted variants
+
+- **Status / weekly report** → drop the sidebar (omit `<div class="report">` wrapper, use `<main>` directly), single column. Reference: <https://thariqs.github.io/html-effectiveness/11-status-report.html>. Canon H2s are `Highlights / Shipped / Velocity / Carryover`. Use a `.summary-band` near the top, a small `.chart-panel` containing one inline `<svg>` velocity chart, `.stat-card` blocks with `.stat-num` + `.stat-label` + `.stat-delta` for KPI deltas (apply `.up`/`.warn` modifiers for direction), and `.carryover` rows containing `.carry-item` + `.carry-tag` pills with a `.risk-dot` (`.high`/`.med`/`.low`) per item.
+
+- **Incident timeline / postmortem** → main is a left-rail timeline, NOT a vertical `<ol>`. Reference: <https://thariqs.github.io/html-effectiveness/12-incident-report.html>. Canon H2s are `Timeline / Root cause / Impact / Action items`. The timeline is a `<section class="timeline">` of `.tl-entry` rows, each with `.tl-time` (HH:MM), `.tl-dot`, and `.tl-body`. Log excerpts inside `.tl-body` go in a `.code-panel` using `.diff-line.add`/`.diff-line.del` for added/removed lines. Action items use an `.actions` grid of `.ai-row` blocks (`.ai-avatar` assignee + `.ai-desc` description + `.ai-due` date + `.ai-check` checkbox). Status pills (`.pill.mitigated`/`.pill.resolved`) plus a `.sev` severity tag sit in a `.meta-row` at the top. Sidebar's anchor list becomes "timeline at a glance" with timestamps.
+
+- **Concept explainer** → centerpiece is an interactive `<svg>` demo, NOT a static diagram. Reference: <https://thariqs.github.io/html-effectiveness/15-research-concept-explainer.html>. Canon drops the sidebar entirely; layout is a single `.demo-grid` placing the SVG widget (`.ring`/`.node`/`.arc`/`.track`) next to `.controls` (sliders + buttons that mutate the SVG via inline JS). Often skips `.tldr` — a brief `.lead` paragraph carries the headline instead. Include a `<table>` for "X vs Y" comparison (use `.good`/`.bad` cells for visual contrast) and a glossary as `<dl>` with `.term` + `.lbl` entries for inline definitions. ~20 lines of vanilla JS to wire control → SVG updates is acceptable here; the interactivity IS the explainer.
+
+> **Canon reference for this workflow:** <https://thariqs.github.io/html-effectiveness/14-research-feature-explainer.html> is the worked example. The canon uses `<div class="page">` for the two-column grid wrapper; this skill uses `<div class="report">` to keep that grid distinct from the wider 1360px `.page` used by the specs workflow.

--- a/ralph/skills/using-html/references/specs.md
+++ b/ralph/skills/using-html/references/specs.md
@@ -1,0 +1,85 @@
+# Reference: Specs & design comparison
+
+**Canon:** <https://thariqs.github.io/html-effectiveness/01-exploration-code-approaches.html>
+(code) · <https://thariqs.github.io/html-effectiveness/02-exploration-visual-designs.html> (visual)
+**JS budget:** Micro (≤ ~15 lines — only if a variant needs a tab switcher).
+
+**Trigger this workflow when** the user says "compare these approaches", "tradeoffs between X and
+Y", "show me N ways to...", "what are my options for...", "side-by-side", "explore designs
+for...", or asks any question that produces ≥2 candidate solutions to a single decision.
+
+## Page anatomy
+
+Build the page in this order from top to bottom:
+
+1. **Header band** — `.eyebrow` (mono uppercase, e.g. `Exploration · acme/web-client`) + `<h1>` (the question being decided in serif) + `.prompt-box` (the user's original question quoted verbatim under a mono "PROMPT" label).
+2. **`.approaches` grid** — CSS grid of 2-4 cards. Set `data-n="3"` (or whatever N is) on the grid so the breakpoint matches the option count.
+3. **Each `<article class="approach">` card** contains, in order:
+   - `<header class="approach-head">` with a numbered badge (`<span class="num">01</span>`), an `<h2>` (the approach name), and a `<p>` dek (one-line summary).
+   - **Code panel** (`<div class="code"><pre>...</pre></div>`) if the approach is code-shaped. Inside the `<pre>`, mark up keywords/strings/comments/identifiers with `<span class="kw">`, `<span class="str">`, `<span class="cm">`, `<span class="fn">`. Don't use a JS highlighter — the theme is already tuned to these four classes against the slate background.
+   - **Tradeoffs grid** (`<div class="tradeoffs">`): one `.row.head` with "Pro" and "Con" cells, then 3-5 `.row` blocks each with a `.cell.pro` and a `.cell.con`. The colored dots come from the CSS — don't add emoji.
+   - **Chips** (`<div class="chips">`): mono pills with concrete numbers — bundle size, latency, complexity rating, anything quantifiable. Use `<strong>` for the value within the chip.
+4. **`.reco` aside** — accent left-border block at the bottom. Name the recommended approach by its number AND name in bold, explain in 1-3 sentences *why*, and note conditions under which a different choice becomes correct.
+
+## Worked example — header + one card
+
+```html
+<header class="page-head">
+  <div class="eyebrow">Exploration · acme/web-client</div>
+  <h1>Three ways to debounce search</h1>
+  <div class="prompt-box">
+    <span class="label">PROMPT</span>
+    Show me three different ways to implement debounced search for the
+    task filter input, with tradeoffs for each.
+  </div>
+</header>
+
+<section class="approaches" data-n="3">
+  <article class="approach">
+    <header class="approach-head">
+      <h2><span class="num">01</span>Inline useEffect + setTimeout</h2>
+      <p>Debounce logic lives directly inside the component that owns the input.</p>
+    </header>
+    <div class="code"><pre><span class="kw">export function</span> <span class="fn">TaskSearch</span>() {
+  <span class="kw">const</span> [draft, setDraft] = <span class="fn">useState</span>(<span class="str">''</span>);
+  <span class="cm">// ...</span>
+}</pre></div>
+    <div class="tradeoffs">
+      <div class="row head">
+        <div class="cell">Pro</div>
+        <div class="cell">Con</div>
+      </div>
+      <div class="row">
+        <div class="cell pro">Zero new abstractions</div>
+        <div class="cell con">Logic duplicated wherever search exists</div>
+      </div>
+    </div>
+    <div class="chips">
+      <span class="chip">Bundle: <strong>+0 kb</strong></span>
+      <span class="chip">Reuse: <strong>low</strong></span>
+    </div>
+  </article>
+  <!-- two more <article class="approach"> cards -->
+</section>
+
+<aside class="reco">
+  <h2>Recommendation</h2>
+  <p>Go with <strong>approach 02, the custom <code>useDebounce</code> hook</strong>. There are already three places using the inline pattern, so extracting one shared hook removes duplication without taking on a new dependency.</p>
+</aside>
+```
+
+## Anti-patterns (each with why)
+
+- **Don't list "approaches" as bullet paragraphs without cards.** The grid is what makes side-by-side comparison glanceable; collapsed into bullets, the reader is back to sequential prose and we might as well have shipped Markdown.
+- **Don't bury tradeoffs in prose.** Show them in the 2-column pro/con grid. Prose forces the reader to extract and mentally tabulate; the grid lets them scan across approaches in seconds — that scanning ability is the whole reason we went to HTML.
+- **Don't use a 2-column grid when there are 3 options.** Set `data-n="3"` so the third card aligns under the heading. Two-up with one orphan card on row two breaks the comparison shape.
+- **Don't conclude with "depends on context".** The reader came to make a decision. Pick the approach that best fits the stated constraints and name it. If genuinely no winner exists, write one sentence explaining why — that's still an answer.
+- **Don't use a JS syntax highlighter or default-monospace `<code>` blocks.** The theme ships `.kw`/`.str`/`.cm`/`.fn` spans tuned to the palette; a generic highlighter (Prism, highlight.js) adds bytes, breaks self-containment, and produces colors that fight the slate background.
+
+## Permitted variants
+
+- **2 approaches** → `data-n="2"`; still keep the recommendation aside.
+- **Non-code comparisons** (architecture choices, vendor selection) → drop the code panel, keep header/tradeoffs/chips.
+- **Visual design directions** (palettes, layouts, empty-state treatments) → drop BOTH the code panel and the tradeoffs grid; replace with a stage that shows the actual visual. Reference: <https://thariqs.github.io/html-effectiveness/02-exploration-visual-designs.html>. The canon uses a card-per-direction grid where each card contains a `.stage` wrapping an `.artboard` (the live mockup canvas), a small `.rationale` paragraph underneath, and optional toolbar controls (`.toolbar` + `.seg` + `.field`) when the direction is tunable. Per-direction theme overrides — class hooks like `.es-a`/`.es-b`/`.es-c`/`.es-d` on each card — let every card render its own palette without changing the surrounding chrome. H1 stays descriptive ("Four visual directions for the empty state"); H2s per card are usually omitted in favor of `.title` + `.tag`.
+
+> **Canon reference for this workflow:** <https://thariqs.github.io/html-effectiveness/01-exploration-code-approaches.html> is the worked example this anatomy is derived from. The `data-n="N"` attribute is a flexibility enhancement — the canon hardcodes `grid-template-columns: repeat(3, 1fr)` per page since each demo knows its own card count. Both work; the `data-n` mechanism lets one stylesheet serve 2/3/4-card pages.


### PR DESCRIPTION
## Summary

Ships the `using-html` skill in the **ralph** slim plugin. It produces self-contained, offline-capable HTML artifacts instead of long Markdown — multi-option comparisons, research synthesis, status/incident reports, implementation plans, PR writeups, module maps, SVG diagrams/flowcharts, interactive prototypes, and slide decks.

- Lands at `ralph/skills/using-html/` → auto-discovered as **`/ralph:using-html`**
- 12 files: `SKILL.md` (router) + `assets/` (skeleton.html, theme.css, interactive.css) + `references/` (8 per-workflow guides)
- Byte-identical to the source skill; no manifest change needed (skills auto-discover; `plugin.json` version is CI-auto-bumped on merge)
- Its built-in path logic writes artifacts to `thoughts/shared/html-out/`, which every ralph repo already has

## Notes

- Kept the skill's internal `assets/` + `references/` subdirs rather than flattening to the plugin's flat-sibling convention, to avoid rewriting paths in a known-good SKILL.md and mixing CSS/HTML with the docs.
- **Attribution:** the source skill carries no author/license metadata. If it originated from a third party, add an attribution note and confirm redistribution rights before release.

## Test plan

- [ ] `/ralph:using-html` resolves and the router reads its `assets/` + `references/` relative paths
- [ ] A generated artifact writes to `thoughts/shared/html-out/` and opens in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)