### PR TITLE
GH-1431: ralph self-containment — Phase 1: MCP re-point + tool-prefix sweep + guard test

### DIFF
--- a/ralph/.mcp.json
+++ b/ralph/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "ralph-github": {
+      "command": "npx",
+      "args": ["-y", "ralph-hero-mcp-server@2.5.186"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+    }
+  }
+}

--- a/ralph/CLAUDE.md
+++ b/ralph/CLAUDE.md
@@ -10,7 +10,7 @@ The slim successor to `ralph-hero`. See `../thoughts/shared/research/2026-05-22-
 - **No `references/` subfolder by default.** Reference files are siblings of SKILL.md. Two named exceptions: `caretake/` uses a `modes/` subfolder, and the vendored `using-html/` utility skill keeps its upstream `references/` + `assets/` subfolders. `using-html/` is preserved byte-identical from its source so it tracks upstream cleanly — do not flatten it to match this convention.
 - **No SOUL.md files.** Substrate is the product (principle P10).
 - **Enforcement lives in hooks/, not skill prose.** If you find yourself writing "make sure to validate X" in a SKILL.md, that's a hook.
-- **Artifact state lives in the MCP server.** Skills read/write via `mcp__plugin_ralph-hero_ralph-github__*` tools (cross-plugin during migration).
+- **Artifact state lives in the MCP server.** Skills read/write via `mcp__plugin_ralph_ralph-github__*` tools (cross-plugin during migration).
 
 ## Adding a new verb
 

--- a/ralph/POST_MERGE_VERIFICATION.md
+++ b/ralph/POST_MERGE_VERIFICATION.md
@@ -24,7 +24,7 @@ In Claude Code:
 /ralph:_smoke
 ```
 
-Expected behavior: the skill invokes `mcp__plugin_ralph-hero_ralph-github__get_issue` with `issue_number: 1` and returns the issue title + a "success" confirmation.
+Expected behavior: the skill invokes `mcp__plugin_ralph_ralph-github__get_issue` with `issue_number: 1` and returns the issue title + a "success" confirmation.
 
 **If the call succeeds:** cross-plugin MCP works → migration is unblocked for Plan 1.
 

