### PR TITLE
GH-1452: Fix agent-roster drift + factual errors in README.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ mcp-server/              # TypeScript MCP server (published as ralph-hero-mcp-se
 ralph/                   # Main plugin — 9 fat skills, 16 agents, hooks
 ├── skills/              # 9 verb skills (catch-up, form, research, plan, impl, review, caretake, hero, setup)
 │   └── shared/          # Shared references: loop-wrapper, auto-alias, mcp-prefix guard
-├── agents/              # 16 agents (8 thin per-phase + 8 fat investigators)
+├── agents/              # 16 agents (8 per-phase + 8 investigators)
 ├── hooks/               # Lifecycle enforcement hooks
 └── .claude-plugin/      # Plugin manifest + .mcp.json pin
 plugin/
@@ -73,9 +73,9 @@ plugin/
 
 ### ralph Plugin — 16 Agents
 
-**8 thin per-phase agents** (in `ralph/agents/`): `impl-agent`, `plan-agent`, `research-agent`, `review-agent`, `merge-agent`, `catch-up-agent`, `caretake-agent`, `form-agent`
+**8 per-phase agents** (in `ralph/agents/`): `catch-up-agent`, `impl-agent`, `merge-agent`, `plan-agent`, `research-agent`, `review-agent`, `triage-agent`, `val-agent`
 
-**8 fat investigators** (in `ralph/agents/`): `codebase-locator`, `plan-investigator`, `research-investigator`, `impl-investigator`, `review-investigator`, `caretake-investigator`, `hero-investigator`, `scout-agent`
+**8 investigators** (in `ralph/agents/`): `codebase-analyzer`, `codebase-locator`, `codebase-pattern-finder`, `log-reader`, `sre-fixit`, `thoughts-analyzer`, `thoughts-locator`, `web-search-researcher`
 
 On `IMPL BLOCKED needs=opus` verdict, the hero re-dispatches `impl-agent` once at `model="opus"`. Override default models via `RALPH_IMPL_MODEL`, `RALPH_SPLIT_MODEL`.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each transition is enforced by hooks and validated by the MCP server. Issues flo
 ### Prerequisites
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI
-- Node.js 18+
+- Node.js 20+
 - A GitHub Personal Access Token with `repo` and `project` scopes
 
 ### Install the Plugin
@@ -74,7 +74,7 @@ If you're using explicit `RALPH_GH_REPO_TOKEN` / `RALPH_GH_PROJECT_TOKEN` / `RAL
 | `/ralph:plan` | Create or review an implementation plan |
 | `/ralph:impl` | Implement an approved plan in an isolated worktree |
 | `/ralph:review` | Validate implementation or review a plan |
-| `/ralph:caretake` | Triage, hygiene, unblock, trends, split |
+| `/ralph:caretake` | Triage, hygiene, unblock, trends, split, debug, report |
 | `/ralph:catch-up` | Session orientation — narrative, dashboard, or status report |
 | `/ralph:form` | Crystallize ideas into structured GitHub issues |
 | `/ralph:setup` | One-time project board setup |
