### PR TITLE
GH-1456: Add CONTRIBUTING.md and CHANGELOG.md at repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this repo are recorded here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+This repo ships **two independently-versioned artifacts**, each released
+automatically on merge to `main` (see [CONTRIBUTING.md](https://github.com/cdubiel08/ralph-hero/blob/main/CONTRIBUTING.md) § Releases):
+
+- **`ralph`** — the Claude Code plugin. Tags: `ralph-vX.Y.Z` (via `release-ralph.yml`).
+- **`ralph-hero-mcp-server`** — the npm package. Tags: `vX.Y.Z` (via `release.yml`).
+
+Because releases are tag-driven and automated, this changelog is **human-maintained**:
+add entries under `## [Unreleased]` as you land user-visible changes; reconcile them
+to a version heading when that artifact next releases. Full tag history:
+<https://github.com/cdubiel08/ralph-hero/tags>.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+## Released
+
+### ralph plugin — [ralph-v0.1.32](https://github.com/cdubiel08/ralph-hero/releases/tag/ralph-v0.1.32)
+
+Latest released version of the `ralph` Claude Code plugin (9 verb skills:
+catch-up, form, research, plan, impl, review, caretake, hero, setup). This
+changelog was seeded at this version; earlier history is in the
+[git tags](https://github.com/cdubiel08/ralph-hero/tags) and release notes.
+
+### ralph-hero-mcp-server — [v2.5.191](https://github.com/cdubiel08/ralph-hero/releases/tag/v2.5.191)
+
+Latest published version of the `ralph-hero-mcp-server` npm package (GitHub
+Projects V2 workflow tools). Seeded at this version; earlier history is in the
+[git tags](https://github.com/cdubiel08/ralph-hero/tags).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to ralph-hero
+
+Thanks for contributing. This repo holds the **`ralph`** Claude Code plugin, its **`ralph-hero-mcp-server`** npm package, and a few sibling sub-plugins. This guide is the contributor entry point; deeper architecture lives in [`CLAUDE.md`](https://github.com/cdubiel08/ralph-hero/blob/main/CLAUDE.md).
+
+## Project layout
+
+```
+mcp-server/          # TypeScript MCP server, published to npm as ralph-hero-mcp-server
+ralph/               # The Claude Code plugin (9 verb skills, agents, hooks)
+plugin/
+├── ralph-knowledge/ # Semantic search over thoughts/ (MCP server)
+├── ralph-playwright/# UI-testing skills
+└── ralph-demo/      # Sprint-demo video generation (Remotion)
+```
+
+See the [README](https://github.com/cdubiel08/ralph-hero/blob/main/README.md) for the plugin's user-facing surface and [`CLAUDE.md`](https://github.com/cdubiel08/ralph-hero/blob/main/CLAUDE.md) for internals.
+
+## Dev setup
+
+The MCP server is the main build target. From `mcp-server/`:
+
+```bash
+npm install
+npm run build        # TypeScript -> dist/ (tsc)
+npm test             # vitest
+npx vitest run src/__tests__/cache.test.ts   # single test file
+```
+
+The **ralph-knowledge** plugin builds from `plugin/ralph-knowledge/` (`npm install && npm run build && npm test`).
+
+No linter is configured — TypeScript strict mode is the primary code-quality gate. The slim plugin's hook tests live in `ralph/hooks/scripts/__tests__/` (bash).
+
+## Branch & commit conventions
+
+- Branch per issue: `feature/GH-NNN`.
+- Conventional-commit style headings (`docs(...)`, `fix(...)`, `feat(...)`).
+- Open a PR against `main`; CI (`ci.yml`) runs build + test (Node 20/22), hook tests, ShellCheck, and workflow lint.
+
+## Releases (automated — do not publish manually)
+
+Releases are **fully automated** on merge to `main`; two artifacts version independently:
+
+- **`ralph-hero-mcp-server` (npm):** `release.yml` fires when a merge touches `mcp-server/src/**`. It auto-bumps `mcp-server/package.json`, publishes to npm with provenance, and pins `ralph/.mcp.json`. Tags look like `vX.Y.Z`.
+- **`ralph` plugin:** `release-ralph.yml` fires when a merge touches `ralph/**`. It bumps `ralph/.claude-plugin/plugin.json` and tags `ralph-vX.Y.Z`.
+
+Include `#minor` or `#major` in a commit message for a larger-than-patch bump.
+
+**Do NOT** run `npm publish` or push `v*` tags manually — the release workflows own both.
+
+## Changelog
+
+Releases are tag-driven and automated, so the changelog is **not** auto-generated. Add a bullet under the `## [Unreleased]` section of [`CHANGELOG.md`](https://github.com/cdubiel08/ralph-hero/blob/main/CHANGELOG.md) as you land user-visible changes; entries are reconciled to a version when that artifact releases.

--- a/thoughts/shared/plans/2026-05-26-GH-1456-contributing-changelog.md
+++ b/thoughts/shared/plans/2026-05-26-GH-1456-contributing-changelog.md
@@ -69,13 +69,13 @@ Create a contributor-facing `CONTRIBUTING.md` at repo root.
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `test -f CONTRIBUTING.md` succeeds.
-- [ ] `grep -qiE '#minor|#major' CONTRIBUTING.md && grep -qE 'mcp-server' CONTRIBUTING.md && grep -qiE 'release' CONTRIBUTING.md` (release mechanics + dev setup covered).
-- [ ] `grep -cE '\]\(\.\.?/' CONTRIBUTING.md` returns 0 (no repo-relative links).
-- [ ] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass.
+- [x] `test -f CONTRIBUTING.md` succeeds.
+- [x] `grep -qiE '#minor|#major' CONTRIBUTING.md && grep -qE 'mcp-server' CONTRIBUTING.md && grep -qiE 'release' CONTRIBUTING.md` (release mechanics + dev setup covered).
+- [x] `grep -cE '\]\(\.\.?/' CONTRIBUTING.md` returns 0 (no repo-relative links).
+- [x] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass.
 
 #### Manual Verification
-- [ ] Reads as a genuine contributor entry point; release/changelog relationship is clear.
+- [x] Reads as a genuine contributor entry point; release/changelog relationship is clear.
 
 ## Phase 2: Write CHANGELOG.md
 depends_on: null
@@ -90,13 +90,13 @@ Create a seeded `CHANGELOG.md` at repo root in Keep-a-Changelog format.
 
 ### Success Criteria
 #### Automated Verification
-- [ ] `test -f CHANGELOG.md` succeeds.
-- [ ] `grep -qiE 'Unreleased' CHANGELOG.md && grep -qE '2\.5\.191|0\.1\.32' CHANGELOG.md` (Keep-a-Changelog skeleton + seeded current versions).
-- [ ] `grep -cE '\]\(\.\.?/' CHANGELOG.md` returns 0.
-- [ ] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass.
+- [x] `test -f CHANGELOG.md` succeeds.
+- [x] `grep -qiE 'Unreleased' CHANGELOG.md && grep -qE '2\.5\.191|0\.1\.32' CHANGELOG.md` (Keep-a-Changelog skeleton + seeded current versions).
+- [x] `grep -cE '\]\(\.\.?/' CHANGELOG.md` returns 0.
+- [x] `bash ralph/hooks/scripts/__tests__/*.test.sh` pass.
 
 #### Manual Verification
-- [ ] CHANGELOG reflects the two independent release streams and is ready to accrue future entries.
+- [x] CHANGELOG reflects the two independent release streams and is ready to accrue future entries.
 
 ## Testing Strategy
 


### PR DESCRIPTION
## Summary

Adds the two missing repo-root standard files (epic #1459, Documentation hardening). Pure additive; no code change.

- **`CONTRIBUTING.md`:** contributor entry point — project layout, `mcp-server` dev setup (build/test), branch/commit conventions, the **dual auto-release model** (`release.yml` for `mcp-server/src/**` → npm; `release-ralph.yml` for `ralph/**` → plugin tag; `#minor`/`#major` commit tags; never publish/tag manually), and how the changelog relates to auto-publish.
- **`CHANGELOG.md`:** [Keep a Changelog](https://keepachangelog.com/) format noting the two **independently-versioned** artifacts (plugin `ralph-vX.Y.Z` + npm `vX.Y.Z`), seeded with `## [Unreleased]` + current state (ralph plugin `v0.1.32`, mcp-server `v2.5.191`). Human-maintained (releases are tag-driven/automated).

## Plan

[`thoughts/shared/plans/2026-05-26-GH-1456-contributing-changelog.md`](https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-26-GH-1456-contributing-changelog.md) — reviewed APPROVED (all 6 applicable rubric dimensions PASS; release-workflow facts + tag streams independently verified).

## Test plan

- [x] `test -f CONTRIBUTING.md && test -f CHANGELOG.md`
- [x] CONTRIBUTING: `#minor`/`#major` + `mcp-server` + release mechanics present
- [x] CHANGELOG: `Unreleased` + seeded versions (`v0.1.32`/`v2.5.191`) present
- [x] `grep -cE '\]\(\.\.?/'` = 0 in both (no repo-relative links)
- [x] `ralph/hooks/scripts/__tests__/*.test.sh` all pass

Closes #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
