### PR TITLE
GH-1487: Fable 5 model ladder — re-tier hero parent, research/plan, escalation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,14 +61,14 @@ plugin/
 
 | Verb | Model tier | Purpose |
 |------|-----------|---------|
-| `/ralph:catch-up` | haiku/sonnet | Orientation: narrative + picker or single-surface mode |
-| `/ralph:form` | sonnet | Issue intake: dedup, draft, tree |
-| `/ralph:research` | sonnet/opus | Research: interactive or autonomous queue-drain |
-| `/ralph:plan` | opus | Planning: interactive, auto, epic, iterate, review |
-| `/ralph:impl` | sonnet | Implementation: auto, pr, address |
-| `/ralph:review` | sonnet/opus | Review: val, code, merge |
-| `/ralph:caretake` | sonnet | Caretaking: triage, hygiene, unblock, trends, split, debug, report |
-| `/ralph:hero` | sonnet | Orchestrator: auto (adaptive queue-drainer) + watch + classify + pr-drain |
+| `/ralph:catch-up` | inherit (haiku narrative agent) | Orientation: narrative + picker or single-surface mode |
+| `/ralph:form` | inherit | Issue intake: dedup, draft, tree |
+| `/ralph:research` | fable | Research: interactive or autonomous queue-drain |
+| `/ralph:plan` | fable | Planning: interactive, auto, epic, iterate, review |
+| `/ralph:impl` | opus session / sonnet ladder | Implementation: auto, pr, address |
+| `/ralph:review` | opus | Review: val, code, merge |
+| `/ralph:caretake` | opus | Caretaking: triage, hygiene, unblock, trends, split, debug, report |
+| `/ralph:hero` | fable | Orchestrator: auto (adaptive queue-drainer) + watch + classify + pr-drain |
 | `/ralph:setup` | haiku | Bootstrap: project setup, CLI install, repo-registry |
 
 ### ralph Plugin — 16 Agents
@@ -77,7 +77,7 @@ plugin/
 
 **8 investigators** (in `ralph/agents/`): `codebase-analyzer`, `codebase-locator`, `codebase-pattern-finder`, `log-reader`, `sre-fixit`, `thoughts-analyzer`, `thoughts-locator`, `web-search-researcher`
 
-On `IMPL BLOCKED needs=opus` verdict, the hero re-dispatches `impl-agent` once at `model="opus"`. Override default models via `RALPH_IMPL_MODEL`, `RALPH_SPLIT_MODEL`.
+On `IMPL BLOCKED needs=fable` verdict, the hero re-dispatches `impl-agent` once at `model="fable"`. Override the default impl tier via `RALPH_IMPL_MODEL`. Model-tier rationale: [`docs/model-tier-policy.md`](docs/model-tier-policy.md).
 
 ### MCP Server Internals
 
