### PR TITLE
fix(ralph): guard hook find pipelines against silent pipefail abort

### DIFF
--- a/ralph/hooks/scripts/__tests__/stop-hook-pipefail-guard.test.sh
+++ b/ralph/hooks/scripts/__tests__/stop-hook-pipefail-guard.test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ralph/hooks/scripts/__tests__/stop-hook-pipefail-guard.test.sh
+#
+# Regression: Stop hooks must never abort silently (rc=1, empty stderr) when
+# the thoughts/shared/* artifact dirs are missing under the project root.
+#
+# Mechanism of the bug: `doc=$(find "$dir" … 2>/dev/null | head -1)` under
+# `set -euo pipefail`. `find` on a missing dir exits 1 (stderr suppressed),
+# pipefail propagates the 1 through `head`, the failing command substitution
+# fails the assignment, and `set -e` kills the script with exit 1 and nothing
+# on stderr. Skill-frontmatter Stop hooks stay registered for the rest of the
+# session, so interactive /ralph:research + /ralph:plan sessions in any repo
+# without the full thoughts/ layout hit this on EVERY Stop.
+#
+# review-postcondition.sh:44 already guards this with `|| true`; these tests
+# pin the same contract onto the sibling hooks.
+#
+# Run: bash ralph/hooks/scripts/__tests__/stop-hook-pipefail-guard.test.sh
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+STOP_JSON='{"hook_event_name":"Stop","stop_hook_active":false,"transcript_path":"/nonexistent/t.jsonl"}'
+STDERR_FILE="$TEST_DIR/stderr.txt"
+
+PASS=0
+FAIL=0
+assert_eq() {
+  if [ "$1" = "$2" ]; then PASS=$((PASS+1)); echo "  PASS: $3";
+  else FAIL=$((FAIL+1)); echo "  FAIL: $3"; echo "    expected: $1"; echo "    actual:   $2"; fi
+}
+assert_contains() {
+  if grep -q "$1" "$2" 2>/dev/null; then PASS=$((PASS+1)); echo "  PASS: $3";
+  else FAIL=$((FAIL+1)); echo "  FAIL: $3"; echo "    expected stderr to contain: $1"; fi
+}
+
+# run_hook <script> <project_dir>          (no ticket env)
+run_hook() {
+  printf '%s' "$STOP_JSON" \
+    | env -u RALPH_TICKET_ID RALPH_COMMAND=plan RALPH_HOOK_INPUT= \
+        CLAUDE_PROJECT_DIR="$2" bash "$HOOK_DIR/$1" >/dev/null 2>"$STDERR_FILE"
+  echo $?
+}
+
+# run_hook_ticket <script> <project_dir> <ticket>
+run_hook_ticket() {
+  printf '%s' "$STOP_JSON" \
+    | env RALPH_TICKET_ID="$3" RALPH_COMMAND=plan RALPH_HOOK_INPUT= \
+        CLAUDE_PROJECT_DIR="$2" bash "$HOOK_DIR/$1" >/dev/null 2>"$STDERR_FILE"
+  echo $?
+}
+
+echo "== interactive Stop (no ticket) in a project with NO thoughts/ layout =="
+EMPTY_PROJ="$TEST_DIR/empty-proj"
+mkdir -p "$EMPTY_PROJ"
+
+ec=$(run_hook doc-structure-validator.sh "$EMPTY_PROJ")
+assert_eq "0" "$ec" "doc-structure-validator exits 0 when all artifact dirs are missing"
+
+ec=$(run_hook research-postcondition.sh "$EMPTY_PROJ")
+assert_eq "0" "$ec" "research-postcondition exits 0 without RALPH_TICKET_ID"
+
+ec=$(run_hook plan-postcondition.sh "$EMPTY_PROJ")
+assert_eq "0" "$ec" "plan-postcondition exits 0 without RALPH_TICKET_ID"
+
+echo
+echo "== partial thoughts/ layout: only research dir exists, with a fresh valid doc =="
+PARTIAL_PROJ="$TEST_DIR/partial-proj"
+mkdir -p "$PARTIAL_PROJ/thoughts/shared/research"
+TODAY=$(date +%Y-%m-%d)
+cat > "$PARTIAL_PROJ/thoughts/shared/research/${TODAY}-test-topic.md" <<'EOF'
+## Research Question
+
+How does the thing work?
+
+## Summary
+
+It works via `src/thing.ts`.
+
+## Files Affected
+
+### Will Modify
+- `src/thing.ts`
+
+### Will Read (Dependencies)
+- `src/other.ts`
+EOF
+
+# Must not die on the missing plans/ and reviews/ dirs before reaching the
+# research dir, and the valid doc must pass structure validation.
+ec=$(run_hook doc-structure-validator.sh "$PARTIAL_PROJ")
+assert_eq "0" "$ec" "doc-structure-validator validates research doc despite missing plans/reviews dirs"
+
+echo
+echo "== auto flow (ticket set) with missing artifact dirs: block loudly, not crash silently =="
+ec=$(run_hook_ticket research-postcondition.sh "$EMPTY_PROJ" "GH-1234")
+assert_eq "2" "$ec" "research-postcondition blocks (rc=2) when ticket set but no doc/dir"
+assert_contains "Research postcondition failed" "$STDERR_FILE" "research-postcondition block has an actionable stderr message"
+
+ec=$(run_hook_ticket plan-postcondition.sh "$EMPTY_PROJ" "GH-1234")
+assert_eq "2" "$ec" "plan-postcondition blocks (rc=2) when ticket set but no doc/dir"
+assert_contains "Plan postcondition failed" "$STDERR_FILE" "plan-postcondition block has an actionable stderr message"
+
+echo
+echo "== find_existing_artifact (hook-utils) tolerates a missing artifact dir under set -euo pipefail =="
+ec=$(bash -c '
+  set -euo pipefail
+  source "'"$HOOK_DIR"'/hook-utils.sh"
+  result=$(find_existing_artifact "'"$EMPTY_PROJ"'/thoughts/shared/plans" "GH-1234")
+  [[ -z "$result" ]]
+' 2>"$STDERR_FILE"; echo $?)
+assert_eq "0" "$ec" "find_existing_artifact returns empty (rc=0) on missing dir instead of aborting"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/ralph/hooks/scripts/doc-structure-validator.sh
+++ b/ralph/hooks/scripts/doc-structure-validator.sh
@@ -27,7 +27,11 @@ today=$(date +%Y-%m-%d)
 doc=""
 command=""
 for candidate_dir in "thoughts/shared/plans" "thoughts/shared/reviews" "thoughts/shared/research"; do
-  found=$(find "$project_root/$candidate_dir" -name "${today}-*.md" -type f -mmin -15 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)
+  # `|| true`: find exits 1 when the candidate dir is missing (most repos
+  # don't have all three), pipefail would fail the assignment, and `set -e`
+  # would kill the hook with rc=1 and nothing on stderr — on EVERY Stop for
+  # the rest of the session, since skill frontmatter hooks stay registered.
+  found=$(find "$project_root/$candidate_dir" -name "${today}-*.md" -type f -mmin -15 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1 || true)
   if [[ -n "$found" ]]; then
     # Pick the freshest across dirs.
     if [[ -z "$doc" ]] || [[ "$found" -nt "$doc" ]]; then

--- a/ralph/hooks/scripts/hook-utils.sh
+++ b/ralph/hooks/scripts/hook-utils.sh
@@ -164,8 +164,11 @@ find_existing_artifact() {
     return 1
   fi
 
+  # `|| true`: find exits 1 on a missing artifact dir; under the callers'
+  # `set -euo pipefail` an unguarded failure here would abort the hook with
+  # rc=1 and nothing on stderr. Missing dir means "no artifact", not a crash.
   local result
-  result=$(find "$artifact_dir" -name "*${ticket_id}*" -type f 2>/dev/null | head -1)
+  result=$(find "$artifact_dir" -name "*${ticket_id}*" -type f 2>/dev/null | head -1 || true)
   if [[ -n "$result" ]]; then
     echo "$result"
     return 0
@@ -174,7 +177,7 @@ find_existing_artifact() {
   local alt
   alt=$(ticket_id_alt_form "$ticket_id")
   if [[ -n "$alt" ]]; then
-    find "$artifact_dir" -name "*${alt}*" -type f 2>/dev/null | head -1
+    find "$artifact_dir" -name "*${alt}*" -type f 2>/dev/null | head -1 || true
   fi
 }
 

--- a/ralph/hooks/scripts/impl-plan-required.sh
+++ b/ralph/hooks/scripts/impl-plan-required.sh
@@ -47,18 +47,20 @@ alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
 plan_doc=$(find_existing_artifact "$plans_dir" "$ticket_id")
 
 # Check 2: Group plan
+# `|| true` on the find pipelines: a missing plans dir must read as "no plan
+# doc" (block below), not a pipefail+set-e silent crash with empty stderr.
 if [[ -z "$plan_doc" ]]; then
-  plan_doc=$(find "$plans_dir" -name "*group*${ticket_id}*" -type f 2>/dev/null | head -1)
+  plan_doc=$(find "$plans_dir" -name "*group*${ticket_id}*" -type f 2>/dev/null | head -1 || true)
   if [[ -z "$plan_doc" && -n "$alt_ticket_id" ]]; then
-    plan_doc=$(find "$plans_dir" -name "*group*${alt_ticket_id}*" -type f 2>/dev/null | head -1)
+    plan_doc=$(find "$plans_dir" -name "*group*${alt_ticket_id}*" -type f 2>/dev/null | head -1 || true)
   fi
 fi
 
 # Check 3: Stream plan
 if [[ -z "$plan_doc" ]]; then
-  plan_doc=$(find "$plans_dir" -name "*stream*${ticket_id}*" -type f 2>/dev/null | head -1)
+  plan_doc=$(find "$plans_dir" -name "*stream*${ticket_id}*" -type f 2>/dev/null | head -1 || true)
   if [[ -z "$plan_doc" && -n "$alt_ticket_id" ]]; then
-    plan_doc=$(find "$plans_dir" -name "*stream*${alt_ticket_id}*" -type f 2>/dev/null | head -1)
+    plan_doc=$(find "$plans_dir" -name "*stream*${alt_ticket_id}*" -type f 2>/dev/null | head -1 || true)
   fi
 fi
 

--- a/ralph/hooks/scripts/plan-postcondition.sh
+++ b/ralph/hooks/scripts/plan-postcondition.sh
@@ -67,12 +67,14 @@ if [[ -d "$reviews_dir" ]]; then
 fi
 
 plans_dir="$project_root/thoughts/shared/plans"
-doc=$(find "$plans_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+# `|| true`: a missing plans dir must mean "no doc" (block below), not a
+# pipefail+set-e silent crash. Same guard as the reviews find above.
+doc=$(find "$plans_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1 || true)
 
 if [[ -z "$doc" ]]; then
   alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
   if [[ -n "$alt_ticket_id" ]]; then
-    doc=$(find "$plans_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+    doc=$(find "$plans_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1 || true)
   fi
 fi
 

--- a/ralph/hooks/scripts/research-postcondition.sh
+++ b/ralph/hooks/scripts/research-postcondition.sh
@@ -17,12 +17,16 @@ if [[ -z "$ticket_id" ]]; then
 fi
 
 research_dir="$(get_project_root)/thoughts/shared/research"
-doc=$(find "$research_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+# `|| true`: find exits 1 on a missing dir (stderr suppressed) and pipefail
+# would fail the assignment, making `set -e` kill the hook with rc=1 and
+# nothing on stderr. Missing dir must mean "no doc" (block below), not a
+# silent crash. Same guard as review-postcondition.sh.
+doc=$(find "$research_dir" -name "*${ticket_id}*" -type f -mmin -30 2>/dev/null | head -1 || true)
 
 if [[ -z "$doc" ]]; then
   alt_ticket_id=$(ticket_id_alt_form "$ticket_id")
   if [[ -n "$alt_ticket_id" ]]; then
-    doc=$(find "$research_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1)
+    doc=$(find "$research_dir" -name "*${alt_ticket_id}*" -type f -mmin -30 2>/dev/null | head -1 || true)
   fi
 fi
 


### PR DESCRIPTION
## Problem

A session reported: after invoking `/ralph:research` and `/ralph:plan` interactively, every subsequent Stop fired a hook that exited non-zero with **nothing on stderr**. Skill-frontmatter Stop hooks stay registered for the rest of the session, so the failure repeated on every Stop.

## Root cause (reproduced)

`doc-structure-validator.sh:30`:

```bash
found=$(find "$project_root/$candidate_dir" ... 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)
```

under `set -euo pipefail`. In any project missing one of `thoughts/shared/{plans,reviews,research}`, `find` exits 1 (stderr suppressed), `pipefail` carries the failure through the pipe, the command substitution fails the assignment, and `set -e` kills the hook — rc=1, empty stderr, on the **first** missing dir. With `RALPH_TICKET_ID` set (auto flow), `research-postcondition.sh` and `plan-postcondition.sh` hit the identical crash instead of their intended exit-2 block.

`review-postcondition.sh:44` already guards this exact case with `|| true` and a comment describing the lesson — it just never propagated to the sibling hooks.

## Fix

Apply the same `|| true` guard to every unguarded `find` pipeline:

- `doc-structure-validator.sh` (the always-firing Stop hook)
- `research-postcondition.sh`, `plan-postcondition.sh` (ticket-gated Stop hooks)
- `impl-plan-required.sh` (PreToolUse, same top-level assignment pattern)
- `hook-utils.sh` `find_existing_artifact` (feeds three PreToolUse hooks)

Missing dir now means "no artifact found" and flows into each hook's designed allow/block path with an actionable stderr message — never a silent rc=1.

## Tests

New `ralph/hooks/scripts/__tests__/stop-hook-pipefail-guard.test.sh` (picked up by the existing CI glob):

- interactive Stop (no ticket) in a project with no/partial `thoughts/` layout → rc 0
- auto flow (ticket set) with missing dirs → rc 2 **with** an actionable message
- `find_existing_artifact` tolerates a missing dir under `set -euo pipefail`

6 of 9 assertions failed before the fix; all 9 pass after. Full hook suite passes 7/7. No new ShellCheck findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)