### PR TITLE
GH-1457: add docs/README.md index separating living guides from historical records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# `docs/`
+
+Documentation for **ralph** — a Claude Code plugin for autonomous GitHub Projects V2 workflow automation. This index separates **living / reference docs** (current, maintained guidance) from **historical / design records** (dated, frozen design and plan artifacts kept for provenance).
+
+> Project overview, build/test commands, and architecture live in the repo-root [`README.md`](../README.md) and [`CLAUDE.md`](../CLAUDE.md). Long-form research, plans, and reviews live under [`thoughts/`](../thoughts/) (no index of its own yet — out of scope here).
+
+## Living / Reference Docs
+
+Current, evergreen reference material — safe to treat as up-to-date guidance:
+
+- [cross-repo-routing.md](cross-repo-routing.md) — setting up cross-repo issue routing for a multi-repo workspace.
+- [reference/angular-acceleration-playbook.md](reference/angular-acceleration-playbook.md) — playbook for accelerating Angular work.
+- [reference/design-system-maturity-checklist.md](reference/design-system-maturity-checklist.md) — AI-ready design-system maturity checklist.
+- [reference/figma-file-hygiene-checklist.md](reference/figma-file-hygiene-checklist.md) — checklist for keeping Figma files clean and well-structured.
+
+## Historical / Design Records
+
+**Frozen, dated artifacts** kept for provenance. These describe decisions and plans *as of their date* and are **not** maintained as current guidance — read them as historical context, not instructions.
+
+- [plans/](plans/) — early design + implementation plans (2026-03-04 to 2026-03-08).
+- [superpowers/plans/](superpowers/plans/) — phased "superpowers" implementation plans (2026-03-12 to 2026-05-02).
+- [superpowers/specs/](superpowers/specs/) — "superpowers" design specs, one `*-design.md` per feature (2026-03-11 to 2026-05-25).
+- [archive/](archive/) — docs describing the removed `plugin/ralph-hero/` package, archived in GH-1453.


### PR DESCRIPTION
## Summary

Adds `docs/README.md` — an index that separates **living / reference docs** (current guidance: `cross-repo-routing.md`, `reference/*`) from **historical / design records** (dated, frozen artifacts under `plans/`, `superpowers/plans/`, `superpowers/specs/`, `archive/`).

Labeled-section approach — **no files relocated**, so inbound links from issues/PRs/commits stay intact. `docs/archive/` (from #1453) is referenced, not re-created.

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-28-GH-1457-docs-readme-index.md

## Test plan

- [x] `docs/README.md` exists with both `## Living / Reference Docs` and `## Historical / Design Records` sections.
- [x] All 11 relative links resolve (`../README.md`, `../CLAUDE.md`, `../thoughts/`, `cross-repo-routing.md`, 3× `reference/*`, `plans/`, `superpowers/plans/`, `superpowers/specs/`, `archive/`).
- [ ] Reviewer: render on GitHub and confirm the living-vs-historical split reads clearly and links navigate correctly.

Closes #1457