@@ -224,7 +224,7 @@ When no `RALPH_*_TOKEN` env var is set, the MCP server falls back to `gh auth to
 | `RALPH_GH_REPO_TOKEN` | No | Separate repo token (falls back to main token, then to `gh auth token`) |
 | `RALPH_GH_PROJECT_TOKEN` | No | Separate project token (falls back to repo token) |
 | `RALPH_GH_PROJECT_OWNER` | No | Project owner if different from repo owner |
-| `RALPH_IMPL_MODEL` | No | Override model for `impl-agent` (e.g. `sonnet`, `opus`). Defaults to `sonnet`. |
+| `RALPH_IMPL_MODEL` | No | Override model for `impl-agent` (e.g. `sonnet`, `opus`, `fable`). Defaults to `sonnet`; BLOCKED escalation re-dispatches once at `fable`. |
 | `RALPH_DEBUG` | No | Set to `"true"` to enable JSONL debug logging and OpenTelemetry export. |
 
 **Do NOT put tokens in `.mcp.json`** — the `.mcp.json` has no `env` block; the MCP server inherits the parent environment.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ plugin/
 | `RALPH_GH_PROJECT_OWNER` | No | Project owner if different from repo owner |
 | `RALPH_GH_REPO_TOKEN` | No | Separate repo token (falls back to main token) |
 | `RALPH_GH_PROJECT_TOKEN` | No | Separate project token (falls back to repo token) |
-| `RALPH_IMPL_MODEL` | No | Override model for `impl-agent` (`sonnet` or `opus`; default `sonnet`) |
+| `RALPH_IMPL_MODEL` | No | Override model for `impl-agent` (`sonnet`, `opus`, or `fable`; default `sonnet`; BLOCKED escalation re-dispatches once at `fable`) |
 | `RALPH_DEBUG` | No | Enable JSONL debug logging + OpenTelemetry export |
 
 Set all variables in `.claude/settings.local.json` under the `"env"` key. Do not put tokens in `.mcp.json`.

--- a/docs/model-tier-policy.md
+++ b/docs/model-tier-policy.md
@@ -1,0 +1,83 @@
+# Ralph Model-Tier Policy
+
+Adapted from superpowers/subagent-driven-development. Updated 2026-06-09 for
+the Fable 5 ladder (see thoughts/shared/research/2026-06-09-GH-1487-hero-model-pinning-per-phase.md).
+
+## The rule
+
+Complexity drives tier, not role — with one refinement: the few steps whose
+output every downstream step inherits (orchestration, research findings, plan
+content) are pinned at the frontier tier preemptively.
+
+| Signal                                                  | Tier      | Model  |
+| ------------------------------------------------------- | --------- | ------ |
+| 1-2 files, fully-specified spec, mechanical             | cheap     | haiku  |
+| Multi-file, integration, pattern matching, debugging    | standard  | sonnet |
+| Architecture, design judgment, broad-codebase review    | capable   | opus   |
+| Orchestration, research synthesis, plan author/critique | frontier  | fable  |
+
+Escalate on BLOCKED, never preemptively (frontier pins above are the
+exception, justified by downstream compounding).
+
+## Default tier by surface
+
+| Surface | Model | Pin location |
+|---|---|---|
+| hero parent session (all modes) | fable | `ralph/skills/hero/SKILL.md` |
+| research skill session | fable | `ralph/skills/research/SKILL.md` |
+| plan skill session (incl. `--mode review`) | fable | `ralph/skills/plan/SKILL.md` |
+| plan-agent / review-agent (`Agent()`-forked) | fable | `ralph/agents/{plan,review}-agent.md` |
+| impl / review / caretake skill sessions | opus | respective `SKILL.md` |
+| research / impl / val / triage agents, sre-fixit, analyzers | sonnet | `ralph/agents/*.md` |
+| merge / catch-up agents, locators, log-reader | haiku | `ralph/agents/*.md` |
+| impl per-task sub-agents | haiku/sonnet/opus by `complexity:` | `ralph/skills/impl/phase-execution.md` |
+
+## Per-session overrides
+
+`RALPH_IMPL_MODEL=fable|opus|sonnet|haiku` overrides the impl dispatch tier
+(default `sonnet`). It is the ONLY wired model env var in the slim plugin —
+per-agent `RALPH_<AGENT>_MODEL` vars from the legacy plugin were never wired;
+edit frontmatter instead.
+
+## Escalation contract
+
+When ralph-impl's internal budget exhausts below the top tier it emits a
+verdict-prefix line and stops:
+
+```text
+IMPL BLOCKED model=<current> needs=fable reason=<short>
+```
+
+Hero matches the `IMPL BLOCKED ` prefix (never the full string) and
+re-dispatches ONCE with `RALPH_IMPL_MODEL=fable`. A second BLOCKED at fable
+escalates to Human Needed via `save_issue(workflowState="__ESCALATE__")`.
+`impl-postcondition.sh` also greps only the bare prefix, so the `needs=`
+value can change without touching hooks.
+
+## Why not preemptive Fable everywhere?
+
+From the landcrawler-ai 30-day audit (GH-1250):
+
+1. Most impl phases are mechanical when the plan is detailed — sonnet handles
+   them. A frontier default wastes tokens on the common case.
+2. Failure cases that need a higher tier are detectable (BLOCKED). One retry
+   at the top tier costs less than always paying for it.
+
+Fable 5 is pinned preemptively only where quality compounds: hero decisions,
+research findings, and plan content feed every downstream phase.
+
+## Fable 5 operational notes
+
+- Requires Claude Code v2.1.170+.
+- Priced above opus-tier; its tokenizer yields ~30% more tokens for the same
+  content — expect higher per-tick cost on hero/research/plan sessions.
+- 1M context window: pinning fable on inline-`Skill()`-loaded skills never
+  shrinks the parent context envelope.
+
+## Context window and inline Skill() calls
+
+Inline `Skill()` runs in the parent session — the called skill's `model:`
+frontmatter applies to the parent for the duration, INCLUDING its context
+cap. `Agent()` forks an isolated context. Rule (GH-1265): any `model: haiku`
+skill that may be called from a parent carrying >200k tokens MUST be
+dispatched via `Agent()`. Upward pins (opus → fable) are safe inline.

--- a/ralph/agents/impl-agent.md
+++ b/ralph/agents/impl-agent.md
@@ -1,10 +1,10 @@
 ---
 name: impl-agent
-description: Implement issues - executes one phase per invocation in an isolated worktree, handles PR review feedback. Default sonnet per docs/model-tier-policy.md. The dispatcher passes the full procedure inline (worktree setup, phase execution, plan compliance, address-mode classification) via the ralph/skills/impl/*.md sibling refs. Escalates to opus on BLOCKED. Honors the IMPL BLOCKED verdict-prefix contract.
+description: Implement issues - executes one phase per invocation in an isolated worktree, handles PR review feedback. Default sonnet per docs/model-tier-policy.md. The dispatcher passes the full procedure inline (worktree setup, phase execution, plan compliance, address-mode classification) via the ralph/skills/impl/*.md sibling refs. Escalates to fable on BLOCKED. Honors the IMPL BLOCKED verdict-prefix contract.
 model: sonnet
 tools: Read, Write, Edit, Glob, Grep, Bash, Agent, mcp__plugin_ralph_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph_ralph-github__ralph_hero__create_comment, mcp__plugin_ralph_ralph-github__ralph_hero__list_sub_issues
 ---
 
 You are an impl agent — a thin shell. You carry no preloaded skill. Your task prompt supplies the full implementation procedure inline, including paths to the worker prose under `ralph/skills/impl/` (e.g. `worktree-setup.md`, `phase-execution.md`, `implementer-prompt.md`, `plan-compliance.md`, `address-mode.md`, `pr-creation.md`).
 
-Read every referenced procedure file before acting, then follow it exactly. Work only inside the worktree the prompt names. Emit the terminal verdict line the prompt asks for (e.g. `IMPL BLOCKED model=<current> needs=opus reason=<short>` when the internal retry budget is exhausted below opus). Do not invent scope beyond the prompt and its referenced procedures.
+Read every referenced procedure file before acting, then follow it exactly. Work only inside the worktree the prompt names. Emit the terminal verdict line the prompt asks for (e.g. `IMPL BLOCKED model=<current> needs=fable reason=<short>` when the internal retry budget is exhausted below fable). Do not invent scope beyond the prompt and its referenced procedures.

--- a/ralph/agents/plan-agent.md
+++ b/ralph/agents/plan-agent.md
@@ -1,7 +1,7 @@
 ---
 name: plan-agent
 description: Plan issues - reads research findings, creates phased implementation plans with file ownership and verification steps. Thin shell; the dispatcher passes the planning procedure inline via the ralph/skills/plan/*.md sibling refs.
-model: opus
+model: fable
 tools: Read, Write, Glob, Grep, Bash, Agent, mcp__plugin_ralph_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
 ---
 

--- a/ralph/agents/review-agent.md
+++ b/ralph/agents/review-agent.md
@@ -1,7 +1,7 @@
 ---
 name: review-agent
 description: Review implementation plans - assesses plan quality, approves or sends back for iteration. Thin shell; the dispatcher passes the review procedure inline via the ralph/skills/plan/plan-review.md sibling ref.
-model: opus
+model: fable
 tools: Read, Write, Glob, Grep, Bash, Agent, AskUserQuestion, mcp__plugin_ralph_ralph-github__ralph_hero__get_issue, mcp__plugin_ralph_ralph-github__ralph_hero__list_issues, mcp__plugin_ralph_ralph-github__ralph_hero__save_issue, mcp__plugin_ralph_ralph-github__ralph_hero__create_comment
 ---
 

--- a/ralph/skills/hero/SKILL.md
+++ b/ralph/skills/hero/SKILL.md
@@ -2,7 +2,7 @@
 description: Autonomous orchestrator for the ralph slim plugin. Drives a GitHub issue through the full lifecycle (research → plan → impl → review → merge) with a human plan-approval gate by default. Five modes:default(one-shot), --mode auto (autopilot drain via /loop), --mode classify (director-only dispatch), --mode watch (watcher heartbeat), --mode pr-drain (PR triage). Triggers on "run the hero", "drain the backlog", "classify this issue", "dispatch this", "watch the alerts", "drain this PR", "auto mode", "ship this ticket".
 argument-hint: "[<issue-number> | --mode <auto|classify|watch|pr-drain>] [--issue NNN] [--pr NNN] [--since <window>] [--loop [duration]] [--auto]"
 context: inline
-model: opus
+model: fable
 hooks:
   SessionStart:
     - hooks:

--- a/ralph/skills/hero/dispatch.md
+++ b/ralph/skills/hero/dispatch.md
@@ -35,19 +35,19 @@ Read `${RALPH_IMPL_MODEL:-sonnet}`. Default is sonnet; override via env or shell
 impl_model="${RALPH_IMPL_MODEL:-sonnet}"
 ```
 
-Pass the resolved model explicitly to dispatched verbs that respect it. Default is `sonnet`; opus is used on BLOCKED-escalation (when impl returns `IMPL BLOCKED needs=opus`).
+Pass the resolved model explicitly to dispatched verbs that respect it. Default is `sonnet`; fable is used on BLOCKED-escalation (when impl returns `IMPL BLOCKED needs=fable`).
 
 ## BLOCKED escalation
 
-After `/ralph:impl --auto` returns, inspect the terminal verdict. If it contains the prefix `IMPL BLOCKED ` (full format: `IMPL BLOCKED model=<x> needs=opus reason=<short>` — match on the prefix, not the full string, so detection cannot drift from the emitted format):
+After `/ralph:impl --auto` returns, inspect the terminal verdict. If it contains the prefix `IMPL BLOCKED ` (full format: `IMPL BLOCKED model=<x> needs=fable reason=<short>` — match on the prefix, not the full string, so detection cannot drift from the emitted format):
 
-1. If this dispatch's model was NOT opus AND no prior opus retry has occurred for this issue:
-   re-dispatch the same issue with `RALPH_IMPL_MODEL=opus`:
+1. If this dispatch's model was NOT fable AND no prior fable retry has occurred for this issue:
+   re-dispatch the same issue with `RALPH_IMPL_MODEL=fable`:
    ```
    Skill("ralph:impl", args="NNN --auto --plan-doc PATH (retry after BLOCKED)")
    ```
-   Track a per-issue retry counter in TaskList metadata so a second BLOCKED at opus does not loop.
-2. If this dispatch's model was opus, OR the retry counter is already 1:
+   Track a per-issue retry counter in TaskList metadata so a second BLOCKED at fable does not loop.
+2. If this dispatch's model was fable, OR the retry counter is already 1:
    escalate via `save_issue(workflowState="__ESCALATE__", command="ralph_impl")` to Human Needed. Fire a best-effort push notification:
    ```
    PushNotification(title="Failed #NNN", body="<blocked-reason> — <issue-url>")

--- a/ralph/skills/impl/SKILL.md
+++ b/ralph/skills/impl/SKILL.md
@@ -169,7 +169,7 @@ Ask the user via AskUserQuestion what to do next:
 4. **Build issues[] + detect phase** — frontmatter `github_issues` array (group) or single `github_issue`. Find the first **unblocked** unchecked phase per `depends_on` annotations; STOP if all remaining phases are blocked.
 5. **Lock** — for every issue in `issues[]`, `save_issue(workflowState="__LOCK__", command="ralph_impl")`. STOP if any issue is not "In Progress".
 6. **Worktree** — consult [worktree-setup.md §Auto-mode](worktree-setup.md) for epic detection, WORKTREE_ID selection (stream / epic / group / single), base-branch detection, create-or-reuse, rebase-onto-main if predecessor merged.
-7. **Execute phase** — consult [phase-execution.md](phase-execution.md) for the task graph + controller pattern + IMPL BLOCKED escalation + phase quality review. If sub-agent budget exhausts at a non-opus tier, emit `IMPL BLOCKED model=<current> needs=opus reason=<short>` and STOP (do NOT escalate to Human Needed; hero re-dispatches at opus once).
+7. **Execute phase** — consult [phase-execution.md](phase-execution.md) for the task graph + controller pattern + IMPL BLOCKED escalation + phase quality review. If sub-agent budget exhausts at a non-fable tier, emit `IMPL BLOCKED model=<current> needs=fable reason=<short>` and STOP (do NOT escalate to Human Needed; hero re-dispatches at fable once).
 8. **Stage + commit + push** — per [plan-compliance.md §Staging Algorithm](plan-compliance.md).
 9. **Check completion** — re-read plan. If ALL automated checkboxes are checked, continue to Step 10; otherwise STOP with `Phase [N]/[M] complete.`.
 10. **Final report** — `Implementation complete for #NNN: <Title>` + issues + branch + worktree.

--- a/ralph/skills/impl/phase-execution.md
+++ b/ralph/skills/impl/phase-execution.md
@@ -37,15 +37,15 @@ Per-task retry budget: **3 attempts**. After three, escalate to Human Needed (`_
 
 ## §IMPL BLOCKED escalation
 
-Tier-escalation path (model-driven BLOCKED). When the implementer's internal retry budget is exhausted at the highest tier WITHIN this invocation AND the current dispatching model is NOT opus, emit a structured terminal line BEFORE stopping:
+Tier-escalation path (model-driven BLOCKED). When the implementer's internal retry budget is exhausted at the highest tier WITHIN this invocation AND the current dispatching model is NOT fable, emit a structured terminal line BEFORE stopping:
 
 ```
-IMPL BLOCKED model=<current> needs=opus reason=<short-reason>
+IMPL BLOCKED model=<current> needs=fable reason=<short-reason>
 ```
 
-Do NOT call `save_issue(workflowState="__ESCALATE__")` in this path — leave the issue in "In Progress" so hero can re-dispatch with `model="opus"` once. The `impl-postcondition.sh` Stop hook greps the transcript for the unanchored `IMPL BLOCKED ` token (the marker is embedded inside a JSON `"text":"..."` field in the JSONL transcript and never appears at column 0) and accepts it as a non-error terminal state.
+Do NOT call `save_issue(workflowState="__ESCALATE__")` in this path — leave the issue in "In Progress" so hero can re-dispatch with `model="fable"` once. The `impl-postcondition.sh` Stop hook greps the transcript for the unanchored `IMPL BLOCKED ` token (the marker is embedded inside a JSON `"text":"..."` field in the JSONL transcript and never appears at column 0) and accepts it as a non-error terminal state.
 
-If the current dispatching model IS already opus, fall through to the existing escalate-to-Human-Needed path (`save_issue(workflowState="__ESCALATE__")`). A double-BLOCKED at opus is a real escalation, not a tier issue.
+If the current dispatching model IS already fable, fall through to the existing escalate-to-Human-Needed path (`save_issue(workflowState="__ESCALATE__")`). A double-BLOCKED at fable is a real escalation, not a tier issue.
 
 ## §Phase quality review
 

--- a/ralph/skills/impl/plan-compliance.md
+++ b/ralph/skills/impl/plan-compliance.md
@@ -87,4 +87,4 @@ Common mismatch sources:
 - Dependency added in a prior phase that changes the API the current phase consumes.
 - Test framework upgraded; old assertion style no longer compiles.
 
-In **default mode**, the user resolves the mismatch interactively (the question becomes part of the phase pause). In **auto mode**, the mismatch is itself a BLOCKED signal — emit `IMPL BLOCKED model=<current> needs=opus reason=<mismatch>` per [phase-execution.md §IMPL BLOCKED escalation](phase-execution.md) so hero can re-dispatch at a higher tier.
+In **default mode**, the user resolves the mismatch interactively (the question becomes part of the phase pause). In **auto mode**, the mismatch is itself a BLOCKED signal — emit `IMPL BLOCKED model=<current> needs=fable reason=<mismatch>` per [phase-execution.md §IMPL BLOCKED escalation](phase-execution.md) so hero can re-dispatch at a higher tier.

--- a/ralph/skills/plan/SKILL.md
+++ b/ralph/skills/plan/SKILL.md
@@ -13,7 +13,7 @@ description: Create, iterate on, or review an implementation plan. Use whenever 
   plan. --mode review produces an APPROVED/NEEDS_ITERATION verdict.
 argument-hint: "[--mode auto|epic|iterate|review] [<issue-number|plan-path|description>] [--playwright|--no-playwright] [--loop [duration]] [--auto]"
 context: inline
-model: opus
+model: fable
 hooks:
   SessionStart:
     - hooks:

--- a/ralph/skills/research/SKILL.md
+++ b/ralph/skills/research/SKILL.md
@@ -10,7 +10,7 @@ description: Investigate a codebase question, a GitHub issue, or a claim. Use wh
   claim investigation that produces a verdict + confidence + evidence chains.
 argument-hint: "[--mode auto|prove] [<question|#NNN|claim>] [--playwright|--no-playwright] [--loop [duration]] [--auto]"
 context: inline
-model: opus
+model: fable
 hooks:
   # branch-gate.sh is intentionally not declared here. In the slim plugin it's
   # patched to no-op when RALPH_REQUIRED_BRANCH is unset, and the autonomous


### PR DESCRIPTION
## Summary

Shift the top rung of the ralph model ladder to **Fable 5** where output quality compounds downstream: the hero parent orchestrator session, the research and plan phase sessions, and the `Agent()`-forked plan/review agents. Retarget the one-shot `IMPL BLOCKED` escalation from `needs=opus` to `needs=fable` so the single retry before Human Needed gets the best model. Resurrect `docs/model-tier-policy.md` (deleted with `plugin/ralph-hero/` in GH-1438 but still referenced by `ralph/agents/impl-agent.md`) and realign CLAUDE.md.

Docs/config-only: 5 frontmatter pin flips, escalation-token prose in 5 files, 1 new doc, CLAUDE.md alignment. **Zero TypeScript, zero hook changes** (detection matches the bare `IMPL BLOCKED ` prefix).

Three commits, one per plan phase:
- **Phase 1** — flip `model: opus` → `model: fable` on hero/research/plan skills + plan-agent/review-agent.
- **Phase 2** — retarget `needs=opus` → `needs=fable` + tier prose across the 5 escalation files.
- **Phase 3** — create `docs/model-tier-policy.md` (fable→opus→sonnet→haiku ladder); align CLAUDE.md (drop dead `RALPH_SPLIT_MODEL`, add `fable` to the `RALPH_IMPL_MODEL` row, fix the stale 9-verbs model column).

## Plan

https://github.com/cdubiel08/ralph-hero/blob/main/thoughts/shared/plans/2026-06-09-GH-1487-fable-model-ladder-retiering.md

## Test plan

- [x] `grep -rn "needs=opus" ralph/ CLAUDE.md docs/` → no matches
- [x] `grep -l "^model: fable"` over the 5 pin files → all 5
- [x] out-of-scope pins (review/impl/caretake sessions, impl complexity ladder `high→opus`) untouched
- [x] `grep -rln "needs=fable" ralph/` → exactly impl-agent.md, hero/dispatch.md, impl/SKILL.md, impl/phase-execution.md, impl/plan-compliance.md
- [x] `test -f docs/model-tier-policy.md`; `impl-agent.md`'s reference now resolves
- [x] CLAUDE.md: no `RALPH_SPLIT_MODEL`, no `needs=opus`; verb-table model column matches frontmatter reality
- [x] Hook suite passes 6/0; `ralph/hooks/` diff empty vs origin/main
- [ ] Manual: fresh `/ralph:hero` session loads at Fable 5 (host requires Claude Code ≥ 2.1.170)

Closes #1487
