### PR TITLE
GH-1458: add CI doc-consistency check for agent/skill/tool rosters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,3 +272,16 @@ jobs:
           scandir: ralph/hooks
           severity: error
           format: gcc
+
+  # GH-1458: assert documented agent/skill/tool rosters in CLAUDE.md / README.md
+  # match the source files, so docs and code can't silently diverge (the failure
+  # mode GH-1452 had to fix by hand).
+  check-doc-rosters:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run doc-roster consistency check
+        run: bash scripts/check-doc-rosters.sh

--- a/scripts/check-doc-rosters.sh
+++ b/scripts/check-doc-rosters.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# check-doc-rosters.sh — assert documented rosters match source (GH-1458)
+#
+# Guards against the drift fixed by hand in GH-1452: agent/skill/tool rosters
+# documented in CLAUDE.md / README.md silently diverging from the source files.
+#
+# Three checks, each with a direction chosen for its roster:
+#   - Agents (bidirectional): the `### ralph Plugin — 16 Agents` section in
+#     CLAUDE.md lists every agent, so documented set == ralph/agents/*.md set.
+#   - Skills (bidirectional): the `### ralph Plugin — 9 Verbs` table lists every
+#     verb, so documented set == ralph/skills/*/ dirs minus shared & using-html.
+#   - Tools (one-directional, documented ⊆ source): the CLAUDE.md / README.md
+#     tool tables are an explicitly curated subset, so every documented
+#     `ralph_hero__*` name must exist in source, but source may have more.
+#
+# Exits 0 when all checks pass, 1 otherwise. Designed to pass on current `main`.
+
+set -euo pipefail
+
+# Resolve repo root so the script works from anywhere (CI, worktree, local).
+REPO_ROOT=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+CLAUDE_MD="CLAUDE.md"
+README_MD="README.md"
+AGENTS_DIR="ralph/agents"
+SKILLS_DIR="ralph/skills"
+SRC_DIR="mcp-server/src"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Check 1: Agents (bidirectional)
+# ---------------------------------------------------------------------------
+# Documented: backtick names on the **N per-phase agents** / **N investigators**
+# bullet lines under the `### ralph Plugin — 16 Agents` heading. We restrict to
+# those bullet lines so trailing prose (e.g. `impl-agent`/`RALPH_IMPL_MODEL` in
+# the paragraph below) does not pollute the set.
+echo "=== Agents (CLAUDE.md <-> ${AGENTS_DIR}/) ==="
+
+doc_agents=$(
+  awk '/^### ralph Plugin — 16 Agents/{f=1; next} /^### /{f=0} f' "$CLAUDE_MD" \
+    | grep -E '^\*\*[0-9]+ (per-phase agents|investigators)\*\*' \
+    | grep -oE '`[a-z][a-z0-9-]+`' \
+    | tr -d '`' \
+    | sort -u
+)
+
+src_agents=$(
+  find "$AGENTS_DIR" -mindepth 1 -maxdepth 1 -name '*.md' -type f \
+    -exec basename {} .md \; \
+    | sort -u
+)
+
+# Documented but not in source -> phantom agent name in the docs.
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  fail "Documented agent '${name}' not found in ${AGENTS_DIR}/"
+done < <(comm -23 <(echo "$doc_agents") <(echo "$src_agents"))
+
+# In source but not documented -> agent missing from CLAUDE.md roster.
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  fail "Agent '${name}' in ${AGENTS_DIR}/ is undocumented in ${CLAUDE_MD}"
+done < <(comm -13 <(echo "$doc_agents") <(echo "$src_agents"))
+
+if [ -z "$(comm -3 <(echo "$doc_agents") <(echo "$src_agents"))" ]; then
+  pass "agent roster matches source ($(echo "$src_agents" | grep -c .) agents)"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: Skills (bidirectional)
+# ---------------------------------------------------------------------------
+# Documented: /ralph:<verb> names from the `### ralph Plugin — 9 Verbs` table.
+# Source: ralph/skills/*/ dir names, excluding non-verb utility dirs.
+echo "=== Skills (CLAUDE.md <-> ${SKILLS_DIR}/) ==="
+
+doc_skills=$(
+  awk '/^### ralph Plugin — 9 Verbs/{f=1; next} /^### /{f=0} f' "$CLAUDE_MD" \
+    | grep -oE '/ralph:[a-z-]+' \
+    | sed 's#/ralph:##' \
+    | sort -u
+)
+
+src_skills=$(
+  find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; \
+    | grep -vxE 'shared|using-html' \
+    | sort -u
+)
+
+# Documented but not a real skill dir -> phantom verb in the docs.
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  fail "Documented skill '/ralph:${name}' has no dir in ${SKILLS_DIR}/"
+done < <(comm -23 <(echo "$doc_skills") <(echo "$src_skills"))
+
+# Skill dir not in the docs -> verb missing from the 9-verbs table.
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  fail "Skill dir '${SKILLS_DIR}/${name}/' is undocumented in ${CLAUDE_MD}"
+done < <(comm -13 <(echo "$doc_skills") <(echo "$src_skills"))
+
+if [ -z "$(comm -3 <(echo "$doc_skills") <(echo "$src_skills"))" ]; then
+  pass "skill roster matches source ($(echo "$src_skills" | grep -c .) verbs)"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: Tools (one-directional, documented ⊆ source)
+# ---------------------------------------------------------------------------
+# Documented: short tool names from the CLAUDE.md "Tool modules" table (col 2,
+# comma-separated) and the README.md "### Tools" table (col 1), prefixed with
+# ralph_hero__. The CLAUDE.md extraction is bounded to the Tool modules table
+# (it precedes a structurally identical Lib modules table) and the prose-only
+# debug-tools.ts row is dropped.
+#
+# Source: the literal quoted pattern "ralph_hero__[a-z_]+" across
+# mcp-server/src/**/*.ts (excluding __tests__). NOTE: we do NOT anchor on
+# server.tool( — that call puts the tool name on the *next* line, so a
+# line-anchored regex matches nothing. Scope includes src/index.ts, where
+# ralph_hero__health_check is registered.
+echo "=== Tools (CLAUDE.md + README.md docs ⊆ ${SRC_DIR}/) ==="
+
+doc_tools=$(
+  {
+    # CLAUDE.md Tool modules table, second column, comma-split.
+    awk '/\*\*Tool modules\*\*/{f=1; next} /\*\*GitHub client\*\*/{f=0} f' "$CLAUDE_MD" \
+      | grep -E '^\| `[a-z-]+\.ts` \|' \
+      | grep -v 'debug-tools.ts' \
+      | sed -E 's/^\| `[a-z-]+\.ts` \| //; s/ \|$//' \
+      | tr ',' '\n' \
+      | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+      | grep -E '^[a-z_]+$'
+    # README.md Tools table, first column backtick names.
+    awk '/^### Tools/{f=1; next} /^### /{f=0} f' "$README_MD" \
+      | grep -oE '^\| `[a-z_]+`' \
+      | tr -d '`|' \
+      | sed -E 's/[[:space:]]+//g'
+  } | sed 's/^/ralph_hero__/' | sort -u
+)
+
+src_tools=$(
+  grep -rhoE '"ralph_hero__[a-z_]+"' "$SRC_DIR" --include='*.ts' \
+    | grep -v __tests__ \
+    | tr -d '"' \
+    | sort -u
+)
+
+# Documented tool absent from source -> phantom/typo/renamed tool in the docs.
+# (We intentionally do NOT flag source tools missing from docs — the docs are a
+# curated subset.)
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  fail "Documented tool '${name}' not found in ${SRC_DIR}/ (phantom/typo/renamed?)"
+done < <(comm -23 <(echo "$doc_tools") <(echo "$src_tools"))
+
+if [ -z "$(comm -23 <(echo "$doc_tools") <(echo "$src_tools"))" ]; then
+  pass "all $(echo "$doc_tools" | grep -c .) documented tools exist in source ($(echo "$src_tools" | grep -c .) source tools)"
+fi
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "Doc rosters diverge from source. Update CLAUDE.md/README.md (or the source) to reconcile."
+  exit 1
+fi
+echo "All doc rosters are consistent with source."
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI doc-consistency check — `scripts/check-doc-rosters.sh` plus an independent `check-doc-rosters` job in `ci.yml` — that asserts the documented agent/skill/tool rosters match source, preventing the drift #1452 had to fix by hand.

- **Agents** (bidirectional): `CLAUDE.md` 16-agents roster ↔ `ralph/agents/*.md`.
- **Skills** (bidirectional): `CLAUDE.md` 9-verbs table ↔ `ralph/skills/*/` (excluding `shared`/`using-html`).
- **Tools** (documented ⊆ source): `CLAUDE.md`/`README.md` tool tables ↔ `ralph_hero__*` literals scanned across `mcp-server/src/**/*.ts` (incl. `src/index.ts`). Docs are a curated subset, so the tool check is one-directional (catches phantoms/typos).

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-05-28-GH-1458-ci-doc-consistency-check.md

## Test plan

- [x] `bash scripts/check-doc-rosters.sh` exits 0 on `main` (3 PASS: agents 16/16, skills 9/9, tools 28⊆49 source).
- [x] `shellcheck` clean (severity error); `actionlint` clean on `ci.yml`.
- [x] Drift detection: injecting a fake agent name → exit 1 naming it → reverted to pristine.
- [ ] Reviewer: confirm the new `check-doc-rosters` job is green on this PR (self-validation).

Closes #1458