### PR TITLE
GH-1473: caretake watch-blockers mode to auto-advance dependency-unblocked items

### DIFF
--- a/ralph/hooks/scripts/__tests__/caretake-watch-blockers.test.sh
+++ b/ralph/hooks/scripts/__tests__/caretake-watch-blockers.test.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# ralph/hooks/scripts/__tests__/caretake-watch-blockers.test.sh
+# Doc-structure assertions for the watch-blockers mode.
+#
+# Strategy: assert structural invariants over the skill surface files using grep,
+# confirming the mode exists with the correct shape, token, and wiring — the same
+# coverage model used by triage-postcondition-palette.test.sh and the CI
+# doc-consistency check (#1458). watch-blockers has no runtime Stop hook (parity
+# with watch-pr/watch-upstream), so doc-structure is the correct coverage target.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+MODE_FILE="${REPO_ROOT}/ralph/skills/caretake/modes/watch-blockers.md"
+TOKENS_FILE="${REPO_ROOT}/ralph/skills/caretake/outcome-tokens.md"
+SKILL_FILE="${REPO_ROOT}/ralph/skills/caretake/SKILL.md"
+TRIAGE_FILE="${REPO_ROOT}/ralph/skills/caretake/modes/triage.md"
+
+pass() {
+  echo "  PASS: $1"
+  ((PASS++)) || true
+}
+
+fail() {
+  echo "  FAIL: $1"
+  ((FAIL++)) || true
+}
+
+assert_file_contains() {
+  local desc="$1"
+  local file="$2"
+  local pattern="$3"
+  if grep -q "$pattern" "$file"; then
+    pass "$desc"
+  else
+    fail "$desc — pattern not found in $(basename "$file"): '$pattern'"
+  fi
+}
+
+assert_file_count_ge() {
+  local desc="$1"
+  local file="$2"
+  local pattern="$3"
+  local min="$4"
+  local count
+  count=$(grep -c "$pattern" "$file" || true)
+  if [[ "$count" -ge "$min" ]]; then
+    pass "$desc (count=$count)"
+  else
+    fail "$desc — expected ≥$min matches, got $count in $(basename "$file") for pattern: '$pattern'"
+  fi
+}
+
+assert_file_exists_nonempty() {
+  local desc="$1"
+  local file="$2"
+  if [[ -s "$file" ]]; then
+    pass "$desc"
+  else
+    fail "$desc — file missing or empty: $file"
+  fi
+}
+
+echo "=== caretake-watch-blockers doc-structure tests ==="
+echo ""
+
+# -----------------------------------------------------------------------
+echo "--- Assertion 1: Mode file exists and is non-empty ---"
+assert_file_exists_nonempty "watch-blockers.md exists and is non-empty" "$MODE_FILE"
+
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Assertion 2: Mirrors watch-upstream shape (required headings + subcommand export) ---"
+assert_file_contains "§Step 1: Verify branch heading present" "$MODE_FILE" "§Step 1: Verify branch"
+assert_file_contains "§Step 2 heading present" "$MODE_FILE" "§Step 2"
+assert_file_contains "§Step 5 heading present" "$MODE_FILE" "§Step 5"
+assert_file_contains "§Constraints heading present" "$MODE_FILE" "§Constraints"
+assert_file_contains "export RALPH_SUBCOMMAND=watch-blockers" "$MODE_FILE" "export RALPH_SUBCOMMAND=watch-blockers"
+assert_file_contains "No Stop hook note present (parity)" "$MODE_FILE" "No .Stop. hook"
+
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Assertion 3: Advance behavior documented ---"
+assert_file_contains "remove_dependency call present" "$MODE_FILE" "remove_dependency"
+assert_file_contains "## Unblocked comment name present" "$MODE_FILE" "## Unblocked"
+assert_file_contains "Default advance target Ready for Plan present" "$MODE_FILE" "Ready for Plan"
+assert_file_contains "OPEN-blocker leave-untouched branch present" "$MODE_FILE" "leave untouched"
+assert_file_contains "blockedNumber param (not blockedByNumber)" "$MODE_FILE" "blockedNumber"
+# Confirm the non-existent blockedByNumber param is NOT used as a call argument
+# (The mode doc may mention it in a "Do NOT use" warning — that is acceptable)
+if grep -qE "remove_dependency\([^)]*blockedByNumber[^)]*\)" "$MODE_FILE" 2>/dev/null; then
+  fail "remove_dependency must NOT use blockedByNumber param (wrong schema)"
+else
+  pass "remove_dependency does not use non-existent blockedByNumber param as an argument"
+fi
+
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Assertion 4: Reads the #1472 convention (dual detection signal) ---"
+assert_file_contains "list_dependencies (edge signal) present" "$MODE_FILE" "list_dependencies"
+assert_file_contains "## Escalation body signal present" "$MODE_FILE" "## Escalation"
+assert_file_contains "Blocked by # phrasing present" "$MODE_FILE" "Blocked by #"
+assert_file_contains "closes / Move to phrasing present" "$MODE_FILE" "Move to"
+
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Assertion 5: Terminal tokens present in mode file, outcome-tokens.md, and SKILL.md ---"
+assert_file_contains "WATCH-BLOCKERS token in mode file" "$MODE_FILE" "WATCH-BLOCKERS"
+assert_file_contains "WATCH-BLOCKERS token in outcome-tokens.md" "$TOKENS_FILE" "WATCH-BLOCKERS"
+assert_file_contains "WATCH-BLOCKERS token in SKILL.md" "$SKILL_FILE" "WATCH-BLOCKERS"
+
+# All three token variants present in mode file
+assert_file_contains "WATCH-BLOCKERS summary token (n advanced, m still blocked)" "$MODE_FILE" "WATCH-BLOCKERS.*advanced.*still blocked"
+assert_file_contains "WATCH-BLOCKERS IDLE token" "$MODE_FILE" "WATCH-BLOCKERS IDLE"
+assert_file_contains "WATCH-BLOCKERS SKIPPED token" "$MODE_FILE" "WATCH-BLOCKERS SKIPPED"
+
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Assertion 6: Heartbeat wiring in SKILL.md ---"
+assert_file_contains "--mode watch-blockers in fan-out dispatch" "$SKILL_FILE" 'mode watch-blockers'
+assert_file_contains "6 total (fan-out child count updated)" "$SKILL_FILE" "6 total"
+assert_file_contains "modes/watch-blockers.md in mode-bodies list" "$SKILL_FILE" "modes/watch-blockers.md"
+assert_file_count_ge "watch-blockers appears ≥5 times in SKILL.md (frontmatter ×2, table, fan-out, mode-bodies, token-ref)" \
+  "$SKILL_FILE" "watch-blockers" 5
+
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Assertion 7: Token registry in outcome-tokens.md ---"
+assert_file_contains "## Watch-Blockers terminal tokens heading" "$TOKENS_FILE" "## Watch-Blockers terminal tokens"
+assert_file_count_ge "WATCH-BLOCKERS appears ≥3 times in outcome-tokens.md" "$TOKENS_FILE" "WATCH-BLOCKERS" 3
+assert_file_contains "no Stop postcondition hook (parity) note in outcome-tokens.md" "$TOKENS_FILE" \
+  "watch-blockers has no .Stop. postcondition hook"
+
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Assertion 8: triage.md cross-ref updated to live (not future) ---"
+assert_file_contains "triage.md names watch-blockers as the live consumer" "$TRIAGE_FILE" \
+  "caretake --mode watch-blockers"
+# Confirm the old "Gap C ... future" language is gone
+if grep -q "no watcher yet" "$TRIAGE_FILE" 2>/dev/null; then
+  fail "triage.md still has stale 'no watcher yet' language — should be updated to live"
+else
+  pass "triage.md no longer has stale 'no watcher yet' language"
+fi
+
+# -----------------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+echo ""
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/ralph/skills/caretake/SKILL.md
+++ b/ralph/skills/caretake/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: All board maintenance, grooming, and reflection in one verb. Triggers on "triage backlog", "clean up board", "scan for stale", "status check", "post-mortem", "capture friction", "retro the session", "trend report", "snapshot metrics", "unblock issue", "answer unblock questions", "collate debug errors", "filer Langfuse errors", "split this issue", "decompose ticket". Default mode is event-driven (reads `--issue NNN` labels and fans out via Skill). Named modes (triage/hygiene/unblock/postmortem/retro/trends/debug/split/watch-pr/watch-upstream) each route to a dedicated mode body under `modes/`.
-argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|watch-pr|watch-upstream|all>] [#NNN] [--since <window>] [--auto-confirm] [--question] [--loop [duration]] [--auto]"
+description: All board maintenance, grooming, and reflection in one verb. Triggers on "triage backlog", "clean up board", "scan for stale", "status check", "post-mortem", "capture friction", "retro the session", "trend report", "snapshot metrics", "unblock issue", "answer unblock questions", "collate debug errors", "filer Langfuse errors", "split this issue", "decompose ticket". Default mode is event-driven (reads `--issue NNN` labels and fans out via Skill). Named modes (triage/hygiene/unblock/postmortem/retro/trends/debug/split/watch-pr/watch-upstream/watch-blockers) each route to a dedicated mode body under `modes/`.
+argument-hint: "[--issue NNN | --mode <triage|hygiene|unblock|postmortem|retro|trends|debug|split|watch-pr|watch-upstream|watch-blockers|all>] [#NNN] [--since <window>] [--auto-confirm] [--question] [--loop [duration]] [--auto]"
 context: inline
 model: opus
 hooks:
@@ -91,7 +91,7 @@ All board maintenance flows through this one entrypoint. Ten named modes plus a 
 | Mode | Trigger | Role |
 |---|---|---|
 | **default** | `/ralph:caretake --issue NNN` | Event-driven: read labels, dispatch the right mode via `Skill()` |
-| **all** | `/ralph:caretake` (no args) or `/ralph:caretake --mode all` | Heartbeat fan-out: hygiene + watch-pr + watch-upstream + catch-up report + trends |
+| **all** | `/ralph:caretake` (no args) or `/ralph:caretake --mode all` | Heartbeat fan-out: hygiene + watch-pr + watch-upstream + watch-blockers + catch-up report + trends |
 | **triage** | `/ralph:caretake --mode triage [#NNN]` | Pick oldest untriaged Backlog, assess, route |
 | **hygiene** | `/ralph:caretake --mode hygiene` | Scan for archive candidates, stale items, WIP violations |
 | **unblock** | `/ralph:caretake --mode unblock [#NNN] [--question]` | Interactive answer OR autonomous request post |
@@ -102,6 +102,7 @@ All board maintenance flows through this one entrypoint. Ten named modes plus a 
 | **split** | `/ralph:caretake --mode split [#NNN]` | Split M/L/XL → multiple XS/S sub-issues |
 | **watch-pr** | `/ralph:caretake --mode watch-pr` | Resolve `blocked:pr-NNN` items when their PR merges (advance) or closes-unmerged (escalate) |
 | **watch-upstream** | `/ralph:caretake --mode watch-upstream` | Resolve `blocked:upstream` items when their external condition resolves (advance) or URL is dead/unparseable (escalate) |
+| **watch-blockers** | `/ralph:caretake --mode watch-blockers` | Auto-advance items whose `blockedBy` dependency edges have all closed (resolves the `WAIT-issue=NNN` triage verdict); leave items with any open blocker |
 
 References: [label-routing.md](label-routing.md) (default-mode dispatch table), [outcome-tokens.md](outcome-tokens.md) (per-mode terminal verdicts), [split-decomposition.md](split-decomposition.md) (split-mode strategy + hook contracts).
 
@@ -144,9 +145,10 @@ esac
   1. `Skill("ralph:caretake", args="--mode hygiene")`
   2. `Skill("ralph:caretake", args="--mode watch-pr")`
   3. `Skill("ralph:caretake", args="--mode watch-upstream")`
-  4. `Skill("ralph:catch-up", args="--mode report")`
-  5. `Skill("ralph:caretake", args="--mode trends")`
-  Report consolidated outcome (one line per child — 5 total). The watch modes run before report/trends so the dashboards reflect post-watch board state; both no-op (`IDLE`) on an empty board, or `SKIPPED` when the heartbeat fires off `main`.
+  4. `Skill("ralph:caretake", args="--mode watch-blockers")`
+  5. `Skill("ralph:catch-up", args="--mode report")`
+  6. `Skill("ralph:caretake", args="--mode trends")`
+  Report consolidated outcome (one line per child — 6 total). The watch modes run before report/trends so the dashboards reflect post-watch board state; all no-op (`IDLE`) on an empty board, or `SKIPPED` when the heartbeat fires off `main`.
 
 ## Step 2: Emit result line
 
@@ -164,6 +166,7 @@ Each mode body ends by emitting its terminal token (see [outcome-tokens.md](outc
 - [modes/split.md](modes/split.md) — M/L/XL → XS/S sub-issues
 - [modes/watch-pr.md](modes/watch-pr.md) — resolve `blocked:pr-NNN` items on PR merge/close
 - [modes/watch-upstream.md](modes/watch-upstream.md) — resolve `blocked:upstream` items on external condition
+- [modes/watch-blockers.md](modes/watch-blockers.md) — resolve dependency-parked items on blocker close
 
 ## Per-mode terminal tokens
 
@@ -180,6 +183,7 @@ The harness reads these from the transcript; do not paraphrase. Full table in [o
 - split: `SPLIT <N>` | `SPLIT SKIPPED <reason>`
 - watch-pr: `WATCH-PR ADVANCED <N>` | `WATCH-PR IDLE` | `WATCH-PR SKIPPED — branch <name> is not main`
 - watch-upstream: `WATCH-UPSTREAM ADVANCED <N>` | `WATCH-UPSTREAM IDLE` | `WATCH-UPSTREAM SKIPPED — branch <name> is not main`
+- watch-blockers: `WATCH-BLOCKERS <n> advanced, <m> still blocked` | `WATCH-BLOCKERS IDLE` | `WATCH-BLOCKERS SKIPPED — branch <name> is not main`
 
 ## Notes
 

--- a/ralph/skills/caretake/modes/triage.md
+++ b/ralph/skills/caretake/modes/triage.md
@@ -107,13 +107,13 @@ Choose ONE of the **9 structured verdicts**. Every verdict names its successor �
 | `PROMOTE-plan` | Ready for Plan | `/ralph:plan --mode auto` |
 | `WAIT-pr=NNN` | Backlog + `blocked:pr-NNN` label | watch-pr (Phase 3, #1406) |
 | `WAIT-upstream=URL` | Backlog + `blocked:upstream` label | watch-upstream (Phase 3, #1407) |
-| `WAIT-issue=NNN` | Human Needed + `## Escalation` naming #NNN | unblock workflow (auto-advances when #NNN closes, via Gap C `watch-blockers`) |
+| `WAIT-issue=NNN` | Human Needed + `## Escalation` naming #NNN | auto-advanced when #NNN closes by `caretake --mode watch-blockers` (#1473) |
 | `WAIT-decision` | Human Needed + `## Escalation` comment | unblock workflow |
 
 **`WAIT-*` verdict family — coherent design:** The three `WAIT-*` verdicts use the same parking pattern but differ in who watches them and whether Backlog is safe:
 - `WAIT-pr=NNN` — stays **Backlog** (watch-pr owns it; PR merge is machine-detectable).
 - `WAIT-upstream=URL` — stays **Backlog** (watch-upstream owns it; URL resolution is machine-detectable).
-- `WAIT-issue=NNN` — moves to **Human Needed** (no watcher owns it yet; Backlog is unsafe because the picker will re-surface it on every autopilot tick). Once Gap A (#1470) and Gap C (`watch-blockers`) ship, this target relaxes to Backlog+edge.
+- `WAIT-issue=NNN` — moves to **Human Needed** (`caretake --mode watch-blockers` owns it; auto-advances when #NNN closes). Once Gap A (#1470) is fully adopted, this target can relax to Backlog+edge.
 
 When uncertain, prefer `PROMOTE-research` (route for investigation) or `WAIT-decision` (escalate) over `CLOSE-*` on valid work.
 
@@ -163,7 +163,7 @@ Add a `## Triage Decision` comment naming the exact condition being waited on.
   3. Apply `ralph-triage` label.
   4. **Do NOT leave the item in Backlog** — the picker's Backlog-fallback will re-surface it on every autopilot tick (see §Step 4a for why In-Progress siblings do not suppress this).
 
-Note: WAIT-issue stays in Human Needed (not Backlog) by design until Gap A (#1470) and Gap C (`watch-blockers`) ship. The dependency edge written here enables Gap C to auto-advance this item when #NNN closes.
+Note: WAIT-issue stays in Human Needed (not Backlog) by design. The dependency edge written here enables `caretake --mode watch-blockers` (#1473) to auto-advance this item when #NNN closes.
 
 **WAIT-decision.** Needs a human call before it can advance. Set `workflowState: "Human Needed"` (`command: "ralph_triage"`), post a `## Escalation` comment stating the specific decision required, and apply `ralph-triage`.
 
@@ -197,7 +197,7 @@ Rationale: **two distinct re-pick suppression mechanisms** are in play:
 
 2. **Workflow-state removal from Backlog** (no label needed): verdicts that move the issue OUT of Backlog are invisible to §Step 2's Backlog query. Affects `PROMOTE-*`, `CLOSE-*`, `WAIT-decision`, and `WAIT-issue=NNN` (all land in non-Backlog states).
 
-`WAIT-issue=NNN` moves to **Human Needed** (not Backlog) — it does NOT need the `ralph-triage` label for re-pick suppression because it exits the Backlog query entirely. The dependency edge ensures Gap C (`watch-blockers`) can find and auto-advance it when #NNN closes. The `WAIT-pr` and `WAIT-upstream` verdicts stay in Backlog (a watcher owns them); `WAIT-issue` does NOT stay in Backlog (no watcher owns it yet). These three are siblings in the `WAIT-*` family but differ in safe parking state.
+`WAIT-issue=NNN` moves to **Human Needed** (not Backlog) — it does NOT need the `ralph-triage` label for re-pick suppression because it exits the Backlog query entirely. The dependency edge ensures `caretake --mode watch-blockers` (#1473) can find and auto-advance it when #NNN closes. The `WAIT-pr` and `WAIT-upstream` verdicts stay in Backlog (a watcher owns them); `WAIT-issue` lands in Human Needed (watch-blockers owns it). These three are siblings in the `WAIT-*` family but differ in safe parking state.
 
 ## §Step 7: Find and Link Related Issues
 
@@ -257,7 +257,7 @@ Emit exactly one token, matching the verdict from §Step 4. One token per verdic
 - `TRIAGED PROMOTE-plan` — routed to Ready for Plan (well-specified, skip research).
 - `TRIAGED WAIT-pr=NNN` — parked in **Backlog** with `blocked:pr-NNN` (the `=NNN` is part of the token; watch-pr owns it).
 - `TRIAGED WAIT-upstream` — parked in **Backlog** with `blocked:upstream` (URL recorded in the `## Triage Decision` comment, not the token; watch-upstream owns it).
-- `TRIAGED WAIT-issue=NNN` — moved to **Human Needed** with `## Escalation` naming #NNN and `add_dependency` edge written (the `=NNN` is part of the token; no watcher yet — will be owned by Gap C `watch-blockers`). **NOT parked in Backlog** — stays Human Needed until #NNN closes.
+- `TRIAGED WAIT-issue=NNN` — moved to **Human Needed** with `## Escalation` naming #NNN and `add_dependency` edge written (the `=NNN` is part of the token; `caretake --mode watch-blockers` owns resolution — #1473). **NOT parked in Backlog** — stays Human Needed until #NNN closes.
 - `TRIAGED WAIT-decision` — escalated to Human Needed with a `## Escalation` comment.
 - `Queue empty.` — no untriaged Backlog issues (emitted at §Step 2).
 

--- a/ralph/skills/caretake/modes/watch-blockers.md
+++ b/ralph/skills/caretake/modes/watch-blockers.md
@@ -1,0 +1,91 @@
+# `--mode watch-blockers`
+
+Resolve items parked by the `WAIT-issue=NNN` triage verdict. Scan OPEN items in **Human Needed** (and Backlog, for forward-compat) carrying a `blockedBy` dependency edge or a `## Escalation` body naming a blocker issue, check whether **all** blockers are CLOSED, and act: on **all closed** advance the item (default `Ready for Plan` + `## Unblocked` comment + remove dependency edge); on **any open blocker** leave it waiting; on **no blocker signal** skip it. Autonomous — no human prompts. Emits one terminal token per invocation (see [outcome-tokens.md](../outcome-tokens.md)).
+
+```bash
+export RALPH_SUBCOMMAND=watch-blockers
+```
+
+This is the downstream consumer that makes the `WAIT-issue=NNN` verdict non-dead-ending: an item waits on a *named, watched dependency edge* and advances automatically when all blockers close. Triage (#1472) produces the `add_dependency` edge + a `## Escalation` comment naming the blocker; this mode resolves it.
+
+No `Stop` hook gates this mode (parity with `--mode watch-pr`/`watch-upstream`/`hygiene`/`trends`) — it mutates only the dependency-parked items it owns. The terminal token is emitted by convention, not hook-enforced.
+
+## §Step 1: Verify branch
+
+```bash
+git branch --show-current
+```
+
+If NOT on `main`, STOP and emit:
+
+```
+WATCH-BLOCKERS SKIPPED — branch <name> is not main
+```
+
+watch-blockers mutates workflow state, so it must run from `main`. (Distinct from `WATCH-BLOCKERS IDLE`, which means "ran cleanly, found nothing to do".)
+
+## §Step 2: Find parked items
+
+Two complementary sweeps, union the results (dedup by issue number):
+
+1. `list_issues(profile: "analyst-triage", workflowState: "Human Needed", limit: 250)` — the canonical `WAIT-issue=NNN` parking state.
+2. `list_issues(profile: "analyst-triage", workflowState: "Backlog", limit: 250)` — forward-compat for the Gap-A relaxation (a future `WAIT-issue` may park Backlog+edge per triage.md Gap A cross-ref).
+
+For each candidate, identify its blocker(s) from **either** signal (prefer the edge; fall back to the `## Escalation` text):
+
+- **Edge:** `list_dependencies(number: NNN)` → inspect the `blockedBy` connection; each node carries `number` + `state`.
+- **`## Escalation` body convention (#1472):** read the issue's body/comments for a `## Escalation` block; parse the blocker number from the `Blocked by #NNN` line and the advance target from `Move to <state> once #NNN closes` (default `Ready for Plan` when no explicit target is named).
+
+If neither signal yields a blocker number, **skip** the item (it is not dependency-parked; not counted in `<m>`).
+
+If the union of candidates with at least one blocker signal is empty, emit:
+
+```
+WATCH-BLOCKERS IDLE
+```
+
+and STOP.
+
+## §Step 3: Check blocker state
+
+For each parked item, `get_issue(<blocker>)` for **every** blocker number found. Branch table:
+
+| Blocker set | Meaning | Action |
+|---|---|---|
+| ALL blockers `state=CLOSED` (Done or Canceled) | unblocked | **advance** (§Step 4) |
+| ANY blocker `state=OPEN` | still blocked | **leave untouched** (no mutation, counted in `<m>`) |
+| Blocker number unresolvable (`get_issue` errors) | can't confirm | **leave untouched**, note in summary — never guess |
+
+Conservative posture: only an all-CLOSED blocker set advances; anything uncertain leaves the item parked (parity with watch-upstream's "never false-advance" stance).
+
+## §Step 4: Act
+
+### Advance (all blockers CLOSED)
+
+For each all-CLOSED item:
+
+1. **Determine the advance target:** read the embedded condition from the `## Escalation` line (`Move to <state> once #NNN closes`), or an explicit `advance:` hint if present, else **default `Ready for Plan`** (matches the `WAIT-issue=NNN` triage contract, triage.md §Step 5).
+2. **Remove the dependency edge:** for each `blockedBy` edge found in §Step 2, call `remove_dependency(blockedNumber: <parked-item-number>, blockingNumber: <blocker-number>)`. Note: `blockedNumber` = the parked item; `blockingNumber` = the now-closed blocker. Do NOT use `blockedByNumber` — that param does not exist in the tool schema.
+3. **Advance and relabel:** read the issue's current labels; `save_issue(number: <parked-item-number>, workflowState: <advance-target>, command: "ralph_triage", labels: <current labels minus any blocked:* and ralph-triage, so the item is re-pickable in its new state>)`. The explicit `labels` array is **required** (`save_issue` replaces the full set; omitting it leaves stale labels attached and the next sweep re-finds the item — mirror watch-upstream §Step 5 rationale). Note: `command: "ralph_triage"` is for parity; `triage-state-gate.sh` scopes to `RALPH_SUBCOMMAND=triage`, not `watch-blockers`, so this mode's transitions are unguarded — pass only valid target states.
+4. **Post a `## Unblocked` comment:** "Blocker(s) #NNN closed → dependency edge removed, advanced to `<target>`." (One comment per advanced item; name every blocker number that closed.)
+
+### Leave (any blocker still OPEN)
+
+No mutation. The item keeps its state + dependency edge + labels and waits for the next sweep. Count it in `<m>`.
+
+## §Step 5: Emit terminal token
+
+Emit exactly one (see [outcome-tokens.md](../outcome-tokens.md)):
+
+- `WATCH-BLOCKERS <n> advanced, <m> still blocked` — `<n>` items resolved this sweep (all blockers closed → advanced to the embedded/default target); `<m>` items left with ≥1 open blocker. Items with no blocker signal are not counted in either.
+- `WATCH-BLOCKERS IDLE` — scan ran cleanly; no dependency-parked items found (emitted at §Step 2).
+- `WATCH-BLOCKERS SKIPPED — branch <name> is not main` — §Step 1 branch-gate short-circuit.
+
+## §Constraints
+
+- One sweep per invocation; process only the Human-Needed and Backlog items found by the initial `list_issues` calls.
+- **Conservative advance** — never false-advance. Only an all-CLOSED blocker set triggers advancement; unresolvable blockers leave the item parked.
+- Mutates only dependency-parked items — never creates or closes issues, never touches items without a blocker signal.
+- No code changes.
+- Rate-limit awareness: the sweep does one `list_dependencies` (or `get_issue`) per candidate across two `list_issues` queries (limit 250 each). On a large board this is a meaningful number of API calls per heartbeat tick — parity with watch-upstream's sweep shape; the proactive rate-limiter in the MCP server will warn at 100 remaining and block at 50.
+- Heartbeat fan-out is wired in SKILL.md (Phase 3, #1473); the mode runs via explicit `--mode watch-blockers` dispatch or as part of `--mode all`.

--- a/ralph/skills/caretake/outcome-tokens.md
+++ b/ralph/skills/caretake/outcome-tokens.md
@@ -106,12 +106,20 @@ watch-pr has no `Stop` postcondition hook (parity with hygiene/trends) — it mu
 
 watch-upstream has no `Stop` postcondition hook (parity with watch-pr/hygiene/trends) — it mutates only the `blocked:upstream`-parked items it owns. The token is reported for harness/loop consumption; no automated verification is performed against it.
 
+## Watch-Blockers terminal tokens
+
+- `WATCH-BLOCKERS <n> advanced, <m> still blocked` — `<n>` items **resolved this sweep** (all blockers CLOSED → dependency edge removed + advanced to the embedded/default target); `<m>` items left with ≥1 open blocker. Items with no blocker signal are not counted in either.
+- `WATCH-BLOCKERS IDLE` — scan ran cleanly; no dependency-parked items found.
+- `WATCH-BLOCKERS SKIPPED — branch <name> is not main` — §Step 1 branch-gate short-circuit (parity with `TRIAGED skipped …`).
+
+watch-blockers has no `Stop` postcondition hook (parity with watch-pr/watch-upstream/hygiene/trends) — it mutates only the dependency-parked items it owns. The token is reported for harness/loop consumption; no automated verification is performed against it.
+
 ## Loop continuation
 
 When a caretake mode is wrapped via `--loop` (see `ralph/skills/shared/loop-wrapper.md` for the canonical continuation-rules manifest), the `/loop` runtime reads each invocation's terminal token to decide whether to re-fire or stop.
 
 **Drain modes** (triage, unblock, debug, split, caretake:default-event): `Queue empty.` is the sole termination signal. Every other terminal token (including progress tokens and `BLOCKED` variants) causes `/loop` to schedule the next tick at the appropriate delay bucket and re-fire.
 
-**Heartbeat modes** (hygiene, trends, all): these modes have no `Queue empty.` termination signal. `/loop` re-fires on a clock regardless of the token emitted — even when the invocation did nothing. The user cancels by deleting the pending wakeup via `/tasks`.
+**Heartbeat modes** (hygiene, trends, all): these modes have no `Queue empty.` termination signal. `/loop` re-fires on a clock regardless of the token emitted — even when the invocation did nothing. The user cancels by deleting the pending wakeup via `/tasks`. The watch modes (watch-pr, watch-upstream, watch-blockers) run as serial children of `--mode all` (not independently looped) and emit their tokens into the consolidated heartbeat report.
 
 **Non-loop invocations** are unaffected: all token semantics above apply to standalone caretake calls; the loop-continuation layer only activates when `--loop` was passed to the outermost invocation.


### PR DESCRIPTION
## Summary

- Adds `--mode watch-blockers` to caretake as the third watcher mode, resolving the `WAIT-issue=NNN` triage verdict (Gap C, #1473)
- Sweeps Human-Needed/Backlog items with a `blockedBy` dependency edge or `## Escalation` body; advances to Ready for Plan (default) once all blockers close; leaves items with any open blocker; emits `WATCH-BLOCKERS <n> advanced, <m> still blocked`
- Wired into the heartbeat fan-out (`--mode all`) as a 6th serial child alongside watch-pr and watch-upstream
- Doc + test only — no `mcp-server/` change; all required tools (`list_dependencies`, `remove_dependency`, `save_issue`, `get_issue`, `create_comment`) already exist

## Changes (4 files + 1 new)

1. **NEW** `ralph/skills/caretake/modes/watch-blockers.md` — mode body mirroring `watch-upstream.md` structure (branch-gate → find → check → act → token → constraints); uses correct `remove_dependency(blockedNumber, blockingNumber)` params per verified schema
2. **`ralph/skills/caretake/outcome-tokens.md`** — adds `## Watch-Blockers terminal tokens` section with all 3 tokens + no-Stop-hook parity note; adds watch-blockers to heartbeat fan-out enumeration
3. **`ralph/skills/caretake/SKILL.md`** — adds watch-blockers to frontmatter, mode table, heartbeat fan-out (5→6 children, "6 total"), mode-bodies list, and terminal token quick-ref
4. **`ralph/skills/caretake/modes/triage.md`** — updates 5 forward references from "Gap C watch-blockers (future)" to live: `caretake --mode watch-blockers (#1473)`
5. **NEW** `ralph/hooks/scripts/__tests__/caretake-watch-blockers.test.sh` — 32-assertion doc-structure test (file exists, shape, advance behavior, dual detection signal, all 3 tokens in all 3 files, heartbeat wiring, token registry, triage cross-ref)

## Test results

- `bash ralph/hooks/scripts/__tests__/caretake-watch-blockers.test.sh` → 32 passed, 0 failed
- `bash ralph/hooks/scripts/__tests__/triage-postcondition-palette.test.sh` → 32 passed, 0 failed
- All 5 hook test suites: 102 passed, 0 failed
- `bash scripts/check-doc-rosters.sh` → 3/3 PASS (no mode count in rosters; mode count lives in SKILL.md itself)

Closes #1473