--- a/ralph/hooks/hooks.json
+++ b/ralph/hooks/hooks.json
@@ -12,7 +12,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__plugin_ralph-hero_ralph-github__ralph_hero__recent_activity",
+        "matcher": "mcp__plugin_ralph_ralph-github__ralph_hero__recent_activity",
         "hooks": [
           {
             "type": "command",

--- a/ralph/hooks/scripts/__tests__/triage-no-skill-dispatch.test.sh
+++ b/ralph/hooks/scripts/__tests__/triage-no-skill-dispatch.test.sh
@@ -84,8 +84,8 @@ else
 fi
 
 # Test 4: triage + MCP tool → pass through
-code=$(RALPH_SUBCOMMAND=triage RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue","tool_input":{}}' \
-  bash "$HOOK" <<< '{"tool_name":"mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue","tool_input":{}}' 2>/dev/null; echo $?)
+code=$(RALPH_SUBCOMMAND=triage RALPH_COMMAND=caretake RALPH_HOOK_INPUT='{"tool_name":"mcp__plugin_ralph_ralph-github__ralph_hero__get_issue","tool_input":{}}' \
+  bash "$HOOK" <<< '{"tool_name":"mcp__plugin_ralph_ralph-github__ralph_hero__get_issue","tool_input":{}}' 2>/dev/null; echo $?)
 if [[ "$code" == "0" ]]; then
   pass "RALPH_SUBCOMMAND=triage + MCP get_issue tool → exit 0"
 else

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -13,11 +13,11 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/branch-gate.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__get_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-estimate-gate.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__create_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-size-gate.sh"
@@ -26,15 +26,15 @@ hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/triage-no-skill-dispatch.sh"
   PostToolUse:
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__get_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-estimate-gate.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__add_sub_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/split-verify-sub-issue.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__save_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/triage-state-gate.sh"
@@ -66,19 +66,19 @@ allowed-tools:
   - TaskGet
   - AskUserQuestion
   - PushNotification
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__project_hygiene
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__archive_items
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__capture_snapshot
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__metrics_trends
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph_ralph-github__ralph_hero__project_hygiene
+  - mcp__plugin_ralph_ralph-github__ralph_hero__archive_items
+  - mcp__plugin_ralph_ralph-github__ralph_hero__capture_snapshot
+  - mcp__plugin_ralph_ralph-github__ralph_hero__metrics_trends
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall

--- a/ralph/skills/catch-up/SKILL.md
+++ b/ralph/skills/catch-up/SKILL.md
@@ -12,11 +12,11 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__recent_activity
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__next_actions
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_status_update
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__metrics_trends
+  - mcp__plugin_ralph_ralph-github__ralph_hero__recent_activity
+  - mcp__plugin_ralph_ralph-github__ralph_hero__next_actions
+  - mcp__plugin_ralph_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_status_update
+  - mcp__plugin_ralph_ralph-github__ralph_hero__metrics_trends
 ---
 
 # /ralph:catch-up — Orientation

--- a/ralph/skills/form/SKILL.md
+++ b/ralph/skills/form/SKILL.md
@@ -19,13 +19,13 @@ allowed-tools:
   - AskUserQuestion
   - WebSearch
   - WebFetch
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
 ---
 
 # /ralph:form — Intake

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -21,13 +21,13 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopilot-wakeup-clear.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__save_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hero-state-gate.sh"
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pr-drain-state-gate.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__advance_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hero-state-gate.sh"
@@ -61,20 +61,20 @@ allowed-tools:
   - AskUserQuestion
   - PushNotification
   - ScheduleWakeup
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__detect_stream_positions
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__next_actions
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__advance_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__remove_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__decompose_feature
+  - mcp__plugin_ralph_ralph-github__ralph_hero__detect_stream_positions
+  - mcp__plugin_ralph_ralph-github__ralph_hero__next_actions
+  - mcp__plugin_ralph_ralph-github__ralph_hero__pipeline_dashboard
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome

--- a/ralph/skills/impl/SKILL.md
+++ b/ralph/skills/impl/SKILL.md
@@ -24,7 +24,7 @@ hooks:
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/impl-plan-required.sh"
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/impl-worktree-gate.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__save_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/impl-state-gate.sh"
@@ -67,11 +67,11 @@ allowed-tools:
   - WebSearch
   - WebFetch
   - AskUserQuestion
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -36,7 +36,7 @@ hooks:
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/review-plan-gate.sh"
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__save_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/plan-state-gate.sh"
@@ -82,17 +82,17 @@ allowed-tools:
   - AskUserQuestion
   - WebSearch
   - WebFetch
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_sub_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_dependencies
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_sub_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__remove_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_dependencies
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__decompose_feature
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -21,7 +21,7 @@ hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=research"
   PostToolUse:
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__get_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/research-state-gate.sh"
@@ -47,12 +47,12 @@ allowed-tools:
   - AskUserQuestion
   - WebSearch
   - WebFetch
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__add_dependency
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__remove_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph_ralph-github__ralph_hero__add_dependency
+  - mcp__plugin_ralph_ralph-github__ralph_hero__remove_dependency
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_recall
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse

--- a/ralph/skills/review/SKILL.md
+++ b/ralph/skills/review/SKILL.md
@@ -9,7 +9,7 @@ hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-skill-env.sh RALPH_COMMAND=review RALPH_VALID_OUTPUT_STATES='In Review,Done,Human Needed'"
   PreToolUse:
-    - matcher: "mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue|mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue"
+    - matcher: "mcp__plugin_ralph_ralph-github__ralph_hero__save_issue|mcp__plugin_ralph_ralph-github__ralph_hero__advance_issue"
       hooks:
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/merge-state-gate.sh"
@@ -36,13 +36,13 @@ allowed-tools:
   - Agent
   - Monitor
   - AskUserQuestion
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_sub_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_dependencies
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__save_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__advance_issue
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_comment
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_sub_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_dependencies
+  - mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__advance_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
   - mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_record_outcome
 ---
 

--- a/ralph/skills/setup/SKILL.md
+++ b/ralph/skills/setup/SKILL.md
@@ -15,13 +15,13 @@ allowed-tools:
   - Edit
   - Bash
   - AskUserQuestion
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__health_check
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__get_project
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__setup_project
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__pipeline_dashboard
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__list_issues
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__decompose_feature
-  - mcp__plugin_ralph-hero_ralph-github__ralph_hero__create_issue
+  - mcp__plugin_ralph_ralph-github__ralph_hero__health_check
+  - mcp__plugin_ralph_ralph-github__ralph_hero__get_project
+  - mcp__plugin_ralph_ralph-github__ralph_hero__setup_project
+  - mcp__plugin_ralph_ralph-github__ralph_hero__pipeline_dashboard
+  - mcp__plugin_ralph_ralph-github__ralph_hero__list_issues
+  - mcp__plugin_ralph_ralph-github__ralph_hero__decompose_feature
+  - mcp__plugin_ralph_ralph-github__ralph_hero__create_issue
 ---
 
 # /ralph:setup — One-time setup in one verb

--- a/ralph/skills/shared/__tests__/mcp-prefix.test.sh
+++ b/ralph/skills/shared/__tests__/mcp-prefix.test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# mcp-prefix.test.sh — Guard: assert zero stale mcp__plugin_ralph-hero_ralph-github
+#                       references in ralph/ and that every hooks.json matcher
+#                       tool-prefix maps to a tool the MCP server registers.
+# Usage: bash ralph/skills/shared/__tests__/mcp-prefix.test.sh
+# Exit 0 = all pass; exit 1 = at least one failure.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+# Locate repo root from this script's location (ralph/skills/shared/__tests__)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+RALPH_DIR="${REPO_ROOT}/ralph"
+HOOKS_JSON="${RALPH_DIR}/hooks/hooks.json"
+MCP_JSON="${RALPH_DIR}/.mcp.json"
+MCP_SERVER_SRC="${REPO_ROOT}/plugin/ralph-hero/mcp-server/src"
+
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; echo "      expected: $2"; echo "      got:      $3"; FAIL=$((FAIL + 1)); }
+
+# ── 1. Zero stale prefix occurrences in ralph/ ──────────────────────────────
+
+# Exclude this test file itself — it necessarily references the old prefix as a literal string.
+THIS_FILE="$(realpath "${BASH_SOURCE[0]}")"
+# Build the search pattern via variable to avoid this script self-matching.
+OLD_PREFIX="mcp__plugin_ralph-hero_ralph-github"
+stale_count=$(grep -rn "$OLD_PREFIX" "${RALPH_DIR}/" 2>/dev/null \
+  | grep -v "^${THIS_FILE}:" | wc -l | tr -d ' ')
+if [[ "$stale_count" -eq 0 ]]; then
+  ok "zero stale ${OLD_PREFIX} references in ralph/ (excluding this test file)"
+else
+  fail "zero stale ${OLD_PREFIX} references in ralph/" \
+    "0" \
+    "${stale_count} occurrence(s)"
+  # Print offending lines to aid debugging
+  grep -rn "$OLD_PREFIX" "${RALPH_DIR}/" 2>/dev/null \
+    | grep -v "^${THIS_FILE}:" | head -20 >&2
+fi
+
+# ── 2. ralph/.mcp.json exists and is valid JSON ──────────────────────────────
+
+if [[ -f "$MCP_JSON" ]]; then
+  ok "ralph/.mcp.json exists"
+else
+  fail "ralph/.mcp.json exists" "file present" "not found at ${MCP_JSON}"
+fi
+
+if [[ -f "$MCP_JSON" ]]; then
+  if python3 -c "import json, sys; json.load(open('${MCP_JSON}'))" 2>/dev/null; then
+    ok "ralph/.mcp.json is valid JSON"
+  elif command -v node >/dev/null 2>&1 && node -e "JSON.parse(require('fs').readFileSync('${MCP_JSON}','utf8'))" 2>/dev/null; then
+    ok "ralph/.mcp.json is valid JSON"
+  else
+    fail "ralph/.mcp.json is valid JSON" "valid JSON" "parse error"
+  fi
+fi
+
+# ── 3. ralph/.mcp.json registers server key "ralph-github" ──────────────────
+
+if [[ -f "$MCP_JSON" ]]; then
+  if grep -q '"ralph-github"' "$MCP_JSON"; then
+    ok "ralph/.mcp.json registers server key ralph-github"
+  else
+    fail "ralph/.mcp.json registers server key ralph-github" \
+      '"ralph-github" present' "not found in .mcp.json"
+  fi
+fi
+
+# ── 4. Every hooks.json matcher tool-prefix maps to a registered server tool ─
+#
+# Extract tool names from matcher values that start with the new prefix.
+# Pipe-separated matchers (e.g., "tool_a|tool_b") are split on |.
+# Strip the prefix to get the bare tool name, then check it exists in
+# the MCP server source (non-debug tools in src/tools/*.ts).
+
+if [[ ! -f "$HOOKS_JSON" ]]; then
+  fail "hooks.json exists" "file present" "not found at ${HOOKS_JSON}"
+else
+  ok "hooks.json exists"
+
+  # Collect registered tool names from MCP server source (non-debug tools)
+  registered_tools=""
+  if [[ -d "$MCP_SERVER_SRC/tools" ]]; then
+    registered_tools=$(grep -rh '"ralph_hero__' "${MCP_SERVER_SRC}/tools/" 2>/dev/null \
+      | grep -oE '"ralph_hero__[a-zA-Z0-9_]+"' \
+      | tr -d '"' \
+      | sort -u)
+  fi
+
+  # Also include health_check which is registered directly in index.ts
+  if [[ -f "${MCP_SERVER_SRC}/index.ts" ]]; then
+    index_tools=$(grep -oE '"ralph_hero__[a-zA-Z0-9_]+"' "${MCP_SERVER_SRC}/index.ts" 2>/dev/null \
+      | tr -d '"' \
+      | sort -u)
+    registered_tools=$(printf '%s\n%s' "$registered_tools" "$index_tools" | sort -u)
+  fi
+
+  # Extract all tool names from matcher fields in hooks.json
+  # Matchers can be pipe-joined: "toolA|toolB"
+  matcher_tools=$(grep -oE '"mcp__plugin_ralph_ralph-github__[a-zA-Z0-9_|]+"' "$HOOKS_JSON" \
+    | tr -d '"' \
+    | tr '|' '\n' \
+    | grep '^mcp__plugin_ralph_ralph-github__' \
+    | sed 's/^mcp__plugin_ralph_ralph-github__//' \
+    | sort -u)
+
+  # Also sweep SKILL.md files for PreToolUse/PostToolUse matchers
+  skill_matcher_tools=$(grep -rh 'matcher.*mcp__plugin_ralph_ralph-github' "${RALPH_DIR}/" 2>/dev/null \
+    | grep -oE 'mcp__plugin_ralph_ralph-github__[a-zA-Z0-9_|]+' \
+    | tr '|' '\n' \
+    | grep '^mcp__plugin_ralph_ralph-github__' \
+    | sed 's/^mcp__plugin_ralph_ralph-github__//' \
+    | sort -u)
+
+  # Combine both sources
+  all_matcher_tools=$(printf '%s\n%s' "$matcher_tools" "$skill_matcher_tools" | sort -u | grep -v '^$')
+
+  if [[ -z "$all_matcher_tools" ]]; then
+    # No MCP matchers in hooks.json/SKILL files — that's valid (only one in hooks.json now)
+    ok "no MCP tool matchers found (skipping matcher/tool correspondence check)"
+  else
+    while IFS= read -r tool; do
+      [[ -z "$tool" ]] && continue
+      if echo "$registered_tools" | grep -qx "$tool"; then
+        ok "hooks.json/SKILL matcher tool registered in MCP server: ${tool}"
+      else
+        fail "hooks.json/SKILL matcher tool registered in MCP server: ${tool}" \
+          "tool ${tool} found in server source" \
+          "NOT found — possible typo or missing registration"
+      fi
+    done <<< "$all_matcher_tools"
+  fi
+fi
+
+# ── 5. New prefix is present (forward-presence sanity check) ─────────────────
+
+new_prefix_count=$(grep -rn 'mcp__plugin_ralph_ralph-github' "${RALPH_DIR}/" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$new_prefix_count" -gt 0 ]]; then
+  ok "new prefix mcp__plugin_ralph_ralph-github is present in ralph/ (${new_prefix_count} occurrences)"
+else
+  fail "new prefix present in ralph/" "at least 1 occurrence" "0 occurrences found"
+fi
+
+# ── summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Phase 1 of epic #1430 (ralph self-containment). Adds `ralph/.mcp.json` (server `ralph-github`, `npx -y ralph-hero-mcp-server@2.5.186`), sweeps the project-tool prefix `mcp__plugin_ralph-hero_ralph-github__` → `mcp__plugin_ralph_ralph-github__` across 13 files in `ralph/` (91 occurrences), and adds guard test `ralph/skills/shared/__tests__/mcp-prefix.test.sh`. `plugin/ralph-hero/` is untouched (keeps working during the parallel period).

## Plan

[ralph self-containment and ralph-hero deletion](https://github.com/cdubiel08/ralph-hero/blob/feature/GH-1431/thoughts/shared/plans/2026-05-25-ralph-self-containment-and-ralph-hero-deletion.md) § Phase 1.

## Test plan

- [x] Guard test: `ralph/skills/shared/__tests__/mcp-prefix.test.sh` — 12/12 assertions pass
- [x] Prefix sweep verification: `grep -rn 'ralph-hero_ralph-github' ralph/` returns zero matches
- [x] Existing ralph tests green: 8 existing shell tests pass

**Note:** One existing test (`ralph/.../loop-continuation.test.sh`) has a single pre-existing failure (`hero:auto` bucketed in `DRAIN_MODES` vs `NEVER_TERMINATE_MODES`) that predates this branch and is out of scope for GH-1431 (not introduced by this PR).

Closes #1431
