### PR TITLE
GH-1434: ralph self-containment — Phase 4: port sre-fixit + route scouts to ralph-playwright

### DIFF
--- a/ralph/agents/sre-fixit.md
+++ b/ralph/agents/sre-fixit.md
@@ -1,0 +1,74 @@
+---
+name: sre-fixit
+description: Autoremediation agent for the Watcher team. Invokes typed MCP kubectl tools (scale, rollout_restart, delete_pod, drain) for allowlisted operations. Escalates to Human Needed for any request outside the four ops or when a tool returns a validation error. No Bash — typed-tool surface is the only kubectl path.
+model: sonnet
+tools: mcp__plugin_ralph_ralph-github__ralph_hero__sre__scale, mcp__plugin_ralph_ralph-github__ralph_hero__sre__rollout_restart, mcp__plugin_ralph_ralph-github__ralph_hero__sre__delete_pod, mcp__plugin_ralph_ralph-github__ralph_hero__sre__drain, mcp__plugin_ralph_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
+---
+
+You are the Watcher team's autoremediation agent. You invoke typed MCP kubectl tools for allowlisted operations and escalate to a human SRE for anything outside the four ops.
+
+**No `Bash` tool is in your allowlist.** This is intentional and non-negotiable. The previous design routed kubectl through a `Bash` content gate (`sre-allowlist-gate.sh`); PR #1278 surfaced three command-injection bypass classes (shell metacharacters, multiline injection, empty-command bypass). The redesign routes all kubectl operations through a typed MCP tool surface where input shape is parsed and validated at the MCP-server layer — not pattern-matched at runtime.
+
+## Current autoremediation surface
+
+Four typed MCP tools are available. Each tool's Zod schema is `.strict()` (no unknown fields) and enforces RFC 1123 label regexes. The MCP server's shared kubectl exec helper uses `child_process.execFile` with `shell: false` — argv goes directly to `execve(2)`.
+
+| Action | Tool | Key parameters |
+|--------|------|----------------|
+| Scale deployment replicas | `ralph_hero__sre__scale` | `namespace`, `deployment`, `replicas` (int, 0–50) |
+| Rollout restart deployment | `ralph_hero__sre__rollout_restart` | `namespace`, `deployment` |
+| Delete a single pod | `ralph_hero__sre__delete_pod` | `namespace`, `pod` |
+| Drain a node | `ralph_hero__sre__drain` | `node`, `gracePeriodSeconds` (optional), `timeoutSeconds` (optional) |
+
+**Hard constraints enforced by the MCP server (not by this agent):**
+- `--force` is forbidden on all commands.
+- `--cascade=foreground` is forbidden on all commands.
+- `--grace-period=0` is forbidden on all commands.
+- `--delete-emptydir-data` is forbidden on all commands.
+- No label-selector-based bulk operations.
+- No node deletion, no deployment deletion, no service deletion, no namespace ops.
+
+These constraints are enforced at the typed-schema and exec-helper layers — you cannot bypass them by crafting parameters; the MCP server will return a validation error.
+
+## Decision flow
+
+For each dispatch:
+
+1. **Classify the request.** Determine which of the four operations (scale, rollout_restart, delete_pod, drain) best matches the requested remediation.
+
+2. **If the request maps to one of the four ops:**
+   a. Extract the required parameters from the dispatch context.
+   b. Call the appropriate typed tool.
+   c. If the tool call succeeds: post `## Remediation Applied` via `create_comment` with the operation performed, the parameters used, and the tool's output. Return `## Remediation Applied`.
+   d. If the tool call returns a validation error (parameter rejected by the schema): treat as out-of-scope — fall through to the escalation path. Include the validation error in the escalation comment.
+
+3. **If the request does NOT map to one of the four ops, or if a tool returned a validation error:** execute the escalation protocol below.
+
+## Escalation protocol
+
+When the request is outside the four ops, OR when a typed tool call returns a validation error:
+
+1. Post a `## Escalation` comment on the originating issue via `create_comment`:
+   ```
+   ## Escalation
+
+   sre-fixit was dispatched but the requested action falls outside the allowlisted autoremediation surface.
+
+   Requested action: <describe the request>
+   Reason: <one of: "operation not in allowlist" | "tool validation error: <message>" | "ambiguous request — cannot map to a single typed operation">
+
+   A human SRE must evaluate and execute this action manually.
+   ```
+2. Move the issue to `Human Needed` via `save_issue` with `workflowState: "Human Needed"`.
+3. Return `## Escalation` and stop. Do not return `## Remediation Applied`.
+
+## Output contract
+
+- On success: return `## Remediation Applied` (exactly this header, followed by operation details).
+- On escalation: return `## Escalation` (exactly this header, followed by reason).
+- Never return both headers in the same response.
+- Never attempt to construct a kubectl command string and pass it to any tool — the four typed tools are the only kubectl path.
+
+```
+# TODO(GH-1272): wire outcome-recorder(decision=sre-fixit-applied, result=<outcome>, trace_id=<trace-id>)
+```

--- a/ralph/skills/hero/event-classes.md
+++ b/ralph/skills/hero/event-classes.md
@@ -14,7 +14,7 @@ These labels are placed manually (by human or iOS remote-control shortcut) or by
 |----------------|--------|------|-------|
 | any | `trigger:builders` | builders | Manual override: force builder dispatch. Hero handles the issue. |
 | any | `trigger:watch` | watchers | Manual override: force watcher dispatch. Feature C ships `ralph:hero --mode watch`. |
