### PR TITLE
GH-1455: Add plugin/ralph-demo/README.md

### DIFF
--- a/plugin/ralph-demo/README.md
+++ b/plugin/ralph-demo/README.md
@@ -1,0 +1,51 @@
+# ralph-demo
+
+Sprint-demo video generation for the [Ralph](https://github.com/cdubiel08/ralph-hero) workflow — record a live screen demo or composite a structured demo video from JSON content.
+
+## Overview
+
+`ralph-demo` is a Claude Code sub-plugin that turns sprint work into shareable demo media. It offers two complementary skills (live screen capture vs. programmatic video compositing) backed by a [Remotion](https://www.remotion.dev/) project (`remotion/`, the `demo-studio` package).
+
+Unlike the other sub-plugins, `ralph-demo` is **not** published to npm — it ships as part of this repo.
+
+## Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `record-demo` | Capture an OBS-based **live screen demo** for a GitHub issue — orchestrates `obs-cli` to record, optionally trim/thumbnail, upload, and post a `## Demo Recording` comment. Requires OBS Studio + `obs-cli` with the OBS WebSocket server running. |
+| `demo-video` | Generate a **composited sprint-demo video** with Remotion from structured content (features, screenshots, bullet points). Trigger on "demo video", "sprint recap", "presentation video". |
+
+Pick `record-demo` for a live screen-capture; pick `demo-video` to render a structured video from JSON without recording.
+
+## Architecture
+
+```
+plugin/ralph-demo/
+├── skills/
+│   ├── record-demo/    # OBS screen-capture skill
+│   └── demo-video/     # Remotion composited-video skill
+└── remotion/           # `demo-studio` — the Remotion video generator (pnpm)
+    ├── src/            # React-based video compositions
+    ├── inputs/         # JSON content fed to the compositions
+    └── remotion.config.ts
+```
+
+The `remotion/` project (`demo-studio`) is a [Remotion](https://www.remotion.dev/) app managed with **pnpm**:
+
+```bash
+cd plugin/ralph-demo/remotion
+pnpm install
+pnpm dev      # Remotion studio (preview/iterate)
+pnpm build    # render the video
+pnpm test     # vitest
+```
+
+## Usage
+
+- **Live demo:** invoke the `record-demo` skill (e.g. "record a demo for #NNN") — ensure OBS Studio + `obs-cli` + the OBS WebSocket server are running first.
+- **Composited video:** invoke the `demo-video` skill (e.g. "make a sprint demo video") — it feeds structured content (features/screenshots/bullets) into the `demo-studio` Remotion compositions and renders an MP4.
+
+## Links
+
+- Repository: <https://github.com/cdubiel08/ralph-hero>
+- Remotion docs: <https://www.remotion.dev/docs>

--- a/thoughts/shared/plans/2026-05-26-GH-1455-ralph-demo-readme.md
+++ b/thoughts/shared/plans/2026-05-26-GH-1455-ralph-demo-readme.md
@@ -69,13 +69,13 @@ Create a concise README for the `ralph-demo` sub-plugin.
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `test -f plugin/ralph-demo/README.md` succeeds.
-- [ ] `grep -qE 'record-demo' plugin/ralph-demo/README.md && grep -qE 'demo-video' plugin/ralph-demo/README.md && grep -qiE 'remotion' plugin/ralph-demo/README.md` (both skills + Remotion covered).
-- [ ] `grep -cE '\]\(\.\.?/' plugin/ralph-demo/README.md` returns 0 (no repo-relative links).
-- [ ] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass (no regression).
+- [x] `test -f plugin/ralph-demo/README.md` succeeds.
+- [x] `grep -qE 'record-demo' plugin/ralph-demo/README.md && grep -qE 'demo-video' plugin/ralph-demo/README.md && grep -qiE 'remotion' plugin/ralph-demo/README.md` (both skills + Remotion covered).
+- [x] `grep -cE '\]\(\.\.?/' plugin/ralph-demo/README.md` returns 0 (no repo-relative links).
+- [x] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass (no regression).
 
 #### Manual Verification
-- [ ] README parallels the sibling sub-plugin READMEs and accurately describes the two skills + the Remotion pipeline.
+- [x] README parallels the sibling sub-plugin READMEs and accurately describes the two skills + the Remotion pipeline.
 
 ## Testing Strategy
 


### PR DESCRIPTION
## Summary

Adds `plugin/ralph-demo/README.md` — the only sub-plugin lacking a README (siblings `ralph-knowledge` + `ralph-playwright` have them). Epic #1459 (Documentation hardening). Pure additive; one new file, no code change.

The README covers: overview (sprint-demo media), the two skills (`record-demo` = OBS live screen capture posting a `## Demo Recording` comment; `demo-video` = Remotion composited video from structured JSON), the `demo-studio`/`remotion/` pnpm architecture (`pnpm dev`/`build`/`test`), and usage. Mirrors the sibling sub-plugin README structure. Absolute repo URLs; `ralph-demo` is not npm-published.

## Plan

[`thoughts/shared/plans/2026-05-26-GH-1455-ralph-demo-readme.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-26-GH-1455-ralph-demo-readme.md) — reviewed APPROVED (all 6 applicable rubric dimensions PASS).

## Test plan

- [x] `test -f plugin/ralph-demo/README.md`
- [x] both skills (`record-demo`, `demo-video`) + `remotion` mentioned
- [x] `grep -cE '\]\(\.\.?/' README.md` = 0 (no repo-relative links)
- [x] `ralph/hooks/scripts/__tests__/*.test.sh` all pass

Closes #1455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
