### PR TITLE
GH-1389: Document knowledge_expert domain-extraction heuristic

### DIFF
--- a/ralph/skills/research/research-shapes.md
+++ b/ralph/skills/research/research-shapes.md
@@ -44,6 +44,14 @@ Use results to:
 
 If knowledge tools return zero results, broaden search terms (remove qualifiers, drop component prefixes), then fall back to `thoughts-locator` filesystem scan. Do NOT skip sub-agent dispatch on the basis of an empty knowledge result alone — the graph may be stale or sparsely indexed.
 
+### Picking the `domain` parameter
+
+`knowledge_expert(domain=...)` (autonomous mode) needs a `domain` string. Derive it with this three-priority heuristic — first match wins:
+
+1. **Issue label match** — if the issue carries a label that maps to a known domain / component area, use that label as the `domain`.
+2. **Noun-phrase extraction** — else extract the dominant noun phrase from the issue title and use it as the `domain`.
+3. **Skip** — if neither yields a usable domain, omit the `knowledge_expert` call entirely (consistent with the "no domain extractable → skip silently" row in § Graceful degradation). The tool tolerates a loose/missing domain, but skipping is cleaner than passing noise.
+
 ## Cross-repo addendum
 
 If `.ralph-repos.yml` exists at the repo root, the issue may span multiple repos. Read the file (via `Read`, not `decompose_feature`) and parse the YAML for `localDir` paths and `pattern` definitions.

--- a/thoughts/shared/plans/2026-05-26-GH-1389-knowledge-expert-domain-heuristic.md
+++ b/thoughts/shared/plans/2026-05-26-GH-1389-knowledge-expert-domain-heuristic.md
@@ -70,9 +70,9 @@ Document the three-priority `domain` heuristic in `research-shapes.md` so the sl
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `grep -nE 'Picking the .domain. parameter' ralph/skills/research/research-shapes.md` returns 1 match.
-- [ ] `grep -ciE 'label match|noun.?phrase|skip' ralph/skills/research/research-shapes.md` shows the three priorities present.
-- [ ] `bash ralph/skills/shared/__tests__/*.test.sh` and `bash ralph/hooks/scripts/__tests__/*.test.sh` pass.
+- [x] `grep -cE 'Picking the .domain. parameter' ralph/skills/research/research-shapes.md` returns `1`.
+- [x] `grep -cE 'Issue label match|Noun-phrase extraction' ralph/skills/research/research-shapes.md` returns `2` (falsifiable priority-presence check — replaces the original loose `|skip` count per plan-review GAP).
+- [x] `bash ralph/hooks/scripts/__tests__/*.test.sh` all pass; `bash ralph/skills/shared/__tests__/*.test.sh` introduces no new failures (only the unchanged pre-existing out-of-scope `hero:auto` failure in `loop-continuation.test.sh`, which this change does not touch).
 
 #### Manual Verification
 - [ ] The subsection reads naturally in context and cross-references the § Graceful degradation skip fallback.


### PR DESCRIPTION
## Summary

Documents the `knowledge_expert` `domain`-extraction heuristic in `ralph/skills/research/research-shapes.md`, closing a slim-restructure discoverability gap. Adds a `### Picking the domain parameter` subsection to § Knowledge-graph dispatch shape with the three-priority rule — (1) issue **label** match, (2) **noun-phrase** extraction from the title, (3) **skip** (consistent with the existing § Graceful degradation "skip silently" fallback). The rule previously lived only in the now-deleted `plugin/ralph-hero/skills/ralph-research/SKILL.md`. Doc-only — no code, no behavior change (the tool already tolerates a loose/missing `domain`).

## Plan

[`thoughts/shared/plans/2026-05-26-GH-1389-knowledge-expert-domain-heuristic.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-26-GH-1389-knowledge-expert-domain-heuristic.md) — reviewed APPROVED (1 non-blocking GAP on a verification command, addressed by using a falsifiable check).

## Test plan

- [x] `grep -cE 'Picking the .domain. parameter' research-shapes.md` → 1
- [x] `grep -cE 'Issue label match|Noun-phrase extraction' research-shapes.md` → 2 (falsifiable priority-presence check)
- [x] `ralph/hooks/scripts/__tests__/*.test.sh` all pass; shared suite introduces no new failures (the lone `hero:auto` failure in `loop-continuation.test.sh` is pre-existing, out of scope, not CI-gated, and untouched by this PR).

Closes #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
