### PR TITLE
GH-1454: Add mcp-server/README.md for the published npm package

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,64 @@
+# ralph-hero-mcp-server
+
+MCP server for GitHub Projects V2 — the workflow-automation engine behind the [Ralph](https://github.com/cdubiel08/ralph-hero) Claude Code plugin.
+
+## What it is
+
+`ralph-hero-mcp-server` exposes [GitHub Projects V2](https://docs.github.com/en/issues/planning-and-tracking-with-projects) as a set of [Model Context Protocol](https://modelcontextprotocol.io/) tools, so an agent (Claude Code) can read and drive an issue through a workflow state machine — `Backlog → Research Needed → … → In Review → Done` — entirely through typed tool calls instead of shelling out to `gh`.
+
+It is bundled and consumed by the `ralph` Claude Code plugin (the skills call these tools), but it is a standalone stdio MCP server and can be wired into any MCP client.
+
+## Install
+
+The server is published to npm and is normally run via `npx` from an MCP client config (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ralph-github": {
+      "command": "npx",
+      "args": ["-y", "ralph-hero-mcp-server"]
+    }
+  }
+}
+```
+
+All tools are namespaced with the `ralph_hero__` prefix (e.g. `ralph_hero__get_issue`, `ralph_hero__save_issue`, `ralph_hero__next_actions`).
+
+## Configuration
+
+Configuration flows through the parent process's environment (the `.mcp.json` has **no** `env` block — do not put tokens there).
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RALPH_GH_OWNER` | Yes | GitHub owner (user or org). |
+| `RALPH_GH_PROJECT_NUMBER` | Yes | GitHub Projects V2 number. |
+| `RALPH_GH_REPO` | No | Repository name (inferred from the project if omitted). |
+| `RALPH_HERO_GITHUB_TOKEN` | No | GitHub PAT with `repo` + `project` scopes. **Falls back to `gh auth token`** when unset — so with `gh auth login -s repo,project,read:org` you usually need no token in any config. |
+| `RALPH_GH_PROJECT_OWNER` | No | Project owner, if different from the repo owner (split-owner setups). |
+
+## Tool architecture
+
+Each tool module exports a `registerXyzTools()` function that registers tools onto the MCP server. All tools use the `ralph_hero__` prefix and return via `toolSuccess()` / `toolError()`. Modules cover issues (`get_issue`, `save_issue`, `list_issues`), projects, relationships (`add_sub_issue`, `add_dependency`, `advance_issue`), dashboards (`pipeline_dashboard`, `next_actions`), trends, and more.
+
+For the full module/tool inventory and internals (GitHub client dual-endpoint design, caching, the workflow state machine), see [the repo's CLAUDE.md § "MCP Server Internals"](https://github.com/cdubiel08/ralph-hero/blob/main/CLAUDE.md#mcp-server-internals).
+
+## Build & test
+
+```bash
+npm install
+npm run build   # TypeScript -> dist/ (tsc)
+npm test        # vitest
+```
+
+The server is ESM (`"type": "module"`, `"module": "NodeNext"`) — internal imports use `.js` extensions. TypeScript strict mode is the primary quality gate (no linter).
+
+## Links
+
+- Repository: <https://github.com/cdubiel08/ralph-hero>
+- Plugin + workflow docs: <https://github.com/cdubiel08/ralph-hero/blob/main/README.md>
+- Issues: <https://github.com/cdubiel08/ralph-hero/issues>
+
+## License
+
+See the [repository](https://github.com/cdubiel08/ralph-hero).

--- a/thoughts/shared/plans/2026-05-26-GH-1454-mcp-server-readme.md
+++ b/thoughts/shared/plans/2026-05-26-GH-1454-mcp-server-readme.md
@@ -74,13 +74,13 @@ Create a concise, npm-rendering README for the `ralph-hero-mcp-server` package.
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `test -f mcp-server/README.md` succeeds.
-- [ ] `grep -c 'github.com/cdubiel08/ralph-hero' mcp-server/README.md` ≥ 1; `grep -cE '\]\(\.\.?/' mcp-server/README.md` returns 0 (no repo-relative links).
-- [ ] `grep -qE 'RALPH_GH_OWNER' mcp-server/README.md && grep -qiE 'registerXyzTools|register[A-Za-z]+Tools|ralph_hero__' mcp-server/README.md` (env vars + tool pattern covered).
-- [ ] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass (no regression).
+- [x] `test -f mcp-server/README.md` succeeds.
+- [x] `grep -c 'github.com/cdubiel08/ralph-hero' mcp-server/README.md` ≥ 1; `grep -cE '\]\(\.\.?/' mcp-server/README.md` returns 0 (no repo-relative links).
+- [x] `grep -qE 'RALPH_GH_OWNER' mcp-server/README.md && grep -qiE 'registerXyzTools|register[A-Za-z]+Tools|ralph_hero__' mcp-server/README.md` (env vars + tool pattern covered).
+- [x] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass (no regression).
 
 #### Manual Verification
-- [ ] README reads correctly as a standalone npm package page (no assumed repo-root context; all links absolute).
+- [x] README reads correctly as a standalone npm package page (no assumed repo-root context; all links absolute).
 
 ## Testing Strategy
 


### PR DESCRIPTION
## Summary

Adds `mcp-server/README.md` — the `ralph-hero-mcp-server` npm package currently renders a blank page (epic #1459, Documentation hardening). Pure additive; one new file, no code change.

The README covers: what the package is (MCP server exposing GitHub Projects V2 tools; bundled by the `ralph` plugin), install via `npx`/`.mcp.json`, required env vars (`RALPH_GH_OWNER`, `RALPH_GH_PROJECT_NUMBER`, token via `RALPH_HERO_GITHUB_TOKEN` or `gh auth` fallback), the `registerXyzTools()` tool-registration pattern + `ralph_hero__` prefix, build/test commands, and repo links — all **absolute** GitHub URLs (npm doesn't resolve repo-relative links).

`package.json` verified: README ships by default (npm always packs README regardless of `files`), `repository.directory: mcp-server` already correct — no package.json edit needed.

## Plan

[`thoughts/shared/plans/2026-05-26-GH-1454-mcp-server-readme.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-26-GH-1454-mcp-server-readme.md) — reviewed APPROVED (all 7 rubric dimensions PASS).

## Test plan

- [x] `test -f mcp-server/README.md`
- [x] `grep -c 'github.com/cdubiel08/ralph-hero' README.md` = 6; `grep -cE '\]\(\.\.?/' README.md` = 0 (no repo-relative links)
- [x] env vars (`RALPH_GH_OWNER`) + tool pattern (`registerXyzTools`/`ralph_hero__`) present
- [x] `ralph/hooks/scripts/__tests__/*.test.sh` all pass

Note: release.yml keys on `mcp-server/src/**`, so this README-only change won't trigger a publish — it ships with the next src-triggered release.

Closes #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
