### PR TITLE
docs(agents): optimize investigator agent descriptions for selection

### DIFF
--- a/ralph/agents/codebase-analyzer.md
+++ b/ralph/agents/codebase-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-analyzer
-description: Analyzes codebase implementation details with precise file:line references. Use for understanding how specific components work.
+description: Explains HOW specific code works — traces implementation, data flow, and call paths with precise file:line references. Use once you know which files matter; not to locate them (use codebase-locator) or find reusable examples (use codebase-pattern-finder).
 tools: Read, Grep, Glob, Bash
 model: sonnet
 color: red

--- a/ralph/agents/codebase-locator.md
+++ b/ralph/agents/codebase-locator.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-locator
-description: Locates files, directories, and components relevant to a feature or task. A "Super Grep/Glob" tool for finding where code lives.
+description: Finds WHERE code lives — locates and groups files, directories, and components for a feature or task (a "Super Grep/Glob"). Use to map where things are; not to explain how code works (use codebase-analyzer) or find patterns to copy (use codebase-pattern-finder).
 tools: Grep, Glob, Bash
 model: haiku
 color: orange

--- a/ralph/agents/codebase-pattern-finder.md
+++ b/ralph/agents/codebase-pattern-finder.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-pattern-finder
-description: Finds similar implementations, usage examples, and existing patterns in the codebase. Returns concrete code examples with file:line references.
+description: Finds existing patterns and usage examples to model new code after, returning concrete snippets with file:line references. Use when you want precedent to copy; not to map a feature's files (use codebase-locator) or explain one component in depth (use codebase-analyzer).
 tools: Grep, Glob, Read, Bash
 model: haiku
 color: pink

--- a/ralph/agents/log-reader.md
+++ b/ralph/agents/log-reader.md
@@ -1,6 +1,6 @@
 ---
 name: log-reader
-description: Read-only LQL/log-query subagent for GCP log investigation and trace retrieval. No write or mutation access.
+description: Read-only GCP log and trace investigation via LQL/log queries — pulls Cloud Logging entries and traces. Use to inspect logs or chase a trace; never writes or mutates.
 model: haiku
 tools: Read, Grep, Glob, Bash, WebFetch
 ---

--- a/ralph/agents/sre-fixit.md
+++ b/ralph/agents/sre-fixit.md
@@ -1,6 +1,6 @@
 ---
 name: sre-fixit
-description: Autoremediation agent for the Watcher team. Invokes typed MCP kubectl tools (scale, rollout_restart, delete_pod, drain) for allowlisted operations. Escalates to Human Needed for any request outside the four ops or when a tool returns a validation error. No Bash — typed-tool surface is the only kubectl path.
+description: Kubernetes autoremediation for the Watcher team via four typed MCP ops only — scale, rollout_restart, delete_pod, drain (no Bash). Use for allowlisted recovery actions; escalates to Human Needed for anything outside the four ops or on a validation error.
 model: sonnet
 tools: mcp__plugin_ralph_ralph-github__ralph_hero__sre__scale, mcp__plugin_ralph_ralph-github__ralph_hero__sre__rollout_restart, mcp__plugin_ralph_ralph-github__ralph_hero__sre__delete_pod, mcp__plugin_ralph_ralph-github__ralph_hero__sre__drain, mcp__plugin_ralph_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph_ralph-github__ralph_hero__save_issue
 ---

--- a/ralph/agents/thoughts-analyzer.md
+++ b/ralph/agents/thoughts-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: thoughts-analyzer
-description: Extracts key decisions, constraints, and actionable insights from thought documents. Use for deep analysis of research docs, plans, and prior decisions.
+description: Distills key decisions, constraints, and actionable insights FROM specific thought documents (and the ralph-knowledge graph). Use on docs already located; not to discover which docs exist (use thoughts-locator).
 tools: Read, Grep, Glob, Bash, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_paths, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_common, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_query_outcomes
 model: sonnet
 color: blue

--- a/ralph/agents/thoughts-locator.md
+++ b/ralph/agents/thoughts-locator.md
@@ -1,6 +1,6 @@
 ---
 name: thoughts-locator
-description: Discovers relevant documents in thoughts/ directory -- research docs, plans, tickets, handoffs. Use when researching to find prior context.
+description: Finds WHERE prior context lives across the thoughts/ corpus and the ralph-knowledge graph — research docs, plans, tickets, handoffs. Use to discover what's already been written; not to distill a document's contents (use thoughts-analyzer).
 tools: Grep, Glob, Bash, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_search, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_traverse, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_communities, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_central, mcp__plugin_ralph-knowledge_ralph-knowledge__knowledge_bridges
 model: haiku
 color: purple

--- a/ralph/agents/web-search-researcher.md
+++ b/ralph/agents/web-search-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: web-search-researcher
-description: Expert web research specialist for finding accurate information from web sources. Use for external API docs, best practices, and modern techniques.
+description: Researches the public web for accurate, current information — external API docs, library behavior, best practices, standards. Use when the answer isn't in this repo or the thoughts/ corpus (use codebase-* or thoughts-* agents for those).
 tools: WebSearch, WebFetch, Read, Grep, Glob, Bash
 model: sonnet
 color: cyan


### PR DESCRIPTION
## What

Rewrites the **8 selection-driven investigator agent** descriptions in `ralph/agents/` so the orchestrator picks the right agent more reliably. All now follow one shape: **capability-first → "Use when…" → explicit sibling disambiguation**.

## Why

These descriptions are the *trigger surface* — Claude reads them to decide which agent to dispatch. The codebase trio (locator/analyzer/pattern-finder) and the thoughts pair (locator/analyzer) sounded alike and invited mis-selection; two agents also hid real capabilities.

## Changes

| Agent | Key improvement |
|---|---|
| codebase-locator | "Finds WHERE" + steers away from analyzer/pattern-finder |
| codebase-analyzer | "Explains HOW" + steers away from locator/pattern-finder |
| codebase-pattern-finder | "patterns to model new code after" + disambiguation |
| thoughts-locator | now advertises **ralph-knowledge graph**; discover-not-distill |
| thoughts-analyzer | now advertises **ralph-knowledge graph**; distill-not-discover |
| web-search-researcher | steers to repo/thoughts agents for internal answers |
| log-reader | tightened; read-only guarantee kept |
| sre-fixit | trimmed ~25%; four-ops / no-Bash / escalation facts kept |

## Scope / safety

- Goals: triggering accuracy, consistency, token economy.
- Name-dispatched worker agents (research/plan/impl/etc.) and the 9 skill descriptions are **out of scope** here — separate follow-up passes.
- Edits are frontmatter `description:` only; single-line, YAML-safe (no `: ` colon-space); `name`/`tools`/`model` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)