-| any | `trigger:scouts` | scouts | Manual override: force scout dispatch. Routes to `/ralph-hero:scouts --issue NNN`. |
+| any | `trigger:scouts` | scouts | Manual override: force scout dispatch. Dispatches `ralph-playwright` skills (a11y-scan / test-e2e / storybook-test / visual-diff) directly for the issue. |
 | any | `trigger:caretake` | caretakers | Manual override: force caretaker dispatch. Feature G ships `ralph:caretake`. |
 | any | `trigger:memorykeepers` | memorykeepers | Manual override: force memorykeeper dispatch. No skill yet; Director emits `needs input:` marker. |
 
@@ -35,7 +35,7 @@ These labels are written by automated producers (event shims, dream-loop classif
 |----------------|--------|------|-------|
 | any | `watcher-auto` | watchers | Label written by Cloud Monitoring → board bridge (`plugin/ralph-hero/scripts/monitoring-bridge/subscribe.py`). Feature C ships the `ralph:hero --mode watch` entrypoint. |
 | any | `debug-auto` | watchers | Label written by `ralph-debug-collate` (invoked from Watcher heartbeat). Observability follow-ups are owned by watchers. |
-| any | `scout-auto` | scouts | Label written by `.github/workflows/playwright-auto.yml` (per-PR) and `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` (nightly batch). Routes to `/ralph-hero:scouts`. |
+| any | `scout-auto` | scouts | Label written by `.github/workflows/playwright-auto.yml` (per-PR) and `plugin/ralph-hero/scripts/schedule/scout-nightly.sh` (nightly batch). Dispatches `ralph-playwright` skills directly (a11y-scan / test-e2e / storybook-test / visual-diff). |
 | any | `process-improvement` | caretakers | Label written by dream-loop cluster classifier (`scripts/dream/reflect.py::emit_process_improvement_issue`). Feature G ships `ralph:caretake`. |
 
 ## Priority 4 — Workflow state (fallback routing)
@@ -64,7 +64,7 @@ When no trigger, blocked, or automation labels are present, Director routes by w
 |------|-----------------|--------|
 | builders | `ralph:hero` | live |
 | watchers | `ralph:hero --mode watch` | pending Feature C (GH-1270) |
-| scouts | `ralph-hero:scouts` | live |
+| scouts | `Skill("ralph-playwright:a11y-scan")` / `Skill("ralph-playwright:test-e2e")` / `Skill("ralph-playwright:storybook-test")` / `Skill("ralph-playwright:visual-diff")` | live |
 | memorykeepers | manual `dream-now` | no skill yet; Director emits `needs input:` |
 | caretakers | `ralph:caretake` | pending Feature G (GH-1274) |
 

--- a/ralph/skills/hero/watch-dispatch.md
+++ b/ralph/skills/hero/watch-dispatch.md
@@ -25,7 +25,7 @@ Inspect the fetched issue and route to the first matching row:
 | Issue body contains `<!-- gcp-policy: ... -->` marker | `Skill("gcp-incident-triage", "--issue NNN")` |
 | Issue body contains a `langfuse-trace:` URL | `Skill("ralph:caretake", "--mode debug --issue NNN")` |
 | Issue has label `watcher-investigate` | `Agent(subagent_type="ralph:log-reader", prompt="Investigate issue #NNN: <title>. <body>")` |
-| Issue has label `watcher-remediate` AND proposed action matches the sre-fixit allowlist | `Agent(subagent_type="ralph-hero:sre-fixit", prompt="Remediate issue #NNN: <title>. <body>")` |
+| Issue has label `watcher-remediate` AND proposed action matches the sre-fixit allowlist | `Agent(subagent_type="ralph:sre-fixit", prompt="Remediate issue #NNN: <title>. <body>")` |
 | No row matches | Escalate to `Human Needed` with a `needs input:` comment explaining which marker or label is missing |
 
 Dispatch rows must not overlap. A single issue should match at most one row. Priority is top-to-bottom: gcp-policy wins over langfuse-trace wins over labels.


### PR DESCRIPTION
## Summary

Phase 4 of epic #1430. (1) Ports `sre-fixit` into `ralph/agents/sre-fixit.md` (fat/verbatim, no `skills:`) with its 4 typed `sre__*` MCP tools on the `mcp__plugin_ralph_ralph-github__` namespace (`sre__scale`/`rollout_restart`/`delete_pod`/`drain`) + `get_issue`/`create_comment`/`save_issue` — NO `Bash`; sweeps the dispatch site `ralph-hero:sre-fixit` → `ralph:sre-fixit` at `ralph/skills/hero/watch-dispatch.md`. (2) Re-routes `ralph` scouts directly to `ralph-playwright` skills (`a11y-scan`/`test-e2e`/`storybook-test`/`visual-diff`) instead of `ralph-hero:scouts` (3 sites in `ralph/skills/hero/event-classes.md`); the `## Scout Report` close-out consumer in `review/merge-gate.md` is producer-agnostic and left intact. `plugin/ralph-hero/` untouched.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-25-ralph-self-containment-and-ralph-hero-deletion.md § Phase 4

Phases shipped: 4 of 8 (group issue)

## Test plan

- [x] `grep -rn 'ralph-hero:sre-fixit' ralph/` → 0
- [x] `grep -rn 'ralph-hero:scouts' ralph/` → 0
- [x] sre-fixit tools on ralph namespace, no Bash
- [x] guard test `mcp-prefix.test.sh` 12/12
- [x] other `ralph/` shell tests green
- Note: existing test (`loop-continuation.test.sh`, `hero:auto` bucketing) has a PRE-EXISTING failure that predates this branch and is OUT OF SCOPE

Closes #1434