@@ -84,6 +84,8 @@ If you're using explicit `RALPH_GH_REPO_TOKEN` / `RALPH_GH_PROJECT_TOKEN` / `RAL
 The plugin bundles an MCP server ([`ralph-hero-mcp-server`](https://www.npmjs.com/package/ralph-hero-mcp-server)) that provides GitHub Projects V2 tools to Claude Code via the [Model Context Protocol](https://modelcontextprotocol.io/).
 
 ### Tools
+
+The MCP server registers ~38 `ralph_hero__*` tools; the table below is a curated subset of the most-used ones (issue/project CRUD, relationships, dashboards, trends). Additional tools include draft-issue CRUD, `decompose_feature`, `archive_items`, `create_views`, `sync_plan_graph`, `detect_stream_positions`, `remove_dependency`, and the `sre__*` autoremediation set; debug tools register only when `RALPH_DEBUG=true`.
 
 | Tool | Description |
 |------|-------------|

--- a/thoughts/shared/plans/2026-05-26-GH-1452-readme-claude-roster-drift.md
+++ b/thoughts/shared/plans/2026-05-26-GH-1452-readme-claude-roster-drift.md
@@ -74,12 +74,12 @@ Rewrite `CLAUDE.md` § "ralph Plugin — 16 Agents" + the `agents/` tree-comment
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `grep -nE 'caretake-agent|form-agent|plan-investigator|research-investigator|impl-investigator|review-investigator|caretake-investigator|hero-investigator|scout-agent' CLAUDE.md` returns no hits.
-- [ ] `for a in triage-agent val-agent codebase-analyzer codebase-pattern-finder log-reader sre-fixit thoughts-analyzer thoughts-locator web-search-researcher; do grep -q "$a" CLAUDE.md || echo "MISSING $a"; done` prints nothing.
-- [ ] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass (no regression).
+- [x] `grep -nE 'caretake-agent|form-agent|plan-investigator|research-investigator|impl-investigator|review-investigator|caretake-investigator|hero-investigator|scout-agent' CLAUDE.md` returns no hits.
+- [x] `for a in triage-agent val-agent codebase-analyzer codebase-pattern-finder log-reader sre-fixit thoughts-analyzer thoughts-locator web-search-researcher; do grep -q "$a" CLAUDE.md || echo "MISSING $a"; done` prints nothing.
+- [x] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass (no regression).
 
 #### Manual Verification
-- [ ] The roster section reads correctly and the 8/8 split matches `ls ralph/agents/`.
+- [x] The roster section reads correctly and the 8/8 split matches `ls ralph/agents/`.
 
 ## Phase 2: Correct README.md roster, Node version, caretake row, MCP table
 depends_on: null
@@ -98,12 +98,12 @@ Align `README.md` with reality: agents block, Node version, caretake skill-modes
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `grep -n 'Node.js 18' README.md` returns no hits.
-- [ ] `grep -nE 'plan-investigator|hero-investigator|scout-agent|caretake-agent|form-agent' README.md` returns no hits.
-- [ ] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass.
+- [x] `grep -n 'Node.js 18' README.md` returns no hits.
+- [x] `grep -nE 'plan-investigator|hero-investigator|scout-agent|caretake-agent|form-agent' README.md` returns no hits.
+- [x] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass.
 
 #### Manual Verification
-- [ ] README agents block, caretake-modes row, and MCP-tool table match reality (cross-checked against `ls ralph/agents/`, CLAUDE.md, and `mcp-server/src/tools/`).
+- [x] README agents block, caretake-modes row, and MCP-tool table match reality (cross-checked against `ls ralph/agents/`, CLAUDE.md, and `mcp-server/src/tools/`).
 
 ## Testing Strategy
 


### PR DESCRIPTION
## Summary

Corrects agent-roster drift and factual errors in the canonical docs (epic #1459, Documentation hardening). The GH-1438 rewrite left `CLAUDE.md`/`README.md` naming 9 agents that don't exist and omitting 8 that do — actively misleading every human and Claude session that loads these files. Doc-only; no code, no behavior change.

- **CLAUDE.md** § "16 Agents": rewritten to match `ralph/agents/` exactly — per-phase (8): `catch-up/impl/merge/plan/research/review/triage/val`; investigators (8): `codebase-analyzer/codebase-locator/codebase-pattern-finder/log-reader/sre-fixit/thoughts-analyzer/thoughts-locator/web-search-researcher`. Removed all 9 phantoms (`caretake-agent`, `form-agent`, `*-investigator`, `scout-agent`); fixed the `agents/` tree-comment.
- **README.md**: Node.js 18+ → 20+ (matches CI 20/22); caretake skill row now lists all modes (triage/hygiene/unblock/trends/split/debug/report); MCP-tool table labelled a curated subset (~38 `ralph_hero__*` tools registered; table lists the most-used ones).

## Plan

[`thoughts/shared/plans/2026-05-26-GH-1452-readme-claude-roster-drift.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-26-GH-1452-readme-claude-roster-drift.md) — reviewed APPROVED (1 non-blocking verification-symmetry GAP, addressed at impl with the full 9-name phantom grep + curated-subset note).

## Test plan

- [x] `grep -cE '<9 phantom names>' CLAUDE.md README.md` → 0 (all phantoms removed)
- [x] every real `ralph/agents/` file named in CLAUDE.md (no MISSING)
- [x] `grep -c 'Node.js 18' README.md` → 0; caretake row has debug+report; MCP curated-subset note present
- [x] `ralph/hooks/scripts/__tests__/*.test.sh` all pass

Lead child of epic #1459. Sibling #1458 (CI doc-consistency check) will guard against recurrence.

Closes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
